### PR TITLE
fix: refresh account data after reader registration

### DIFF
--- a/changelog/dev-card-reader-cache
+++ b/changelog/dev-card-reader-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Refresh account cache after card reader registration.

--- a/includes/admin/class-wc-rest-payments-reader-controller.php
+++ b/includes/admin/class-wc-rest-payments-reader-controller.php
@@ -200,6 +200,8 @@ class WC_REST_Payments_Reader_Controller extends WC_Payments_REST_Controller {
 
 			$reader = wp_array_slice_assoc( $response, [ 'id', 'livemode', 'device_type', 'label', 'location', 'metadata', 'status' ] );
 
+			WC_Payments::get_account_service()->refresh_account_data();
+
 			return rest_ensure_response( $reader );
 		} catch ( API_Exception $e ) {
 			return rest_ensure_response(

--- a/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-readers-controller.php
@@ -41,13 +41,26 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 	 */
 	private $mock_receipts_service;
 
+	/**
+	 * @var WC_Payments_Account|MockObject
+	 */
+	private $mock_account_service;
+
+	/**
+	 * @var WC_Payments_Account
+	 */
+	private $original_account_service;
+
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_api_client       = $this->createMock( WC_Payments_API_Client::class );
-		$this->mock_wcpay_gateway    = $this->createMock( WC_Payment_Gateway_WCPay::class );
-		$this->mock_receipts_service = $this->createMock( WC_Payments_In_Person_Payments_Receipts_Service::class );
-		$this->controller            = new WC_REST_Payments_Reader_Controller( $this->mock_api_client, $this->mock_wcpay_gateway, $this->mock_receipts_service );
+		$this->mock_api_client          = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_wcpay_gateway       = $this->createMock( WC_Payment_Gateway_WCPay::class );
+		$this->mock_receipts_service    = $this->createMock( WC_Payments_In_Person_Payments_Receipts_Service::class );
+		$this->mock_account_service     = $this->createMock( WC_Payments_Account::class );
+		$this->original_account_service = WC_Payments::get_account_service();
+		WC_Payments::set_account_service( $this->mock_account_service );
+		$this->controller = new WC_REST_Payments_Reader_Controller( $this->mock_api_client, $this->mock_wcpay_gateway, $this->mock_receipts_service );
 
 		$this->reader = [
 			'id'          => 'tmr_P400-123-456-789',
@@ -66,6 +79,7 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 	 */
 	public function tear_down() {
 		parent::tear_down();
+		WC_Payments::set_account_service( $this->original_account_service );
 		delete_transient( Controller::STORE_READERS_TRANSIENT_KEY );
 	}
 
@@ -204,6 +218,10 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->with( 'tml_1234', 'puppies-plug-could', 'Blue Rabbit' )
 			->willReturn( $reader );
 
+		$this->mock_account_service
+			->expects( $this->once() )
+			->method( 'refresh_account_data' );
+
 		$request = new WP_REST_Request(
 			'POST',
 			'/wc/v3/payments/readers'
@@ -239,6 +257,10 @@ class WC_REST_Payments_Reader_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'register_terminal_reader' )
 			->with( 'tml_1234', 'puppies-plug-could' )
 			->willThrowException( new API_Exception( 'Something bad happened', 'test error', 500 ) );
+
+		$this->mock_account_service
+			->expects( $this->never() )
+			->method( 'refresh_account_data' );
 
 		$request = new WP_REST_Request(
 			'POST',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Refresh WooPayments account data after a card reader is successfully registered so cached account state reflects the newly attached reader.

This updates the reader registration REST controller and adds unit coverage confirming the account cache refresh runs on success and is skipped when reader registration fails.

#### Testing instructions

0. Ensure you have a valid formatted address (postcode) set in your WooCommerce Account Settings.
1. Go to `/wp-admin/admin.php?page=wc-admin&path=/payments/overview`.
2. Open the browser console and run:

```js
const loc = await wp.apiFetch( {
	path: '/wc/v3/payments/terminal/locations/store',
} );

const reader = await wp.apiFetch( {
	path: '/wc/v3/payments/readers',
	method: 'POST',
	data: {
		location: loc.id,
		registration_code: 'simulated-wpe',
		label: 'Cache test simulated reader',
	},
} );
```

3. You should see a successful response.
4. Open WCPay Dev Tools.
5. Check the account response and confirm the cache refresh happened. The dev tools should show when the last fetch happened, and `hasCardReaders` should be `true` in the account response.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description above)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios): _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

