### PR TITLE
Fix: Cache React root for WooPay save-user section

### DIFF
--- a/changelog/fix-woopmnt-5951-woopay-react-root-reuse
+++ b/changelog/fix-woopmnt-5951-woopay-react-root-reuse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Cache and reuse React root in WooPay save-user section to prevent multiple roots on the same DOM node.

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -9,6 +9,8 @@ import { createRoot } from 'react-dom/client';
  */
 import CheckoutPageSaveUser from 'wcpay/components/woopay/save-user/checkout-page-save-user';
 
+let blocksCheckoutRoot = null;
+
 const renderSaveUserSection = () => {
 	const saveUserSection = document.getElementsByClassName(
 		'woopay-save-new-user-container'
@@ -49,8 +51,12 @@ const renderSaveUserSection = () => {
 			}
 		}
 
-		const root = createRoot( checkoutPageSaveUserContainer );
-		root.render( <CheckoutPageSaveUser isBlocksCheckout={ true } /> );
+		if ( ! blocksCheckoutRoot ) {
+			blocksCheckoutRoot = createRoot( checkoutPageSaveUserContainer );
+		}
+		blocksCheckoutRoot.render(
+			<CheckoutPageSaveUser isBlocksCheckout={ true } />
+		);
 	} else {
 		const checkoutPageSaveUserContainer = document.createElement( 'div' );
 		checkoutPageSaveUserContainer.className =


### PR DESCRIPTION
## Summary
Fixes WOOPMNT-5951: [Security] React root recreated on WooPay checkout AJAX updates

`renderSaveUserSection` called `createRoot` on the `#remember-me` container every time it ran — on page load AND after every AJAX update. React 18 treats multiple `createRoot` calls on the same DOM node as an error, which could cause the save-user section to stop rendering on blocks checkout.

## Changes
- Added module-level `blocksCheckoutRoot` variable to cache the React root reference
- `createRoot` is only called once; subsequent calls reuse the cached root via `root.render()`
- Classic checkout path was already safe (early return guard on line 19 prevents re-entry)

## Testing
- `npm run test:js -- --testPathPattern="client/checkout/woopay"` → 64/64 pass (10 suites)
- `npm run build:client` → compiles successfully
- Verified checkout page renders with zero console errors in Docker

## Linear Issue
https://linear.app/a8c/issue/WOOPMNT-5951/security-react-root-recreated-on-woopay-checkout-ajax-updates

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)