### PR TITLE
chore: add i18n build notification on failure

### DIFF
--- a/.github/workflows/i18n-weekly-release.yml
+++ b/.github/workflows/i18n-weekly-release.yml
@@ -119,3 +119,43 @@ jobs:
           fi
 
           echo "Translations update triggered."
+
+  notify-failure:
+    name: "Notify Slack on failure"
+    needs: i18n-release
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Slack ping"
+        uses: slackapi/slack-github-action@v1.25.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CODE_FREEZE_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "⚠️ I18N weekly release failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The scheduled weekly I18N build has failed. Translations may not be updated this week."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<https://github.com/Automattic/woocommerce-payments/actions/runs/${{ github.run_id }}|View workflow run>"
+                  }
+                }
+              ]
+            }

--- a/changelog/chore-add-i18n-failure-slack-notification
+++ b/changelog/chore-add-i18n-failure-slack-notification
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: add Slack notification on i18n build failure
+
+


### PR DESCRIPTION
Fixes #1814

#### Changes proposed in this Pull Request

The weekly I18N build (`i18n-weekly-release.yml`) runs every Sunday to create a pre-release and trigger GlotPress translations. If it fails, nobody is notified — the failure is silent and translations can go stale without anyone noticing.

This adds a `notify-failure` job that posts to Slack (via the existing `CODE_FREEZE_SLACK_WEBHOOK_URL`) when the build fails, following the same pattern as `release-code-freeze.yml`.

#### Testing instructions

* Trigger the workflow manually and verify the Slack notification fires on failure (e.g., by temporarily breaking a step).
* Confirm the notification includes the workflow run link.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.