### PR TITLE
chore: update validator dependency

### DIFF
--- a/changelog/chore-validate-dep-update
+++ b/changelog/chore-validate-dep-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+chore: update `validator` dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"decimal.js-light": "2.5.1",
 				"intl-tel-input": "17.0.15",
 				"lodash": "4.17.21",
-				"validator": "13.12.0"
+				"validator": "13.15.26"
 			},
 			"devDependencies": {
 				"@automattic/color-studio": "4.0.0",
@@ -38047,9 +38047,9 @@
 			}
 		},
 		"node_modules/validator": {
-			"version": "13.12.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-			"integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+			"version": "13.15.26",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+			"integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
 			"engines": {
 				"node": ">= 0.10"
 			}

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"decimal.js-light": "2.5.1",
 		"intl-tel-input": "17.0.15",
 		"lodash": "4.17.21",
-		"validator": "13.12.0"
+		"validator": "13.15.26"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "4.0.0",


### PR DESCRIPTION
Fixes WOOPMNT-6035

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Updating the `validator` dependency to the latests version.

The `isEmail` utility from `validator` is used to client-side validate emails for the gift cards extension.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have WooPay enabled in Payments > Settings
- Ensure you have the WooCommerce Gift Cards plugin installed and active
- Ensure you have a gift card product created (single-recipient and multi-recipient variants if possible)
- Ensure you have the "Send as gift?" set as "always" in WooCommerce > Settings > Gift cards
- Add this snippet to your site:
```php
  add_action( 'init', function() {
      remove_filter( 'wcpay_woopay_button_is_product_supported', [ 'WC_GC_WC_Payments_Compatibility', 'handle_express_checkout_buttons' ] );
  }, 20 );
```

1. Go to a multi-recipient gift card product page
2. In the multiple recipients field, enter a mix of valid and invalid emails (e.g., `valid@test.com, notanemail, name@subdomain.example.co.uk, user+tag@example.com`)
3. Click the WooPay button
4. Alert "Please type only valid emails"
5. Refresh the page
6. Correct all emails to be valid (e.g., `valid@test.com, name@subdomain.example.co.uk, user+tag@example.com`)
7. Click the WooPay button
8. You should be redirected to WooPay

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
