### PR TITLE
fix: rename $match to $match_type in server request set_match methods

### DIFF
--- a/changelog/2026-03-29-16-08-26-080376
+++ b/changelog/2026-03-29-16-08-26-080376
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix reserved keyword parameter name $match in server request classes

--- a/includes/core/server/request/class-list-deposits.php
+++ b/includes/core/server/request/class-list-deposits.php
@@ -58,12 +58,12 @@ class List_Deposits extends Paginated {
 	/**
 	 * Set match.
 	 *
-	 * @param string $match Match.
+	 * @param string $match_type Match type.
 	 *
 	 * @return void
 	 */
-	public function set_match( string $match ) {
-		$this->set_param( 'match', $match );
+	public function set_match( string $match_type ) {
+		$this->set_param( 'match', $match_type );
 	}
 
 	/**

--- a/includes/core/server/request/class-list-disputes.php
+++ b/includes/core/server/request/class-list-disputes.php
@@ -66,12 +66,12 @@ class List_Disputes extends Paginated {
 	/**
 	 * Set match.
 	 *
-	 * @param string $match Match.
+	 * @param string $match_type Match type.
 	 *
 	 * @return void
 	 */
-	public function set_match( string $match ) {
-		$this->set_param( 'match', $match );
+	public function set_match( string $match_type ) {
+		$this->set_param( 'match', $match_type );
 	}
 
 	/**

--- a/includes/core/server/request/class-list-documents.php
+++ b/includes/core/server/request/class-list-documents.php
@@ -56,12 +56,12 @@ class List_Documents extends Paginated {
 	/**
 	 * Set match.
 	 *
-	 * @param string $match Match.
+	 * @param string $match_type Match type.
 	 *
 	 * @return void
 	 */
-	public function set_match( string $match ) {
-		$this->set_param( 'match', $match );
+	public function set_match( string $match_type ) {
+		$this->set_param( 'match', $match_type );
 	}
 
 

--- a/includes/core/server/request/class-list-transactions.php
+++ b/includes/core/server/request/class-list-transactions.php
@@ -107,12 +107,12 @@ class List_Transactions extends Paginated {
 	/**
 	 * Set match.
 	 *
-	 * @param string $match Match.
+	 * @param string $match_type Match type.
 	 *
 	 * @return void
 	 */
-	public function set_match( string $match ) {
-		$this->set_param( 'match', $match );
+	public function set_match( string $match_type ) {
+		$this->set_param( 'match', $match_type );
 	}
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,7 +51,6 @@
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.elseFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.arrayFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.classFound" />
-		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.matchFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.returnFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.stringFound" />


### PR DESCRIPTION
Fixes #8545

#### Changes proposed in this Pull Request

Renames the `$match` parameter to `$match_type` in all four `set_match()` methods in the `includes/core/server/request/` layer (`List_Disputes`, `List_Documents`, `List_Deposits`, `List_Transactions`), and removes the `matchFound` exclusion from `phpcs.xml.dist`.

`match` is a reserved keyword in PHP 8.0+. The `Universal.NamingConventions.NoReservedKeywordParameterNames.matchFound` sniff was being suppressed globally rather than fixed at the source. This is a pure rename with no behavioral change — callers pass values positionally so the rename is transparent.

The remaining nine `NoReservedKeywordParameterNames` exclusions (`$return`, `$array`, `$default`, etc.) are out of scope and will be addressed separately under #8438.

#### Testing instructions

* Run `npm run lint:php` — no new violations in the four changed files.
* The pre-commit PHPCS hook passed on commit.
* No functional change; no manual testing required.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.