### PR TITLE
Fix WOOPMNT-5972: Invalidate currency-rate cache on store currency change

### DIFF
--- a/changelog/fix-mc-currency-cache-invalidation
+++ b/changelog/fix-mc-currency-cache-invalidation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Invalidate multi-currency exchange rate cache when the store base currency changes.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -294,6 +294,12 @@ class MultiCurrency {
 
 		$store_currency_updated = $this->check_store_currency_for_change();
 
+		// If the store currency has been updated, invalidate the exchange rate cache
+		// before initializing currencies so fresh rates are fetched immediately.
+		if ( $store_currency_updated ) {
+			$this->cache->delete( MultiCurrencyCacheInterface::CURRENCIES_KEY );
+		}
+
 		$this->initialize_available_currencies();
 		$this->set_default_currency();
 		$this->initialize_enabled_currencies();
@@ -301,7 +307,6 @@ class MultiCurrency {
 		// If the store currency has been updated, we need to update the notice that will display any manual currencies.
 		if ( $store_currency_updated ) {
 			$this->update_manual_rate_currencies_notice_option();
-			$this->cache->delete( MultiCurrencyCacheInterface::CURRENCIES_KEY );
 		}
 
 		$admin_notices = new AdminNotices();

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -301,6 +301,7 @@ class MultiCurrency {
 		// If the store currency has been updated, we need to update the notice that will display any manual currencies.
 		if ( $store_currency_updated ) {
 			$this->update_manual_rate_currencies_notice_option();
+			$this->cache->delete( MultiCurrencyCacheInterface::CURRENCIES_KEY );
 		}
 
 		$admin_notices = new AdminNotices();

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -148,6 +148,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		update_option( 'wcpay_multi_currency_enable_auto_currency', 'no' );
 		delete_option( '_wcpay_feature_mc_cache_optimized' );
 		delete_option( 'wcpay_multi_currency_rendering_mode' );
+		delete_option( 'wcpay_multi_currency_store_currency' );
 
 		parent::tear_down();
 	}
@@ -1603,6 +1604,41 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		update_post_meta( $order_id, '_order_currency', $currency );
 
 		return $order_id;
+	}
+
+	public function test_init_invalidates_cache_when_store_currency_changes() {
+		// Simulate previously known currency was USD, but store currency is now EUR.
+		update_option( 'wcpay_multi_currency_store_currency', 'USD' );
+
+		// Clear filters from prior init (FrontendCurrencies adds one at priority 900).
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => 'EUR' );
+
+		$mock_cache = $this->createMock( MultiCurrencyCacheInterface::class );
+		$mock_cache->method( 'get_or_add' )->willReturn( $this->mock_cached_currencies );
+		$mock_cache->expects( $this->once() )
+			->method( 'delete' )
+			->with( MultiCurrencyCacheInterface::CURRENCIES_KEY );
+
+		$this->init_multi_currency( null, true, null, $mock_cache );
+
+		// Verify the stored currency was updated to the new value.
+		$this->assertSame( 'EUR', get_option( 'wcpay_multi_currency_store_currency' ) );
+	}
+
+	public function test_init_does_not_invalidate_cache_when_store_currency_unchanged() {
+		// Store currency matches the current WooCommerce currency (both USD).
+		update_option( 'wcpay_multi_currency_store_currency', 'USD' );
+
+		// Clear filters from prior init to ensure get_woocommerce_currency() returns USD.
+		remove_all_filters( 'woocommerce_currency' );
+
+		$mock_cache = $this->createMock( MultiCurrencyCacheInterface::class );
+		$mock_cache->method( 'get_or_add' )->willReturn( $this->mock_cached_currencies );
+		$mock_cache->expects( $this->never() )
+			->method( 'delete' );
+
+		$this->init_multi_currency( null, true, null, $mock_cache );
 	}
 
 	public function test_init_returns_early_when_store_currency_not_in_available_wc_currencies() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -1641,6 +1641,24 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->init_multi_currency( null, true, null, $mock_cache );
 	}
 
+	public function test_init_does_not_invalidate_cache_on_first_install() {
+		// No store_currency option exists yet (first-time install).
+		delete_option( 'wcpay_multi_currency_store_currency' );
+
+		// Clear filters from prior init to ensure get_woocommerce_currency() returns USD.
+		remove_all_filters( 'woocommerce_currency' );
+
+		$mock_cache = $this->createMock( MultiCurrencyCacheInterface::class );
+		$mock_cache->method( 'get_or_add' )->willReturn( $this->mock_cached_currencies );
+		$mock_cache->expects( $this->never() )
+			->method( 'delete' );
+
+		$this->init_multi_currency( null, true, null, $mock_cache );
+
+		// Verify the option was set for the first time (not treated as a change).
+		$this->assertSame( 'USD', get_option( 'wcpay_multi_currency_store_currency' ) );
+	}
+
 	public function test_init_returns_early_when_store_currency_not_in_available_wc_currencies() {
 		// Remove lingering woocommerce_currency filters from previous init (e.g. FrontendCurrencies at priority 900).
 		remove_all_filters( 'woocommerce_currency' );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOPMNT-5972

#### Changes proposed in this Pull Request

When the store base currency changes, the multi-currency exchange rate cache is not invalidated. Stale rates (based on the old base currency) persist until TTL expiry — 3 hours for admin, 12 hours for frontend.

This was introduced when the `clear_cache` method was removed in #11045 to address unnecessary cache clears caused by WCCOM switching the store currency on every customer currency change (WOOPMNT-5328). However, the removal also eliminated cache invalidation for *genuine* base currency changes.

This PR restores cache invalidation inside the existing `$store_currency_updated` guard in `MultiCurrency::init()`, so only real base currency changes (detected by `check_store_currency_for_change()`) trigger a cache delete. This does not re-introduce the WOOPMNT-5328 issue because the detection compares the stored currency option against the actual WC currency — WCCOM's per-customer switching does not update that option.

**How can this code break?** Only if `check_store_currency_for_change()` returns `true` in contexts other than a genuine base currency change. This was the root cause of WOOPMNT-5328, but that issue was caused at a different layer (WCCOM custom code), not by this detection method.

#### Testing instructions

1. Set up a WooPayments store with Multi-Currency enabled and at least one additional currency
2. Note the current exchange rates (WooCommerce → Settings → Multi-Currency)
3. Change the store base currency (WooCommerce → Settings → General → Currency)
4. Return to the Multi-Currency settings — rates should refresh immediately (not stale for 3-12 hours)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**No regression test added.** The fix is a single cache delete call inside an existing guard. The real risk is architectural (false positives in currency change detection, as seen in WOOPMNT-5328), which a unit mock test wouldn't protect against — that would require an integration test, which is out of scope for this fix.

This PR was created during the [Woo Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/) by a Happiness Engineer who encounters this bug in support tickets. Validated by @vladolaru in [WOOPMNT-5972 comments](https://linear.app/a8c/issue/WOOPMNT-5972).

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_ (rare edge case, cache-only impact)
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.