### PR TITLE
fix: prevent express checkout scripts loading when no methods are available

### DIFF
--- a/changelog/fix-woopmnt-6046-express-checkout-scripts-loading
+++ b/changelog/fix-woopmnt-6046-express-checkout-scripts-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent unnecessary Stripe JS and express checkout scripts from loading when no express checkout methods are actually available

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -525,18 +525,9 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			return false;
 		}
 
-		// Product page, but no express checkout methods available in settings.
-		if ( $this->is_product() && ! $this->is_any_express_checkout_method_enabled_at( 'product' ) ) {
-			return false;
-		}
-
-		// Checkout page, but no express checkout methods available in settings.
-		if ( $this->is_checkout() && ! $this->is_any_express_checkout_method_enabled_at( 'checkout' ) ) {
-			return false;
-		}
-
-		// Cart page, but no express checkout methods available in settings.
-		if ( $this->is_cart() && ! $this->is_any_express_checkout_method_enabled_at( 'cart' ) ) {
+		// No express checkout methods are actually enabled for the current page context
+		// (checks both location settings and feature flags/availability).
+		if ( empty( $this->get_enabled_express_checkout_methods_for_context() ) ) {
 			return false;
 		}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -319,29 +319,6 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	}
 
 	/**
-	 * Checks if any express checkout method (Google/Apple Pay or Amazon Pay) is enabled at a given location in settings.
-	 *
-	 * This only checks location settings (express_checkout_{location}_methods), not feature flags.
-	 * Feature flags are checked at initialization and in get_enabled_express_checkout_methods_for_context().
-	 *
-	 * @param string $location Location (product, cart, checkout).
-	 * @return boolean
-	 */
-	public function is_any_express_checkout_method_enabled_at( $location ) {
-		// Check Google Pay / Apple Pay (payment_request).
-		if ( $this->is_express_checkout_method_enabled_at( $location, 'payment_request' ) ) {
-			return true;
-		}
-
-		// Check Amazon Pay.
-		if ( $this->is_express_checkout_method_enabled_at( $location, 'amazon_pay' ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Gets the list of enabled express checkout methods for the current page context.
 	 *
 	 * This method checks:

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -327,6 +327,29 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		remove_filter( 'pre_option_woocommerce_tax_display_cart', [ $this, '__return_incl' ] );
 	}
 
+	public function test_should_not_show_express_checkout_button_when_no_methods_enabled_at_location() {
+		$this->mock_wcpay_account
+			->method( 'is_stripe_connected' )
+			->willReturn( true );
+
+		WC_Payments::mode()->dev();
+
+		add_filter( 'woocommerce_is_checkout', '__return_true' );
+
+		// Clear all express checkout methods from the checkout location.
+		$this->mock_wcpay_gateway->update_option( 'express_checkout_checkout_methods', [] );
+
+		// Without mocking get_enabled_express_checkout_methods_for_context, it should
+		// return empty because no methods are enabled at the checkout location, causing
+		// should_show_express_checkout_button to return false.
+		$this->assertFalse( $this->system_under_test->should_show_express_checkout_button() );
+
+		remove_filter( 'woocommerce_is_checkout', '__return_true' );
+
+		// Restore for other tests.
+		$this->mock_wcpay_gateway->update_option( 'express_checkout_checkout_methods', [ 'payment_request', 'woopay' ] );
+	}
+
 	public function test_should_not_show_express_checkout_button_for_non_shipping_but_price_does_not_include_tax() {
 		$this->mock_wcpay_account
 			->method( 'is_stripe_connected' )

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -287,7 +287,14 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 
 		add_filter( 'woocommerce_is_checkout', '__return_true' );
 
-		$this->assertTrue( $this->system_under_test->should_show_express_checkout_button() );
+		$helper = $this->getMockBuilder( WC_Payments_Express_Checkout_Button_Helper::class )
+			->setConstructorArgs( [ $this->mock_wcpay_gateway, $this->mock_wcpay_account ] )
+			->onlyMethods( [ 'get_enabled_express_checkout_methods_for_context' ] )
+			->getMock();
+
+		$helper->method( 'get_enabled_express_checkout_methods_for_context' )->willReturn( [ 'payment_request' ] );
+
+		$this->assertTrue( $helper->should_show_express_checkout_button() );
 
 		remove_filter( 'woocommerce_is_checkout', '__return_true' );
 	}
@@ -306,7 +313,14 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		update_option( 'woocommerce_tax_based_on', 'billing' );
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 
-		$this->assertTrue( $this->system_under_test->should_show_express_checkout_button() );
+		$helper = $this->getMockBuilder( WC_Payments_Express_Checkout_Button_Helper::class )
+			->setConstructorArgs( [ $this->mock_wcpay_gateway, $this->mock_wcpay_account ] )
+			->onlyMethods( [ 'get_enabled_express_checkout_methods_for_context' ] )
+			->getMock();
+
+		$helper->method( 'get_enabled_express_checkout_methods_for_context' )->willReturn( [ 'payment_request' ] );
+
+		$this->assertTrue( $helper->should_show_express_checkout_button() );
 
 		remove_filter( 'woocommerce_is_checkout', '__return_true' );
 		remove_filter( 'wc_tax_enabled', '__return_true' );


### PR DESCRIPTION
Fixes WOOPMNT-6046

#### Changes proposed in this Pull Request

Express checkout scripts (`WCPAY_EXPRESS_CHECKOUT_ECE` + Stripe JS) were loading on product, cart, and checkout pages even when no express checkout methods were actually available. This happened because `should_show_express_checkout_button()` used `is_any_express_checkout_method_enabled_at()` which only checks if a method string exists in the settings array — it doesn't verify whether the method is actually enabled via feature flags or available for the account.

Since the defaults always include `amazon_pay` (from `form_fields` defaults and the `Add_Amazon_Pay_To_Express_Checkout_Locations` migration), the settings array would contain `amazon_pay` even when Amazon Pay isn't actually available, causing unnecessary script loading.

**Fix:** Replace the three per-location `is_any_express_checkout_method_enabled_at()` calls with a single `get_enabled_express_checkout_methods_for_context()` call, which already checks both location settings AND feature flags/availability. This method was already used elsewhere (e.g., in `get_enabled_express_checkout_methods_for_context()` for the frontend) but wasn't being used in the script enqueue path.

**Impact reported by WooCommerce.com (on 10.5):**
- **-2.2 MB** bytes transferred (~43% reduction)
- **-90% TBT** (Total Blocking Time: 3,521ms → 375ms)
- **-13s** fully loaded time

#### Testing instructions

1. Enable Google Pay/Apple Pay globally in WooPayments settings.
2. In the express checkout location settings, configure:
   - **Product page:** Only `amazon_pay` selected (not `payment_request`)
   - **Cart/Checkout:** Both `payment_request` and `amazon_pay` selected
3. Visit a product page and open browser DevTools → Network tab.
4. **Expected:** No `express-checkout.js` or `stripe.com/v3` scripts should load on the product page (since Amazon Pay isn't actually available on most test accounts).
5. Visit the cart or checkout page.
6. **Expected:** Express checkout scripts load normally, Google Pay button appears (over HTTPS).
7. Add `payment_request` back to the product page location.
8. **Expected:** Scripts load and Google Pay button appears on the product page.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.