### PR TITLE
Fix test card copy button font mismatch on themed checkouts

### DIFF
--- a/changelog/agent-gh-11515
+++ b/changelog/agent-gh-11515
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix test card copy button using wrong font on themes with button font overrides

--- a/client/checkout/style.scss
+++ b/client/checkout/style.scss
@@ -13,7 +13,8 @@
 	display: inline-flex;
 	cursor: pointer;
 	color: inherit !important;
-	font-size: initial;
+	font-family: inherit !important;
+	font-size: inherit;
 	padding: 2px 1px !important;
 	align-items: center;
 	box-shadow: none !important;


### PR DESCRIPTION
Fixes #11515

#### Changes proposed in this Pull Request

On themes like Storefront that set an explicit `font-family` on all `button` elements, the test card copy button (`.js-woopayments-copy-test-number`) renders in a different font than the surrounding "Test mode:" text.

The existing selector already overrides `color`, `background`, `border`, `padding`, and `box-shadow` with `!important` to make the button look inline with text, but was missing `font-family`. Additionally, `font-size: initial` resets to the browser default rather than inheriting from the parent.

**Changes:**
- Add `font-family: inherit !important` to match the existing override pattern
- Change `font-size: initial` → `font-size: inherit`

This is the same fix applied to WooCommerce Gateway Stripe in woocommerce/woocommerce-gateway-stripe#5125.

#### Testing instructions

1. Activate the **Storefront** theme (or any theme that sets `font-family` on `button` elements)
2. Enable **test mode** in WooPayments settings
3. Go to the checkout page (blocks or classic)
4. Observe the test card number (`4242 4242 4242 4242`) in the test mode notice
5. **Expected:** The card number text matches the font of the surrounding instruction text
6. **Before fix:** The card number renders in Storefront's button font (Source Sans Pro) instead of the paragraph font

---

- [x] Run `npm run changelog` to add a changelog file
- [x] Covered with tests (or have a good reason not to test in description ☝️) — Pure CSS change, no testable logic
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
☢️ Powered by [Gamma AI Tools](https://github.a8c.com/Automattic/gamma-ai-tools/)

## Before
<img width="776" height="355" alt="image" src="https://github.com/user-attachments/assets/c1a99ec0-2f99-4341-9ed2-16ced5f3ede1" />

## After
<img width="784" height="366" alt="image" src="https://github.com/user-attachments/assets/8ab0210d-1b64-4f24-88cf-81b8052c7aea" />
