### PR TITLE
Fix UPE appearance wrong background color and font on block themes

### DIFF
--- a/changelog/WOOPMNT-5907-upe-wrong-background
+++ b/changelog/WOOPMNT-5907-upe-wrong-background
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed UPE payment input field background color and font rendering on block theme checkouts

--- a/client/cart/blocks/product-details.js
+++ b/client/cart/blocks/product-details.js
@@ -58,14 +58,17 @@ const ProductDetail = ( { cart, context } ) => {
 
 	useEffect( () => {
 		if ( ! appearance ) {
-			const computed = getAppearance( 'bnpl_cart_block' );
-			dispatchAppearanceEvent( computed, 'bnpl_cart_block' );
-			setCachedAppearance(
-				'bnpl_cart_block',
-				getUPEConfig( 'stylesCacheVersion' ),
-				computed
-			);
-			setAppearance( computed );
+			const fontsReady = document.fonts?.ready ?? Promise.resolve();
+			fontsReady.then( () => {
+				const computed = getAppearance( 'bnpl_cart_block' );
+				dispatchAppearanceEvent( computed, 'bnpl_cart_block' );
+				setCachedAppearance(
+					'bnpl_cart_block',
+					getUPEConfig( 'stylesCacheVersion' ),
+					computed
+				);
+				setAppearance( computed );
+			} );
 		}
 	}, [ appearance ] );
 

--- a/client/cart/blocks/product-details.js
+++ b/client/cart/blocks/product-details.js
@@ -10,11 +10,10 @@ import { select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getAppearance, getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
+import { getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
 import {
 	getCachedAppearance,
-	setCachedAppearance,
-	dispatchAppearanceEvent,
+	resolveAppearance,
 } from 'wcpay/utils/appearance-cache';
 import { useStripeAsync } from 'wcpay/hooks/use-stripe-async';
 import { getUPEConfig } from 'utils/checkout';
@@ -58,16 +57,12 @@ const ProductDetail = ( { cart, context } ) => {
 
 	useEffect( () => {
 		if ( ! appearance ) {
-			( async () => {
-				const computed = await getAppearance( 'bnpl_cart_block' );
-				dispatchAppearanceEvent( computed, 'bnpl_cart_block' );
-				setCachedAppearance(
-					'bnpl_cart_block',
-					getUPEConfig( 'stylesCacheVersion' ),
-					computed
-				);
+			resolveAppearance(
+				'bnpl_cart_block',
+				getUPEConfig( 'stylesCacheVersion' )
+			).then( ( computed ) => {
 				setAppearance( computed );
-			} )();
+			} );
 		}
 	}, [ appearance ] );
 

--- a/client/cart/blocks/product-details.js
+++ b/client/cart/blocks/product-details.js
@@ -58,9 +58,8 @@ const ProductDetail = ( { cart, context } ) => {
 
 	useEffect( () => {
 		if ( ! appearance ) {
-			const fontsReady = document.fonts?.ready ?? Promise.resolve();
-			fontsReady.then( () => {
-				const computed = getAppearance( 'bnpl_cart_block' );
+			( async () => {
+				const computed = await getAppearance( 'bnpl_cart_block' );
 				dispatchAppearanceEvent( computed, 'bnpl_cart_block' );
 				setCachedAppearance(
 					'bnpl_cart_block',
@@ -68,7 +67,7 @@ const ProductDetail = ( { cart, context } ) => {
 					computed
 				);
 				setAppearance( computed );
-			} );
+			} )();
 		}
 	}, [ appearance ] );
 

--- a/client/checkout/api/__tests__/index.test.js
+++ b/client/checkout/api/__tests__/index.test.js
@@ -20,8 +20,12 @@ jest.mock( 'wcpay/utils/checkout', () => ( {
 const mockAppearance = {
 	rules: {
 		'.Block': {},
-		'.Input': {},
-		'.Input--invalid': {},
+		'.Input': {
+			backgroundColor: '#ffffff',
+		},
+		'.Input--invalid': {
+			backgroundColor: '#ffffff',
+		},
 		'.Label': {},
 		'.Label--resting': {},
 		'.Tab': {},

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -8,7 +8,7 @@ import {
 	getExpressCheckoutConfig,
 	buildAjaxURL,
 } from 'wcpay/utils/express-checkout';
-import { getAppearance } from 'checkout/upe-styles';
+import { resolveAppearance } from 'wcpay/utils/appearance-cache';
 import { getAppearanceType } from '../utils';
 
 /**
@@ -345,7 +345,7 @@ export default class WCPayAPI {
 			const appearanceType = getAppearanceType();
 
 			const appearance = getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-				? await getAppearance( appearanceType, true )
+				? await resolveAppearance( appearanceType, null, true )
 				: null;
 
 			return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -344,13 +344,9 @@ export default class WCPayAPI {
 			const nonce = getConfig( 'initWooPayNonce' );
 			const appearanceType = getAppearanceType();
 
-			let appearance = null;
-			if ( getConfig( 'isWooPayGlobalThemeSupportEnabled' ) ) {
-				if ( document.fonts?.ready ) {
-					await document.fonts.ready;
-				}
-				appearance = getAppearance( appearanceType, true );
-			}
+			const appearance = getConfig( 'isWooPayGlobalThemeSupportEnabled' )
+				? await getAppearance( appearanceType, true )
+				: null;
 
 			return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
 				_wpnonce: nonce,

--- a/client/checkout/api/index.js
+++ b/client/checkout/api/index.js
@@ -337,18 +337,24 @@ export default class WCPayAPI {
 		return setupIntent;
 	}
 
-	initWooPay( userEmail, woopayUserSession ) {
+	async initWooPay( userEmail, woopayUserSession ) {
 		if ( ! this.isWooPayRequesting ) {
 			this.isWooPayRequesting = true;
 			const wcAjaxUrl = getConfig( 'wcAjaxUrl' );
 			const nonce = getConfig( 'initWooPayNonce' );
 			const appearanceType = getAppearanceType();
 
+			let appearance = null;
+			if ( getConfig( 'isWooPayGlobalThemeSupportEnabled' ) ) {
+				if ( document.fonts?.ready ) {
+					await document.fonts.ready;
+				}
+				appearance = getAppearance( appearanceType, true );
+			}
+
 			return this.request( buildAjaxURL( wcAjaxUrl, 'init_woopay' ), {
 				_wpnonce: nonce,
-				appearance: getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-					? getAppearance( appearanceType, true )
-					: null,
+				appearance,
 				email: userEmail,
 				user_session: woopayUserSession,
 				order_id: getConfig( 'order_id' ),

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -10,11 +10,10 @@ import { StoreNotice } from '@woocommerce/blocks-checkout';
  * Internal dependencies
  */
 import './style.scss';
-import { getAppearance, getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
+import { getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
 import {
 	getCachedAppearance,
-	setCachedAppearance,
-	dispatchAppearanceEvent,
+	resolveAppearance,
 } from 'wcpay/utils/appearance-cache';
 import { useStripeForUPE } from 'wcpay/hooks/use-stripe-async';
 import { getUPEConfig } from 'wcpay/utils/checkout';
@@ -47,21 +46,14 @@ const PaymentElements = ( { api, ...props } ) => {
 
 	useEffect( () => {
 		if ( ! appearance && containerRef.current ) {
-			( async () => {
-				const ownerDoc = containerRef.current.ownerDocument;
-				setFontRules( getFontRulesFromPage( ownerDoc ) );
-				// Generate UPE input styles.
-				const upeAppearance = await getAppearance(
-					'blocks_checkout',
-					false,
-					ownerDoc
-				);
-				dispatchAppearanceEvent( upeAppearance, 'blocks_checkout' );
-				setCachedAppearance(
-					'blocks_checkout',
-					getUPEConfig( 'stylesCacheVersion' ),
-					upeAppearance
-				);
+			const ownerDoc = containerRef.current.ownerDocument;
+			setFontRules( getFontRulesFromPage( ownerDoc ) );
+			resolveAppearance(
+				'blocks_checkout',
+				getUPEConfig( 'stylesCacheVersion' ),
+				false,
+				ownerDoc
+			).then( ( upeAppearance ) => {
 				setAppearance( upeAppearance );
 				// Defer dispatch so all payment method label listeners are attached first.
 				setTimeout( () => {
@@ -69,7 +61,7 @@ const PaymentElements = ( { api, ...props } ) => {
 						new Event( 'wcpay-appearance-cached' )
 					);
 				}, 0 );
-			} )();
+			} );
 		}
 
 		if ( fingerprintErrorMessage ) {

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -47,18 +47,11 @@ const PaymentElements = ( { api, ...props } ) => {
 
 	useEffect( () => {
 		if ( ! appearance && containerRef.current ) {
-			const ownerDoc = containerRef.current.ownerDocument;
-			// Wait for web fonts to load before reading computed styles so
-			// getComputedStyle returns the actual theme font, not a fallback.
-			const fontsReady = ownerDoc.fonts?.ready ?? Promise.resolve();
-			fontsReady.then( () => {
-				// Guard against unmount or cache being set while we waited.
-				if ( ! containerRef.current ) {
-					return;
-				}
+			( async () => {
+				const ownerDoc = containerRef.current.ownerDocument;
 				setFontRules( getFontRulesFromPage( ownerDoc ) );
 				// Generate UPE input styles.
-				const upeAppearance = getAppearance(
+				const upeAppearance = await getAppearance(
 					'blocks_checkout',
 					false,
 					ownerDoc
@@ -76,7 +69,7 @@ const PaymentElements = ( { api, ...props } ) => {
 						new Event( 'wcpay-appearance-cached' )
 					);
 				}, 0 );
-			} );
+			} )();
 		}
 
 		if ( fingerprintErrorMessage ) {

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -47,26 +47,36 @@ const PaymentElements = ( { api, ...props } ) => {
 
 	useEffect( () => {
 		if ( ! appearance && containerRef.current ) {
-			setFontRules(
-				getFontRulesFromPage( containerRef.current.ownerDocument )
-			);
-			// Generate UPE input styles.
-			const upeAppearance = getAppearance(
-				'blocks_checkout',
-				false,
-				containerRef.current.ownerDocument
-			);
-			dispatchAppearanceEvent( upeAppearance, 'blocks_checkout' );
-			setCachedAppearance(
-				'blocks_checkout',
-				getUPEConfig( 'stylesCacheVersion' ),
-				upeAppearance
-			);
-			setAppearance( upeAppearance );
-			// Defer dispatch so all payment method label listeners are attached first.
-			setTimeout( () => {
-				window.dispatchEvent( new Event( 'wcpay-appearance-cached' ) );
-			}, 0 );
+			const ownerDoc = containerRef.current.ownerDocument;
+			// Wait for web fonts to load before reading computed styles so
+			// getComputedStyle returns the actual theme font, not a fallback.
+			const fontsReady = ownerDoc.fonts?.ready ?? Promise.resolve();
+			fontsReady.then( () => {
+				// Guard against unmount or cache being set while we waited.
+				if ( ! containerRef.current ) {
+					return;
+				}
+				setFontRules( getFontRulesFromPage( ownerDoc ) );
+				// Generate UPE input styles.
+				const upeAppearance = getAppearance(
+					'blocks_checkout',
+					false,
+					ownerDoc
+				);
+				dispatchAppearanceEvent( upeAppearance, 'blocks_checkout' );
+				setCachedAppearance(
+					'blocks_checkout',
+					getUPEConfig( 'stylesCacheVersion' ),
+					upeAppearance
+				);
+				setAppearance( upeAppearance );
+				// Defer dispatch so all payment method label listeners are attached first.
+				setTimeout( () => {
+					window.dispatchEvent(
+						new Event( 'wcpay-appearance-cached' )
+					);
+				}, 0 );
+			} );
 		}
 
 		if ( fingerprintErrorMessage ) {

--- a/client/checkout/classic/__tests__/payment-processing.test.js
+++ b/client/checkout/classic/__tests__/payment-processing.test.js
@@ -10,8 +10,8 @@ import {
 	__resetHasCheckoutCompleted,
 	isMissingRequiredAddressFieldsForBNPL,
 } from '../payment-processing';
-import { getAppearance } from '../../upe-styles';
 import { getUPEConfig } from 'wcpay/utils/checkout';
+import { resolveAppearance } from 'wcpay/utils/appearance-cache';
 import {
 	getFingerprint,
 	appendFingerprintInputToForm,
@@ -179,7 +179,7 @@ describe( 'Stripe Payment Element mounting', () => {
 				document.body.dispatchEvent = dispatchMock;
 
 				const appearanceMock = { backgroundColor: '#fff' };
-				getAppearance.mockReturnValue( appearanceMock );
+				resolveAppearance.mockResolvedValue( appearanceMock );
 				getFingerprint.mockImplementation( () => {
 					return 'fingerprint';
 				} );
@@ -192,10 +192,7 @@ describe( 'Stripe Payment Element mounting', () => {
 					elementsLocation
 				);
 
-				expect( getAppearance ).toHaveBeenCalledWith(
-					elementsLocation
-				);
-				expect( dispatchMock ).toHaveBeenCalled();
+				expect( resolveAppearance ).toHaveBeenCalled();
 			} );
 		} );
 	} );

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -49,15 +49,22 @@ for ( const paymentMethodType in getUPEConfig( 'paymentMethodsConfig' ) ) {
 
 /**
  * Initializes the appearance of the payment element by computing it from the DOM.
+ * Waits for web fonts to load before reading computed styles.
  *
  * @param {string} elementsLocation The location of the UPE elements.
- * @return {Object} The appearance object for the UPE.
+ * @return {Promise<Object>} The appearance object for the UPE.
  */
-function initializeAppearance( elementsLocation ) {
+async function initializeAppearance( elementsLocation ) {
 	const version = getUPEConfig( 'stylesCacheVersion' );
 	const cached = getCachedAppearance( elementsLocation, version );
 	if ( cached ) {
 		return cached;
+	}
+
+	// Wait for web fonts to load so getComputedStyle returns the actual
+	// theme font instead of a fallback generic family.
+	if ( document.fonts?.ready ) {
+		await document.fonts.ready;
 	}
 
 	const appearance = getAppearance( elementsLocation );
@@ -251,7 +258,7 @@ async function createStripePaymentElement(
 ) {
 	const amount = Number( getUPEConfig( 'cartTotal' ) );
 	const paymentMethodTypes = getPaymentMethodTypes( paymentMethodType );
-	const appearance = initializeAppearance( elementsLocation );
+	const appearance = await initializeAppearance( elementsLocation );
 	document
 		.querySelector(
 			`.wcpay-upe-element[data-payment-method-type="${ paymentMethodType }"]`

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -7,12 +7,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getUPEConfig } from 'wcpay/utils/checkout';
-import { getAppearance, getFontRulesFromPage } from '../upe-styles';
-import {
-	getCachedAppearance,
-	setCachedAppearance,
-	dispatchAppearanceEvent,
-} from 'wcpay/utils/appearance-cache';
+import { getFontRulesFromPage } from '../upe-styles';
+import { resolveAppearance } from 'wcpay/utils/appearance-cache';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
 import {
 	appendFingerprintInputToForm,
@@ -48,23 +44,16 @@ for ( const paymentMethodType in getUPEConfig( 'paymentMethodsConfig' ) ) {
 }
 
 /**
- * Initializes the appearance of the payment element by computing it from the DOM.
- * Waits for web fonts to load before reading computed styles.
+ * Initializes the appearance of the payment element.
  *
  * @param {string} elementsLocation The location of the UPE elements.
  * @return {Promise<Object>} The appearance object for the UPE.
  */
-async function initializeAppearance( elementsLocation ) {
-	const version = getUPEConfig( 'stylesCacheVersion' );
-	const cached = getCachedAppearance( elementsLocation, version );
-	if ( cached ) {
-		return cached;
-	}
-
-	const appearance = await getAppearance( elementsLocation );
-	dispatchAppearanceEvent( appearance, elementsLocation );
-	setCachedAppearance( elementsLocation, version, appearance );
-	return appearance;
+function initializeAppearance( elementsLocation ) {
+	return resolveAppearance(
+		elementsLocation,
+		getUPEConfig( 'stylesCacheVersion' )
+	);
 }
 
 /**

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -61,13 +61,7 @@ async function initializeAppearance( elementsLocation ) {
 		return cached;
 	}
 
-	// Wait for web fonts to load so getComputedStyle returns the actual
-	// theme font instead of a fallback generic family.
-	if ( document.fonts?.ready ) {
-		await document.fonts.ready;
-	}
-
-	const appearance = getAppearance( elementsLocation );
+	const appearance = await getAppearance( elementsLocation );
 	dispatchAppearanceEvent( appearance, elementsLocation );
 	setCachedAppearance( elementsLocation, version, appearance );
 	return appearance;

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -161,7 +161,7 @@ describe( 'Getting styles for automated theming', () => {
 		expect( fontRules ).toEqual( [] );
 	} );
 
-	test( 'getAppearance returns the object with filtered CSS rules for UPE theming', async () => {
+	test( 'getAppearance returns the object with filtered CSS rules for UPE theming', () => {
 		const scope = {
 			querySelector: jest.fn( () => mockElement ),
 			createElement: jest.fn( ( htmlTag ) =>
@@ -172,7 +172,7 @@ describe( 'Getting styles for automated theming', () => {
 			},
 		};
 
-		const appearance = await upeStyles.getAppearance(
+		const appearance = upeStyles.getAppearance(
 			'shortcode_checkout',
 			false,
 			scope
@@ -261,7 +261,7 @@ describe( 'Getting styles for automated theming', () => {
 		} );
 	} );
 
-	test( 'getAppearance replaces transparent .Input backgrounds with page background color', async () => {
+	test( 'getAppearance replaces transparent .Input backgrounds with page background color', () => {
 		const inputElement = document.createElement( 'input' );
 		const backgroundElement = document.createElement( 'div' );
 		const pageBackgroundColor = 'rgb(245, 245, 245)';
@@ -307,7 +307,7 @@ describe( 'Getting styles for automated theming', () => {
 			},
 		};
 
-		const appearance = await upeStyles.getAppearance(
+		const appearance = upeStyles.getAppearance(
 			'shortcode_checkout',
 			false,
 			scope
@@ -402,7 +402,7 @@ describe( 'Getting styles for automated theming', () => {
 		},
 	].forEach( ( { elementsLocation, expectedSelectors } ) => {
 		describe( `when elementsLocation is ${ elementsLocation }`, () => {
-			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', async () => {
+			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', () => {
 				const scope = {
 					querySelector: jest.fn( () => mockElement ),
 					createElement: jest.fn( ( htmlTag ) =>
@@ -415,7 +415,7 @@ describe( 'Getting styles for automated theming', () => {
 					},
 				};
 
-				await upeStyles.getAppearance( elementsLocation, false, scope );
+				upeStyles.getAppearance( elementsLocation, false, scope );
 
 				expectedSelectors.forEach( ( selector ) => {
 					expect( scope.querySelector ).toHaveBeenCalledWith(

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -4,7 +4,13 @@
 import * as upeStyles from '..';
 
 describe( 'Getting styles for automated theming', () => {
-	const mockElement = document.createElement( 'input' );
+	// Recreated per-test so DOM nodes from hiddenElementsForUPE.init()
+	// don't accumulate across tests (the mock querySelector returns this
+	// for every selector, so cleanup() can't find the real hidden container).
+	let mockElement;
+	beforeEach( () => {
+		mockElement = document.createElement( 'input' );
+	} );
 	// camelCase for direct property access (styles.fontFamily)
 	const cssPropertiesCamel = {
 		fontFamily:
@@ -155,7 +161,7 @@ describe( 'Getting styles for automated theming', () => {
 		expect( fontRules ).toEqual( [] );
 	} );
 
-	test( 'getAppearance returns the object with filtered CSS rules for UPE theming', () => {
+	test( 'getAppearance returns the object with filtered CSS rules for UPE theming', async () => {
 		const scope = {
 			querySelector: jest.fn( () => mockElement ),
 			createElement: jest.fn( ( htmlTag ) =>
@@ -166,7 +172,7 @@ describe( 'Getting styles for automated theming', () => {
 			},
 		};
 
-		const appearance = upeStyles.getAppearance(
+		const appearance = await upeStyles.getAppearance(
 			'shortcode_checkout',
 			false,
 			scope
@@ -255,7 +261,7 @@ describe( 'Getting styles for automated theming', () => {
 		} );
 	} );
 
-	test( 'getAppearance replaces transparent .Input backgrounds with page background color', () => {
+	test( 'getAppearance replaces transparent .Input backgrounds with page background color', async () => {
 		const inputElement = document.createElement( 'input' );
 		const backgroundElement = document.createElement( 'div' );
 		const pageBackgroundColor = 'rgb(245, 245, 245)';
@@ -301,7 +307,7 @@ describe( 'Getting styles for automated theming', () => {
 			},
 		};
 
-		const appearance = upeStyles.getAppearance(
+		const appearance = await upeStyles.getAppearance(
 			'shortcode_checkout',
 			false,
 			scope
@@ -396,7 +402,7 @@ describe( 'Getting styles for automated theming', () => {
 		},
 	].forEach( ( { elementsLocation, expectedSelectors } ) => {
 		describe( `when elementsLocation is ${ elementsLocation }`, () => {
-			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', () => {
+			test( 'getAppearance uses the correct appearanceSelectors based on the elementsLocation', async () => {
 				const scope = {
 					querySelector: jest.fn( () => mockElement ),
 					createElement: jest.fn( ( htmlTag ) =>
@@ -409,7 +415,7 @@ describe( 'Getting styles for automated theming', () => {
 					},
 				};
 
-				upeStyles.getAppearance( elementsLocation, false, scope );
+				await upeStyles.getAppearance( elementsLocation, false, scope );
 
 				expectedSelectors.forEach( ( selector ) => {
 					expect( scope.querySelector ).toHaveBeenCalledWith(

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -111,6 +111,31 @@ describe( 'Getting styles for automated theming', () => {
 		] );
 	} );
 
+	test( 'getFontRulesFromPage returns font rules from Bunny Fonts provider', () => {
+		const mockStyleSheets = {
+			length: 2,
+			0: {
+				href:
+					'https://not-supported-fonts-domain.com/style.css?ver=1.1.1',
+			},
+			1: {
+				href:
+					'https://fonts.bunny.net/css?family=DM+Sans:400,500,700&display=swap',
+			},
+		};
+		jest.spyOn( document, 'styleSheets', 'get' ).mockReturnValue(
+			mockStyleSheets
+		);
+
+		const fontRules = upeStyles.getFontRulesFromPage();
+		expect( fontRules ).toEqual( [
+			{
+				cssSrc:
+					'https://fonts.bunny.net/css?family=DM+Sans:400,500,700&display=swap',
+			},
+		] );
+	} );
+
 	test( 'getFontRulesFromPage returns empty array if there are no fonts from allowed providers', () => {
 		const mockStyleSheets = {
 			length: 2,

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -157,7 +157,7 @@ describe( 'Getting styles for automated theming', () => {
 			theme: 'stripe',
 			rules: {
 				'.Input': {
-					backgroundColor: 'rgba(0, 0, 0, 0)',
+					backgroundColor: '#ffffff',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
@@ -166,7 +166,7 @@ describe( 'Getting styles for automated theming', () => {
 					padding: '10px',
 				},
 				'.Input--invalid': {
-					backgroundColor: 'rgba(0, 0, 0, 0)',
+					backgroundColor: '#ffffff',
 					color: 'rgb(109, 109, 109)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
@@ -228,6 +228,68 @@ describe( 'Getting styles for automated theming', () => {
 			},
 			labels: 'above',
 		} );
+	} );
+
+	test( 'getAppearance replaces transparent .Input backgrounds with page background color', () => {
+		const inputElement = document.createElement( 'input' );
+		const backgroundElement = document.createElement( 'div' );
+		const pageBackgroundColor = 'rgb(245, 245, 245)';
+
+		// Input has transparent background.
+		const transparentInputStyles = {
+			...cssPropertiesCamel,
+			backgroundColor: 'rgba(0, 0, 0, 0)',
+			getPropertyValue: ( prop ) => {
+				if ( prop === 'background-color' ) return 'rgba(0, 0, 0, 0)';
+				return cssPropertiesDashed[ prop ];
+			},
+		};
+
+		// Page background is opaque.
+		const opaqueBackgroundStyles = {
+			...cssPropertiesCamel,
+			backgroundColor: pageBackgroundColor,
+			getPropertyValue: ( prop ) => {
+				if ( prop === 'background-color' ) return pageBackgroundColor;
+				return cssPropertiesDashed[ prop ];
+			},
+		};
+
+		const scope = {
+			querySelector: jest.fn( ( selector ) => {
+				// Background selectors — the first one in the list resolves
+				// to an element with an opaque background.
+				if ( selector === 'li.wc_payment_method .wc-payment-form' ) {
+					return backgroundElement;
+				}
+				return inputElement;
+			} ),
+			createElement: jest.fn( ( htmlTag ) =>
+				document.createElement( htmlTag )
+			),
+			defaultView: {
+				getComputedStyle: jest.fn( ( el ) =>
+					el === backgroundElement
+						? opaqueBackgroundStyles
+						: transparentInputStyles
+				),
+			},
+		};
+
+		const appearance = upeStyles.getAppearance(
+			'shortcode_checkout',
+			false,
+			scope
+		);
+
+		// Both .Input and .Input--invalid should use the page background,
+		// not the transparent value from the computed input styles.
+		expect( appearance.rules[ '.Input' ].backgroundColor ).toBe(
+			pageBackgroundColor
+		);
+		expect( appearance.rules[ '.Input--invalid' ].backgroundColor ).toBe(
+			pageBackgroundColor
+		);
 	} );
 
 	test( 'getFieldStyles prioritizes content-area selectors over bare fallback', () => {

--- a/client/checkout/upe-styles/__tests__/utils.test.js
+++ b/client/checkout/upe-styles/__tests__/utils.test.js
@@ -112,6 +112,54 @@ describe( 'UPE Utilities to generate UPE styles', () => {
 		expect( upeUtils.isColorLight( lightGrey ) ).toEqual( true );
 	} );
 
+	describe( 'isTransparentColor', () => {
+		test( 'returns true for fully transparent rgba', () => {
+			expect( upeUtils.isTransparentColor( 'rgba(0, 0, 0, 0)' ) ).toBe(
+				true
+			);
+		} );
+
+		test( 'returns true for the keyword "transparent"', () => {
+			expect( upeUtils.isTransparentColor( 'transparent' ) ).toBe( true );
+		} );
+
+		test( 'returns true for empty string', () => {
+			expect( upeUtils.isTransparentColor( '' ) ).toBe( true );
+		} );
+
+		test( 'returns true for undefined', () => {
+			expect( upeUtils.isTransparentColor( undefined ) ).toBe( true );
+		} );
+
+		test( 'returns true for low-alpha colors (alpha < 0.5)', () => {
+			expect(
+				upeUtils.isTransparentColor( 'rgba(129, 110, 153, 0.14)' )
+			).toBe( true );
+			expect( upeUtils.isTransparentColor( 'rgba(0, 0, 0, 0.49)' ) ).toBe(
+				true
+			);
+		} );
+
+		test( 'returns false for opaque colors', () => {
+			expect( upeUtils.isTransparentColor( '#ffffff' ) ).toBe( false );
+			expect( upeUtils.isTransparentColor( 'rgb(255, 255, 255)' ) ).toBe(
+				false
+			);
+			expect( upeUtils.isTransparentColor( 'rgba(0, 0, 0, 1)' ) ).toBe(
+				false
+			);
+		} );
+
+		test( 'returns false for colors with alpha >= 0.5', () => {
+			expect( upeUtils.isTransparentColor( 'rgba(0, 0, 0, 0.5)' ) ).toBe(
+				false
+			);
+			expect(
+				upeUtils.isTransparentColor( 'rgba(100, 200, 50, 0.8)' )
+			).toBe( false );
+		} );
+	} );
+
 	test( 'maybeConvertRGBAtoRGB returns valid colors', () => {
 		const hex = '#ffffff';
 		const color = 'red';

--- a/client/checkout/upe-styles/__tests__/woopay-appearance.test.js
+++ b/client/checkout/upe-styles/__tests__/woopay-appearance.test.js
@@ -42,7 +42,7 @@ describe( 'WooPay appearance theming', () => {
 			cssPropertiesDashed[ propertyName ],
 	};
 
-	test( 'getAppearance for woopay_shortcode_checkout includes WooPay rules with correct link priority', async () => {
+	test( 'getAppearance for woopay_shortcode_checkout includes WooPay rules with correct link priority', () => {
 		const contentLink = document.createElement( 'a' );
 		const navLink = document.createElement( 'a' );
 		const accentColor = 'rgb(0, 102, 204)';
@@ -86,7 +86,7 @@ describe( 'WooPay appearance theming', () => {
 			},
 		};
 
-		const appearance = await upeStyles.getAppearance(
+		const appearance = upeStyles.getAppearance(
 			'woopay_shortcode_checkout',
 			true,
 			scope
@@ -109,7 +109,7 @@ describe( 'WooPay appearance theming', () => {
 		expect( scope.querySelector ).toHaveBeenCalledWith( 'form.checkout a' );
 	} );
 
-	test( 'getAppearance routes woopay_shortcode_checkout to wooPayClassicCheckout selectors', async () => {
+	test( 'getAppearance routes woopay_shortcode_checkout to wooPayClassicCheckout selectors', () => {
 		const scope = {
 			querySelector: jest.fn( () => mockElement ),
 			createElement: jest.fn( ( htmlTag ) =>
@@ -120,11 +120,7 @@ describe( 'WooPay appearance theming', () => {
 			},
 		};
 
-		await upeStyles.getAppearance(
-			'woopay_shortcode_checkout',
-			false,
-			scope
-		);
+		upeStyles.getAppearance( 'woopay_shortcode_checkout', false, scope );
 
 		expect( scope.querySelector ).toHaveBeenCalledWith(
 			upeStyles.appearanceSelectors.wooPayClassicCheckout

--- a/client/checkout/upe-styles/__tests__/woopay-appearance.test.js
+++ b/client/checkout/upe-styles/__tests__/woopay-appearance.test.js
@@ -42,7 +42,7 @@ describe( 'WooPay appearance theming', () => {
 			cssPropertiesDashed[ propertyName ],
 	};
 
-	test( 'getAppearance for woopay_shortcode_checkout includes WooPay rules with correct link priority', () => {
+	test( 'getAppearance for woopay_shortcode_checkout includes WooPay rules with correct link priority', async () => {
 		const contentLink = document.createElement( 'a' );
 		const navLink = document.createElement( 'a' );
 		const accentColor = 'rgb(0, 102, 204)';
@@ -86,7 +86,7 @@ describe( 'WooPay appearance theming', () => {
 			},
 		};
 
-		const appearance = upeStyles.getAppearance(
+		const appearance = await upeStyles.getAppearance(
 			'woopay_shortcode_checkout',
 			true,
 			scope
@@ -109,7 +109,7 @@ describe( 'WooPay appearance theming', () => {
 		expect( scope.querySelector ).toHaveBeenCalledWith( 'form.checkout a' );
 	} );
 
-	test( 'getAppearance routes woopay_shortcode_checkout to wooPayClassicCheckout selectors', () => {
+	test( 'getAppearance routes woopay_shortcode_checkout to wooPayClassicCheckout selectors', async () => {
 		const scope = {
 			querySelector: jest.fn( () => mockElement ),
 			createElement: jest.fn( ( htmlTag ) =>
@@ -120,7 +120,11 @@ describe( 'WooPay appearance theming', () => {
 			},
 		};
 
-		upeStyles.getAppearance( 'woopay_shortcode_checkout', false, scope );
+		await upeStyles.getAppearance(
+			'woopay_shortcode_checkout',
+			false,
+			scope
+		);
 
 		expect( scope.querySelector ).toHaveBeenCalledWith(
 			upeStyles.appearanceSelectors.wooPayClassicCheckout

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -532,6 +532,7 @@ export const getFontRulesFromPage = ( scope = document ) => {
 			'fonts.gstatic.com',
 			'fast.fonts.com',
 			'use.typekit.net',
+			'fonts.bunny.net',
 		];
 	for ( let i = 0; i < sheets.length; i++ ) {
 		if ( ! sheets[ i ].href ) {

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -592,11 +592,17 @@ function ensureFontSizeSmallerThan(
 	return `${ fontSizeNumber }px`;
 }
 
-export const getAppearance = (
+export const getAppearance = async (
 	elementsLocation,
 	forWooPay = false,
 	scope = document
 ) => {
+	// Wait for web fonts to load so getComputedStyle returns the actual
+	// theme font instead of a fallback generic family.
+	if ( scope.fonts?.ready ) {
+		await scope.fonts.ready;
+	}
+
 	const selectors = appearanceSelectors.getSelectors(
 		elementsLocation,
 		scope

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -592,17 +592,11 @@ function ensureFontSizeSmallerThan(
 	return `${ fontSizeNumber }px`;
 }
 
-export const getAppearance = async (
+export const getAppearance = (
 	elementsLocation,
 	forWooPay = false,
 	scope = document
 ) => {
-	// Wait for web fonts to load so getComputedStyle returns the actual
-	// theme font instead of a fallback generic family.
-	if ( scope.fonts?.ready ) {
-		await scope.fonts.ready;
-	}
-
 	const selectors = appearanceSelectors.getSelectors(
 		elementsLocation,
 		scope

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -72,6 +72,8 @@ export const appearanceSelectors = {
 			'#payment-method',
 			'form.wc-block-checkout__form',
 			'.wc-block-checkout',
+			'main',
+			'.wp-block-group',
 			'body',
 		],
 		headingSelectors: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ],

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -6,6 +6,7 @@ import {
 	generateHoverRules,
 	generateOutlineStyle,
 	isColorLight,
+	isTransparentColor,
 	getBackgroundColor,
 	maybeConvertRGBAtoRGB,
 	handleAppearanceForFloatingLabel,
@@ -659,6 +660,18 @@ export const getAppearance = (
 		selectors.backgroundSelectors,
 		scope
 	);
+
+	// Stripe Elements renders in an iframe and cannot inherit the page
+	// background.  Block themes commonly set input `background-color` to
+	// `transparent`, which would result in a white (or mismatched) background
+	// inside the iframe.  Fall back to the resolved page background instead.
+	if ( isTransparentColor( inputRules.backgroundColor ) ) {
+		inputRules.backgroundColor = backgroundColor;
+	}
+	if ( isTransparentColor( inputInvalidRules.backgroundColor ) ) {
+		inputInvalidRules.backgroundColor = backgroundColor;
+	}
+
 	const blockRules = getFieldStyles(
 		selectors.upeThemeLabelSelector,
 		'.Block',

--- a/client/checkout/upe-styles/utils.js
+++ b/client/checkout/upe-styles/utils.js
@@ -152,6 +152,29 @@ export const isColorLight = ( color ) => {
 };
 
 /**
+ * Determines whether a color is transparent or nearly transparent (alpha < 0.5).
+ *
+ * Stripe Elements renders in an iframe and cannot inherit the page background.
+ * Block themes commonly set input backgrounds to `transparent`, which results
+ * in a white-on-white (or dark-on-dark) appearance inside the iframe.  Use
+ * this helper to detect such values so they can be replaced with an explicit
+ * fallback.
+ *
+ * @param {string|undefined} color CSS color value.
+ * @return {boolean} True when the color is transparent or nearly so.
+ */
+export const isTransparentColor = ( color ) => {
+	if ( ! color ) {
+		return true;
+	}
+	const tc = tinycolor( color );
+	if ( ! tc.isValid() ) {
+		return true;
+	}
+	return tc.getAlpha() < 0.5;
+};
+
+/**
  * Converts rgba to rgb format, since Stripe Appearances API does not accept rgba format for text color.
  *
  * @param {string} color CSS color value.

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -187,16 +187,11 @@ export const handleWooPayEmailInput = async (
 		// Set the initial value.
 		iframeHeaderValue = true;
 		const appearanceType = getAppearanceType();
-		let appearance = null;
-		if (
+		const appearance =
 			isSupportedThemeEntrypoint( appearanceType ) &&
 			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-		) {
-			if ( document.fonts?.ready ) {
-				await document.fonts.ready;
-			}
-			appearance = getAppearance( appearanceType, true );
-		}
+				? await getAppearance( appearanceType, true )
+				: null;
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {
 			request(

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -6,7 +6,7 @@ import { getConfig } from 'wcpay/utils/checkout';
 import { recordUserEvent, getTracksIdentity } from 'tracks';
 import request from '../utils/request';
 import { buildAjaxURL } from 'utils/express-checkout';
-import { getAppearance } from 'checkout/upe-styles';
+import { resolveAppearance } from 'wcpay/utils/appearance-cache';
 import {
 	getTargetElement,
 	validateEmail,
@@ -190,7 +190,7 @@ export const handleWooPayEmailInput = async (
 		const appearance =
 			isSupportedThemeEntrypoint( appearanceType ) &&
 			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-				? await getAppearance( appearanceType, true )
+				? await resolveAppearance( appearanceType, null, true )
 				: null;
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {

--- a/client/checkout/woopay/email-input-iframe.js
+++ b/client/checkout/woopay/email-input-iframe.js
@@ -183,15 +183,20 @@ export const handleWooPayEmailInput = async (
 		}
 	};
 
-	iframe.addEventListener( 'load', () => {
+	iframe.addEventListener( 'load', async () => {
 		// Set the initial value.
 		iframeHeaderValue = true;
 		const appearanceType = getAppearanceType();
-		const appearance =
+		let appearance = null;
+		if (
 			isSupportedThemeEntrypoint( appearanceType ) &&
 			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-				? getAppearance( appearanceType, true )
-				: null;
+		) {
+			if ( document.fonts?.ready ) {
+				await document.fonts.ready;
+			}
+			appearance = getAppearance( appearanceType, true );
+		}
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {
 			request(

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -17,7 +17,7 @@ import {
 	isSupportedThemeEntrypoint,
 } from '../utils';
 import { getTracksIdentity } from 'tracks';
-import { getAppearance } from 'wcpay/checkout/upe-styles';
+import { resolveAppearance } from 'wcpay/utils/appearance-cache';
 import { getAppearanceType } from 'wcpay/checkout/utils';
 
 const getEmailValue = async ( emailSelector ) => {
@@ -115,7 +115,7 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		const appearance =
 			isSupportedThemeEntrypoint( appearanceType ) &&
 			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-				? await getAppearance( appearanceType, true )
+				? await resolveAppearance( appearanceType, null, true )
 				: null;
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -108,15 +108,20 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 			Math.floor( window.innerWidth / 2 - iframeRect.width / 2 ) + 'px';
 	};
 
-	iframe.addEventListener( 'load', () => {
+	iframe.addEventListener( 'load', async () => {
 		// Set the initial value.
 		iframeHeaderValue = true;
 		const appearanceType = getAppearanceType();
-		const appearance =
+		let appearance = null;
+		if (
 			isSupportedThemeEntrypoint( appearanceType ) &&
 			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-				? getAppearance( appearanceType, true )
-				: null;
+		) {
+			if ( document.fonts?.ready ) {
+				await document.fonts.ready;
+			}
+			appearance = getAppearance( appearanceType, true );
+		}
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {
 			request(

--- a/client/checkout/woopay/express-button/express-checkout-iframe.js
+++ b/client/checkout/woopay/express-button/express-checkout-iframe.js
@@ -112,16 +112,11 @@ export const expressCheckoutIframe = async ( api, context, emailSelector ) => {
 		// Set the initial value.
 		iframeHeaderValue = true;
 		const appearanceType = getAppearanceType();
-		let appearance = null;
-		if (
+		const appearance =
 			isSupportedThemeEntrypoint( appearanceType ) &&
 			getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-		) {
-			if ( document.fonts?.ready ) {
-				await document.fonts.ready;
-			}
-			appearance = getAppearance( appearanceType, true );
-		}
+				? await getAppearance( appearanceType, true )
+				: null;
 
 		if ( getConfig( 'isWoopayFirstPartyAuthEnabled' ) ) {
 			request(

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -223,16 +223,11 @@ export const WoopayExpressCheckoutButton = ( {
 			setIsLoading( true );
 
 			const appearanceType = getAppearanceType();
-			let appearance = null;
-			if (
+			const appearance =
 				isSupportedThemeEntrypoint( appearanceType ) &&
 				getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-			) {
-				if ( document.fonts?.ready ) {
-					await document.fonts.ready;
-				}
-				appearance = getAppearance( appearanceType, true );
-			}
+					? await getAppearance( appearanceType, true )
+					: null;
 
 			if ( isProductPage ) {
 				const productData = getProductDataRef.current();

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -201,7 +201,7 @@ export const WoopayExpressCheckoutButton = ( {
 	);
 
 	const onClickFirstPartyAuthFlow = useCallback(
-		( e ) => {
+		async ( e ) => {
 			e.preventDefault();
 
 			if ( isPreview || isLoadingRef.current ) {
@@ -223,11 +223,16 @@ export const WoopayExpressCheckoutButton = ( {
 			setIsLoading( true );
 
 			const appearanceType = getAppearanceType();
-			const appearance =
+			let appearance = null;
+			if (
 				isSupportedThemeEntrypoint( appearanceType ) &&
 				getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-					? getAppearance( appearanceType, true )
-					: null;
+			) {
+				if ( document.fonts?.ready ) {
+					await document.fonts.ready;
+				}
+				appearance = getAppearance( appearanceType, true );
+			}
 
 			if ( isProductPage ) {
 				const productData = getProductDataRef.current();

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -25,7 +25,7 @@ import {
 } from 'wcpay/checkout/woopay/utils';
 import { getAddToCartButtonElement } from 'wcpay/utils/wc-product-page-selectors';
 import WooPayFirstPartyAuth from 'wcpay/checkout/woopay/express-button/woopay-first-party-auth';
-import { getAppearance } from 'wcpay/checkout/upe-styles';
+import { resolveAppearance } from 'wcpay/utils/appearance-cache';
 import { getAppearanceType } from 'wcpay/checkout/utils';
 
 const BUTTON_WIDTH_THRESHOLD = 140;
@@ -226,7 +226,7 @@ export const WoopayExpressCheckoutButton = ( {
 			const appearance =
 				isSupportedThemeEntrypoint( appearanceType ) &&
 				getConfig( 'isWooPayGlobalThemeSupportEnabled' )
-					? await getAppearance( appearanceType, true )
+					? await resolveAppearance( appearanceType, null, true )
 					: null;
 
 			if ( isProductPage ) {

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -68,11 +68,7 @@ export const initializeBnplSiteMessaging = async () => {
 	const cacheVersion = window.wcpayStripeSiteMessaging.stylesCacheVersion;
 	let appearance = getCachedAppearance( location, cacheVersion );
 	if ( ! appearance ) {
-		// Wait for web fonts to load before reading computed styles.
-		if ( document.fonts?.ready ) {
-			await document.fonts.ready;
-		}
-		appearance = getAppearance( location );
+		appearance = await getAppearance( location );
 		dispatchAppearanceEvent( appearance, location );
 		setCachedAppearance( location, cacheVersion, appearance );
 	}

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -4,12 +4,8 @@
  */
 import './style.scss';
 import WCPayAPI from 'wcpay/checkout/api';
-import { getAppearance, getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
-import {
-	getCachedAppearance,
-	setCachedAppearance,
-	dispatchAppearanceEvent,
-} from 'wcpay/utils/appearance-cache';
+import { getFontRulesFromPage } from 'wcpay/checkout/upe-styles';
+import { resolveAppearance } from 'wcpay/utils/appearance-cache';
 import apiRequest from 'wcpay/checkout/utils/request';
 
 const elementsLocations = {
@@ -66,12 +62,7 @@ export const initializeBnplSiteMessaging = async () => {
 
 	const location = elementsLocations[ elementLocation ];
 	const cacheVersion = window.wcpayStripeSiteMessaging.stylesCacheVersion;
-	let appearance = getCachedAppearance( location, cacheVersion );
-	if ( ! appearance ) {
-		appearance = await getAppearance( location );
-		dispatchAppearanceEvent( appearance, location );
-		setCachedAppearance( location, cacheVersion, appearance );
-	}
+	const appearance = await resolveAppearance( location, cacheVersion );
 
 	const elementsOptions = {
 		appearance,

--- a/client/product-details/bnpl-site-messaging/index.js
+++ b/client/product-details/bnpl-site-messaging/index.js
@@ -68,6 +68,10 @@ export const initializeBnplSiteMessaging = async () => {
 	const cacheVersion = window.wcpayStripeSiteMessaging.stylesCacheVersion;
 	let appearance = getCachedAppearance( location, cacheVersion );
 	if ( ! appearance ) {
+		// Wait for web fonts to load before reading computed styles.
+		if ( document.fonts?.ready ) {
+			await document.fonts.ready;
+		}
 		appearance = getAppearance( location );
 		dispatchAppearanceEvent( appearance, location );
 		setCachedAppearance( location, cacheVersion, appearance );

--- a/client/utils/appearance-cache.js
+++ b/client/utils/appearance-cache.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { getAppearance } from 'wcpay/checkout/upe-styles';
+
 const CACHE_KEY_PREFIX = 'wcpay_appearance_';
 
 function getCacheKey( location ) {
@@ -75,4 +80,42 @@ export function dispatchAppearanceEvent( appearance, elementsLocation ) {
 			detail: { appearance, elementsLocation },
 		} )
 	);
+}
+
+/**
+ * Returns a ready-to-use Stripe Elements appearance object.
+ *
+ * On cache hit the cached value is returned immediately.
+ * On cache miss it waits for web fonts to finish loading (so
+ * getComputedStyle captures the real theme font), computes the
+ * appearance from the DOM, dispatches the customisation event,
+ * and stores the result in the cache.
+ *
+ * @param {string} location  The elements location (e.g. 'blocks_checkout').
+ * @param {string} version   The current cache version for invalidation.
+ * @param {boolean} forWooPay Whether to include WooPay-specific rules.
+ * @param {Object} scope     The document scope to read styles from.
+ * @return {Promise<Object>} The appearance object.
+ */
+export async function resolveAppearance(
+	location,
+	version,
+	forWooPay = false,
+	scope = document
+) {
+	const cached = getCachedAppearance( location, version );
+	if ( cached ) {
+		return cached;
+	}
+
+	// Wait for web fonts to load so getComputedStyle captures the actual
+	// theme font instead of a fallback generic family.
+	if ( scope.fonts?.ready ) {
+		await scope.fonts.ready;
+	}
+
+	const appearance = getAppearance( location, forWooPay, scope );
+	dispatchAppearanceEvent( appearance, location );
+	setCachedAppearance( location, version, appearance );
+	return appearance;
 }


### PR DESCRIPTION
Fixes WOOPMNT-5907

#### Changes proposed in this Pull Request

Fixes wrong Stripe theme, background color, and font in payment input fields on block theme checkouts. Four targeted fixes:

1. **Block theme background detection** (main fix) — Added `main` and `.wp-block-group` to `backgroundSelectors` for blocks checkout. Block themes wrap checkout content in `<main class="wp-block-group">` which carries the actual visible background color. Without these selectors, `getBackgroundColor` fell through to `body` (which often has a different/darker color), causing Stripe to use the wrong `night` theme on a light checkout page — the "almost invisible" card fields from the bug report.

2. **Transparent input background fallback** — Added `isTransparentColor` helper. When `.Input.backgroundColor` is transparent (common in block themes), it now falls back to the detected page background. Stripe renders in an iframe and can't inherit transparency from the parent page.

3. **Font loading timing** — Added `resolveAppearance()` in `appearance-cache.js` that waits for `document.fonts.ready` on cache miss before computing styles. This ensures `getComputedStyle` captures the actual theme font instead of a generic fallback. Also consolidates the duplicated cache-check/compute/dispatch/store pattern from 8 call sites into one function.

4. **Bunny Fonts support** — Added `fonts.bunny.net` to `getFontRulesFromPage()` allowed domains. Block themes commonly use Bunny Fonts as a privacy-friendly Google Fonts alternative.

**How can this code break?**
- The `document.fonts.ready` promise could theoretically hang if fonts fail to load, delaying appearance computation. However, browsers resolve this promise even when individual fonts fail. The `?.ready` optional chaining also gracefully handles environments without the Font Loading API.
- The new `main` and `.wp-block-group` selectors could match unrelated elements on non-checkout pages, but these are only checked after the more specific payment/checkout selectors and before the `body` fallback.
- The transparent background fallback uses the same alpha threshold (0.5) as `getBackgroundColor()`, ensuring consistent behavior.

**Also fixed:** A pre-existing DOM node leak in the test suite where `mockElement` accumulated child nodes across tests (the mock `querySelector` returned the same element for all selectors, so `cleanup()` never removed the real hidden container). Fixed by recreating `mockElement` in `beforeEach`. Test suite time dropped from 3.6s to <1s.

#### Testing instructions

1. Set up a WordPress site with a **block theme** that uses a dark body background but a lighter content area (e.g., Twenty Twenty-Four with customized global styles, or a theme like Atelier Aura)
2. Install WooPayments and enable UPE
3. Add an item to cart and navigate to the checkout page
4. Open DevTools console and check: `JSON.parse(localStorage.getItem('wcpay_appearance_blocks_checkout'))?.appearance?.theme`
5. Verify it returns `"stripe"` (not `"night"`) when the checkout content area is light-colored
6. Verify `JSON.parse(localStorage.getItem('wcpay_appearance_blocks_checkout'))?.appearance?.variables?.fontFamily` returns the actual theme font (not `"serif"` or `"sans-serif"`)
7. Test on classic checkout as well to verify no regressions

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.