### PR TITLE
fix(a11y): Render WooPay express button as anchor when it navigates

### DIFF
--- a/changelog/fix-wooa11y-220-woopay-button-a11y
+++ b/changelog/fix-wooa11y-220-woopay-button-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Change WooPay express button to an anchor element when first-party auth is enabled for correct screen reader semantics.

--- a/client/checkout/woopay/express-button/__tests__/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/__tests__/woopay-express-checkout-button.test.js
@@ -87,7 +87,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'render the express checkout button', () => {
+	test( 'renders as a link when first-party auth is enabled', () => {
 		render(
 			<WoopayExpressCheckoutButton
 				isPreview={ false }
@@ -98,9 +98,30 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			/>
 		);
 
-		expect(
-			screen.queryByRole( 'button', { name: 'WooPay' } )
-		).toBeInTheDocument();
+		const link = screen.queryByRole( 'link', { name: 'WooPay' } );
+		expect( link ).toBeInTheDocument();
+		expect( link.tagName ).toBe( 'A' );
+		expect( link ).toHaveAttribute( 'href', 'foo/woopay/' );
+	} );
+
+	test( 'renders as a button when first-party auth is disabled', () => {
+		getConfig.mockImplementation( ( v ) => {
+			return v === 'isWoopayFirstPartyAuthEnabled' ? false : 'foo';
+		} );
+		render(
+			<WoopayExpressCheckoutButton
+				isPreview={ false }
+				buttonSettings={ buttonSettings }
+				api={ api }
+				isProductPage={ false }
+				emailSelector="#email"
+			/>
+		);
+
+		const button = screen.queryByRole( 'button', { name: 'WooPay' } );
+		expect( button ).toBeInTheDocument();
+		expect( button.tagName ).toBe( 'BUTTON' );
+		expect( button ).toHaveAttribute( 'type', 'button' );
 	} );
 
 	test( 'respect buttonAttributes API when available ', () => {
@@ -118,8 +139,8 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			/>
 		);
 
-		const button = screen.queryByRole( 'button', { name: 'WooPay' } );
-		expect( button.getAttribute( 'style' ) ).toBe(
+		const link = screen.queryByRole( 'link', { name: 'WooPay' } );
+		expect( link.getAttribute( 'style' ) ).toBe(
 			'height: 55px; border-radius: 20px;'
 		);
 	} );
@@ -186,7 +207,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			/>
 		);
 
-		const expressButton = screen.queryByRole( 'button', {
+		const expressButton = screen.queryByRole( 'link', {
 			name: 'WooPay',
 		} );
 		await userEvent.click( expressButton );
@@ -240,7 +261,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			/>
 		);
 
-		const expressButton = screen.queryByRole( 'button', {
+		const expressButton = screen.queryByRole( 'link', {
 			name: 'WooPay',
 		} );
 		await userEvent.click( expressButton );

--- a/client/checkout/woopay/express-button/__tests__/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/__tests__/woopay-express-checkout-button.test.js
@@ -124,6 +124,44 @@ describe( 'WoopayExpressCheckoutButton', () => {
 		expect( button ).toHaveAttribute( 'type', 'button' );
 	} );
 
+	test( 'link variant sets aria-disabled and removes href when loading', async () => {
+		getConfig.mockImplementation( ( v ) => {
+			switch ( v ) {
+				case 'isWoopayFirstPartyAuthEnabled':
+					return true;
+				case 'woopayHost':
+					return 'https://pay.woo.com';
+				case 'woopaySessionNonce':
+					return 'nonce';
+				default:
+					return 'foo';
+			}
+		} );
+
+		render(
+			<WoopayExpressCheckoutButton
+				isPreview={ false }
+				buttonSettings={ buttonSettings }
+				api={ api }
+				isProductPage={ false }
+				emailSelector="#email"
+			/>
+		);
+
+		const link = screen.queryByRole( 'link', { name: 'WooPay' } );
+		expect( link ).toBeInTheDocument();
+		expect( link ).toHaveAttribute( 'href', 'https://pay.woo.com/woopay/' );
+		expect( link ).not.toHaveAttribute( 'aria-disabled' );
+
+		await userEvent.click( link );
+
+		await waitFor( () => {
+			const el = screen.getByLabelText( 'WooPay' );
+			expect( el ).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( el ).not.toHaveAttribute( 'href' );
+		} );
+	} );
+
 	test( 'respect buttonAttributes API when available ', () => {
 		render(
 			<WoopayExpressCheckoutButton

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -3,6 +3,18 @@
 	container-type: inline-size;
 	container-name: woopay-button;
 
+	a.woopay-express-button {
+		text-decoration: none;
+		color: inherit;
+
+		&:hover,
+		&:focus,
+		&:visited {
+			text-decoration: none;
+			color: inherit;
+		}
+	}
+
 	.woopay-express-button {
 		font-size: 18px;
 		font-weight: 500;

--- a/client/checkout/woopay/express-button/style.scss
+++ b/client/checkout/woopay/express-button/style.scss
@@ -57,6 +57,7 @@
 		}
 
 		&:disabled,
+		&[aria-disabled='true'],
 		&.is-placeholder {
 			opacity: 0.5;
 			cursor: not-allowed;

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -362,7 +362,6 @@ export const WoopayExpressCheckoutButton = ( {
 
 	const sharedProps = {
 		ref: buttonRef,
-		key: `${ buttonType }-${ theme }-${ buttonSize }`,
 		'aria-label': buttonText,
 		onClick: ( e ) => onClickCallbackRef.current( e ),
 		className: clsx( 'woopay-express-button', {
@@ -398,15 +397,21 @@ export const WoopayExpressCheckoutButton = ( {
 		<div id="wcpay-woopay-button">
 			{ isFirstPartyAuth ? (
 				<a
+					key={ `${ buttonType }-${ theme }-${ buttonSize }` }
 					{ ...sharedProps }
-					href={ woopayUrl }
+					href={ isLoading ? undefined : woopayUrl }
 					aria-disabled={ isLoading || undefined }
 					tabIndex={ isLoading ? -1 : undefined }
 				>
 					{ buttonContent }
 				</a>
 			) : (
-				<button { ...sharedProps } disabled={ isLoading } type="button">
+				<button
+					key={ `${ buttonType }-${ theme }-${ buttonSize }` }
+					{ ...sharedProps }
+					disabled={ isLoading }
+					type="button"
+				>
 					{ buttonContent }
 				</button>
 			) }

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -82,6 +82,9 @@ export const WoopayExpressCheckoutButton = ( {
 
 	const ThemedWooPayIcon = theme === 'dark' ? WoopayIcon : WoopayIconLight;
 
+	const isFirstPartyAuth = getConfig( 'isWoopayFirstPartyAuthEnabled' );
+	const woopayUrl = getConfig( 'woopayHost' ) + '/woopay/';
+
 	const { addToCart, getProductData } = useExpressCheckoutProductHandler(
 		api
 	);
@@ -357,43 +360,56 @@ export const WoopayExpressCheckoutButton = ( {
 		};
 	}, [] );
 
+	const sharedProps = {
+		ref: buttonRef,
+		key: `${ buttonType }-${ theme }-${ buttonSize }`,
+		'aria-label': buttonText,
+		onClick: ( e ) => onClickCallbackRef.current( e ),
+		className: clsx( 'woopay-express-button', {
+			'is-loading': isLoading,
+		} ),
+		'data-type': buttonType,
+		'data-size': buttonSize,
+		'data-theme': theme,
+		'data-width-type': buttonWidthType,
+		style: {
+			height: `${ buttonHeight }px`,
+			borderRadius: `${ borderRadius }px`,
+		},
+	};
+
+	const buttonContent = isLoading ? (
+		<span className="wc-block-components-spinner" />
+	) : (
+		<div className="button-content">
+			{ interpolateComponents( {
+				mixedString: buttonText.replace(
+					ButtonTypeTextMap.default,
+					'{{wooPayLogo /}}'
+				),
+				components: {
+					wooPayLogo: <ThemedWooPayIcon />,
+				},
+			} ) }
+		</div>
+	);
+
 	return (
 		<div id="wcpay-woopay-button">
-			<button
-				ref={ buttonRef }
-				key={ `${ buttonType }-${ theme }-${ buttonSize }` }
-				aria-label={ buttonText }
-				onClick={ ( e ) => onClickCallbackRef.current( e ) }
-				className={ clsx( 'woopay-express-button', {
-					'is-loading': isLoading,
-				} ) }
-				data-type={ buttonType }
-				data-size={ buttonSize }
-				data-theme={ theme }
-				data-width-type={ buttonWidthType }
-				style={ {
-					height: `${ buttonHeight }px`,
-					borderRadius: `${ borderRadius }px`,
-				} }
-				disabled={ isLoading }
-				type="button"
-			>
-				{ isLoading ? (
-					<span className="wc-block-components-spinner" />
-				) : (
-					<div className="button-content">
-						{ interpolateComponents( {
-							mixedString: buttonText.replace(
-								ButtonTypeTextMap.default,
-								'{{wooPayLogo /}}'
-							),
-							components: {
-								wooPayLogo: <ThemedWooPayIcon />,
-							},
-						} ) }
-					</div>
-				) }
-			</button>
+			{ isFirstPartyAuth ? (
+				<a
+					{ ...sharedProps }
+					href={ woopayUrl }
+					aria-disabled={ isLoading || undefined }
+					tabIndex={ isLoading ? -1 : undefined }
+				>
+					{ buttonContent }
+				</a>
+			) : (
+				<button { ...sharedProps } disabled={ isLoading } type="button">
+					{ buttonContent }
+				</button>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes WOOPMNT-6058

#### Changes proposed in this Pull Request

The WooPay express checkout button was always rendered as a `<button>` element, but when first-party auth is enabled it redirects users to `pay.woo.com` — which is navigation behavior, not an in-page action. Screen readers announced it as a button, setting incorrect expectations for users who rely on assistive technology. This violates WCAG 2 Success Criterion 4.1.2 (Name, Role, Value) at Level A.

**What changed:**

- **Conditional element rendering:** When `isWoopayFirstPartyAuthEnabled` is true (navigation flow), the component now renders an `<a href="...">` element. When false (OTP iframe flow), it keeps the existing `<button>` element. Each mode gets the semantically correct role.
- **Anchor reset styles:** Added `a.woopay-express-button` CSS reset to ensure the anchor variant is visually identical to the button variant (no underline, inherited colors).
- **Accessible loading state:** The `<a>` variant uses `aria-disabled="true"` and `tabIndex={-1}` during loading, since anchors don't support the native `disabled` attribute.

**How this could break:**
- Theme CSS targeting `button.woopay-express-button` specifically would not apply to the anchor variant. Mitigated by our styles targeting the `.woopay-express-button` class without element qualifier.
- The `<a>` variant's click handler calls `e.preventDefault()` before running the async flow, so no unwanted navigation occurs.

#### Testing instructions

1. Enable WooPay with first-party auth enabled on a test store
2. Navigate to a product page, cart, or checkout where the WooPay express button appears
3. **Screen reader test:** I used [Chrome Screen Reader](https://chromewebstore.google.com/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn?authuser=4) — the button should be announced as a "link" (not "button")
4. **Keyboard test:** Tab to the WooPay button — verify a visible focus indicator appears
5. Verify clicking the button still initiates the WooPay payment flow normally
6. Disable first-party auth (if possible) and verify the button renders as a `<button>` and opens the OTP iframe flow
7. Verify the button looks identical in both modes (no visual difference)

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
☢️ Powered by [Gamma AI Tools](https://github.a8c.com/Automattic/gamma-ai-tools/)