### PR TITLE
chore: add Stripe payment method to payment method definition

### DIFF
--- a/changelog/chore-add-stripe-payment-method-type-to-definition
+++ b/changelog/chore-add-stripe-payment-method-type-to-definition
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: chore: add stripe payment method to payment method definition
+
+

--- a/changelog/chore-add-stripe-payment-method-type-to-definition
+++ b/changelog/chore-add-stripe-payment-method-type-to-definition
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: chore: add stripe payment method to payment method definition
+Comment: chore: add Stripe payment method type to payment method definition
 
 

--- a/includes/payment-methods/Configs/Definitions/AffirmDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AffirmDefinition.php
@@ -46,6 +46,15 @@ class AffirmDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/AfterpayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AfterpayDefinition.php
@@ -47,6 +47,15 @@ class AfterpayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/AlipayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AlipayDefinition.php
@@ -46,6 +46,15 @@ class AlipayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/AmazonPayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/AmazonPayDefinition.php
@@ -46,6 +46,15 @@ class AmazonPayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/ApplePayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/ApplePayDefinition.php
@@ -44,6 +44,16 @@ class ApplePayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 * Apple Pay is processed as a card payment by Stripe.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return 'card';
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/BancontactDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/BancontactDefinition.php
@@ -46,6 +46,15 @@ class BancontactDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/BecsDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/BecsDefinition.php
@@ -46,6 +46,15 @@ class BecsDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/CardDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/CardDefinition.php
@@ -45,6 +45,15 @@ class CardDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/EpsDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/EpsDefinition.php
@@ -46,6 +46,15 @@ class EpsDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/GiropayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/GiropayDefinition.php
@@ -46,6 +46,15 @@ class GiropayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/GooglePayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/GooglePayDefinition.php
@@ -44,6 +44,16 @@ class GooglePayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 * Google Pay is processed as a card payment by Stripe.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return 'card';
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/GrabPayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/GrabPayDefinition.php
@@ -46,6 +46,15 @@ class GrabPayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/IdealDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/IdealDefinition.php
@@ -46,6 +46,15 @@ class IdealDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/KlarnaDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/KlarnaDefinition.php
@@ -47,6 +47,15 @@ class KlarnaDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/LinkDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/LinkDefinition.php
@@ -45,6 +45,15 @@ class LinkDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/MultibancoDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/MultibancoDefinition.php
@@ -46,6 +46,15 @@ class MultibancoDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/P24Definition.php
+++ b/includes/payment-methods/Configs/Definitions/P24Definition.php
@@ -46,6 +46,15 @@ class P24Definition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/SepaDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/SepaDefinition.php
@@ -46,6 +46,15 @@ class SepaDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/SofortDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/SofortDefinition.php
@@ -46,6 +46,15 @@ class SofortDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Definitions/WechatPayDefinition.php
+++ b/includes/payment-methods/Configs/Definitions/WechatPayDefinition.php
@@ -46,6 +46,15 @@ class WechatPayDefinition implements PaymentMethodDefinitionInterface {
 	}
 
 	/**
+	 * Get the Stripe PaymentMethod type.
+	 *
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/includes/payment-methods/Configs/Interfaces/PaymentMethodDefinitionInterface.php
+++ b/includes/payment-methods/Configs/Interfaces/PaymentMethodDefinitionInterface.php
@@ -34,6 +34,17 @@ interface PaymentMethodDefinitionInterface {
 	public static function get_stripe_id(): string;
 
 	/**
+	 * Get the Stripe PaymentMethod type used in PaymentIntent payment_method_types[].
+	 *
+	 * For most payment methods this matches get_id(). For wallet payment methods
+	 * processed as card payments by Stripe (Google Pay, Apple Pay), this returns 'card'.
+	 *
+	 * @see https://stripe.com/docs/api/payment_methods/object#payment_method_object-type
+	 * @return string
+	 */
+	public static function get_stripe_payment_method_type(): string;
+
+	/**
 	 * Get the customer-facing title of the payment method
 	 *
 	 * @param string|null $account_country Optional. The merchant's account country.

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
@@ -26,6 +26,10 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 		return 'second_mock_method_payments';
 	}
 
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
 	public static function get_payment_method_class(): string {
 		return 'SecondMockPaymentMethod';
 	}

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
@@ -26,6 +26,10 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return 'mock_method_payments';
 	}
 
+	public static function get_stripe_payment_method_type(): string {
+		return self::get_id();
+	}
+
 	public static function get_payment_method_class(): string {
 		return 'MockPaymentMethod';
 	}


### PR DESCRIPTION
Fixes WOOPMNT-6026

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I need this method as part of two different PRs - trying to reduce the scope from both of them.

I need a way to determine which underlying payment method each payment method definition maps to.
Most payment method IDs can just match to the Stripe id.
However, Google Pay, Apple Pay are "wallets" of the `card` payment method.

This distinction is needed when elaborating payment methods on the server and client side - the `google_pay`/`apple_pay` payment methods don't exist in Stripe.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR doesn't implement any functional changes, it's just adding a `get_stripe_payment_method_type()` method into each definition.
Nothing to test.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
