### PR TITLE
fix: distinguish bank debit paydowns in Capital Loans timeline

### DIFF
--- a/changelog/agent-woopmnt-5988
+++ b/changelog/agent-woopmnt-5988
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+
+Show bank debit loan repayments with correct wording in Capital Loans timeline
+

--- a/client/payment-details/timeline/__tests__/__snapshots__/map-events.test.js.snap
+++ b/client/payment-details/timeline/__tests__/__snapshots__/map-events.test.js.snap
@@ -1143,25 +1143,6 @@ exports[`mapTimelineEvents single currency events formats dispute_won events 1`]
 ]
 `;
 
-exports[`mapTimelineEvents single currency events formats financing paydown events 1`] = `
-[
-  {
-    "body": [
-      <React.Fragment>
-        Loan repayment: 
-        <Link
-          href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_1KOKzdR4ByxURRrFX9A65q40"
-        >
-          Loan flxln_1KOKzdR4ByxURRrFX9A65q40
-        </Link>
-      </React.Fragment>,
-    ],
-    "date": 2022-02-01T12:04:04.000Z,
-    "headline": "$110.00 will be subtracted from a future payout.",
-    "icon": <MinusIcon />,
-  },
-]
-`;
 
 exports[`mapTimelineEvents single currency events formats full_refund events 1`] = `
 [

--- a/client/payment-details/timeline/__tests__/map-events.test.js
+++ b/client/payment-details/timeline/__tests__/map-events.test.js
@@ -501,7 +501,7 @@ describe( 'mapTimelineEvents', () => {
 			).toMatchSnapshot();
 		} );
 
-		test( 'formats financing paydown events', () => {
+		test( 'formats financing paydown events (bank debit)', () => {
 			expect(
 				mapTimelineEvents( [
 					{
@@ -509,6 +509,20 @@ describe( 'mapTimelineEvents', () => {
 						datetime: 1643717044,
 						amount: -11000,
 						loan_id: 'flxln_1KOKzdR4ByxURRrFX9A65q40',
+					},
+				] )
+			).toMatchSnapshot();
+		} );
+
+		test( 'formats financing paydown events (pending charge withholding)', () => {
+			expect(
+				mapTimelineEvents( [
+					{
+						type: 'financing_paydown',
+						datetime: 1643717044,
+						amount: -11000,
+						loan_id: 'flxln_1KOKzdR4ByxURRrFX9A65q40',
+						charge_id: 'ch_mock1234',
 					},
 				] )
 			).toMatchSnapshot();

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -162,6 +162,16 @@ const getFinancingPaydownTimelineItem = ( event, formattedAmount, body ) => {
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
 			a: <Link href={ depositUrl } />,
 		} );
+	} else if ( ! event.charge_id ) {
+		// Bank debit paydowns have no associated charge or payout — the merchant's
+		// connected bank account was debited directly for the monthly minimum.
+		headline = sprintf(
+			__(
+				'%s was debited from your bank account.',
+				'woocommerce-payments'
+			),
+			formattedAmount
+		);
 	} else {
 		headline = sprintf(
 			__(


### PR DESCRIPTION
## Summary

A merchant with an active Capital loan reported that all 2026 loan repayments were missing from the Payments → Capital Loans UI. The root cause is that bank debit paydowns (monthly minimum payments debited directly from the merchant's bank account) have no `charge_id` and are not currently captured by the Transact-API polling mechanism. This PR makes the plugin-side UI changes to correctly display bank debit paydowns once Transact-API begins forwarding them from Stripe's Financing Transactions API.

Closes: WOOPMNT-5988

## Changes

- **`client/payment-details/timeline/map-events.js`**: Updated `getFinancingPaydownTimelineItem` to detect bank debit paydowns (no `charge_id`, no `deposit`) and show "was debited from your bank account" instead of the misleading "will be subtracted from a future payout" message.
- **`client/payment-details/timeline/__tests__/map-events.test.js`**: Renamed the existing `financing_paydown` test to clarify it tests the bank debit case; added a second test for the pending charge withholding case (has `charge_id`, no `deposit`).
- **`changelog/agent-woopmnt-5988`**: Added changelog entry for this fix.

## Context

The Capital Loans feature (built 2022) was designed around charge-based withholdings. Stripe had no webhook or API for bank debit paydowns at the time. Stripe has since added the [Financing Transactions API](https://docs.stripe.com/api/capital/financing_transactions) and `capital.financing_transaction.created` webhook. The actual fix for missing data requires Transact-API to integrate those Stripe APIs. This plugin PR prepares the UI layer for correct display once that backend work lands.

The three-way logic in `getFinancingPaydownTimelineItem` is now:
1. Has `deposit` → charge withholding linked to a specific payout
2. No `deposit`, no `charge_id` → bank debit paydown ("was debited from your bank account")
3. No `deposit`, has `charge_id` → pending charge withholding ("will be subtracted from a future payout")

## Test Plan

- Manually verify with a merchant that has both charge-based and bank debit paydowns once Transact-API ships the Financing Transactions API integration.
- New unit tests added for both bank debit and pending charge withholding cases.

### Guardrail Results

- PHP tests: skipped (no PHP files changed)
- JS tests: skipped — test infrastructure unavailable in pipeline (node_modules not installed; pnpm required but not available). Snapshot entries for the two new test cases were removed so Jest will generate them on first run.
- PHP lint: skipped (no PHP files changed)
- JS lint: skipped (node_modules not installed)
- Changelog: added (`changelog/agent-woopmnt-5988`)

## Deviations from Plan

- **Option A only, plugin-side only**: Implemented the UI-layer change described in Phase 2 (Option A). No new REST endpoints or data-layer changes (Option B) were implemented — those are only needed if Transact-API cannot expose financing transactions, and that decision requires coordination with the Transact-API team.
- **Snapshot entries removed**: Rather than hand-crafting snapshot strings (which are tricky to format exactly), snapshot entries for the two new test cases were removed so Jest regenerates them correctly on first run.

## Open Questions

1. **Transact-API timeline**: When will Transact-API integrate Stripe's Financing Transactions API? This plugin change alone cannot make missing data appear — it only ensures the UI displays correctly once the data exists.
2. **Backfill**: Will Transact-API backfill historical bank debit paydowns for affected merchants?
3. **Copy review**: The string "was debited from your bank account" was chosen based on plan guidance. UX/copy review is recommended before shipping to merchants.
4. **WOOPMNT-4112**: The Financing Transactions API fix on the Transact-API side should also resolve the "last repayment missing" issue if it shares the same root cause.