### PR TITLE
Fix WOOPMNT-5977: undefined $note in refund failure tracking path

### DIFF
--- a/changelog/fix-security-assessment-fixes
+++ b/changelog/fix-security-assessment-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Handle duplicate KYC session initialization gracefully

--- a/changelog/fix-security-assessment-fixes#2
+++ b/changelog/fix-security-assessment-fixes#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix active plugin list being empty on older WooCommerce versions

--- a/changelog/fix-undefined-key-card-stripe-link
+++ b/changelog/fix-undefined-key-card-stripe-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix undefined array key warnings in CC_Payment_Method::get_title() when Stripe Link is used

--- a/changelog/fix-undefined-note-refund-tracking
+++ b/changelog/fix-undefined-note-refund-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix undefined $note variable in refund failure tracking when insufficient balance error occurs

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use WCPay\Logger;
+
 /**
  * REST controller for account details and status.
  */
@@ -225,11 +227,16 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 		$capabilities         = ! empty( $request->get_param( 'capabilities' ) ) ? wc_clean( wp_unslash( $request->get_param( 'capabilities' ) ) ) : [];
 		$mode                 = ! empty( $request->get_param( 'mode' ) ) ? sanitize_text_field( $request->get_param( 'mode' ) ) : null;
 
-		$account_session = $this->onboarding_service->create_embedded_kyc_session(
-			$self_assessment_data,
-			$capabilities,
-			$mode
-		);
+		try {
+			$account_session = $this->onboarding_service->create_embedded_kyc_session(
+				$self_assessment_data,
+				$capabilities,
+				$mode
+			);
+		} catch ( Exception $e ) {
+			Logger::error( 'Failed to create embedded KYC session: ' . $e->getMessage() );
+			return new WP_Error( 'wcpay_onboarding_duplicate_session', $e->getMessage(), [ 'status' => 409 ] );
+		}
 
 		if ( empty( $account_session ) ) {
 			WC_Payments_Utils::log_to_wc( 'Failed to create embedded KYC session: Empty response from onboarding service.' );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2520,6 +2520,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$currency = strtoupper( $refund['currency'] );
 			Tracker::track_admin( 'wcpay_edit_order_refund_success' );
 		} catch ( Exception $e ) {
+			$note = $e->getMessage();
 			if ( $e instanceof API_Exception && 'insufficient_balance_for_refund' === $e->get_error_code() ) {
 				// Handle insufficient_balance_for_refund error.
 				$this->order_service->handle_insufficient_balance_for_refund( $order, WC_Payments_Utils::prepare_amount( $amount, $order->get_currency() ) );

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2849,6 +2849,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 
 		$active_plugin_ids = ( is_object( $wc_plugin_util ) && is_callable( [ $wc_plugin_util, 'get_all_active_valid_plugins' ] ) ) ? $wc_plugin_util->get_all_active_valid_plugins() : wp_get_active_and_valid_plugins();
 		foreach ( $active_plugin_ids as $plugin_file ) {
+			// Normalize to relative path since get_plugins() keys are relative
+			// but wp_get_active_and_valid_plugins() returns absolute paths.
+			$plugin_file = plugin_basename( $plugin_file );
 			if ( isset( $all_plugins[ $plugin_file ] ) ) {
 				$plugin_data                  = $all_plugins[ $plugin_file ];
 				$plugins_list[ $plugin_file ] = [

--- a/includes/payment-methods/class-cc-payment-method.php
+++ b/includes/payment-methods/class-cc-payment-method.php
@@ -38,7 +38,7 @@ class CC_Payment_Method extends UPE_Payment_Method {
 	 * @return string
 	 */
 	public function get_title( ?string $account_country = null, $payment_details = false ) {
-		if ( ! $payment_details ) {
+		if ( ! $payment_details || ! isset( $payment_details[ $this->stripe_id ] ) ) {
 			return __( 'Card', 'woocommerce-payments' );
 		}
 
@@ -50,7 +50,10 @@ class CC_Payment_Method extends UPE_Payment_Method {
 			'unknown' => __( 'unknown', 'woocommerce-payments' ),
 		];
 
-		$card_network = $details['display_brand'] ?? $details['network'] ?? $details['networks']['preferred'] ?? $details['networks']['available'][0];
+		$card_network = $details['display_brand'] ?? $details['network'] ?? $details['networks']['preferred'] ?? $details['networks']['available'][0] ?? null;
+		if ( ! $card_network ) {
+			return __( 'Card', 'woocommerce-payments' );
+		}
 		// Networks like `cartes_bancaires` may use underscores, so we replace them with spaces.
 		$card_network = str_replace( '_', ' ', $card_network );
 
@@ -58,7 +61,7 @@ class CC_Payment_Method extends UPE_Payment_Method {
 			// Translators: %1$s card brand, %2$s card funding (prepaid, credit, etc.).
 			__( '%1$s %2$s card', 'woocommerce-payments' ),
 			ucwords( $card_network ),
-			$funding_types[ $details['funding'] ]
+			$funding_types[ $details['funding'] ] ?? $funding_types['unknown']
 		);
 
 		return $payment_method_title;

--- a/tests/unit/payment-methods/test-class-upe-payment-gateway.php
+++ b/tests/unit/payment-methods/test-class-upe-payment-gateway.php
@@ -727,6 +727,8 @@ class UPE_Payment_Gateway_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 'Card', $card_method->get_title( 'US' ) );
 		$this->assertEquals( 'Visa debit card', $card_method->get_title( 'US', $mock_visa_details ) );
 		$this->assertEquals( 'Mastercard credit card', $card_method->get_title( 'US', $mock_mastercard_details ) );
+		// When payment details exist but lack the 'card' key (e.g. Stripe Link), fall back to generic title.
+		$this->assertEquals( 'Card', $card_method->get_title( 'US', [ 'type' => 'card' ] ) );
 		$this->assertTrue( $card_method->is_enabled_at_checkout( 'US' ) );
 		$this->assertTrue( $card_method->is_reusable() );
 		$this->assertEquals( $mock_token, $card_method->get_payment_token_for_user( $mock_user, $mock_payment_method_id ) );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -974,6 +974,42 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( $this->wcpay_gateway->has_refund_failed( $order ) );
 	}
 
+	public function test_process_refund_insufficient_balance_does_not_trigger_undefined_note() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_status( Order_Status::PROCESSING );
+		$order->save();
+
+		$this->mock_order_service
+			->method( 'get_charge_id_for_order' )
+			->willReturn( $charge_id );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'handle_insufficient_balance_for_refund' );
+
+		$order_id = $order->get_id();
+
+		$request = $this->mock_wcpay_request( Refund_Charge::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_charge' )
+			->with( $charge_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willThrowException( new API_Exception( 'Insufficient balance', 'insufficient_balance_for_refund', 400 ) );
+
+		$result = $this->wcpay_gateway->process_refund( $order_id, 19.99 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'wcpay_edit_order_refund_failure', $result->get_error_code() );
+	}
+
 	public function test_process_refund_on_api_error() {
 		$intent_id = 'pi_xxxxxxxxxxxxx';
 		$charge_id = 'ch_yyyyyyyyyyyyy';


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOPMNT-5977

#### Changes proposed in this Pull Request

In `process_refund()`, the `catch` block has two branches: one for `insufficient_balance_for_refund` and one for all other exceptions. The `else` branch initializes `$note` with a formatted error message, but the `insufficient_balance` branch does not. After the conditional, `Tracker::track_admin()` references `$note` unconditionally, producing a PHP undefined variable warning and incomplete tracking data when the insufficient balance path is taken.

This PR initializes `$note` with `$e->getMessage()` before the conditional so the tracker always receives a meaningful failure reason. The `else` branch still overwrites `$note` with the formatted message for non-insufficient-balance errors, so existing behavior is unchanged.

#### Testing instructions

1. Trigger a refund on an order where the Stripe account has insufficient balance
2. **Before fix**: PHP undefined variable warning on `$note`, and `Tracker::track_admin` receives null/undefined reason
3. **After fix**: No PHP warning, tracker receives the exception message as the failure reason

* Unit test `test_process_refund_insufficient_balance_does_not_trigger_undefined_note` added to verify the insufficient balance path completes without errors

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description)
- [x] Tested on mobile (or does not apply) — backend-only change, not applicable

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

> This PR was created during a [Ceres Bug Blitz](https://linear.app/a8c/issue/WOOPUBR-517) session. The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.