### PR TITLE
fix: Guard resolve_css_var() against non-string input from wp_get_global_styles()

### DIFF
--- a/changelog/fix-resolve-css-var-type-guard
+++ b/changelog/fix-resolve-css-var-type-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error in WooPay appearance computation when theme.json returns non-string values for typography properties.

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -157,40 +157,41 @@ class WC_Payments_Styles_Cache {
 
 		// Extract colors and resolve any CSS custom property references
 		// like var(--wp--preset--color--base) to concrete values.
-		$bg_color   = self::resolve_css_var( $styles['color']['background'] ?? '#ffffff' );
-		$text_color = self::resolve_css_var( $styles['color']['text'] ?? '#000000' );
+		$bg_color   = self::resolve_css_var( $styles['color']['background'] ?? '', '#ffffff' );
+		$text_color = self::resolve_css_var( $styles['color']['text'] ?? '', '#000000' );
 		$link_color = self::resolve_css_var(
 			$styles['elements']['link']['color']['text']
 				?? $styles['elements']['a']['color']['text']
-				?? $text_color
+				?? '',
+			$text_color
 		);
 
 		// Extract typography.
-		$font_family = self::resolve_css_var( $styles['typography']['fontFamily'] ?? 'inherit' );
-		$font_size   = self::resolve_css_var( $styles['typography']['fontSize'] ?? '16px' );
+		$font_family = self::resolve_css_var( $styles['typography']['fontFamily'] ?? '', 'inherit' );
+		$font_size   = self::resolve_css_var( $styles['typography']['fontSize'] ?? '', '16px' );
 
 		// Extract heading styles.
-		$heading_color       = self::resolve_css_var( $styles['elements']['heading']['color']['text'] ?? $text_color );
-		$heading_font_family = self::resolve_css_var( $styles['elements']['heading']['typography']['fontFamily'] ?? $font_family );
+		$heading_color       = self::resolve_css_var( $styles['elements']['heading']['color']['text'] ?? '', $text_color );
+		$heading_font_family = self::resolve_css_var( $styles['elements']['heading']['typography']['fontFamily'] ?? '', $font_family );
 
 		// Extract button styles.
-		$button_bg_color   = self::resolve_css_var( $styles['elements']['button']['color']['background'] ?? $bg_color );
-		$button_text_color = self::resolve_css_var( $styles['elements']['button']['color']['text'] ?? $text_color );
-		$button_font_size  = self::resolve_css_var( $styles['elements']['button']['typography']['fontSize'] ?? $font_size );
+		$button_bg_color   = self::resolve_css_var( $styles['elements']['button']['color']['background'] ?? '', $bg_color );
+		$button_text_color = self::resolve_css_var( $styles['elements']['button']['color']['text'] ?? '', $text_color );
+		$button_font_size  = self::resolve_css_var( $styles['elements']['button']['typography']['fontSize'] ?? '', $font_size );
 
 		// Extract input styles if available.
-		$input_border_color  = self::resolve_css_var( $styles['elements']['input']['border']['color'] ?? $text_color );
-		$input_border_radius = self::resolve_css_var( $styles['elements']['input']['border']['radius'] ?? '0px' );
+		$input_border_color  = self::resolve_css_var( $styles['elements']['input']['border']['color'] ?? '', $text_color );
+		$input_border_radius = self::resolve_css_var( $styles['elements']['input']['border']['radius'] ?? '', '0px' );
 
 		// Extract button font family.
-		$button_font_family = self::resolve_css_var( $styles['elements']['button']['typography']['fontFamily'] ?? $font_family );
+		$button_font_family = self::resolve_css_var( $styles['elements']['button']['typography']['fontFamily'] ?? '', $font_family );
 
 		// Extract header/footer colors. First try the actual header template
 		// part block attributes, then fall back to template part default styles.
 		$header_colors     = self::get_template_part_colors( 'header' );
 		$footer_colors     = self::get_template_part_colors( 'footer' );
-		$header_bg_color   = $header_colors['background'] ?? self::resolve_css_var( $tp_styles['color']['background'] ?? $bg_color );
-		$header_text_color = $header_colors['text'] ?? self::resolve_css_var( $tp_styles['color']['text'] ?? $text_color );
+		$header_bg_color   = $header_colors['background'] ?? self::resolve_css_var( $tp_styles['color']['background'] ?? '', $bg_color );
+		$header_text_color = $header_colors['text'] ?? self::resolve_css_var( $tp_styles['color']['text'] ?? '', $text_color );
 
 		// Determine theme (light vs dark) from background color.
 		$theme = self::is_color_light( $bg_color ) ? 'stripe' : 'night';
@@ -243,7 +244,7 @@ class WC_Payments_Styles_Cache {
 					'color'           => $footer_colors['text'] ?? $text_color,
 				],
 				'.Footer-link'    => [
-					'color' => self::resolve_css_var( $tp_styles['elements']['link']['color']['text'] ?? $link_color ),
+					'color' => self::resolve_css_var( $tp_styles['elements']['link']['color']['text'] ?? '', $link_color ),
 				],
 				'.Button'         => [
 					'color'           => $button_text_color,
@@ -500,14 +501,15 @@ class WC_Payments_Styles_Cache {
 	 *
 	 * Accepts mixed input because wp_get_global_styles() can return arrays
 	 * for some values (e.g. fontFamily in newer theme.json specs). Non-string
-	 * values are returned as an empty string so callers fall back gracefully.
+	 * values return the provided fallback so callers get a sensible default.
 	 *
-	 * @param mixed $value The CSS value, possibly a var() reference.
-	 * @return string The resolved value or the original.
+	 * @param mixed  $value    The CSS value, possibly a var() reference.
+	 * @param string $fallback Value to return when $value is non-string or empty.
+	 * @return string The resolved value, the original, or the fallback.
 	 */
-	private static function resolve_css_var( $value ): string {
-		if ( ! is_string( $value ) ) {
-			return '';
+	private static function resolve_css_var( $value, string $fallback = '' ): string {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return $fallback;
 		}
 		if ( 0 !== strpos( $value, 'var(' ) ) {
 			return $value;

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -498,10 +498,17 @@ class WC_Payments_Styles_Cache {
 	 * Attempts to resolve a CSS var() reference to a concrete value using
 	 * the global styles presets. Returns the original string if unresolvable.
 	 *
-	 * @param string $value The CSS value, possibly a var() reference.
+	 * Accepts mixed input because wp_get_global_styles() can return arrays
+	 * for some values (e.g. fontFamily in newer theme.json specs). Non-string
+	 * values are returned as an empty string so callers fall back gracefully.
+	 *
+	 * @param mixed $value The CSS value, possibly a var() reference.
 	 * @return string The resolved value or the original.
 	 */
-	private static function resolve_css_var( string $value ): string {
+	private static function resolve_css_var( $value ): string {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
 		if ( 0 !== strpos( $value, 'var(' ) ) {
 			return $value;
 		}

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -396,4 +396,27 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 			remove_filter( 'stylesheet', $stylesheet_filter );
 		}
 	}
+
+	public function test_resolve_css_var_returns_empty_string_for_non_string_input() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'resolve_css_var' );
+		$method->setAccessible( true );
+
+		// Array value (the actual bug: fontFamily can be an array in theme.json v3).
+		$this->assertSame( '', $method->invoke( null, [ 'System Sans-Serif' ] ) );
+
+		// Integer.
+		$this->assertSame( '', $method->invoke( null, 42 ) );
+
+		// Null.
+		$this->assertSame( '', $method->invoke( null, null ) );
+
+		// Boolean.
+		$this->assertSame( '', $method->invoke( null, true ) );
+
+		// Normal string still works.
+		$this->assertSame( '#ffffff', $method->invoke( null, '#ffffff' ) );
+
+		// CSS var string passes through (unresolvable var returns original).
+		$this->assertSame( 'var(--unknown-prop)', $method->invoke( null, 'var(--unknown-prop)' ) );
+	}
 }

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -397,26 +397,32 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
-	public function test_resolve_css_var_returns_empty_string_for_non_string_input() {
+	public function test_resolve_css_var_returns_fallback_for_non_string_input() {
 		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'resolve_css_var' );
 		$method->setAccessible( true );
 
 		// Array value (the actual bug: fontFamily can be an array in theme.json v3).
-		$this->assertSame( '', $method->invoke( null, [ 'System Sans-Serif' ] ) );
+		$this->assertSame( 'inherit', $method->invoke( null, [ 'System Sans-Serif' ], 'inherit' ) );
 
 		// Integer.
-		$this->assertSame( '', $method->invoke( null, 42 ) );
+		$this->assertSame( '16px', $method->invoke( null, 42, '16px' ) );
 
 		// Null.
-		$this->assertSame( '', $method->invoke( null, null ) );
+		$this->assertSame( '#000000', $method->invoke( null, null, '#000000' ) );
 
 		// Boolean.
 		$this->assertSame( '', $method->invoke( null, true ) );
 
-		// Normal string still works.
-		$this->assertSame( '#ffffff', $method->invoke( null, '#ffffff' ) );
+		// Empty string returns fallback.
+		$this->assertSame( '#ffffff', $method->invoke( null, '', '#ffffff' ) );
+
+		// Non-string without fallback returns empty string.
+		$this->assertSame( '', $method->invoke( null, [ 'array' ] ) );
+
+		// Normal string still works (fallback ignored).
+		$this->assertSame( '#ffffff', $method->invoke( null, '#ffffff', 'ignored' ) );
 
 		// CSS var string passes through (unresolvable var returns original).
-		$this->assertSame( 'var(--unknown-prop)', $method->invoke( null, 'var(--unknown-prop)' ) );
+		$this->assertSame( 'var(--unknown-prop)', $method->invoke( null, 'var(--unknown-prop)', 'ignored' ) );
 	}
 }


### PR DESCRIPTION
Related: WOOPMNT-6032

Fixes a fatal `TypeError` in `WC_Payments_Styles_Cache::resolve_css_var()` when `wp_get_global_styles()` returns non-string values (e.g., arrays for `fontFamily` in theme.json v3).

#### Changes proposed in this Pull Request

- Added a `$fallback` parameter to `resolve_css_var()` so non-string or empty input returns the caller-specified default instead of crashing
- Updated all call sites to pass their intended fallback explicitly (e.g. `'inherit'`, `'#ffffff'`, `'16px'`)
- Added unit test covering arrays, integers, null, booleans, empty strings, and normal string passthrough with fallback

The root cause: newer theme.json specs (v3) can represent `fontFamily` as an array rather than a string. When a block theme uses this format, `wp_get_global_styles()` returns an array, which causes a `TypeError` when passed to the `string`-typed `resolve_css_var()`. The appearance is computed during wp-admin page loads (via `WC_Payments_Admin` localizing `woopayAppearance`) and WooPay session/button initialization.

#### Testing instructions

1. Install and activate the **Assembler** theme (this theme uses array-based `fontFamily` in its theme.json, which is what originally triggered the fatal)
2. Enable WooPay in WooPayments settings
3. Visit any WooPayments admin page (e.g.,**Orders > Order Details** or **Payments > Overview** or **Payments > Settings**) — confirm no fatal error
4. Also verify the storefront checkout page loads without error (WooPay button handler also calls this path)
5. Run the unit test: `vendor/bin/phpunit --filter test_resolve_css_var_returns_fallback_for_non_string_input`

---

<details>
<summary>🔍 Review Report (4-agent parallel review)</summary>

### Overall Verdict: APPROVE

| Dimension | Verdict | Notes |
|-----------|---------|-------|
| Architecture Compliance | ✅ PASS | Change is within styles cache utility, outside payment flow. File placement correct (existing class in `includes/`). |
| Security | ✅ PASS | No security surface change. Method is `private static`, only processes `wp_get_global_styles()` output — no user-controlled input. |
| Performance | ✅ PASS | Single `is_string()` opcode branch. No new allocations, loops, or I/O. Entire path runs at most once per request (cached to WP option). |
| Test Coverage | ✅ PASS | Test covers exact bug scenario (array input), edge cases (int, null, bool), and happy path (string passthrough). Uses `ReflectionMethod` appropriately. |

No required changes. No non-blocking suggestions.

</details>

---

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
☢️ Powered by [Gamma AI Tools](https://github.a8c.com/Automattic/gamma-ai-tools/)