### PR TITLE
fix: Add fallback selectors for Stripe Payment Element appearance on non-standard themes

### DIFF
--- a/changelog/woopmnt-6039-stripe-payment-element-loses-all-styling-on-shortcode
+++ b/changelog/woopmnt-6039-stripe-payment-element-loses-all-styling-on-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Stripe Payment Element losing styling on shortcode checkout with non-standard themes like Avada

--- a/client/checkout/blocks/payment-elements.js
+++ b/client/checkout/blocks/payment-elements.js
@@ -15,6 +15,7 @@ import {
 	getCachedAppearance,
 	setCachedAppearance,
 	dispatchAppearanceEvent,
+	isAppearanceValid,
 } from 'wcpay/utils/appearance-cache';
 import { useStripeForUPE } from 'wcpay/hooks/use-stripe-async';
 import { getUPEConfig } from 'wcpay/utils/checkout';
@@ -57,11 +58,17 @@ const PaymentElements = ( { api, ...props } ) => {
 				containerRef.current.ownerDocument
 			);
 			dispatchAppearanceEvent( upeAppearance, 'blocks_checkout' );
-			setCachedAppearance(
-				'blocks_checkout',
-				getUPEConfig( 'stylesCacheVersion' ),
-				upeAppearance
-			);
+
+			// Only cache if extraction produced meaningful rules.
+			// Empty results (e.g. non-standard theme markup) should not be cached
+			// so the next page load can retry extraction.
+			if ( isAppearanceValid( upeAppearance ) ) {
+				setCachedAppearance(
+					'blocks_checkout',
+					getUPEConfig( 'stylesCacheVersion' ),
+					upeAppearance
+				);
+			}
 			setAppearance( upeAppearance );
 			// Defer dispatch so all payment method label listeners are attached first.
 			setTimeout( () => {

--- a/client/checkout/classic/payment-processing.js
+++ b/client/checkout/classic/payment-processing.js
@@ -12,6 +12,7 @@ import {
 	getCachedAppearance,
 	setCachedAppearance,
 	dispatchAppearanceEvent,
+	isAppearanceValid,
 } from 'wcpay/utils/appearance-cache';
 import showErrorCheckout from 'wcpay/checkout/utils/show-error-checkout';
 import {
@@ -62,7 +63,14 @@ function initializeAppearance( elementsLocation ) {
 
 	const appearance = getAppearance( elementsLocation );
 	dispatchAppearanceEvent( appearance, elementsLocation );
-	setCachedAppearance( elementsLocation, version, appearance );
+
+	// Only cache if extraction produced meaningful rules.
+	// Empty results (e.g. non-standard theme markup) should not be cached
+	// so the next page load can retry extraction.
+	if ( isAppearanceValid( appearance ) ) {
+		setCachedAppearance( elementsLocation, version, appearance );
+	}
+
 	return appearance;
 }
 

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -2,6 +2,107 @@
  * Internal dependencies
  */
 import * as upeStyles from '..';
+import { appearanceSelectors } from '..';
+
+describe( 'appearanceSelectors.updateSelectors', () => {
+	let scope;
+
+	beforeEach( () => {
+		scope = document;
+		document.body.innerHTML = '';
+	} );
+
+	it( 'uses primary selectors when they exist in the DOM', () => {
+		document.body.innerHTML =
+			'<div class="woocommerce-billing-fields__field-wrapper">' +
+			'<input id="billing_first_name" type="text" />' +
+			'</div>';
+
+		const selectors = {
+			appendTarget: '.woocommerce-billing-fields__field-wrapper',
+			upeThemeInputSelector: '#billing_first_name',
+			alternateSelectors: {
+				appendTarget: 'form.checkout',
+				upeThemeInputSelector: 'form.checkout input[type="text"]',
+			},
+		};
+
+		const result = appearanceSelectors.updateSelectors( selectors, scope );
+		expect( result.appendTarget ).toBe(
+			'.woocommerce-billing-fields__field-wrapper'
+		);
+		expect( result.upeThemeInputSelector ).toBe( '#billing_first_name' );
+		expect( result ).not.toHaveProperty( 'alternateSelectors' );
+	} );
+
+	it( 'falls back to alternate selectors when primary are missing', () => {
+		document.body.innerHTML =
+			'<form class="checkout">' +
+			'<input type="text" name="name" />' +
+			'</form>';
+
+		const selectors = {
+			appendTarget: '.woocommerce-billing-fields__field-wrapper',
+			upeThemeInputSelector: '#billing_first_name',
+			alternateSelectors: {
+				appendTarget: 'form.checkout',
+				upeThemeInputSelector: 'form.checkout input[type="text"]',
+			},
+		};
+
+		const result = appearanceSelectors.updateSelectors( selectors, scope );
+		expect( result.appendTarget ).toBe( 'form.checkout' );
+		expect( result.upeThemeInputSelector ).toBe(
+			'form.checkout input[type="text"]'
+		);
+	} );
+
+	it( 'falls back array selectors when none of the primary match', () => {
+		document.body.innerHTML =
+			'<form class="checkout">' +
+			'<div class="woocommerce">content</div>' +
+			'</form>';
+
+		const selectors = {
+			upeThemeTextSelectors: [
+				'#payment .payment_methods li .payment_box fieldset',
+				'.woocommerce-checkout .form-row',
+			],
+			alternateSelectors: {
+				upeThemeTextSelectors: [ 'form.checkout', '.woocommerce' ],
+			},
+		};
+
+		const result = appearanceSelectors.updateSelectors( selectors, scope );
+		expect( result.upeThemeTextSelectors ).toEqual( [
+			'form.checkout',
+			'.woocommerce',
+		] );
+	} );
+
+	it( 'keeps array selectors when at least one primary matches', () => {
+		document.body.innerHTML =
+			'<div class="woocommerce-checkout">' +
+			'<div class="form-row">content</div>' +
+			'</div>';
+
+		const selectors = {
+			upeThemeTextSelectors: [
+				'#payment .payment_methods li .payment_box fieldset',
+				'.woocommerce-checkout .form-row',
+			],
+			alternateSelectors: {
+				upeThemeTextSelectors: [ 'form.checkout', '.woocommerce' ],
+			},
+		};
+
+		const result = appearanceSelectors.updateSelectors( selectors, scope );
+		expect( result.upeThemeTextSelectors ).toEqual( [
+			'#payment .payment_methods li .payment_box fieldset',
+			'.woocommerce-checkout .form-row',
+		] );
+	} );
+} );
 
 describe( 'Getting styles for automated theming', () => {
 	const mockElement = document.createElement( 'input' );

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -40,6 +40,12 @@ export const appearanceSelectors = {
 			'woocommerce-invalid',
 			'woocommerce-invalid-required-field',
 		],
+		alternateSelectors: {
+			appendTarget: 'form.checkout',
+			upeThemeInputSelector: 'form.checkout input[type="text"]',
+			upeThemeLabelSelector: 'form.checkout label',
+			upeThemeTextSelectors: [ 'form.checkout', '.woocommerce' ],
+		},
 		backgroundSelectors: [
 			'li.wc_payment_method .wc-payment-form',
 			'li.wc_payment_method .payment_box',
@@ -158,6 +164,11 @@ export const appearanceSelectors = {
 			'woocommerce-invalid',
 			'woocommerce-invalid-required-field',
 		],
+		alternateSelectors: {
+			appendTarget: 'form.checkout',
+			upeThemeInputSelector: 'form.checkout input[type="text"]',
+			upeThemeLabelSelector: 'form.checkout label',
+		},
 		backgroundSelectors: [
 			'#customer_details',
 			'#order_review',

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -168,6 +168,7 @@ export const appearanceSelectors = {
 			appendTarget: 'form.checkout',
 			upeThemeInputSelector: 'form.checkout input[type="text"]',
 			upeThemeLabelSelector: 'form.checkout label',
+			upeThemeTextSelectors: [ 'form.checkout', '.woocommerce' ],
 		},
 		backgroundSelectors: [
 			'#customer_details',

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -277,9 +277,28 @@ export const appearanceSelectors = {
 			Object.entries( selectors.alternateSelectors ).forEach(
 				( altSelector ) => {
 					const [ key, value ] = altSelector;
+					const current = selectors[ key ];
 
-					if ( ! scope.querySelector( selectors[ key ] ) ) {
-						selectors[ key ] = value;
+					if ( Array.isArray( current ) ) {
+						// For array selectors, check if any element matches.
+						const anyMatch = current.some( ( s ) => {
+							try {
+								return scope.querySelector( s );
+							} catch ( e ) {
+								return false;
+							}
+						} );
+						if ( ! anyMatch ) {
+							selectors[ key ] = value;
+						}
+					} else {
+						try {
+							if ( ! scope.querySelector( selectors[ key ] ) ) {
+								selectors[ key ] = value;
+							}
+						} catch ( e ) {
+							selectors[ key ] = value;
+						}
 					}
 				}
 			);

--- a/client/utils/__tests__/appearance-cache.test.js
+++ b/client/utils/__tests__/appearance-cache.test.js
@@ -6,6 +6,7 @@ import {
 	setCachedAppearance,
 	getCachedTheme,
 	dispatchAppearanceEvent,
+	isAppearanceValid,
 } from '../appearance-cache';
 
 describe( 'Appearance cache', () => {
@@ -172,6 +173,38 @@ describe( 'Appearance cache', () => {
 				'wcpay_elements_appearance',
 				handler
 			);
+		} );
+	} );
+
+	describe( 'isAppearanceValid', () => {
+		test( 'returns false for null appearance', () => {
+			expect( isAppearanceValid( null ) ).toBe( false );
+		} );
+
+		test( 'returns false for appearance without rules', () => {
+			expect( isAppearanceValid( { variables: {} } ) ).toBe( false );
+		} );
+
+		test( 'returns false when .Input rules are empty', () => {
+			const appearance = {
+				variables: { colorBackground: '#ffffff' },
+				rules: { '.Input': {}, '.Label': {} },
+			};
+			expect( isAppearanceValid( appearance ) ).toBe( false );
+		} );
+
+		test( 'returns true when .Input rules have properties', () => {
+			const appearance = {
+				variables: { colorBackground: '#ffffff' },
+				rules: {
+					'.Input': {
+						color: 'rgb(0, 0, 0)',
+						fontFamily: 'Arial',
+						fontSize: '16px',
+					},
+				},
+			};
+			expect( isAppearanceValid( appearance ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/utils/appearance-cache.js
+++ b/client/utils/appearance-cache.js
@@ -76,3 +76,18 @@ export function dispatchAppearanceEvent( appearance, elementsLocation ) {
 		} )
 	);
 }
+
+/**
+ * Checks whether an extracted appearance has meaningful styling rules.
+ * Returns false when all `.Input` rules are empty (extraction failed).
+ *
+ * @param {Object} appearance The appearance object to validate.
+ * @return {boolean} True if the appearance has meaningful rules.
+ */
+export function isAppearanceValid( appearance ) {
+	if ( ! appearance?.rules ) {
+		return false;
+	}
+	const inputRules = appearance.rules[ '.Input' ];
+	return inputRules && Object.keys( inputRules ).length > 0;
+}


### PR DESCRIPTION
Fixes WOOPMNT-6039

#### Changes proposed in this Pull Request

After upgrading to WooPayments 10.6.0, the Stripe Payment Element renders completely unstyled on classic shortcode checkout when using themes with non-standard DOM structures (reported with Avada). This happens because:

1. Server-side appearance transients were removed in 10.6.0 (WOOPMNT-5806) for security
2. Client-side DOM extraction in `hiddenElementsForUPE.init()` hardcodes WooCommerce-standard selectors (`.woocommerce-billing-fields__field-wrapper`, `#billing_first_name`) that don't exist on Avada's Fusion Builder markup
3. When selectors miss, the function returns early and all `getFieldStyles()` calls return `{}`, producing an empty appearance that gets cached in localStorage

This PR fixes the issue with three complementary changes:

**1. Fallback selectors (`alternateSelectors`)** — Extends the existing `alternateSelectors` pattern (already used by `blocksCheckout`) to `classicCheckout` and `wooPayClassicCheckout`. When primary selectors miss, generic fallbacks (`form.checkout`, `input[type="text"]`, etc.) are tried.

**2. Array selector support in `updateSelectors`** — The existing `updateSelectors` method only handled string selectors. Array-valued selectors like `upeThemeTextSelectors` are now checked correctly (falls back only when *none* of the array entries match).

**3. Empty appearance cache guard** — Added `isAppearanceValid()` that checks whether `.Input` rules are empty. Empty appearances (extraction failure) are no longer cached in localStorage, allowing retry on the next page load instead of locking in the broken state.

#### Testing instructions

##### Prerequisites

- WooCommerce store with **classic shortcode checkout** (`[woocommerce_checkout]`) — not blocks checkout
- WooPayments connected and card payments enabled
- A product in the cart

##### Test 1 — Regression test (standard theme)

1. Use Storefront or any standard WooCommerce theme
2. Navigate to checkout with an item in cart
3. Verify the Stripe Payment Element renders with proper styling (card fields have themed borders, font, background — not plain browser-default inputs)
4. Open DevTools → Application → Local Storage → look for `wcpay_appearance_shortcode_checkout`
5. Verify the cached value contains populated rules (e.g., `.Input` should have `color`, `fontFamily`, `fontSize`, etc.)

**Expected:** Payment Element is styled and matches the site theme. Cached appearance has populated rules.

##### Test 2 — Bug fix test (simulated non-standard theme)

Since Avada is a paid theme, you can simulate its behavior with this mu-plugin snippet that renames the standard WooCommerce billing wrapper class:

<details>
<summary>mu-plugin: <code>simulate-avada.php</code></summary>

Create `wp-content/mu-plugins/simulate-avada.php`:

```php
<?php
/**
 * Simulates Avada theme checkout markup by renaming the standard
 * WooCommerce billing wrapper class to a custom one.
 * To disable: delete this file.
 */
add_action( 'woocommerce_checkout_billing', function() {
    ob_start( function( $html ) {
        return str_replace(
            'woocommerce-billing-fields__field-wrapper',
            'fusion-billing-wrapper',
            $html
        );
    } );
}, 1 );

add_action( 'woocommerce_after_checkout_billing_form', function() {
    if ( ob_get_level() > 0 ) {
        ob_end_flush();
    }
}, 999 );
```

</details>

1. Install the mu-plugin snippet above
2. Clear localStorage: DevTools → Application → Local Storage → delete `wcpay_appearance_shortcode_checkout`
3. Navigate to checkout with an item in cart
4. Verify the Stripe Payment Element still renders **with styling** (not plain unstyled inputs)
5. Inspect localStorage `wcpay_appearance_shortcode_checkout` — the `.Input` rules should be populated (fallback selectors `form.checkout input[type="text"]` kicked in)

**Expected:** Payment Element is styled even though the primary selector (`.woocommerce-billing-fields__field-wrapper`) is missing from the DOM. The fallback selectors extract styles from the generic `form.checkout` elements instead.

##### Test 3 — Cache guard test

1. Keep the mu-plugin snippet active
2. In DevTools Console, temporarily break ALL selectors to force a completely empty extraction:
   ```js
   localStorage.removeItem('wcpay_appearance_shortcode_checkout');
   document.querySelector('form.checkout')?.classList.remove('checkout');
   jQuery(document.body).trigger('updated_checkout');
   ```
3. After re-extraction, check localStorage — `wcpay_appearance_shortcode_checkout` should **not exist** (empty results are not cached)
4. Reload the page — the extraction retries and this time `form.checkout` is back, so styling should work

**Expected:** Empty/broken appearance is never cached. Next page load gets a fresh chance to extract.

##### Test 4 — Blocks checkout regression

1. Remove the mu-plugin snippet
2. Switch the checkout page to block-based checkout (replace content with the Checkout block)
3. Navigate to checkout
4. Verify Payment Element renders correctly with styling

**Expected:** No regression on blocks checkout.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
