### PR TITLE
fix: align .Footer-link key naming in WooPay appearance rules

### DIFF
--- a/changelog/fix-woopmnt-5787-footer-link-key-mismatch
+++ b/changelog/fix-woopmnt-5787-footer-link-key-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed .Footer-link key naming inconsistency in WooPay themed checkout appearance rules

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -858,7 +858,7 @@ export const getAppearance = (
 			'.Footer': footerRules,
 			'.Footer-link': getFieldStyles(
 				selectors.footerLink,
-				'.Footer--link',
+				'.Footer-link',
 				null,
 				scope
 			),

--- a/client/checkout/upe-styles/upe-styles.js
+++ b/client/checkout/upe-styles/upe-styles.js
@@ -125,7 +125,7 @@ export const upeRestrictedProperties = {
 	'.Container': upeSupportedProperties[ '.Container' ],
 	'.Header': upeSupportedProperties[ '.Header' ],
 	'.Footer': upeSupportedProperties[ '.Footer' ],
-	'.Footer--link': upeSupportedProperties[ '.Text' ],
+	'.Footer-link': upeSupportedProperties[ '.Text' ],
 	'.Text': upeSupportedProperties[ '.Text' ],
 	'.Text--redirect': upeSupportedProperties[ '.Text' ],
 };


### PR DESCRIPTION
## Summary

- Fixes the `.Footer--link` (double dash) vs `.Footer-link` (single dash) naming inconsistency in WooPay themed checkout appearance rules
- Aligns `upeRestrictedProperties` key in `upe-styles.js` and the `getFieldStyles` lookup arg in `index.js` to `.Footer-link`, consistent with the WooPay server PHP, preview component, and all tests
- No functional change — the styles were already being applied correctly end-to-end

Closes [WOOPMNT-5787](https://linear.app/a8c/issue/WOOPMNT-5787)

## Test plan

- [ ] Verify WooPay themed checkout appearance styles still apply correctly (footer link color matches the configured value)
- [ ] `npm run test:js -- client/checkout/upe-styles/__tests__/woopay-appearance.test.js --env jsdom` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)