### PR TITLE
fix: e2e tests failure for some test cards

### DIFF
--- a/changelog/fix-e2e-tests-failure-incorrect-card-error-message
+++ b/changelog/fix-e2e-tests-failure-incorrect-card-error-message
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: e2e tests failures on shopper-myaccount-payment-methods-add-fail.spec.t for incorrect card number
+
+

--- a/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts
@@ -85,9 +85,8 @@ test.describe( 'Payment Methods', () => {
 					await expect(
 						shopperPage
 							.frameLocator(
-								'iframe[name^="__privateStripeFrame"]'
+								'iframe[title="Secure payment input frame"]'
 							)
-							.first()
 							.getByRole( 'alert' )
 					).toContainText( errorText );
 				} else {

--- a/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts
@@ -78,12 +78,9 @@ test.describe( 'Payment Methods', () => {
 					await isUIUnblocked( shopperPage );
 				}
 
-				// Verify that we get the expected error message.
-				await expect( shopperPage.getByRole( 'alert' ) ).toHaveText(
-					errorText
-				);
-
-				// Declined incorrect card also puts the errorText under the card number field.
+				// For declined-incorrect, Stripe validates client-side and shows
+				// the error only in the iframe - the form is never submitted to
+				// WooCommerce so no page-level alert is shown.
 				if ( 'declined-incorrect' === cardType ) {
 					await expect(
 						shopperPage
@@ -93,6 +90,12 @@ test.describe( 'Payment Methods', () => {
 							.first()
 							.getByRole( 'alert' )
 					).toContainText( errorText );
+				} else {
+					// For all other decline types, the error comes from the
+					// server and displays as a WooCommerce notice on the page.
+					await expect( shopperPage.getByRole( 'alert' ) ).toHaveText(
+						errorText
+					);
 				}
 
 				// Verify that the card is not added to the list of payment methods.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Trying to fix these failures: https://github.com/Automattic/woocommerce-payments/actions/runs/23640117796/job/68858467141 / https://github.com/Automattic/woocommerce-payments/actions/runs/23640117796/job/68858467123

```
chromium › wcpay/shopper/shopper-myaccount-payment-methods-add-fail.spec.ts › Payment Methods › when attempting to add a declined-incorrect card › it should not add the card
```

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This should pass (I did a couple of tries): https://github.com/Automattic/woocommerce-payments/actions/runs/23642843922
https://github.com/Automattic/woocommerce-payments/actions/runs/23648132433

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.