### PR TITLE
Fix: Use atomic rename for migration log file merging

### DIFF
--- a/changelog/fix-woopmnt-5962-log-cleanup-atomic-rename
+++ b/changelog/fix-woopmnt-5962-log-cleanup-atomic-rename
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use atomic temp-file-then-rename for migration log file merging to prevent dropped entries during cleanup.

--- a/includes/subscriptions/class-wc-payments-subscription-migration-log-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscription-migration-log-handler.php
@@ -90,29 +90,48 @@ class WC_Payments_Subscription_Migration_Log_Handler {
 					// Uses a temp file + atomic rename to avoid a deletion window where
 					// concurrent writes to the "today" file could be lost.
 					if ( file_exists( $new_file_path ) ) {
-						$temp_file_path = $new_file_path . '.tmp';
+						// Use a unique temp filename in the same directory (same filesystem,
+						// so the final rename is atomic) to avoid collisions if cleanup runs
+						// concurrently, e.g. overlapping cron runs.
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_tempnam
+						$temp_file_path = tempnam( $log_dir, self::HANDLE . '-merge-' );
+
+						// Bail on this file if the temp file couldn't be created.
+						if ( false === $temp_file_path ) {
+							continue;
+						}
 
 						// Copy old (historical) content to temp file first.
 						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_copy
-						copy( $old_file_path, $temp_file_path );
+						$merge_ok = copy( $old_file_path, $temp_file_path );
 
 						// Append current "today" file content (preserves: old logs first, then new logs).
-						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-						$source_handle = fopen( $new_file_path, 'r' );
-						if ( false !== $source_handle ) {
-							// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-							file_put_contents( $temp_file_path, $source_handle, FILE_APPEND );
-							// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-							fclose( $source_handle );
+						if ( $merge_ok ) {
+							// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+							$source_handle = fopen( $new_file_path, 'r' );
+							if ( false !== $source_handle ) {
+								// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+								$merge_ok = false !== file_put_contents( $temp_file_path, $source_handle, FILE_APPEND );
+								// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+								fclose( $source_handle );
+							} else {
+								$merge_ok = false;
+							}
 						}
 
-						// Atomic rename: replaces the "today" file in one operation, no deletion window.
+						// Only replace the active "today" file and delete the historical file if
+						// the merge fully succeeded; otherwise leave both originals untouched so no
+						// log data is lost.
 						// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
-						rename( $temp_file_path, $new_file_path );
-
-						// Clean up the old (historical) file.
-						// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
-						unlink( $old_file_path );
+						if ( $merge_ok && rename( $temp_file_path, $new_file_path ) ) {
+							// Atomic replacement succeeded — clean up the old (historical) file.
+							// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+							unlink( $old_file_path );
+						} elseif ( file_exists( $temp_file_path ) ) {
+							// Merge failed — discard the temp file and leave the originals intact.
+							// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+							unlink( $temp_file_path );
+						}
 					} else {
 						// No merge needed — just rename old file to new filename (with today's date).
 						// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename

--- a/includes/subscriptions/class-wc-payments-subscription-migration-log-handler.php
+++ b/includes/subscriptions/class-wc-payments-subscription-migration-log-handler.php
@@ -87,24 +87,37 @@ class WC_Payments_Subscription_Migration_Log_Handler {
 				// Only rename if the filename would actually change.
 				if ( $new_file_name !== $log_file_name && file_exists( $old_file_path ) ) {
 					// If target file already exists, merge files maintaining chronological order.
-					// Uses stream-based operations for memory efficiency with large log files.
+					// Uses a temp file + atomic rename to avoid a deletion window where
+					// concurrent writes to the "today" file could be lost.
 					if ( file_exists( $new_file_path ) ) {
-						// Append new file content to old file (preserves: old logs first, then new logs).
+						$temp_file_path = $new_file_path . '.tmp';
+
+						// Copy old (historical) content to temp file first.
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_copy
+						copy( $old_file_path, $temp_file_path );
+
+						// Append current "today" file content (preserves: old logs first, then new logs).
 						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 						$source_handle = fopen( $new_file_path, 'r' );
 						if ( false !== $source_handle ) {
 							// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-							file_put_contents( $old_file_path, $source_handle, FILE_APPEND );
+							file_put_contents( $temp_file_path, $source_handle, FILE_APPEND );
 							// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 							fclose( $source_handle );
 						}
-						// Delete the new file since its content is now merged into old file.
+
+						// Atomic rename: replaces the "today" file in one operation, no deletion window.
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+						rename( $temp_file_path, $new_file_path );
+
+						// Clean up the old (historical) file.
 						// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
-						unlink( $new_file_path );
+						unlink( $old_file_path );
+					} else {
+						// No merge needed — just rename old file to new filename (with today's date).
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+						rename( $old_file_path, $new_file_path );
 					}
-					// Rename old file to new filename (with today's date).
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
-					rename( $old_file_path, $new_file_path );
 				}
 			}
 		}

--- a/tests/unit/subscriptions/test-class-wc-payments-subscription-migration-log-handler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscription-migration-log-handler.php
@@ -158,6 +158,10 @@ class WC_Payments_Subscription_Migration_Log_Handler_Test extends WCPAY_UnitTest
 		// New file should exist with merged content.
 		$this->assertFileExists( $new_file_path, 'New log file should exist after merge.' );
 
+		// No temp merge files should be left behind after a successful merge.
+		$leftover_temp_files = glob( $log_dir . WC_Payments_Subscription_Migration_Log_Handler::HANDLE . '-merge-*' );
+		$this->assertEmpty( $leftover_temp_files, 'Temp merge files should be cleaned up after merge.' );
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$merged_content = file_get_contents( $new_file_path );
 


### PR DESCRIPTION
## Summary
Fixes WOOPMNT-5962: [Security] Log cleanup unlinks active log file — risk of dropped entries

The merge path in `extend_life_of_migration_file_logs` appended content to the old file, `unlink`'d the "today" file, then `rename`'d — creating a *deletion window* where the active log file was briefly absent and concurrent writes to it would be silently lost.

## Changes
Replaced the unlink-then-rename sequence with a temp-file approach so the active "today" log file is never absent:

1. `tempnam()` a uniquely-named temp file in the log dir (same filesystem, so the final rename is atomic; unique name avoids collisions on overlapping cron runs)
2. `copy()` old (historical) content to the temp file
3. Append "today" file content to the temp file
4. `rename()` the temp file over the target — atomic replacement, no deletion window
5. `unlink()` the old historical file (no longer the active log)

Each step's result is checked: the active file is only replaced and the historical file only deleted when the full merge succeeds. On any failure the temp file is removed and both originals are left untouched, so a partial failure cannot clobber the active log or destroy the only copy of the historical logs.

**Note:** This eliminates the deletion window. A much narrower race remains — writes to the "today" file between the read and the atomic rename are overwritten — but given this runs on the daily `woocommerce_cleanup_logs` cron over migration logs, the probability is very low. See the discussion on the Copilot review thread.

## Testing
- `npm run test:php -- --filter 'WC_Payments_Subscription_Migration_Log_Handler_Test'` → 4/4 pass
- Existing merge test (`test_extend_life_of_migration_file_logs_merges_files_in_chronological_order`) validates chronological order is preserved and now also asserts no temp merge files linger after a merge
- `phpcs` clean on both changed files

## Linear Issue
https://linear.app/a8c/issue/WOOPMNT-5962/security-log-cleanup-unlinks-active-log-file-risk-of-dropped-entries

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)
