### PR TITLE
Fix: Remove help icon from deposits loading skeleton

### DIFF
--- a/changelog/fix-woopmnt-4387-deposits-loading-state
+++ b/changelog/fix-woopmnt-4387-deposits-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix help icon showing through loading skeleton in Deposits overview card.

--- a/client/components/deposits-overview/index.tsx
+++ b/client/components/deposits-overview/index.tsx
@@ -103,16 +103,7 @@ const DepositsOverview: React.FC = () => {
 				<CardBody className="wcpay-deposits-overview__schedule__container">
 					<Loadable
 						isLoading
-						placeholder={
-							<DepositSchedule
-								depositsSchedule={ {
-									delay_days: 0,
-									interval: 'daily',
-									monthly_anchor: 1,
-									weekly_anchor: 'monday',
-								} }
-							/>
-						}
+						placeholder="Available funds are automatically dispatched every day."
 					/>
 				</CardBody>
 			</Card>


### PR DESCRIPTION
## Summary
Fixes WOOPMNT-4387: Deposits card on payments overview screen looks weird in loading state

The loading state rendered a full `DepositSchedule` component (including its `ClickTooltip` help icon) inside a `Loadable` placeholder. The help icon showed through the skeleton animation, looking broken.

## Changes
Replaced the `DepositSchedule` component placeholder with a plain text string. The skeleton animation now renders cleanly without interactive elements bleeding through.

**Before:** `<DepositSchedule depositsSchedule={...} />` as placeholder (renders help icon)
**After:** `"Available funds are automatically dispatched every day."` as placeholder (clean skeleton)

## Testing
- `npm run test:js -- --testPathPattern="client/components/deposits-overview"` → 24/24 pass (3 snapshots pass)
- Note: Visual testing of the overview page requires a connected Stripe account

## Linear Issue
https://linear.app/a8c/issue/WOOPMNT-4387/deposits-card-on-payments-overview-screen-looks-weird-in-loading-state

---
Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)