### PR TITLE
fix: remove type=charge filter from Capital loan transaction links

### DIFF
--- a/changelog/fix-capital-loan-transaction-filter
+++ b/changelog/fix-capital-loan-transaction-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove type=charge filter from Capital loan transaction links so all loan repayment types are visible

--- a/client/capital/__tests__/__snapshots__/index.test.tsx.snap
+++ b/client/capital/__tests__/__snapshots__/index.test.tsx.snap
@@ -639,7 +639,7 @@ exports[`CapitalPage renders the TableCard component with loan data 1`] = `
                     <a
                       class="woocommerce-table__clickable-cell"
                       data-link-type="wc-admin"
-                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
                       tabindex="-1"
                     >
                       Oct 28, 2024
@@ -651,7 +651,7 @@ exports[`CapitalPage renders the TableCard component with loan data 1`] = `
                     <a
                       class="woocommerce-table__clickable-cell"
                       data-link-type="wc-admin"
-                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
                       tabindex="-1"
                     >
                       <span
@@ -667,7 +667,7 @@ exports[`CapitalPage renders the TableCard component with loan data 1`] = `
                     <a
                       class="woocommerce-table__clickable-cell"
                       data-link-type="wc-admin"
-                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
                       tabindex="-1"
                     >
                       $1,000.00
@@ -679,7 +679,7 @@ exports[`CapitalPage renders the TableCard component with loan data 1`] = `
                     <a
                       class="woocommerce-table__clickable-cell"
                       data-link-type="wc-admin"
-                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
                       tabindex="-1"
                     >
                       $100.00
@@ -691,7 +691,7 @@ exports[`CapitalPage renders the TableCard component with loan data 1`] = `
                     <a
                       class="woocommerce-table__clickable-cell"
                       data-link-type="wc-admin"
-                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
                       tabindex="-1"
                     >
                       15%
@@ -703,7 +703,7 @@ exports[`CapitalPage renders the TableCard component with loan data 1`] = `
                     <a
                       class="woocommerce-table__clickable-cell"
                       data-link-type="wc-admin"
-                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
+                      href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&loan_id_is=financingoffer_1QEpQ2J5cIRIG92xWoVJJE3S"
                       tabindex="-1"
                     >
                       -

--- a/client/capital/index.tsx
+++ b/client/capital/index.tsx
@@ -103,7 +103,6 @@ const getRowsData = ( loans: CapitalLoan[] ) =>
 				href={ getAdminUrl( {
 					page: 'wc-admin',
 					path: '/payments/transactions',
-					type: 'charge',
 					filter: 'advanced',
 					loan_id_is: loan.stripe_loan_id,
 				} ) }

--- a/client/components/active-loan-summary/__tests__/__snapshots__/index.test.js.snap
+++ b/client/components/active-loan-summary/__tests__/__snapshots__/index.test.js.snap
@@ -166,7 +166,7 @@ exports[`Active loan summary renders correctly 1`] = `
         >
           <a
             class="components-button is-next-40px-default-size is-link"
-            href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_123456"
+            href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&loan_id_is=flxln_123456"
           >
             View transactions
           </a>

--- a/client/components/active-loan-summary/index.tsx
+++ b/client/components/active-loan-summary/index.tsx
@@ -166,7 +166,6 @@ const ActiveLoanSummary = (): JSX.Element => {
 							href={ getAdminUrl( {
 								page: 'wc-admin',
 								path: '/payments/transactions',
-								type: 'charge',
 								filter: 'advanced',
 								loan_id_is: getActiveLoanId(),
 							} ) }

--- a/client/payment-details/timeline/__tests__/__snapshots__/map-events.test.js.snap
+++ b/client/payment-details/timeline/__tests__/__snapshots__/map-events.test.js.snap
@@ -1150,7 +1150,7 @@ exports[`mapTimelineEvents single currency events formats financing paydown even
       <React.Fragment>
         Loan repayment: 
         <Link
-          href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&type=charge&filter=advanced&loan_id_is=flxln_1KOKzdR4ByxURRrFX9A65q40"
+          href="admin.php?page=wc-admin&path=%2Fpayments%2Ftransactions&filter=advanced&loan_id_is=flxln_1KOKzdR4ByxURRrFX9A65q40"
         >
           Loan flxln_1KOKzdR4ByxURRrFX9A65q40
         </Link>

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -1174,7 +1174,6 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 										href={ getAdminUrl( {
 											page: 'wc-admin',
 											path: '/payments/transactions',
-											type: 'charge',
 											filter: 'advanced',
 											loan_id_is: event.loan_id,
 										} ) }


### PR DESCRIPTION
Fixes WOOPMNT-5988

#### Changes proposed in this Pull Request

A merchant with an active Capital loan reported that no 2026 repayment transactions appeared in the Payments → Capital Loans UI. The root cause (on the plugin side) is that all three locations generating links to the Capital loan transaction list include a hardcoded `type=charge` URL parameter, which filters out `financing_paydown` and `financing_payout` transaction types entirely.

This PR removes the `type: 'charge'` parameter from those three link-generation sites:

- **`client/capital/index.tsx`** — clickable cells in the Capital loans table
- **`client/components/active-loan-summary/index.tsx`** — "View transactions" button in the active loan summary widget
- **`client/payment-details/timeline/map-events.js`** — loan repayment link in the payment timeline

The `loan_id_is` filter alone is sufficient to scope the transaction list to the correct loan. With `type=charge` removed, the UI will show all transaction types (charges, financing paydowns, financing payouts) for the loan.

**Note:** This plugin-side fix is necessary but not sufficient on its own. The missing 2026 transactions are bank debit paydowns (monthly minimum payments from the merchant's bank account), which the Transact-API backend currently does not forward to the plugin. Stripe added the Financing Transactions API (`/v1/capital/financing_transactions`) and `capital.financing_transaction.created` webhook after Capital was originally built in 2022. Once Transact-API integrates those Stripe APIs, this plugin change ensures the transactions will appear correctly in the UI.

Test snapshots for the three affected components are updated to reflect the new URLs (without `type=charge`).

#### Testing instructions

1. On a site with an active Capital loan, navigate to **Payments → Capital Loans**.
2. Click a loan row — the URL should be `...&filter=advanced&loan_id_is=<loan_id>` without a `type=charge` parameter.
3. Navigate to a payment that has a financing paydown in its timeline and click the loan link — same check.
4. Check the active loan summary widget's "View transactions" button — same URL format.
5. Verify that the transactions list loads and shows all transaction types for the loan (not just charges).

---

- [x] Run `npm run changelog` to add a changelog file — `changelog/fix-capital-loan-transaction-filter` added
- [ ] Covered with tests (snapshots updated; JS unit test infrastructure unavailable in pipeline due to Node.js version mismatch — tests should be verified in CI)
- [x] Tested on mobile (does not apply — backend URL parameter change only)

**Post merge**

- [ ] Link to testing instructions from release testing doc: QA Testing Not Applicable
- [ ] Add or update critical flows and testing instructions, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)