### PR TITLE
Fix: Distinguish manual deposits from instant payouts

### DIFF
--- a/changelog/fix-woopmnt-3797-manual-deposit-label
+++ b/changelog/fix-woopmnt-3797-manual-deposit-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly distinguish manual deposits from instant payouts by checking for non-zero service fees.

--- a/client/deposits/details/index.tsx
+++ b/client/deposits/details/index.tsx
@@ -43,6 +43,14 @@ import { formatDateTimeFromString } from 'wcpay/utils/date-time';
 import { MaybeShowMerchantFeedbackPrompt } from 'wcpay/merchant-feedback-prompt';
 
 /**
+ * Checks if a deposit is an instant payout (as opposed to a manual deposit).
+ * Both instant and manual deposits have `automatic: false`, but only instant
+ * deposits have a non-zero service fee.
+ */
+const isInstant = ( deposit: CachedDeposit ): boolean =>
+	! deposit.automatic && ( deposit.fee > 0 || deposit.fee_percentage > 0 );
+
+/**
  * Renders the deposit status indicator UI, re-purposing the OrderStatus component from @woocommerce/components.
  */
 const DepositStatusIndicator: React.FC< {
@@ -108,8 +116,10 @@ interface DepositDateItemProps {
 
 const DepositDateItem: React.FC< DepositDateItemProps > = ( { deposit } ) => {
 	let depositDateLabel = __( 'Payout date', 'woocommerce-payments' );
-	if ( ! deposit.automatic ) {
+	if ( isInstant( deposit ) ) {
 		depositDateLabel = __( 'Instant payout date', 'woocommerce-payments' );
+	} else if ( ! deposit.automatic ) {
+		depositDateLabel = __( 'Manual payout date', 'woocommerce-payments' );
 	}
 	if ( deposit.type === 'withdrawal' ) {
 		depositDateLabel = __( 'Withdrawal date', 'woocommerce-payments' );
@@ -161,7 +171,7 @@ export const DepositOverview: React.FC< DepositOverviewProps > = ( {
 					</ul>
 				</Card>
 			) : (
-				<SummaryList // For instant deposits only
+				<SummaryList // For non-automatic (instant or manual) deposits
 					label={
 						isWithdrawal
 							? __(
@@ -311,7 +321,8 @@ export const DepositDetails: React.FC< DepositDetailsProps > = ( {
 } ) => {
 	const { deposit, isLoading } = useDeposit( depositId );
 
-	const isInstantDeposit = ! isLoading && deposit && ! deposit.automatic;
+	const isInstantDeposit =
+		! isLoading && deposit && isInstant( deposit );
 
 	return (
 		<Page>


### PR DESCRIPTION
## Summary
Fixes WOOPMNT-3797: Manual deposits are incorrectly labeled as "Instant" in WooPayments

The code assumed `!deposit.automatic` meant "instant payout", but manual deposits (initiated by support) are also non-automatic. The only distinguishing signal is that instant deposits have a non-zero service fee, while manual deposits have `0` for both `fee` and `fee_percentage`.

## Changes
- Added `isInstant()` helper that checks `fee > 0 || fee_percentage > 0` to distinguish instant from manual
- **Date label:** "Instant payout date" → now shows "Manual payout date" for manual deposits
- **Overview layout:** Updated comment, behavior unchanged (SummaryList used for both instant and manual)
- **Transactions display:** `isInstantDeposit` now correctly identifies only instant payouts, so manual deposits show the full transactions list

## Testing
- `npm run test:js -- --testPathPattern="client/deposits/details"` → 8/8 pass (4 snapshots pass unchanged)
- Existing test mock has `fee: 30, fee_percentage: 1.5` so `automatic: false` correctly renders as instant

## Linear Issue
https://linear.app/a8c/issue/WOOPMNT-3797/deposits-all-manual-deposits-are-labeled-in-as-instant

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)