### PR TITLE
fix(a11y): Improve WooPay button focus contrast and semantic markup

### DIFF
--- a/changelog/agent-wooa11y-164
+++ b/changelog/agent-wooa11y-164
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add visible focus indicator to WooPay express checkout button for WCAG 2.4.7 compliance

--- a/changelog/fix-wooa11y-220-woopay-button-a11y
+++ b/changelog/fix-wooa11y-220-woopay-button-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Change WooPay express button to an anchor element when first-party auth is enabled for correct screen reader semantics.

--- a/client/checkout/woopay/express-button/__tests__/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/__tests__/woopay-express-checkout-button.test.js
@@ -87,7 +87,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'render the express checkout button', () => {
+	test( 'renders as a link when first-party auth is enabled', () => {
 		render(
 			<WoopayExpressCheckoutButton
 				isPreview={ false }
@@ -98,9 +98,30 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			/>
 		);
 
-		expect(
-			screen.queryByRole( 'button', { name: 'WooPay' } )
-		).toBeInTheDocument();
+		const link = screen.queryByRole( 'link', { name: 'WooPay' } );
+		expect( link ).toBeInTheDocument();
+		expect( link.tagName ).toBe( 'A' );
+		expect( link ).toHaveAttribute( 'href', 'foo/woopay/' );
+	} );
+
+	test( 'renders as a button when first-party auth is disabled', () => {
+		getConfig.mockImplementation( ( v ) => {
+			return v === 'isWoopayFirstPartyAuthEnabled' ? false : 'foo';
+		} );
+		render(
+			<WoopayExpressCheckoutButton
+				isPreview={ false }
+				buttonSettings={ buttonSettings }
+				api={ api }
+				isProductPage={ false }
+				emailSelector="#email"
+			/>
+		);
+
+		const button = screen.queryByRole( 'button', { name: 'WooPay' } );
+		expect( button ).toBeInTheDocument();
+		expect( button.tagName ).toBe( 'BUTTON' );
+		expect( button ).toHaveAttribute( 'type', 'button' );
 	} );
 
 	test( 'respect buttonAttributes API when available ', () => {
@@ -118,8 +139,8 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			/>
 		);
 
-		const button = screen.queryByRole( 'button', { name: 'WooPay' } );
-		expect( button.getAttribute( 'style' ) ).toBe(
+		const link = screen.queryByRole( 'link', { name: 'WooPay' } );
+		expect( link.getAttribute( 'style' ) ).toBe(
 			'height: 55px; border-radius: 20px;'
 		);
 	} );
@@ -186,7 +207,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			/>
 		);
 
-		const expressButton = screen.queryByRole( 'button', {
+		const expressButton = screen.queryByRole( 'link', {
 			name: 'WooPay',
 		} );
 		await userEvent.click( expressButton );
@@ -240,7 +261,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			/>
 		);
 
-		const expressButton = screen.queryByRole( 'button', {
+		const expressButton = screen.queryByRole( 'link', {
 			name: 'WooPay',
 		} );
 		await userEvent.click( expressButton );

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -34,9 +34,9 @@
 		}
 
 		&:not( :disabled ):not( .is-placeholder ) {
-			&:focus,
-			&:focus-within {
-				outline: 4px solid $studio-woocommerce-purple-10;
+			&:focus-visible {
+				box-shadow: inset 0 0 0 2px $studio-woocommerce-purple-60;
+				outline: none;
 			}
 
 			&:hover {
@@ -114,12 +114,18 @@
 				border-color: $studio-woocommerce-purple-30;
 				background: $studio-woocommerce-purple-30;
 			}
+			&:not( :disabled ):not( .is-placeholder ):focus-visible {
+				box-shadow: inset 0 0 0 2px $white;
+			}
 		}
 
 		&[data-theme='light-outline'] {
 			border: 1px solid $studio-black;
 			&:not( :disabled ):not( .is-placeholder ):hover {
 				background: #e0e0e0;
+			}
+			&:not( :disabled ):not( .is-placeholder ):focus-visible {
+				box-shadow: inset 0 0 0 2px $studio-black;
 			}
 		}
 

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -3,6 +3,18 @@
 	container-type: inline-size;
 	container-name: woopay-button;
 
+	a.woopay-express-button {
+		text-decoration: none;
+		color: inherit;
+
+		&:hover,
+		&:focus,
+		&:visited {
+			text-decoration: none;
+			color: inherit;
+		}
+	}
+
 	.woopay-express-button {
 		font-size: 18px;
 		font-weight: 500;

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -82,6 +82,9 @@ export const WoopayExpressCheckoutButton = ( {
 
 	const ThemedWooPayIcon = theme === 'dark' ? WoopayIcon : WoopayIconLight;
 
+	const isFirstPartyAuth = getConfig( 'isWoopayFirstPartyAuthEnabled' );
+	const woopayUrl = getConfig( 'woopayHost' ) + '/woopay/';
+
 	const { addToCart, getProductData } = useExpressCheckoutProductHandler(
 		api
 	);
@@ -357,43 +360,56 @@ export const WoopayExpressCheckoutButton = ( {
 		};
 	}, [] );
 
+	const sharedProps = {
+		ref: buttonRef,
+		key: `${ buttonType }-${ theme }-${ buttonSize }`,
+		'aria-label': buttonText,
+		onClick: ( e ) => onClickCallbackRef.current( e ),
+		className: clsx( 'woopay-express-button', {
+			'is-loading': isLoading,
+		} ),
+		'data-type': buttonType,
+		'data-size': buttonSize,
+		'data-theme': theme,
+		'data-width-type': buttonWidthType,
+		style: {
+			height: `${ buttonHeight }px`,
+			borderRadius: `${ borderRadius }px`,
+		},
+	};
+
+	const buttonContent = isLoading ? (
+		<span className="wc-block-components-spinner" />
+	) : (
+		<div className="button-content">
+			{ interpolateComponents( {
+				mixedString: buttonText.replace(
+					ButtonTypeTextMap.default,
+					'{{wooPayLogo /}}'
+				),
+				components: {
+					wooPayLogo: <ThemedWooPayIcon />,
+				},
+			} ) }
+		</div>
+	);
+
 	return (
 		<div id="wcpay-woopay-button">
-			<button
-				ref={ buttonRef }
-				key={ `${ buttonType }-${ theme }-${ buttonSize }` }
-				aria-label={ buttonText }
-				onClick={ ( e ) => onClickCallbackRef.current( e ) }
-				className={ clsx( 'woopay-express-button', {
-					'is-loading': isLoading,
-				} ) }
-				data-type={ buttonType }
-				data-size={ buttonSize }
-				data-theme={ theme }
-				data-width-type={ buttonWidthType }
-				style={ {
-					height: `${ buttonHeight }px`,
-					borderRadius: `${ borderRadius }px`,
-				} }
-				disabled={ isLoading }
-				type="button"
-			>
-				{ isLoading ? (
-					<span className="wc-block-components-spinner" />
-				) : (
-					<div className="button-content">
-						{ interpolateComponents( {
-							mixedString: buttonText.replace(
-								ButtonTypeTextMap.default,
-								'{{wooPayLogo /}}'
-							),
-							components: {
-								wooPayLogo: <ThemedWooPayIcon />,
-							},
-						} ) }
-					</div>
-				) }
-			</button>
+			{ isFirstPartyAuth ? (
+				<a
+					{ ...sharedProps }
+					href={ woopayUrl }
+					aria-disabled={ isLoading || undefined }
+					tabIndex={ isLoading ? -1 : undefined }
+				>
+					{ buttonContent }
+				</a>
+			) : (
+				<button { ...sharedProps } disabled={ isLoading } type="button">
+					{ buttonContent }
+				</button>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes WOOA11Y-219

#### Changes proposed in this Pull Request

The WooPay express checkout button had two accessibility issues flagged in the WCAG audit (WooExt-441):

1. **Insufficient focus contrast (WCAG 1.4.11):** The focus outline used `$studio-woocommerce-purple-10` (`#d1c1ff`) which has a ~1.57:1 contrast ratio against white — well below the 3:1 minimum for non-text contrast. Replaced with `focus-visible` + inset `box-shadow` using theme-appropriate colors that meet contrast requirements:
   - Default (white bg): `$studio-woocommerce-purple-60` (~5.8:1 ratio)
   - Dark theme (purple bg): `$white`
   - Light-outline theme (white bg, black border): `$studio-black`

2. **Incorrect semantic element:** When first-party auth is enabled, the WooPay button navigates to a URL rather than performing an in-page action. Rendered as an `<a>` element in this case for correct screen reader semantics, while keeping `<button>` when first-party auth is disabled.

#### Testing instructions

1. Navigate to a product page with WooPay enabled
2. Tab to the WooPay express button
3. Verify the focus indicator is clearly visible (inset purple border on white, white border on dark theme, black border on outline theme)
4. With first-party auth enabled: verify the button renders as a link (`<a>` tag) with proper `href`
5. With first-party auth disabled: verify the button renders as a `<button>` tag
6. Verify keyboard navigation works correctly in both modes

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
☢️ Powered by [Gamma AI Tools](https://github.a8c.com/Automattic/gamma-ai-tools/)