### PR TITLE
Fix duplicate partial refund amounts and order notes

### DIFF
--- a/changelog/2026-03-30-08-55-51-052498
+++ b/changelog/2026-03-30-08-55-51-052498
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed a race condition causing duplicate refund amounts and order notes during partial refunds.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -26,6 +26,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Payments_Webhook_Processing_Service {
 	/**
+	 * Action hook for delayed charge.refunded webhook processing.
+	 */
+	const PROCESS_CHARGE_REFUNDED_WEBHOOK_ACTION = 'wcpay_process_delayed_charge_refunded_webhook';
+
+	/**
+	 * Delay in seconds before processing charge.refunded webhooks.
+	 */
+	const CHARGE_REFUNDED_WEBHOOK_DELAY = 60;
+
+	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
 	 * @var WC_Payments_API_Client
@@ -131,6 +141,8 @@ class WC_Payments_Webhook_Processing_Service {
 		$this->database_cache      = $database_cache;
 		$this->onboarding_service  = $onboarding_service;
 		$this->token_service       = $token_service;
+
+		$this->init_hooks();
 	}
 
 	/**
@@ -171,7 +183,7 @@ class WC_Payments_Webhook_Processing_Service {
 
 		switch ( $event_type ) {
 			case 'charge.refunded':
-				$this->process_webhook_refund_triggered_externally( $event_body );
+				$this->schedule_delayed_refund_webhook_processing( $event_body );
 				break;
 			case 'charge.refund.updated':
 				$this->process_webhook_refund_updated( $event_body );
@@ -235,6 +247,91 @@ class WC_Payments_Webhook_Processing_Service {
 		} catch ( Exception $e ) {
 			Logger::error( $e );
 		}
+	}
+
+	/**
+	 * Register hooks for delayed webhook processing.
+	 *
+	 * @return void
+	 */
+	public function init_hooks(): void {
+		add_action( self::PROCESS_CHARGE_REFUNDED_WEBHOOK_ACTION, [ $this, 'process_webhook_refund_triggered_externally' ] );
+	}
+
+	/**
+	 * Process webhook refund for events triggered externally.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Invalid_Webhook_Data_Exception           Required parameters not found.
+	 * @throws Invalid_Webhook_Data_Exception           When the refund amount is not valid.
+	 * @throws Order_Not_Found_Exception                When unable to resolve charge ID to order.
+	 */
+	public function process_webhook_refund_triggered_externally( array $event_body ): void {
+		$event_data   = $this->read_webhook_property( $event_body, 'data' );
+		$event_object = $this->read_webhook_property( $event_data, 'object' );
+
+		$is_refunded_event = isset( $event_body['type'] ) && 'charge.refunded' === $event_body['type'];
+		$status            = $this->read_webhook_property( $event_object, 'status' );
+		if ( 'succeeded' !== $status || ! $is_refunded_event ) {
+			return;
+		}
+
+		// Check if the charge was actually captured before processing the refund.
+		// Stripe sends charge.refunded webhooks for cancelled authorizations even though no payment was captured.
+		// We should not create WooCommerce refund objects for these cases as they cause negative values in analytics.
+		$captured = $event_object['captured'] ?? false;
+		if ( ! $captured ) {
+			return;
+		}
+
+		// Fetch the details of the refund so that we can find the associated order and write a note.
+		$charge_id                     = $this->read_webhook_property( $event_object, 'id' );
+		$refund                        = $this->read_webhook_property( $event_object, 'refunds' )['data'][0]; // Most recent refund.
+		$refund_id                     = $refund['id'] ?? '';
+		$refund_reason                 = $refund['reason'] ?? '';
+		$refund_balance_transaction_id = $refund['balance_transaction'] ?? '';
+		$charge_amount                 = $this->read_webhook_property( $event_object, 'amount' );
+		$currency                      = $this->read_webhook_property( $event_object, 'currency' );
+		$refunded_amount               = WC_Payments_Utils::interpret_stripe_amount( $refund['amount'], $currency );
+		$is_partial_refund             = $refund['amount'] < $charge_amount;
+
+		// Look up the order related to this charge.
+		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
+		if ( ! $order ) {
+			throw new Order_Not_Found_Exception(
+				sprintf(
+				/* translators: %1: charge ID */
+					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
+					$charge_id
+				),
+				'order_not_found'
+			);
+		}
+		// Only care about refunds that are triggered externally, i.e. outside WP Admin.
+		// Refunds triggered in WP Admin are handled by WC_Payment_Gateway_WCPay::process_refund.
+		$wc_refunds = $order->get_refunds();
+		if ( ! empty( $wc_refunds ) ) {
+			foreach ( $wc_refunds as $wc_refund ) {
+				$wcpay_refund_id = $this->order_service->get_wcpay_refund_id_for_order( $wc_refund );
+				if ( $refund_id === $wcpay_refund_id ) {
+					return;
+				}
+			}
+		}
+		if ( $charge_amount < 0 || $refunded_amount > $order->get_total() ) {
+			throw new Invalid_Webhook_Data_Exception(
+				sprintf(
+				/* translators: %1: charge ID */
+					__( 'The refund amount is not valid for charge ID: %1$s', 'woocommerce-payments' ),
+					$charge_id
+				)
+			);
+		}
+
+		$wc_refund = $this->order_service->create_refund_for_order( $order, $refunded_amount, $refund_reason, ( ! $is_partial_refund ? $order->get_items() : [] ) );
+		// Process the refund in the order service.
+		$this->order_service->add_note_and_metadata_for_created_refund( $order, $wc_refund, $refund_id, $refund_balance_transaction_id, Refund_Status::PENDING === $refund['status'] );
 	}
 
 	/**
@@ -864,79 +961,30 @@ class WC_Payments_Webhook_Processing_Service {
 	}
 
 	/**
-	 * Process webhook refund for events triggered externally.
+	 * Schedule delayed processing of a charge.refunded webhook.
 	 *
-	 * @param array $event_body The event that triggered the webhook.
+	 * We delay processing by 1 minute to avoid a race condition with admin-initiated refunds.
+	 * When a merchant refunds from WP Admin, Stripe immediately sends a charge.refunded webhook.
+	 * If the webhook is processed before the admin flow finishes writing _wcpay_refund_id metadata,
+	 * the duplicate check fails and a second WC_Order_Refund is created.
 	 *
-	 * @throws Invalid_Webhook_Data_Exception           Required parameters not found.
-	 * @throws Invalid_Webhook_Data_Exception           When the refund amount is not valid.
-	 * @throws Order_Not_Found_Exception                When unable to resolve charge ID to order.
+	 * @param array $event_body The full webhook event body.
+	 *
+	 * @return void
 	 */
-	private function process_webhook_refund_triggered_externally( array $event_body ): void {
-		$event_data   = $this->read_webhook_property( $event_body, 'data' );
-		$event_object = $this->read_webhook_property( $event_data, 'object' );
+	private function schedule_delayed_refund_webhook_processing( array $event_body ): void {
+		$args = [ $event_body ];
 
-		$is_refunded_event = isset( $event_body['type'] ) && 'charge.refunded' === $event_body['type'];
-		$status            = $this->read_webhook_property( $event_object, 'status' );
-		if ( 'succeeded' !== $status || ! $is_refunded_event ) {
+		if ( as_has_scheduled_action( self::PROCESS_CHARGE_REFUNDED_WEBHOOK_ACTION, $args, 'woocommerce_payments' ) ) {
 			return;
 		}
 
-		// Check if the charge was actually captured before processing the refund.
-		// Stripe sends charge.refunded webhooks for cancelled authorizations even though no payment was captured.
-		// We should not create WooCommerce refund objects for these cases as they cause negative values in analytics.
-		$captured = $event_object['captured'] ?? false;
-		if ( ! $captured ) {
-			return;
-		}
-
-		// Fetch the details of the refund so that we can find the associated order and write a note.
-		$charge_id                     = $this->read_webhook_property( $event_object, 'id' );
-		$refund                        = $this->read_webhook_property( $event_object, 'refunds' )['data'][0]; // Most recent refund.
-		$refund_id                     = $refund['id'] ?? '';
-		$refund_reason                 = $refund['reason'] ?? '';
-		$refund_balance_transaction_id = $refund['balance_transaction'] ?? '';
-		$charge_amount                 = $this->read_webhook_property( $event_object, 'amount' );
-		$currency                      = $this->read_webhook_property( $event_object, 'currency' );
-		$refunded_amount               = WC_Payments_Utils::interpret_stripe_amount( $refund['amount'], $currency );
-		$is_partial_refund             = $refund['amount'] < $charge_amount;
-
-		// Look up the order related to this charge.
-		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
-		if ( ! $order ) {
-			throw new Order_Not_Found_Exception(
-				sprintf(
-				/* translators: %1: charge ID */
-					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
-					$charge_id
-				),
-				'order_not_found'
-			);
-		}
-		// Only care about refunds that are triggered externally, i.e. outside WP Admin.
-		// Refunds triggered in WP Admin are handled by WC_Payment_Gateway_WCPay::process_refund.
-		$wc_refunds = $order->get_refunds();
-		if ( ! empty( $wc_refunds ) ) {
-			foreach ( $wc_refunds as $wc_refund ) {
-				$wcpay_refund_id = $this->order_service->get_wcpay_refund_id_for_order( $wc_refund );
-				if ( $refund_id === $wcpay_refund_id ) {
-					return;
-				}
-			}
-		}
-		if ( $charge_amount < 0 || $refunded_amount > $order->get_total() ) {
-			throw new Invalid_Webhook_Data_Exception(
-				sprintf(
-				/* translators: %1: charge ID */
-					__( 'The refund amount is not valid for charge ID: %1$s', 'woocommerce-payments' ),
-					$charge_id
-				)
-			);
-		}
-
-		$wc_refund = $this->order_service->create_refund_for_order( $order, $refunded_amount, $refund_reason, ( ! $is_partial_refund ? $order->get_items() : [] ) );
-		// Process the refund in the order service.
-		$this->order_service->add_note_and_metadata_for_created_refund( $order, $wc_refund, $refund_id, $refund_balance_transaction_id, Refund_Status::PENDING === $refund['status'] );
+		as_schedule_single_action(
+			time() + self::CHARGE_REFUNDED_WEBHOOK_DELAY,
+			self::PROCESS_CHARGE_REFUNDED_WEBHOOK_ACTION,
+			$args,
+			'woocommerce_payments'
+		);
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -1641,6 +1641,137 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		$this->webhook_processing_service->process( $this->event_body );
 	}
 
+	public function test_charge_refunded_webhook_is_scheduled_not_processed_immediately(): void {
+		$this->event_body['type']           = 'charge.refunded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'test_charge_id',
+			'refunds'  => [
+				'data' => [
+					[
+						'id'                  => 'test_refund_id',
+						'status'              => 'succeeded',
+						'amount'              => 900,
+						'currency'            => 'usd',
+						'reason'              => 'requested_by_customer',
+						'balance_transaction' => 'txn_123',
+					],
+				],
+			],
+			'status'   => 'succeeded',
+			'amount'   => 1800,
+			'currency' => 'usd',
+			'captured' => true,
+		];
+
+		// The order service should NOT be called during scheduling —
+		// processing happens later when the scheduled action fires.
+		$this->order_service
+			->expects( $this->never() )
+			->method( 'create_refund_for_order' );
+
+		$this->webhook_processing_service->process( $this->event_body );
+
+		// Verify an action was scheduled.
+		$this->assertTrue(
+			as_has_scheduled_action(
+				WC_Payments_Webhook_Processing_Service::PROCESS_CHARGE_REFUNDED_WEBHOOK_ACTION,
+				[ $this->event_body ],
+				'woocommerce_payments'
+			)
+		);
+	}
+
+	public function test_charge_refunded_webhook_duplicate_scheduling_is_prevented(): void {
+		$this->event_body['type']           = 'charge.refunded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'test_charge_id',
+			'refunds'  => [
+				'data' => [
+					[
+						'id'                  => 'test_refund_id',
+						'status'              => 'succeeded',
+						'amount'              => 900,
+						'currency'            => 'usd',
+						'reason'              => 'requested_by_customer',
+						'balance_transaction' => 'txn_123',
+					],
+				],
+			],
+			'status'   => 'succeeded',
+			'amount'   => 1800,
+			'currency' => 'usd',
+			'captured' => true,
+		];
+
+		// Process the same webhook twice (simulates Stripe retry).
+		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process( $this->event_body );
+
+		// Should only have one scheduled action, not two.
+		$scheduled_actions = as_get_scheduled_actions(
+			[
+				'hook'   => WC_Payments_Webhook_Processing_Service::PROCESS_CHARGE_REFUNDED_WEBHOOK_ACTION,
+				'args'   => [ $this->event_body ],
+				'group'  => 'woocommerce_payments',
+				'status' => ActionScheduler_Store::STATUS_PENDING,
+			]
+		);
+
+		$this->assertCount( 1, $scheduled_actions );
+	}
+
+	public function test_delayed_charge_refunded_webhook_processes_refund(): void {
+		$this->event_body['type']           = 'charge.refunded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'test_charge_id',
+			'refunds'  => [
+				'data' => [
+					[
+						'id'                  => 'test_refund_id',
+						'status'              => Refund_Status::SUCCEEDED,
+						'amount'              => 900,
+						'currency'            => 'usd',
+						'reason'              => 'requested_by_customer',
+						'balance_transaction' => 'txn_123',
+					],
+				],
+			],
+			'status'   => 'succeeded',
+			'amount'   => 1800,
+			'currency' => 'usd',
+			'captured' => true,
+		];
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'get_total' )
+			->willReturn( 18 );
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $this->mock_order );
+
+		$mock_refund = $this->createMock( WC_Order_Refund::class );
+
+		$this->order_service
+			->expects( $this->once() )
+			->method( 'create_refund_for_order' )
+			->willReturn( $mock_refund );
+
+		$this->order_service
+			->expects( $this->once() )
+			->method( 'add_note_and_metadata_for_created_refund' )
+			->with( $this->mock_order, $mock_refund, 'test_refund_id', 'txn_123' );
+
+		// Call the method directly (simulating Action Scheduler firing the hook).
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
+	}
+
 	public function test_process_full_refund_succeeded(): void {
 		$this->event_body['type']           = 'charge.refunded';
 		$this->event_body['livemode']       = true;
@@ -1696,7 +1827,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'add_note_and_metadata_for_created_refund' )
 			->with( $this->mock_order, $mock_refund, 'test_refund_id', 'txn_123' );
 
-		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
 	}
 
 	public function test_process_partial_refund_succeeded(): void {
@@ -1745,7 +1876,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'add_note_and_metadata_for_created_refund' )
 			->with( $this->mock_order, $mock_refund, 'test_refund_id', 'txn_123' );
 
-		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
 	}
 
 	public function test_process_refund_ignores_processed_event(): void {
@@ -1806,7 +1937,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'add_note_and_metadata_for_created_refund' );
 
-		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
 	}
 
 	public function test_process_refund_ignores_event(): void {
@@ -1850,6 +1981,8 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		$this->order_service
 			->expects( $this->never() )
 			->method( 'add_note_and_metadata_for_created_refund' );
+
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
 	}
 
 	public function test_process_refund_throws_when_order_not_found(): void {
@@ -1880,7 +2013,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->expectException( Order_Not_Found_Exception::class );
 
-		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
 	}
 
 	public function test_process_refund_throws_with_negative_amount(): void {
@@ -1915,7 +2048,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->expectException( Invalid_Webhook_Data_Exception::class );
 
-		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
 	}
 
 	public function test_process_refund_throws_with_invalid_refunded_amount(): void {
@@ -1951,7 +2084,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->expectException( Invalid_Webhook_Data_Exception::class );
 
-		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
 	}
 
 	public function test_process_refund_ignores_uncaptured_charge(): void {
@@ -1995,7 +2128,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'add_note_and_metadata_for_created_refund' );
 
-		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process_webhook_refund_triggered_externally( $this->event_body );
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOPMNT-5660

#### Changes proposed in this Pull Request

When a merchant processes a partial refund from WP Admin, Stripe immediately fires a `charge.refunded` webhook. A race condition occurs because the webhook can arrive and be processed before the admin refund flow finishes writing `_wcpay_refund_id` metadata to the `WC_Order_Refund` object. When this happens, the webhook's duplicate check fails and it creates a second refund — resulting in duplicate order notes and doubled refund amounts.

This PR delays `charge.refunded` webhook processing by 1 minute via Action Scheduler instead of processing it synchronously. By the time the scheduled action fires, the admin flow has completed and the existing duplicate detection works correctly.

**How can this code break?**
- If Action Scheduler is unavailable or not running, the delayed webhook would not fire. This is acceptable because the webhook reliability service already handles missed webhooks.
- External refunds (from Stripe Dashboard) will have a ~1 minute delay before appearing in WooCommerce. This is imperceptible to merchants.

**What are we doing to make sure this code doesn't break?**
- Added 3 new unit tests covering: scheduling behavior, duplicate scheduling prevention, and delayed handler execution.
- Updated 8 existing tests to call the handler directly (testing handler logic, not routing).
- All 57 webhook processing service tests and 26 gateway refund tests pass.

#### Testing instructions

1. Create a test order paid with WooPayments
2. Process a **partial refund** from WP Admin
3. Verify only **one** order note and **one** refund entry are recorded (not duplicated)
4. Process a refund from the **Stripe Dashboard** and verify a WC refund appears after ~1 minute
5. Check Action Scheduler (Tools > Scheduled Actions) for `wcpay_process_delayed_charge_refunded_webhook` actions

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)