### PR TITLE
Fix WooPay header/footer colors to use checkout template parts

### DIFF
--- a/changelog/fix-woopmnt-6050
+++ b/changelog/fix-woopmnt-6050
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay header and footer colors to match the checkout page instead of the site-wide header.

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -252,6 +252,8 @@
 			&__woopay-logo {
 				display: flex;
 				align-items: center;
+				height: 0.375rem;
+				width: auto;
 
 				svg {
 					height: 0.375rem;

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -437,17 +437,19 @@
 
 			&__footer {
 				background-color: $studio-white;
-				height: 24px;
-				padding: 0 3.797%;
+				min-height: 24px;
+				padding: 0.125rem 3.797%;
 				border-radius: 0 0 $grid-unit-05 $grid-unit-05;
 				box-shadow: 0 -1px 0 $studio-gray-5;
 				display: flex;
+				flex-wrap: wrap;
 				justify-content: space-between;
 				align-items: center;
 			}
 
 			&__footer-links {
 				display: flex;
+				flex-wrap: wrap;
 				align-items: center;
 				gap: 0.125rem;
 				font-size: 0.25rem;

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -437,19 +437,17 @@
 
 			&__footer {
 				background-color: $studio-white;
-				min-height: 24px;
-				padding: 0.125rem 3.797%;
+				height: 24px;
+				padding: 0 3.797%;
 				border-radius: 0 0 $grid-unit-05 $grid-unit-05;
 				box-shadow: 0 -1px 0 $studio-gray-5;
 				display: flex;
-				flex-wrap: wrap;
 				justify-content: space-between;
 				align-items: center;
 			}
 
 			&__footer-links {
 				display: flex;
-				flex-wrap: wrap;
 				align-items: center;
 				gap: 0.125rem;
 				font-size: 0.25rem;

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -194,10 +194,13 @@ class WC_Payments_Styles_Cache {
 		// Extract button font family.
 		$button_font_family = self::resolve_style_value( $styles['elements']['button']['typography']['fontFamily'] ?? $font_family, $font_family, $styles );
 
-		// Extract header/footer colors. First try the actual header template
-		// part block attributes, then fall back to template part default styles.
-		$header_colors     = self::get_template_part_colors( 'header' );
-		$footer_colors     = self::get_template_part_colors( 'footer' );
+		// Extract header/footer colors from the checkout page template's parts,
+		// not the global site header/footer. Falls back to global parts if
+		// no checkout-specific template exists.
+		$header_slug       = self::get_checkout_template_part_slug( 'header' ) ?? 'header';
+		$header_colors     = self::get_template_part_colors( $header_slug );
+		$footer_slug       = self::get_checkout_template_part_slug( 'footer' );
+		$footer_colors     = $footer_slug ? self::get_template_part_colors( $footer_slug ) : [];
 		$header_bg_color   = $header_colors['background'] ?? self::resolve_style_value( $tp_styles['color']['background'] ?? $bg_color, $bg_color, $tp_styles );
 		$header_text_color = $header_colors['text'] ?? self::resolve_style_value( $tp_styles['color']['text'] ?? $text_color, $text_color, $tp_styles );
 
@@ -621,7 +624,14 @@ class WC_Payments_Styles_Cache {
 	 * @return array Associative array with 'background' and/or 'text' keys, or empty.
 	 */
 	private static function get_template_part_colors( string $slug ): array {
+		// Try active theme first.
 		$template = get_block_template( get_stylesheet() . '//' . $slug, 'wp_template_part' );
+
+		// Fall back to WooCommerce-provided template parts (e.g. checkout-header).
+		if ( ( ! $template || empty( $template->content ) ) && 'woocommerce/woocommerce' !== get_stylesheet() ) {
+			$template = get_block_template( 'woocommerce/woocommerce//' . $slug, 'wp_template_part' );
+		}
+
 		if ( ! $template || empty( $template->content ) ) {
 			return [];
 		}
@@ -751,5 +761,58 @@ class WC_Payments_Styles_Cache {
 		$parts .= time();
 
 		return md5( $parts );
+	}
+
+	/**
+	 * Resolves the template part slug used by the checkout page template for a given area.
+	 *
+	 * Parses the checkout page block template to find which template part it references
+	 * for the specified area (header or footer). Returns null if the checkout template
+	 * has no template part for that area (e.g., WooCommerce checkout has no footer).
+	 *
+	 * @param string $area The template part area: 'header' or 'footer'.
+	 * @return string|null The template part slug, or null if not found.
+	 */
+	private static function get_checkout_template_part_slug( string $area ): ?string {
+		// Try the active theme's checkout template first, then WooCommerce's.
+		$template = get_block_template( get_stylesheet() . '//page-checkout', 'wp_template' );
+		if ( ! $template || empty( $template->content ) ) {
+			$template = get_block_template( 'woocommerce/woocommerce//page-checkout', 'wp_template' );
+		}
+
+		if ( ! $template || empty( $template->content ) ) {
+			return $area; // Fall back to global slug.
+		}
+
+		return self::find_template_part_slug_by_area( parse_blocks( $template->content ), $area );
+	}
+
+	/**
+	 * Recursively searches parsed blocks for a wp:template-part block
+	 * matching the given area (via tagName or area attribute).
+	 *
+	 * @param array  $blocks Parsed blocks.
+	 * @param string $area   The area to match: 'header' or 'footer'.
+	 * @return string|null The template part slug, or null.
+	 */
+	private static function find_template_part_slug_by_area( array $blocks, string $area ): ?string {
+		foreach ( $blocks as $block ) {
+			if ( 'core/template-part' === ( $block['blockName'] ?? '' ) ) {
+				$attrs = $block['attrs'] ?? [];
+				if (
+					( $attrs['tagName'] ?? '' ) === $area ||
+					( $attrs['area'] ?? '' ) === $area
+				) {
+					return $attrs['slug'] ?? null;
+				}
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = self::find_template_part_slug_by_area( $block['innerBlocks'], $area );
+				if ( $found ) {
+					return $found;
+				}
+			}
+		}
+		return null;
 	}
 }

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -806,7 +806,9 @@ class WC_Payments_Styles_Cache {
 
 	/**
 	 * Recursively searches parsed blocks for a wp:template-part block
-	 * matching the given area (via tagName or area attribute).
+	 * matching the given area. Checks tagName, area attribute, and falls
+	 * back to slug matching (WordPress omits tagName/area when they match
+	 * the registered template part's default area).
 	 *
 	 * @param array  $blocks Parsed blocks.
 	 * @param string $area   The area to match: 'header' or 'footer'.
@@ -816,11 +818,13 @@ class WC_Payments_Styles_Cache {
 		foreach ( $blocks as $block ) {
 			if ( 'core/template-part' === ( $block['blockName'] ?? '' ) ) {
 				$attrs = $block['attrs'] ?? [];
+				$slug  = $attrs['slug'] ?? '';
 				if (
 					( $attrs['tagName'] ?? '' ) === $area ||
-					( $attrs['area'] ?? '' ) === $area
+					( $attrs['area'] ?? '' ) === $area ||
+					$slug === $area
 				) {
-					return $attrs['slug'] ?? null;
+					return '' !== $slug ? $slug : null;
 				}
 			}
 			if ( ! empty( $block['innerBlocks'] ) ) {

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -197,9 +197,10 @@ class WC_Payments_Styles_Cache {
 		// Extract header/footer colors from the checkout page template's parts,
 		// not the global site header/footer. Falls back to global parts if
 		// no checkout-specific template exists.
-		$header_slug       = self::get_checkout_template_part_slug( 'header' ) ?? 'header';
+		$checkout_slugs    = self::get_checkout_template_part_slugs();
+		$header_slug       = $checkout_slugs['header'] ?? 'header';
 		$header_colors     = self::get_template_part_colors( $header_slug );
-		$footer_slug       = self::get_checkout_template_part_slug( 'footer' );
+		$footer_slug       = $checkout_slugs['footer'] ?? null;
 		$footer_colors     = $footer_slug ? self::get_template_part_colors( $footer_slug ) : [];
 		$header_bg_color   = $header_colors['background'] ?? self::resolve_style_value( $tp_styles['color']['background'] ?? $bg_color, $bg_color, $tp_styles );
 		$header_text_color = $header_colors['text'] ?? self::resolve_style_value( $tp_styles['color']['text'] ?? $text_color, $text_color, $tp_styles );
@@ -764,16 +765,15 @@ class WC_Payments_Styles_Cache {
 	}
 
 	/**
-	 * Resolves the template part slug used by the checkout page template for a given area.
+	 * Resolves the template part slugs used by the checkout page template.
 	 *
-	 * Parses the checkout page block template to find which template part it references
-	 * for the specified area (header or footer). Returns null if the checkout template
-	 * has no template part for that area (e.g., WooCommerce checkout has no footer).
+	 * Fetches and parses the checkout page block template once, then extracts
+	 * the header and footer template part slugs. Returns null for an area if
+	 * the checkout template has no template part for it (e.g., no footer).
 	 *
-	 * @param string $area The template part area: 'header' or 'footer'.
-	 * @return string|null The template part slug, or null if not found.
+	 * @return array{header: string|null, footer: string|null}
 	 */
-	private static function get_checkout_template_part_slug( string $area ): ?string {
+	private static function get_checkout_template_part_slugs(): array {
 		// Try the active theme's checkout template first, then WooCommerce's.
 		$template = get_block_template( get_stylesheet() . '//page-checkout', 'wp_template' );
 		if ( ! $template || empty( $template->content ) ) {
@@ -781,10 +781,18 @@ class WC_Payments_Styles_Cache {
 		}
 
 		if ( ! $template || empty( $template->content ) ) {
-			return $area; // Fall back to global slug.
+			return [
+				'header' => null,
+				'footer' => null,
+			];
 		}
 
-		return self::find_template_part_slug_by_area( parse_blocks( $template->content ), $area );
+		$blocks = parse_blocks( $template->content );
+
+		return [
+			'header' => self::find_template_part_slug_by_area( $blocks, 'header' ),
+			'footer' => self::find_template_part_slug_by_area( $blocks, 'footer' ),
+		];
 	}
 
 	/**

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -197,9 +197,18 @@ class WC_Payments_Styles_Cache {
 		// Extract header/footer colors from the checkout page template's parts,
 		// not the global site header/footer. Falls back to global parts if
 		// no checkout-specific template exists.
-		$checkout_slugs    = self::get_checkout_template_part_slugs();
-		$header_slug       = $checkout_slugs['header'] ?? 'header';
-		$header_colors     = self::get_template_part_colors( $header_slug );
+		$checkout_slugs = self::get_checkout_template_part_slugs();
+		$header_slug    = $checkout_slugs['header'] ?? 'header';
+		$header_colors  = self::get_template_part_colors( $header_slug );
+		// WooCommerce's checkout template deliberately omits a footer — the
+		// checkout flow is distraction-free. When no footer template part is
+		// found, $footer_colors stays empty and the .Footer rule falls back
+		// to page-level colors ($bg_color, $text_color, $link_color). This
+		// keeps WooPay's functional footer (policy links, guest checkout,
+		// accepted cards) visually blended with the checkout page rather than
+		// introducing a distinct branded band that competes with the CTA.
+		// If WooCommerce adds a footer template part to checkout in the
+		// future, it will be picked up automatically here.
 		$footer_slug       = $checkout_slugs['footer'] ?? null;
 		$footer_colors     = $footer_slug ? self::get_template_part_colors( $footer_slug ) : [];
 		$header_bg_color   = $header_colors['background'] ?? self::resolve_style_value( $tp_styles['color']['background'] ?? $bg_color, $bg_color, $tp_styles );

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -425,6 +425,21 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		$this->assertNull( $result );
 	}
 
+	public function test_find_template_part_slug_by_area_finds_nested_template_part() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'find_template_part_slug_by_area' );
+		$method->setAccessible( true );
+
+		// Template part nested inside a wrapper group block.
+		$blocks = parse_blocks(
+			'<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:template-part {"slug":"nested-header","tagName":"header"} /-->'
+			. '</div><!-- /wp:group -->'
+		);
+
+		$result = $method->invoke( null, $blocks, 'header' );
+		$this->assertSame( 'nested-header', $result );
+	}
+
 	public function test_find_template_part_slug_by_area_matches_area_attribute() {
 		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'find_template_part_slug_by_area' );
 		$method->setAccessible( true );

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -440,6 +440,20 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'nested-header', $result );
 	}
 
+	public function test_find_template_part_slug_by_area_matches_slug_as_area() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'find_template_part_slug_by_area' );
+		$method->setAccessible( true );
+
+		// WordPress omits tagName/area when they match the template part's
+		// registered default. The slug itself serves as the area identifier.
+		$blocks = parse_blocks(
+			'<!-- wp:template-part {"slug":"footer","theme":"twentytwentyfive"} /-->'
+		);
+
+		$result = $method->invoke( null, $blocks, 'footer' );
+		$this->assertSame( 'footer', $result );
+	}
+
 	public function test_find_template_part_slug_by_area_matches_area_attribute() {
 		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'find_template_part_slug_by_area' );
 		$method->setAccessible( true );

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -397,6 +397,47 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_find_template_part_slug_by_area_finds_header() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'find_template_part_slug_by_area' );
+		$method->setAccessible( true );
+
+		// Simulates WooCommerce's page-checkout.html block content.
+		$blocks = parse_blocks(
+			'<!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce","tagName":"header"} /-->'
+			. '<!-- wp:group {"tagName":"main"} --><main class="wp-block-group"><!-- wp:post-content /--></main><!-- /wp:group -->'
+		);
+
+		$result = $method->invoke( null, $blocks, 'header' );
+		$this->assertSame( 'checkout-header', $result );
+	}
+
+	public function test_find_template_part_slug_by_area_returns_null_when_area_absent() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'find_template_part_slug_by_area' );
+		$method->setAccessible( true );
+
+		// Template with header but no footer.
+		$blocks = parse_blocks(
+			'<!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce","tagName":"header"} /-->'
+			. '<!-- wp:group {"tagName":"main"} --><main class="wp-block-group"><!-- wp:post-content /--></main><!-- /wp:group -->'
+		);
+
+		$result = $method->invoke( null, $blocks, 'footer' );
+		$this->assertNull( $result );
+	}
+
+	public function test_find_template_part_slug_by_area_matches_area_attribute() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'find_template_part_slug_by_area' );
+		$method->setAccessible( true );
+
+		// Some templates use "area" instead of "tagName".
+		$blocks = parse_blocks(
+			'<!-- wp:template-part {"slug":"custom-footer","area":"footer"} /-->'
+		);
+
+		$result = $method->invoke( null, $blocks, 'footer' );
+		$this->assertSame( 'custom-footer', $result );
+	}
+
 	public function test_resolve_style_value_returns_string_as_is() {
 		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'resolve_style_value' );
 		$method->setAccessible( true );


### PR DESCRIPTION
## Description

WooPay header colors (`.Header` appearance rule) were always extracted from the **global site header** template part. But WooCommerce's checkout page uses a different header — `checkout-header` — which is a simplified header (site title only, no nav/logo) that may have different colors.

If a merchant customizes their checkout header to have different colors, WooPay ignored it and rendered the site-wide header colors. Checkout and WooPay should look identical.

The same issue applied to footers — WooCommerce's checkout template deliberately omits the footer, but the code always loaded the global footer colors. When no checkout footer exists, WooPay's functional footer (policy links, guest checkout, accepted cards) now uses page-level colors to blend with the checkout rather than introducing a distinct branded band. If a merchant adds a footer template part to checkout via the Site Editor, it will be picked up automatically.

Also fixes the WooPay preview logo rendering at full intrinsic size on some themes due to a CSS selector mismatch (`svg` vs `img`).

Fixes WOOPMNT-6050

### Known limitation: block patterns and style variations (WOOPMNT-6051)

Template part color extraction only reads inline block attributes (`backgroundColor`, `textColor`, `style.color.*`). It does not resolve:

1. **`core/pattern` references** — template parts that contain `<!-- wp:pattern {"slug":"theme/footer"} -->` instead of inline blocks. The pattern content is not expanded before parsing, so color extraction finds nothing.
2. **Block style variations** — themes that use CSS class-based color schemes like `is-style-section-1` (common in WordPress.com themes like `assembler-wpcom`). These map to colors in `wp_get_global_styles()` but the extraction code doesn't look them up.

This is a pre-existing limitation that affects both header and footer extraction and will be addressed in WOOPMNT-6051.

## Changes proposed in this Pull Request

### Checkout template part resolution
- Add `get_checkout_template_part_slugs()` to resolve which template parts the checkout page template actually references (e.g., `checkout-header` instead of `header`)
- Update `compute_woopay_appearance_from_theme()` to use checkout-specific header/footer slugs instead of hardcoded `'header'`/`'footer'`
- Update `get_template_part_colors()` to fall back to WooCommerce-provided template parts (since `checkout-header` is registered by WooCommerce, not the active theme)
- Match template parts by slug when `tagName`/`area` attributes are absent (WordPress omits these when they match the registered default)

### WooPay preview logo fix
- Apply `height: 0.375rem` directly on `.preview-layout__woopay-logo` element — the logo is imported as a URL (`?asset`) so it renders as `<img>`, but the CSS only targeted child `svg` elements

### Tests
- 5 PHPUnit tests for template part slug resolution (tagName match, area match, slug match, nested blocks, null when absent)

**Note:** Only the server-side (block theme) path is affected for header colors. The client-side DOM extraction already runs on the checkout page and picks up the correct header.

## Testing instructions

### Header colors
1. Use a block theme (e.g., Twenty Twenty-Five)
2. In the Site Editor, customize the **checkout header** template part with a distinct background color (e.g., dark blue)
3. Keep the global **site header** a different color (e.g., white)
4. Go to WooCommerce → Settings → Payments → WooPayments → Express Checkout
5. Verify the WooPay preview shows the **checkout header** color (dark blue), not the site header color (white)

### Footer colors
6. Verify the WooPay preview footer blends with the checkout page background (no distinct footer band)
7. Optionally: add a footer template part to the checkout template in the Site Editor and verify it gets picked up

### Logo fix
8. On a theme where the WooPay preview logo was oversized (e.g., Aether), verify it now renders at the correct small size

## Pre-review checklist

- [x] Added changelog entry
- [x] Added/updated tests
- [x] PHP lint passes
- [x] JS/CSS lint passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
☢️ Powered by [Gamma AI Tools](https://github.a8c.com/Automattic/gamma-ai-tools/)

In testing, Checkout Blocks correctly does not pull in site header styles only checkout header styles if present. Otherwise, it falls back to main checkout styles. Correctly does not pull in site footer styles. Attempts to pull footer styles but checkout doesn't have a footer template part. If it does in the future (unlikely) it will be automatically supported.  https://github.com/Automattic/woocommerce-payments/pull/11542 addresses a gap in color extraction from themes like Assembler.

<img width="820" height="407" alt="image" src="https://github.com/user-attachments/assets/698d5dfe-e323-4364-9b7b-a93150dfa599" />

<img width="822" height="397" alt="image" src="https://github.com/user-attachments/assets/ef1821d7-51da-4ac9-b4f8-e0e600202b3a" />

Shortcode - Unaffected by changes. 

<img width="807" height="387" alt="image" src="https://github.com/user-attachments/assets/7dd1e481-8701-4b37-95b1-f1b308396d8b" />

