### PR TITLE
Add fonts.wp.com to font domain allow list for Stripe PE, WooPay, and admin preview

### DIFF
--- a/changelog/add-woopmnt-6048-fonts-wp-com-allowlist
+++ b/changelog/add-woopmnt-6048-fonts-wp-com-allowlist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add fonts.wp.com to the WooPay font domain allow list so merchants using Automattic's GDPR-compliant font proxy see their theme fonts in WooPay checkout.

--- a/client/checkout/upe-styles/__tests__/index.test.js
+++ b/client/checkout/upe-styles/__tests__/index.test.js
@@ -85,7 +85,7 @@ describe( 'Getting styles for automated theming', () => {
 
 	test( 'getFontRulesFromPage returns font rules from allowed font providers', () => {
 		const mockStyleSheets = {
-			length: 4,
+			length: 5,
 			0: {
 				href:
 					'https://not-supported-fonts-domain.com/style.css?ver=1.1.1',
@@ -98,6 +98,9 @@ describe( 'Getting styles for automated theming', () => {
 			},
 			3: {
 				href: 'https://fonts.bunny.net/css?family=Inter:400,700',
+			},
+			4: {
+				href: 'https://fonts.wp.com/css?family=Open+Sans:400,700',
 			},
 		};
 		jest.spyOn( document, 'styleSheets', 'get' ).mockReturnValue(
@@ -112,6 +115,9 @@ describe( 'Getting styles for automated theming', () => {
 					'https://fonts.googleapis.com/css?family=Source+Sans+Pro%3A400%2C300%2C300italic%2C400italic%2C600%2C700%2C900&subset=latin%2Clatin-ext&ver=3.6.0',
 			},
 			{ cssSrc: 'https://fonts.bunny.net/css?family=Inter:400,700' },
+			{
+				cssSrc: 'https://fonts.wp.com/css?family=Open+Sans:400,700',
+			},
 		] );
 	} );
 

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -607,6 +607,7 @@ export const getFontRulesFromPage = ( scope = document ) => {
 			'fonts.gstatic.com',
 			'use.typekit.net',
 			'fonts.bunny.net',
+			'fonts.wp.com',
 		];
 	for ( let i = 0; i < sheets.length; i++ ) {
 		if ( ! sheets[ i ].href ) {

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -351,6 +351,7 @@ const ALLOWED_FONT_DOMAINS = [
 	'fonts.gstatic.com',
 	'use.typekit.net',
 	'fonts.bunny.net',
+	'fonts.wp.com',
 ];
 
 export default ( {

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -32,6 +32,7 @@ class WC_Payments_Styles_Cache {
 		'fonts.gstatic.com',
 		'use.typekit.net',
 		'fonts.bunny.net',
+		'fonts.wp.com',
 	];
 
 	/**

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -323,6 +323,7 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		// phpcs:disable WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Test fixtures for CDN font stylesheets.
 		wp_register_style( 'test-google-font', 'https://fonts.googleapis.com/css?family=Roboto', [], null );
 		wp_register_style( 'test-bunny-font', 'https://fonts.bunny.net/css?family=Inter', [], null );
+		wp_register_style( 'test-wp-font', 'https://fonts.wp.com/css?family=Open+Sans', [], null );
 		// phpcs:enable WordPress.WP.EnqueuedResourceParameters.MissingVersion
 
 		try {
@@ -331,9 +332,11 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 			$sources = array_column( $result, 'cssSrc' );
 			$this->assertContains( 'https://fonts.googleapis.com/css?family=Roboto', $sources );
 			$this->assertContains( 'https://fonts.bunny.net/css?family=Inter', $sources );
+			$this->assertContains( 'https://fonts.wp.com/css?family=Open+Sans', $sources );
 		} finally {
 			wp_deregister_style( 'test-google-font' );
 			wp_deregister_style( 'test-bunny-font' );
+			wp_deregister_style( 'test-wp-font' );
 		}
 	}
 


### PR DESCRIPTION
## Description

Add `fonts.wp.com` to the font domain allow list so merchants using Automattic's GDPR-compliant font proxy see their theme fonts across the Stripe Payment Element, WooPay checkout, and the merchant admin preview.

`fonts.wp.com` is owned by Automattic and serves Google Fonts via a privacy-respecting proxy. It is used by WordPress.com sites and Jetpack-connected sites. Without this change, fonts from `fonts.wp.com` are silently dropped — the Stripe PE iframe renders with fallback fonts, WooPay checkout ignores the merchant's typography, and the admin preview doesn't load the fonts.

Fixes WOOPMNT-6048

## Changes proposed in this Pull Request

- Add `fonts.wp.com` to the PHP `ALLOWED_FONT_DOMAINS` constant in `WC_Payments_Styles_Cache` (used by server-side font extraction and client-submitted font rule sanitization)
- Add `fonts.wp.com` to the JS allow list in `woopay-preview.js` (merchant admin preview)
- Add `fonts.wp.com` to the JS `fontDomains` array in `upe-styles/index.js` (checkout DOM extraction → passed to `stripe.elements({ fonts })`)
- Update PHPUnit and Jest tests with `fonts.wp.com` fixtures

## Testing instructions

1. On a WordPress site using Jetpack or WordPress.com fonts (served from `fonts.wp.com`), enable WooPayments
2. Go to the checkout page — verify the Stripe Payment Element renders with the site's theme font (not a fallback)
3. If WooPay is enabled, go to **WooCommerce → Settings → Payments → WooPayments → Express Checkout** — verify the WooPay preview renders the site's theme font correctly
4. Place a test order through WooPay checkout and verify the font appears

## Pre-review checklist

- [x] Added changelog entry
- [x] Added/updated tests

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
☢️ Powered by [Gamma AI Tools](https://github.a8c.com/Automattic/gamma-ai-tools/)