### PR TITLE
fix: remove incorrect timezone shift applied to transaction date filters

### DIFF
--- a/changelog/fix-woopmnt-4354-transaction-date-filter-timezone
+++ b/changelog/fix-woopmnt-4354-transaction-date-filter-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed transaction date filter sending incorrect UTC offset when store and browser timezones differ

--- a/changelog/fix-woopmnt-5787-footer-link-key-mismatch
+++ b/changelog/fix-woopmnt-5787-footer-link-key-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed .Footer-link key naming inconsistency in WooPay themed checkout appearance rules

--- a/client/checkout/upe-styles/index.js
+++ b/client/checkout/upe-styles/index.js
@@ -858,7 +858,7 @@ export const getAppearance = (
 			'.Footer': footerRules,
 			'.Footer-link': getFieldStyles(
 				selectors.footerLink,
-				'.Footer--link',
+				'.Footer-link',
 				null,
 				scope
 			),

--- a/client/checkout/upe-styles/upe-styles.js
+++ b/client/checkout/upe-styles/upe-styles.js
@@ -125,7 +125,7 @@ export const upeRestrictedProperties = {
 	'.Container': upeSupportedProperties[ '.Container' ],
 	'.Header': upeSupportedProperties[ '.Header' ],
 	'.Footer': upeSupportedProperties[ '.Footer' ],
-	'.Footer--link': upeSupportedProperties[ '.Text' ],
+	'.Footer-link': upeSupportedProperties[ '.Text' ],
 	'.Text': upeSupportedProperties[ '.Text' ],
 	'.Text--redirect': upeSupportedProperties[ '.Text' ],
 };

--- a/client/data/transactions/__tests__/resolvers.test.js
+++ b/client/data/transactions/__tests__/resolvers.test.js
@@ -16,7 +16,6 @@ import {
 	updateTransactionsSummary,
 } from '../actions';
 import { getTransactions, getTransactionsSummary } from '../resolvers';
-import { getUserTimeZone } from 'jest-utils/timezone';
 
 const errorResponse = { code: 'error' };
 
@@ -48,9 +47,7 @@ describe( 'getTransactions resolver', () => {
 		'&match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59' +
 		'&type_is=charge&type_is_not=dispute&source_device_is=ios&source_device_is_not=android' +
-		`&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=${ encodeURIComponent(
-			getUserTimeZone()
-		) }`;
+		'&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user';
 	let generator = null;
 
 	beforeEach( () => {
@@ -97,9 +94,7 @@ describe( 'getTransactionsSummary resolver', () => {
 		'match=all&date_before=2020-04-29%2003%3A59%3A59&date_after=2020-04-29%2004%3A00%3A00' +
 		'&date_between%5B0%5D=2020-04-28%2004%3A00%3A00&date_between%5B1%5D=2020-04-30%2003%3A59%3A59' +
 		'&type_is=charge&type_is_not=dispute&source_device_is=ios&source_device_is_not=android' +
-		`&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user&user_timezone=${ encodeURIComponent(
-			getUserTimeZone()
-		) }`;
+		'&loan_id_is=mock_flxln_id&deposit_id=mock_po_id&search=Test%20user';
 	let generator = null;
 
 	beforeEach( () => {

--- a/client/data/transactions/resolvers.js
+++ b/client/data/transactions/resolvers.js
@@ -7,7 +7,6 @@ import { apiFetch } from '@wordpress/data-controls';
 import { controls } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
-import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -24,10 +23,6 @@ import {
 	updateErrorForFraudOutcomeTransactionsSummary,
 } from './actions';
 import { formatDateValue } from 'utils';
-
-function getUserTimeZone() {
-	return moment( new Date() ).format( 'Z' );
-}
 
 export const formatQueryFilters = ( query ) => ( {
 	user_email: query.userEmail,
@@ -57,7 +52,6 @@ export const formatQueryFilters = ( query ) => ( {
 	source_is: query.sourceIs,
 	source_is_not: query.sourceIsNot,
 	search: query.search,
-	user_timezone: getUserTimeZone(),
 	locale: query.locale,
 } );
 

--- a/client/transactions/list/__tests__/index.test.tsx
+++ b/client/transactions/list/__tests__/index.test.tsx
@@ -14,7 +14,6 @@ import { PAYMENT_METHOD_BRANDS } from 'wcpay/constants/payment-method';
 /**
  * Internal dependencies
  */
-import { getUserTimeZone } from 'jest-utils/timezone';
 import { TransactionsList } from '..';
 import { useTransactions, useTransactionsSummary } from 'data';
 import type { Transaction } from 'data/transactions/hooks';
@@ -659,9 +658,7 @@ describe( 'Transactions list', () => {
 				expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 				expect( mockApiFetch ).toHaveBeenCalledWith( {
 					method: 'POST',
-					path: `/wc/v3/payments/transactions/download?user_email=mock%40example.com&deposit_id=po_mock&user_timezone=${ encodeURIComponent(
-						getUserTimeZone()
-					) }&locale=en_US`,
+					path: `/wc/v3/payments/transactions/download?user_email=mock%40example.com&deposit_id=po_mock&locale=en_US`,
 				} );
 			} );
 		} );

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -216,24 +216,12 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	private function get_transactions_filters( $request ) {
-		$date_between_filter = $request->get_param( 'date_between' );
-		$user_timezone       = $request->get_param( 'user_timezone' );
-
-		if ( ! is_null( $date_between_filter ) ) {
-			$date_between_filter = array_map(
-				function ( $transaction_date ) use ( $user_timezone ) {
-					return $this->format_transaction_date_with_timestamp( $transaction_date, $user_timezone );
-				},
-				$date_between_filter
-			);
-		}
-
 		return array_filter(
 			[
 				'match'                    => $request->get_param( 'match' ),
-				'date_before'              => $this->format_transaction_date_with_timestamp( $request->get_param( 'date_before' ), $user_timezone ),
-				'date_after'               => $this->format_transaction_date_with_timestamp( $request->get_param( 'date_after' ), $user_timezone ),
-				'date_between'             => $date_between_filter,
+				'date_before'              => $request->get_param( 'date_before' ),
+				'date_after'               => $request->get_param( 'date_after' ),
+				'date_between'             => $request->get_param( 'date_between' ),
 				'type_is'                  => $request->get_param( 'type_is' ),
 				'type_is_not'              => $request->get_param( 'type_is_not' ),
 				'source_device_is'         => $request->get_param( 'source_device_is' ),
@@ -256,36 +244,5 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 				return null !== $filter;
 			}
 		);
-	}
-
-	/**
-	 * Formats the incoming transaction date as per the blog's timezone.
-	 *
-	 * @param string|null $transaction_date Transaction date to format.
-	 * @param string|null $user_timezone         User's timezone passed from client.
-	 *
-	 * @return string|null The formatted transaction date as per timezone.
-	 */
-	private function format_transaction_date_with_timestamp( $transaction_date, $user_timezone ) {
-		if ( is_null( $transaction_date ) || is_null( $user_timezone ) ) {
-			return $transaction_date;
-		}
-
-		// Get blog timezone.
-		$blog_time = new DateTime( $transaction_date );
-		$blog_time->setTimezone( new DateTimeZone( wp_timezone_string() ) );
-
-		// Get local timezone.
-		$local_time = new DateTime( $transaction_date );
-		$local_time->setTimezone( new DateTimeZone( $user_timezone ) );
-
-		// Compute time difference in minutes.
-		$time_difference = ( strtotime( $local_time->format( 'Y-m-d H:i:s' ) ) - strtotime( $blog_time->format( 'Y-m-d H:i:s' ) ) ) / 60;
-
-		// Shift date by time difference.
-		$formatted_date = new DateTime( $transaction_date );
-		date_modify( $formatted_date, $time_difference . 'minutes' );
-
-		return $formatted_date->format( 'Y-m-d H:i:s' );
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes WOOPMNT-4354: transaction date filters were passing an incorrect UTC offset to the server when the store and browser timezones differed
- The JS (`formatDateValue`) already correctly converts user-selected dates to UTC using `moment().startOf/endOf('day').utc()`, so no server-side correction was needed
- PHP's `format_transaction_date_with_timestamp()` was incorrectly applying an additional offset equal to `(user_timezone − store_timezone)`, causing the wrong date range to be sent to the API
- Removed `format_transaction_date_with_timestamp()` and the `user_timezone` param from both PHP and JS — dates now pass through as-is since they arrive already in UTC

Closes [WOOPMNT-4354](https://linear.app/a8c/issue/WOOPMNT-4354)

## Test plan

- [ ] Set blog timezone to something different from your browser timezone (wp-admin > Settings > General > Timezone)
- [ ] Apply a date range filter on the Transactions list page
- [ ] Confirm the filtered results match the expected date range in your local timezone (not shifted by the store/browser difference)
- [ ] `npm run test:js -- client/data/transactions/__tests__/resolvers.test.js --config tests/js/jest.config.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)