### PR TITLE
fix: align payment method notice copy with Figma designs

### DIFF
--- a/changelog/fix-pay-538-notice-copy-alignment
+++ b/changelog/fix-pay-538-notice-copy-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Align payment method notice copy with Figma designs

--- a/client/settings/payment-methods-list/__tests__/use-payment-method-availability.test.js
+++ b/client/settings/payment-methods-list/__tests__/use-payment-method-availability.test.js
@@ -86,11 +86,11 @@ describe( 'usePaymentMethodAvailability', () => {
 		expect( result.current.chip ).toBe( 'More information needed' );
 		// Since in this case we use `interpolateComponents`, I'm using `render` to render the notice, and asserting on its text content.
 		expect( render( result.current.notice ).container.textContent ).toMatch(
-			/We need more information from you to enable this method./
+			/More information is needed to finish setting up this payment method./
 		);
 	} );
 
-	it( 'returns "Approval pending" for the "pending" status and Alipay', () => {
+	it( 'returns "Approval pending" for the "pending" status and Alipay with Learn more link', () => {
 		const { result } = renderHook( () =>
 			usePaymentMethodAvailability( 'alipay' )
 		);
@@ -98,9 +98,14 @@ describe( 'usePaymentMethodAvailability', () => {
 		expect( result.current.isActionable ).toBe( false );
 		expect( result.current.chip ).toBe( 'Approval pending' );
 		// Since in this case we use `interpolateComponents`, I'm using `render` to render the notice, and asserting on its text content.
-		expect( render( result.current.notice ).container.textContent ).toMatch(
-			/Alipay requires your store to be live and fully functional before it can be reviewed for use with their service./
+		const { container } = render( result.current.notice );
+		expect( container.textContent ).toMatch(
+			/Your store must be live and fully functional before this payment method can be offered./
 		);
+		expect( container.textContent ).toMatch(
+			/Approval typically takes 2–3 days./
+		);
+		expect( container.querySelector( 'a' ) ).not.toBeNull();
 	} );
 
 	it( 'returns "Approval pending" message for the "pending" status', () => {
@@ -110,19 +115,24 @@ describe( 'usePaymentMethodAvailability', () => {
 		expect( result.current.isActionable ).toBe( false );
 		expect( result.current.chip ).toBe( 'Approval pending' );
 		expect( result.current.notice ).toBe(
-			'This payment method is pending approval. Once approved, you will be able to use it.'
+			"This payment method is pending approval. It won't be available at checkout until it's approved."
 		);
 	} );
 
-	it( 'returns "Pending verification" for the "pending_verification" status', () => {
+	it( 'returns "Pending verification" for the "pending_verification" status with Payments overview link', () => {
 		const { result } = renderHook( () =>
 			usePaymentMethodAvailability( 'sepa_debit' )
 		);
 		expect( result.current.isActionable ).toBe( false );
 		expect( result.current.chip ).toBe( 'Pending verification' );
-		expect( result.current.notice ).toBe(
-			"SEPA Direct Debit won't be visible to your customers until you provide the required information." +
-				' Follow the instructions sent by our partner Stripe to test@woo.com.'
+		const { container } = render( result.current.notice );
+		expect( container.textContent ).toMatch(
+			/SEPA Direct Debit won't be available at checkout yet/
+		);
+		expect( container.textContent ).toMatch( /Payments overview/ );
+		expect( container.querySelector( 'a' ) ).not.toBeNull();
+		expect( container.querySelector( 'a' ).href ).toMatch(
+			/payments(%2F|\/)overview/
 		);
 	} );
 
@@ -134,8 +144,12 @@ describe( 'usePaymentMethodAvailability', () => {
 		expect( result.current.chip ).toBe( 'Rejected' );
 		expect( result.current.chipType ).toBe( 'alert' );
 		// Since in this case we use `interpolateComponents`, I'm using `render` to render the notice, and asserting on its text content.
-		expect( render( result.current.notice ).container.textContent ).toMatch(
-			/Your application to use Affirm has been rejected, please check your email for more information. Need help?/
+		const { container } = render( result.current.notice );
+		expect( container.textContent ).toMatch(
+			/Your application to use Affirm has been rejected\. Need help\?/
+		);
+		expect( container.textContent ).not.toMatch(
+			/please check your email/
 		);
 		expect( result.current.noticeType ).toBe( 'error' );
 	} );

--- a/client/settings/payment-methods-list/use-payment-method-availability.tsx
+++ b/client/settings/payment-methods-list/use-payment-method-availability.tsx
@@ -19,12 +19,15 @@ import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from '@automattic/interpolate-components';
 import { ExternalLink } from '@wordpress/components';
 import { ChipType } from 'wcpay/components/chip';
+import { getAdminUrl } from 'wcpay/utils';
 
 const documentationTypeMap = {
 	DEFAULT:
 		'https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled',
 	BNPLS:
 		'https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#contact-support',
+	DELAYED_APPROVAL:
+		'https://woocommerce.com/document/woopayments/payment-methods/local-payment-methods/#approval-delays',
 };
 
 const getDocumentationUrlForDisabledPaymentMethod = (
@@ -71,7 +74,7 @@ const usePaymentMethodAvailability = ( id: string ) => {
 			notice: interpolateComponents( {
 				// translators: {{learnMoreLink}}: placeholders are opening and closing anchor tags.
 				mixedString: __(
-					'We need more information from you to enable this method. ' +
+					'More information is needed to finish setting up this payment method. ' +
 						'{{learnMoreLink}}Learn more{{/learnMoreLink}}',
 					'woocommerce-payments'
 				),
@@ -103,15 +106,30 @@ const usePaymentMethodAvailability = ( id: string ) => {
 			isActionable: false,
 			chip: __( 'Approval pending', 'woocommerce-payments' ),
 			notice: paymentMethodsWithDelayedApproval.includes( id )
-				? sprintf(
-						__(
-							'%s requires your store to be live and fully functional before it can be reviewed for use with their service. This approval process usually takes 2-3 days.',
+				? interpolateComponents( {
+						// translators: {{learnMoreLink}}: placeholders are opening and closing anchor tags.
+						mixedString: __(
+							'Your store must be live and fully functional before this payment method can be offered. Approval typically takes 2–3 days. ' +
+								'{{learnMoreLink}}Learn more{{/learnMoreLink}}',
 							'woocommerce-payments'
 						),
-						label
-				  )
+						components: {
+							learnMoreLink: (
+								// @ts-expect-error: children is provided when interpolating the component
+								<ExternalLink
+									title={ __(
+										'Learn more about approval delays',
+										'woocommerce-payments'
+									) }
+									href={
+										documentationTypeMap.DELAYED_APPROVAL
+									}
+								/>
+							),
+						},
+				  } )
 				: __(
-						'This payment method is pending approval. Once approved, you will be able to use it.',
+						"This payment method is pending approval. It won't be available at checkout until it's approved.",
 						'woocommerce-payments'
 				  ),
 		};
@@ -121,24 +139,27 @@ const usePaymentMethodAvailability = ( id: string ) => {
 		return {
 			isActionable: false,
 			chip: __( 'Pending verification', 'woocommerce-payments' ),
-			notice: wcpaySettings?.accountEmail
-				? sprintf(
-						__(
-							"%s won't be visible to your customers until you provide the required " +
-								'information. Follow the instructions sent by our partner Stripe to %s.',
-							'woocommerce-payments'
-						),
-						label,
-						wcpaySettings?.accountEmail
-				  )
-				: sprintf(
-						__(
-							"%s won't be visible to your customers until you provide the required " +
-								'information. Follow the instructions sent by our partner Stripe to your email.',
-							'woocommerce-payments'
-						),
-						label
-				  ),
+			notice: interpolateComponents( {
+				mixedString: sprintf(
+					// translators: %s: payment method label. {{overviewLink}}: placeholders are opening and closing anchor tags.
+					__(
+						"%s won't be available at checkout yet. To finish setting it up, review the required steps in {{overviewLink}}Payments overview{{/overviewLink}}.",
+						'woocommerce-payments'
+					),
+					label
+				),
+				components: {
+					overviewLink: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content -- children injected by interpolateComponents
+						<a
+							href={ getAdminUrl( {
+								page: 'wc-admin',
+								path: '/payments/overview',
+							} ) }
+						/>
+					),
+				},
+			} ),
 		};
 	}
 
@@ -148,10 +169,10 @@ const usePaymentMethodAvailability = ( id: string ) => {
 			chip: __( 'Rejected', 'woocommerce-payments' ),
 			chipType: 'alert' as ChipType,
 			notice: interpolateComponents( {
-				// translators: {{learnMoreLink}}: placeholders are opening and closing anchor tags.
+				// translators: {{contactSupportLink}}: placeholders are opening and closing anchor tags.
 				mixedString: sprintf(
 					__(
-						'Your application to use %s has been rejected, please check your email for more information. Need help? {{contactSupportLink}}Contact support{{/contactSupportLink}}',
+						'Your application to use %s has been rejected. Need help? {{contactSupportLink}}Contact support{{/contactSupportLink}}',
 						'woocommerce-payments'
 					),
 					label

--- a/includes/multi-currency/client/utils/missing-currencies-message/__tests__/index.test.js
+++ b/includes/multi-currency/client/utils/missing-currencies-message/__tests__/index.test.js
@@ -6,7 +6,7 @@ import { getMissingCurrenciesTooltipMessage } from 'multi-currency/utils/missing
 describe( 'getMissingCurrenciesTooltipMessage', () => {
 	it( 'returns correct string for a single currency', () => {
 		expect( getMissingCurrenciesTooltipMessage( 'x', [ 'EUR' ] ) ).toBe(
-			'x requires the EUR currency. In order to enable the payment method, you must add this currency to your store.'
+			'x requires the EUR currency. Add EUR to your store to offer this payment method.'
 		);
 	} );
 
@@ -14,7 +14,7 @@ describe( 'getMissingCurrenciesTooltipMessage', () => {
 		expect(
 			getMissingCurrenciesTooltipMessage( 'x', [ 'EUR', 'PLN' ] )
 		).toBe(
-			'x requires at least one of the following currencies: EUR or PLN. You must add at least one of these currencies to your store.'
+			'x requires at least one of the following currencies: EUR or PLN. Add at least one of these currencies to your store to offer this payment method.'
 		);
 	} );
 
@@ -22,7 +22,7 @@ describe( 'getMissingCurrenciesTooltipMessage', () => {
 		expect(
 			getMissingCurrenciesTooltipMessage( 'x', [ 'EUR', 'PLN', 'TRY' ] )
 		).toBe(
-			'x requires at least one of the following currencies: EUR, PLN, or TRY. You must add at least one of these currencies to your store.'
+			'x requires at least one of the following currencies: EUR, PLN, or TRY. Add at least one of these currencies to your store to offer this payment method.'
 		);
 	} );
 } );

--- a/includes/multi-currency/client/utils/missing-currencies-message/index.ts
+++ b/includes/multi-currency/client/utils/missing-currencies-message/index.ts
@@ -40,7 +40,7 @@ export const getMissingCurrenciesTooltipMessage = (
 		return sprintf(
 			/* translators: %1$s: name of payment method, %2$s: name of the required currency */
 			__(
-				'%1$s requires the %2$s currency. In order to enable the payment method, you must add this currency to your store.',
+				'%1$s requires the %2$s currency. Add %2$s to your store to offer this payment method.',
 				'woocommerce-payments'
 			),
 			paymentMethodLabel,
@@ -51,7 +51,7 @@ export const getMissingCurrenciesTooltipMessage = (
 	return sprintf(
 		/* translators: %1$s: name of payment method, %2$s: list of supported currencies joined by "or" (e.g. "EUR or PLN") */
 		__(
-			'%1$s requires at least one of the following currencies: %2$s. You must add at least one of these currencies to your store.',
+			'%1$s requires at least one of the following currencies: %2$s. Add at least one of these currencies to your store to offer this payment method.',
 			'woocommerce-payments'
 		),
 		paymentMethodLabel,


### PR DESCRIPTION
Fixes PAY-538

#### Changes proposed in this Pull Request

Aligns upstream WooPayments notice copy in the payment methods list with the latest Figma designs (CIAB source of truth):

- **Inactive:** "More information is needed to finish setting up this payment method. Learn more"
- **Pending verification:** Replaces email-based copy with a link to Payments overview
- **Approval pending (AliPay/WeChat):** New dedicated notice with "Learn more" link to approval delays doc
- **Approval pending (generic):** "It won't be available at checkout until it's approved"
- **Rejected:** Simplified — removed "please check your email for more information"
- **Missing currency (single):** "Add {currency} to your store to offer this payment method"
- **Missing currency (multiple):** "Add at least one of these currencies to your store to offer this payment method"

No new components or PHP changes — all changes are in the `usePaymentMethodAvailability` hook and `getMissingCurrenciesTooltipMessage` utility.

#### Testing instructions

##### Status notices

1. Apply the dev patch that forces payment methods into each status (so all notices are visible at once):
   ```bash
   curl -sL https://gist.github.com/oaratovskyi/b27576c62456eb052a98a24397be55ab/raw | git apply
   ```
2. Build the client:
   ```bash
   npm run build:client
   ```
3. Start the dev environment if not already running (`npm run up`)
4. Navigate to **WooPayments > Settings > General** → Payment methods list
5. Verify the following notices appear:
   - **Bancontact** (`inactive`): "More information is needed to finish setting up this payment method. Learn more ↗"
   - **EPS** (`pending_verification`): "EPS won't be available at checkout yet. To finish setting it up, review the required steps in Payments overview." (link to `/payments/overview`)
   - **AliPay / WeChat Pay** (`pending_approval`): "Your store must be live and fully functional before this payment method can be offered. Approval typically takes 2–3 days. Learn more ↗"
   - **iDEAL** (`pending_approval`, generic): "This payment method is pending approval. It won't be available at checkout until it's approved."
   - **Multibanco** (`rejected`): "Your application to use Multibanco has been rejected. Need help? Contact support ↗"
6. Revert the dev patch when done:
   ```bash
   curl -sL https://gist.github.com/oaratovskyi/b27576c62456eb052a98a24397be55ab/raw | git apply -R
   ```

##### Missing currency notices

1. Apply the dev patch that forces missing currency notices:
   ```bash
   curl -sL https://gist.github.com/oaratovskyi/6e6b3bef19b467e7b88be59852e55a57/raw | git apply
   ```
2. Rebuild:
   ```bash
   npm run build:client
   ```
3. Navigate to **WooPayments > Settings > General** → Payment methods list
4. Verify the following notices appear:
   - **Bancontact** (single currency): "Bancontact requires the EUR currency. Add EUR to your store to offer this payment method."
   - **EPS** (multiple currencies): "EPS requires at least one of the following currencies: EUR, PLN, or CZK. Add at least one of these currencies to your store to offer this payment method."

<img width="891" height="371" alt="image" src="https://github.com/user-attachments/assets/12585657-68de-4d91-9172-7d60d1af3a2a" />

5. Revert the dev patch when done:
   ```bash
   curl -sL https://gist.github.com/oaratovskyi/6e6b3bef19b467e7b88be59852e55a57/raw | git apply -R
   npm run build:client
   ```

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.