### PR TITLE
Fix: Capital loans text overflow on mobile viewports

### DIFF
--- a/changelog/fix-woopmnt-5202-capital-loans-text-overflow
+++ b/changelog/fix-woopmnt-5202-capital-loans-text-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix text overflow in Active loan overview table on mobile viewports.

--- a/client/components/active-loan-summary/style.scss
+++ b/client/components/active-loan-summary/style.scss
@@ -23,7 +23,7 @@
 		}
 	}
 
-	@media (max-width: 782px) {
+	@media ( max-width: 782px ) {
 		flex-wrap: wrap;
 	}
 }
@@ -44,6 +44,7 @@
 		color: $gray-600;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	&__value {
@@ -53,6 +54,7 @@
 		padding: 8px 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		white-space: nowrap;
 
 		.is-big {
 			font-size: 20px;
@@ -60,7 +62,7 @@
 		}
 	}
 
-	@media (max-width: 782px) {
+	@media ( max-width: 782px ) {
 		min-width: 50%;
 
 		& + & {

--- a/client/components/active-loan-summary/style.scss
+++ b/client/components/active-loan-summary/style.scss
@@ -22,11 +22,17 @@
 			padding-bottom: 0;
 		}
 	}
+
+	@media (max-width: 782px) {
+		flex-wrap: wrap;
+	}
 }
 
 .wcpay-loan-summary-block {
 	padding: 24px 16px;
 	margin-right: 0;
+	min-width: 0;
+	overflow: hidden;
 
 	& + & {
 		border-left: 1px solid $gray-200;
@@ -36,6 +42,8 @@
 		font-size: 12px;
 		line-height: 16px;
 		color: $gray-600;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	&__value {
@@ -43,10 +51,20 @@
 		font-size: 13px;
 		line-height: 20px;
 		padding: 8px 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
 
 		.is-big {
 			font-size: 20px;
 			line-height: 27px;
+		}
+	}
+
+	@media (max-width: 782px) {
+		min-width: 50%;
+
+		& + & {
+			border-left: none;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Fixes WOOPMNT-5202: [Capital Loans] Text overflows in 'Active loan overview' table in responsive view

The Active loan overview table has a Flex row with 5 blocks that don't wrap on narrow viewports, causing text to overflow its container.

## Changes
CSS-only fix in `client/components/active-loan-summary/style.scss`:
- `flex-wrap: wrap` on rows at ≤782px so blocks stack on mobile
- `min-width: 0` + `overflow: hidden` on blocks to prevent content overflow
- `text-overflow: ellipsis` on title and value elements for graceful truncation
- Removed left border between blocks on mobile for cleaner stacked layout
- Blocks take `min-width: 50%` on mobile so they form a 2-column grid

## Testing
- `npm run test:js -- --testPathPattern="client/components/active-loan-summary"` → 2/2 pass
- `npm run build:client` → compiles successfully
- Note: Visual testing of the Capital page requires a connected Stripe account with loan data

## Linear Issue
https://linear.app/a8c/issue/WOOPMNT-5202/capital-loans-text-overflows-in-active-loan-overview-table-in

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)