### PR TITLE
Fix: Prevent caching empty disputes list on API failure

### DIFF
--- a/changelog/fix-woopmnt-5981-api-failure-caches-empty-disputes
+++ b/changelog/fix-woopmnt-5981-api-failure-caches-empty-disputes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent caching empty disputes list on API failure, which could hide active disputes from admin task list

--- a/includes/admin/tasks/class-wc-payments-task-disputes.php
+++ b/includes/admin/tasks/class-wc-payments-task-disputes.php
@@ -349,8 +349,9 @@ class WC_Payments_Task_Disputes extends Task {
 						]
 					);
 				} catch ( \Exception $e ) {
-					// Ensure an array is always returned, even if the API call fails.
-					return [];
+					// Return null so Database_Cache::get_or_add treats this as an error
+					// and does not cache the empty result (which would hide active disputes).
+					return null;
 				}
 
 				$active_disputes = $response['data'] ?? [];

--- a/tests/unit/admin/tasks/test-class-wc-payments-task-disputes.php
+++ b/tests/unit/admin/tasks/test-class-wc-payments-task-disputes.php
@@ -233,6 +233,14 @@ class WC_Payments_Task_Disputes_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( true, $disputes_task->can_view() );
 	}
 
+	public function test_disputes_task_not_visible_when_cache_returns_null() {
+		$this->mock_cache->method( 'get_or_add' )->willReturn( null );
+		$disputes_task = new WC_Payments_Task_Disputes();
+
+		$this->assertFalse( $disputes_task->can_view() );
+		$this->assertSame( '', $disputes_task->get_title() );
+	}
+
 	public function test_disputes_task_with_multiple_disputes_within_7days_multicurrency() {
 		$mock_active_disputes = [
 			[


### PR DESCRIPTION
## Summary

Fixes WOOPMNT-5981.

When the disputes API call throws an exception, the catch block in `WC_Payments_Task_Disputes::get_disputes_needing_response()` returns an empty array `[]`. `Database_Cache::get_or_add` treats `[]` as valid data (it passes the `is_array` validator) and caches it for up to 24 hours, hiding active disputes from the admin task list.

**Fix:** Change the catch block to return `null` instead of `[]`. `get_or_add` treats `null` as an error — it will not cache the result and will fall back to previously cached data if available.

## Changes

- `includes/admin/tasks/class-wc-payments-task-disputes.php` — Return `null` on API exception instead of `[]`
- `tests/unit/admin/tasks/test-class-wc-payments-task-disputes.php` — Add test verifying task handles `null` from cache gracefully
- Changelog entry

## Test plan

- [ ] Verify that when the API returns disputes normally, the task list displays them correctly
- [ ] Verify that when an API exception occurs, the cache does not store the empty result
- [ ] Verify that after an API failure, previously cached dispute data is still returned
- [ ] Verify the new unit test passes: `test_disputes_task_not_visible_when_cache_returns_null`

Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)