### PR TITLE
Fix WooPay preview footer card sizing and column alignment

### DIFF
--- a/changelog/fix-woopmnt-6052
+++ b/changelog/fix-woopmnt-6052
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay admin preview footer card logo sizing and layout at narrow widths.

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -435,21 +435,34 @@
 
 			&__footer {
 				background-color: $studio-white;
-				min-height: 24px;
-				padding: 0.125rem 3.797%;
 				border-radius: 0 0 $grid-unit-05 $grid-unit-05;
 				box-shadow: 0 -1px 0 $studio-gray-5;
+				padding: 0.1875rem 0;
+			}
+
+			// Mirrors columns-container layout so footer content aligns
+			// with the column edges.
+			&__footer-inner {
+				padding: 0 3.797%;
 				display: flex;
-				flex-wrap: wrap;
 				justify-content: center;
 				align-items: center;
-				gap: 0.125rem;
+				gap: 28px;
+
+				.preview-layout__footer-links {
+					width: 59.08%;
+					max-width: 242px;
+				}
+
+				.preview-layout__footer-cards {
+					width: 35.59%;
+					max-width: 146px;
+					justify-content: flex-end;
+				}
 			}
 
 			&__footer-links {
 				display: flex;
-				flex-wrap: wrap;
-				justify-content: center;
 				align-items: center;
 				gap: 0.125rem;
 				font-size: 0.25rem;

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -435,17 +435,21 @@
 
 			&__footer {
 				background-color: $studio-white;
-				height: 24px;
-				padding: 0 3.797%;
+				min-height: 24px;
+				padding: 0.125rem 3.797%;
 				border-radius: 0 0 $grid-unit-05 $grid-unit-05;
 				box-shadow: 0 -1px 0 $studio-gray-5;
 				display: flex;
-				justify-content: space-between;
+				flex-wrap: wrap;
+				justify-content: center;
 				align-items: center;
+				gap: 0.125rem;
 			}
 
 			&__footer-links {
 				display: flex;
+				flex-wrap: wrap;
+				justify-content: center;
 				align-items: center;
 				gap: 0.125rem;
 				font-size: 0.25rem;
@@ -466,6 +470,8 @@
 				display: flex;
 				align-items: center;
 				flex-shrink: 0;
+				height: 0.5rem;
+				width: auto;
 
 				svg {
 					height: 0.5rem;

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -444,6 +444,11 @@ export default ( {
 		<div
 			className="preview-layout"
 			style={ { ...style, ...themed.root } }
+			role="img"
+			aria-label={ __(
+				'WooPay checkout preview',
+				'woocommerce-payments'
+			) }
 			{ ...restProps }
 		>
 			{

--- a/client/settings/express-checkout-settings/woopay-preview.js
+++ b/client/settings/express-checkout-settings/woopay-preview.js
@@ -261,21 +261,23 @@ const PaymentCardIcons = () => {
 const PreviewFooter = ( { themedStyle, guestTextStyle } ) => {
 	return (
 		<div className="preview-layout__footer" style={ themedStyle }>
-			<div className="preview-layout__footer-links">
-				<span
-					className="preview-layout__footer-guest-text"
-					style={ guestTextStyle }
-				>
-					Checkout as guest
-				</span>
-				<span className="preview-layout__footer-dot">•</span>
-				<span>Terms of use</span>
-				<span className="preview-layout__footer-dot">•</span>
-				<span>Privacy policy</span>
-				<span className="preview-layout__footer-dot">•</span>
-				<span>Help</span>
+			<div className="preview-layout__footer-inner">
+				<div className="preview-layout__footer-links">
+					<span
+						className="preview-layout__footer-guest-text"
+						style={ guestTextStyle }
+					>
+						Checkout as guest
+					</span>
+					<span className="preview-layout__footer-dot">•</span>
+					<span>Terms of use</span>
+					<span className="preview-layout__footer-dot">•</span>
+					<span>Privacy policy</span>
+					<span className="preview-layout__footer-dot">•</span>
+					<span>Help</span>
+				</div>
+				<PaymentCardIcons />
 			</div>
-			<PaymentCardIcons />
 		</div>
 	);
 };


### PR DESCRIPTION
## Description

The WooPay admin preview footer had two visual fidelity issues compared to the real WooPay checkout:

1. **Card logos oversized** — `PaymentCardIcons` renders as `<img>` but the CSS targeted child `svg` elements for sizing. The `<img>` got no height constraint and rendered at full intrinsic dimensions.

2. **Footer content misaligned with checkout columns** — The footer links and card icons didn't align with the left/right column edges of the checkout layout above.

Fixes WOOPMNT-6052

## Changes proposed in this Pull Request

- Apply `height: 0.5rem` directly on `&__footer-cards` element (same `svg` vs `img` mismatch pattern as the logo fix in PR #11542)
- Add `footer-inner` container that mirrors the `columns-container` layout (same `padding: 0 3.797%`, `justify-content: center`, `gap: 28px`) so footer content aligns with the column edges
- Footer links constrained to left column width (59.08%, max 242px), card icons to right column width (35.59%, max 146px)

## Testing instructions

1. Go to WooCommerce → Settings → Payments → WooPayments → Express Checkout
2. Verify card logos in the preview footer are correctly sized (small, matching the preview scale)
3. Verify footer links align with the left edge of the left column and card icons align with the right edge of the right column

## Pre-review checklist

- [x] Added changelog entry
- [x] CSS lint passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
☢️ Powered by [Gamma AI Tools](https://github.a8c.com/Automattic/gamma-ai-tools/)


**Footer more aligned with WooPay checkout.**

<img width="803" height="441" alt="image" src="https://github.com/user-attachments/assets/87c45f6c-2b08-413f-8992-694903b51918" />
