### PR TITLE
Fix WOOPMNT-5964: undefined index warning in Puerto Rico address handling

### DIFF
--- a/changelog/fix-undefined-index-country-terminal-locations
+++ b/changelog/fix-undefined-index-country-terminal-locations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix undefined index warning when store country is empty in terminal locations controller

--- a/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
+++ b/includes/admin/class-wc-rest-payments-terminal-locations-controller.php
@@ -124,7 +124,7 @@ class WC_REST_Payments_Terminal_Locations_Controller extends WC_Payments_REST_Co
 		);
 
 		// Special handling for Puerto Rico - treat as US state rather than country.
-		if ( 'PR' === $location_address['country'] ) {
+		if ( 'PR' === ( $location_address['country'] ?? '' ) ) {
 			$location_address['country'] = 'US';
 			$location_address['state']   = 'PR';
 		}

--- a/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-terminal-locations-controller.php
@@ -96,6 +96,27 @@ class WC_REST_Payments_Terminal_Locations_Controller_Test extends WCPAY_UnitTest
 		$this->assertStringEndsWith( '/admin.php?page=wc-settings&tab=general', $result->get_error_message() );
 	}
 
+	public function test_emits_error_when_country_is_empty() {
+		delete_transient( Controller::STORE_LOCATIONS_TRANSIENT_KEY );
+
+		// Remove the country setting so array_filter() strips the key.
+		update_option( 'woocommerce_default_country', '' );
+
+		$this->mock_wcpay_request( Get_Request::class, 0 );
+		$this->mock_api_client
+			->expects( $this->never() )
+			->method( 'create_terminal_location' );
+
+		$request = new WP_REST_Request(
+			'GET',
+			'/wc/v3/payments/terminal/locations'
+		);
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$result = $this->controller->get_store_location( $request );
+		$this->assertSame( 'store_address_is_incomplete', $result->get_error_code() );
+	}
+
 	public function test_emits_error_when_address_is_incorrect() {
 		delete_transient( Controller::STORE_LOCATIONS_TRANSIENT_KEY );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOPMNT-5964

#### Changes proposed in this Pull Request

`get_store_location()` calls `array_filter()` on the store address array, which strips any keys with empty/falsy values. When the store country setting is empty, the `country` key is removed. The code then accesses `$location_address['country']` directly to check for Puerto Rico, triggering an undefined index warning (PHP 7) or TypeError (PHP 8+).

This PR adds a null coalescing operator (`?? ''`) so the check safely returns false when the key is missing, falling through to the existing `isset()` validation on line 134 which properly handles incomplete addresses.

#### Testing instructions

1. Set up a WooPayments store with an empty country setting (`woocommerce_default_country` = '')
2. Hit the terminal locations REST endpoint (`GET /wc/v3/payments/terminal/locations`)
3. **Before fix**: PHP undefined index warning on `$location_address['country']`
4. **After fix**: Clean `store_address_is_incomplete` error response, no PHP warnings

* Unit test `test_emits_error_when_country_is_empty` added to verify this case

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description)
- [x] Tested on mobile (or does not apply) — backend-only change, not applicable

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

> This PR was created during a [Ceres Bug Blitz](https://linear.app/a8c/issue/WOOPUBR-517) session. The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.