### PR TITLE
Fix: Add defensive checks before initializing WC_Payments_Captured_Event_Note

### DIFF
--- a/changelog/fix-defensive-checks-captured-event-note
+++ b/changelog/fix-defensive-checks-captured-event-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add defensive checks before initializing WC_Payments_Captured_Event_Note to prevent fatal errors when timeline data is missing or malformed.

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -574,6 +574,11 @@ class WC_Payments_Order_Service {
 		try {
 			$events = $this->api_client->get_timeline( $intent_id );
 
+			if ( ! isset( $events['data'] ) || ! is_array( $events['data'] ) ) {
+				Logger::log( sprintf( 'Timeline data missing or malformed for intent_id %s.', $intent_id ) );
+				return;
+			}
+
 			$captured_event = current(
 				array_filter(
 					$events['data'],
@@ -582,6 +587,11 @@ class WC_Payments_Order_Service {
 					}
 				)
 			);
+
+			if ( ! is_array( $captured_event ) ) {
+				Logger::log( sprintf( 'No captured event found in timeline for intent_id %s.', $intent_id ) );
+				return;
+			}
 
 			$details = ( new WC_Payments_Captured_Event_Note( $captured_event ) )->generate_html_note();
 

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -2038,4 +2038,67 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Clean up.
 		WC_Helper_Order::delete_order( $order->get_id() );
 	}
+
+	/**
+	 * Test that add_fee_breakdown_to_order_notes returns early when timeline data is missing.
+	 */
+	public function test_add_fee_breakdown_returns_early_when_timeline_data_missing() {
+		$mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$mock_api_client->expects( $this->once() )
+			->method( 'get_timeline' )
+			->willReturn( [] ); // No 'data' key.
+
+		$order_service = new WC_Payments_Order_Service( $mock_api_client );
+
+		$notes_before = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+
+		$order_service->add_fee_breakdown_to_order_notes( $this->order->get_id(), 'pi_test_123' );
+
+		$notes_after = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+		$this->assertCount( count( $notes_before ), $notes_after );
+	}
+
+	/**
+	 * Test that add_fee_breakdown_to_order_notes returns early when timeline data is not an array.
+	 */
+	public function test_add_fee_breakdown_returns_early_when_timeline_data_not_array() {
+		$mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$mock_api_client->expects( $this->once() )
+			->method( 'get_timeline' )
+			->willReturn( [ 'data' => null ] );
+
+		$order_service = new WC_Payments_Order_Service( $mock_api_client );
+
+		$notes_before = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+
+		$order_service->add_fee_breakdown_to_order_notes( $this->order->get_id(), 'pi_test_123' );
+
+		$notes_after = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+		$this->assertCount( count( $notes_before ), $notes_after );
+	}
+
+	/**
+	 * Test that add_fee_breakdown_to_order_notes returns early when no captured event is found.
+	 */
+	public function test_add_fee_breakdown_returns_early_when_no_captured_event() {
+		$mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$mock_api_client->expects( $this->once() )
+			->method( 'get_timeline' )
+			->willReturn(
+				[
+					'data' => [
+						[ 'type' => 'authorized' ],
+					],
+				]
+			);
+
+		$order_service = new WC_Payments_Order_Service( $mock_api_client );
+
+		$notes_before = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+
+		$order_service->add_fee_breakdown_to_order_notes( $this->order->get_id(), 'pi_test_123' );
+
+		$notes_after = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+		$this->assertCount( count( $notes_before ), $notes_after );
+	}
 }


### PR DESCRIPTION
## Summary
Fixes WOOPMNT-2170: Add defensive checks before initializing WC_Payments_Captured_Event_Note

The `add_fee_breakdown_to_order_notes` method could fatal when the timeline API returns malformed data (missing `data` key) or when no captured event exists in the timeline. The `WC_Payments_Captured_Event_Note` constructor requires an array, but `current()` returns `false` when no matching event is found.

## Changes
- Added a check for `$events['data']` existence and type before accessing it
- Added a check that `$captured_event` is an array before passing to constructor
- Both early returns log the issue for debugging
- Added 3 unit tests covering the defensive checks

## Testing
1. The fix prevents a fatal error when:
   - The timeline API returns a response without a `data` key
   - The timeline API returns `data: null`
   - The timeline contains no `captured` event type
2. In all cases, the method returns early with a log message instead of crashing
3. Normal flow (valid timeline with captured event) is unaffected

## Linear Issue
https://linear.app/a8c/issue/WOOPMNT-2170/add-defensive-checks-before-initializing-wc-payments-captured-event

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)