### PR TITLE
fix: accept account_data param in test-drive account init endpoint

### DIFF
--- a/changelog/fix-WOOPRD-3245-pass-extra-bootstrapping
+++ b/changelog/fix-WOOPRD-3245-pass-extra-bootstrapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Accept account_data parameter in test-drive account init endpoint

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -187,10 +187,14 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 						],
 					],
 					'account_data' => [
-						'description' => 'Additional account data to pass to the platform during account creation.',
-						'type'        => 'object',
-						'default'     => [],
-						'required'    => false,
+						'description'          => 'Additional account data to pass to the platform during account creation.',
+						'type'                 => 'object',
+						'default'              => [],
+						'required'             => false,
+						'properties'           => [
+							'extra_bootstrapping' => [ 'type' => 'boolean' ],
+						],
+						'additionalProperties' => false,
 					],
 				],
 			]
@@ -356,7 +360,7 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 		}
 
 		try {
-			$success = $this->onboarding_service->init_test_drive_account( $country, $request->get_param( 'capabilities' ), $request->get_param( 'account_data' ) ?? [] );
+			$success = $this->onboarding_service->init_test_drive_account( $country, $request->get_param( 'capabilities' ) ?? [], $request->get_param( 'account_data' ) ?? [] );
 		} catch ( Exception $e ) {
 			return new WP_Error( self::RESULT_BAD_REQUEST, $e->getMessage(), [ 'status' => 400 ] );
 		}

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -186,6 +186,12 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 							],
 						],
 					],
+					'account_data' => [
+						'description' => 'Additional account data to pass to the platform during account creation.',
+						'type'        => 'object',
+						'default'     => [],
+						'required'    => false,
+					],
 				],
 			]
 		);
@@ -350,7 +356,7 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 		}
 
 		try {
-			$success = $this->onboarding_service->init_test_drive_account( $country, $request->get_param( 'capabilities' ) );
+			$success = $this->onboarding_service->init_test_drive_account( $country, $request->get_param( 'capabilities' ), $request->get_param( 'account_data' ) ?? [] );
 		} catch ( Exception $e ) {
 			return new WP_Error( self::RESULT_BAD_REQUEST, $e->getMessage(), [ 'status' => 400 ] );
 		}

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -684,17 +684,18 @@ class WC_Payments_Onboarding_Service {
 	 *
 	 * Note: This is a subset of the WC_Payments_Account::maybe_handle_onboarding method.
 	 *
-	 * @param string $country      The country code to use for the account.
-	 *                             This is a ISO 3166-1 alpha-2 country code.
-	 * @param array  $capabilities Optional. List keyed by capabilities IDs (payment methods) with boolean values
-	 *                             indicating whether the capability should be requested when the account is created
-	 *                             and enabled in the settings.
+	 * @param string $country                 The country code to use for the account.
+	 *                                         This is a ISO 3166-1 alpha-2 country code.
+	 * @param array  $capabilities             Optional. List keyed by capabilities IDs (payment methods) with boolean values
+	 *                                         indicating whether the capability should be requested when the account is created
+	 *                                         and enabled in the settings.
+	 * @param array  $additional_account_data  Optional. Additional account data to merge into the account data sent to the platform.
 	 *
 	 * @return bool Whether the account was created.
 	 * @throws API_Exception When the API request fails.
 	 * @throws Exception When an onboarding initialization is already in progress.
 	 */
-	public function init_test_drive_account( string $country, array $capabilities = [] ): bool {
+	public function init_test_drive_account( string $country, array $capabilities = [], array $additional_account_data = [] ): bool {
 		if ( ! $this->payments_api_client->is_server_connected() ) {
 			throw new Exception( __( 'Your store is not connected to WordPress.com. Please connect it first.', 'woocommerce-payments' ) );
 		}
@@ -732,6 +733,10 @@ class WC_Payments_Onboarding_Service {
 			],
 			$capabilities
 		);
+
+		if ( ! empty( $additional_account_data ) ) {
+			$account_data = WC_Payments_Utils::array_merge_recursive_distinct( $account_data, $additional_account_data );
+		}
 
 		// Attempt to create the account.
 		$onboarding_data = $this->payments_api_client->get_onboarding_data(

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -734,17 +734,21 @@ class WC_Payments_Onboarding_Service {
 			$capabilities
 		);
 
+		// Attempt to create the account.
+		// Filter out empty values first, then merge additional data so that
+		// boolean `false` values (e.g. `extra_bootstrapping: false`) are preserved.
+		$account_data = WC_Payments_Utils::array_filter_recursive( $account_data );
+
 		if ( ! empty( $additional_account_data ) ) {
 			$account_data = WC_Payments_Utils::array_merge_recursive_distinct( $account_data, $additional_account_data );
 		}
 
-		// Attempt to create the account.
 		$onboarding_data = $this->payments_api_client->get_onboarding_data(
 			false,
 			WC_Payments_Account::get_connect_url(),
 			$site_data,
 			WC_Payments_Utils::array_filter_recursive( $user_data ),
-			WC_Payments_Utils::array_filter_recursive( $account_data ),
+			$account_data,
 			self::get_actioned_notes(),
 		);
 

--- a/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
@@ -101,6 +101,58 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
+	public function test_init_test_drive_account_forwards_account_data_to_service() {
+		$account_data = [ 'extra_bootstrapping' => false ];
+
+		$this->mock_onboarding_service
+			->expects( $this->once() )
+			->method( 'init_test_drive_account' )
+			->with( 'US', [], $account_data )
+			->willReturn( true );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'country'      => 'US',
+				'account_data' => $account_data,
+			]
+		);
+
+		$response = $this->controller->init_test_drive_account( $request );
+		$this->assertSame( 200, $response->status );
+		$this->assertSame( [ 'success' => true ], $response->get_data() );
+	}
+
+	public function test_init_test_drive_account_defaults_account_data_to_empty_array() {
+		$this->mock_onboarding_service
+			->expects( $this->once() )
+			->method( 'init_test_drive_account' )
+			->with( 'US', [], [] )
+			->willReturn( true );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params( [ 'country' => 'US' ] );
+
+		$response = $this->controller->init_test_drive_account( $request );
+		$this->assertSame( 200, $response->status );
+		$this->assertSame( [ 'success' => true ], $response->get_data() );
+	}
+
+	public function test_init_test_drive_account_returns_error_on_service_exception() {
+		$this->mock_onboarding_service
+			->expects( $this->once() )
+			->method( 'init_test_drive_account' )
+			->willThrowException( new Exception( 'Something went wrong' ) );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params( [ 'country' => 'US' ] );
+
+		$response = $this->controller->init_test_drive_account( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'bad_request', $response->get_error_code() );
+		$this->assertSame( 'Something went wrong', $response->get_error_message() );
+	}
+
 	public function test_finalize_embedded_kyc() {
 		$response_data = [
 			'success'           => true,

--- a/tests/unit/test-class-wc-payments-onboarding-service.php
+++ b/tests/unit/test-class-wc-payments-onboarding-service.php
@@ -763,6 +763,62 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertNotEmpty( $result );
 	}
 
+	public function test_init_test_drive_account_merges_additional_account_data() {
+		// Arrange.
+		$this->mock_api_client
+			->method( 'is_server_connected' )
+			->willReturn( true );
+
+		$captured_account_data = null;
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_onboarding_data' )
+			->willReturnCallback(
+				function ( $collect_payout_requirements, $return_url, $site_data, $user_data, $account_data ) use ( &$captured_account_data ) {
+					$captured_account_data = $account_data;
+					return [
+						'url' => false,
+					];
+				}
+			);
+
+		// Act.
+		$this->onboarding_service->init_test_drive_account( 'US', [], [ 'extra_bootstrapping' => false ] );
+
+		// Assert: The `extra_bootstrapping => false` key should survive into the API call.
+		$this->assertArrayHasKey( 'extra_bootstrapping', $captured_account_data );
+		$this->assertFalse( $captured_account_data['extra_bootstrapping'] );
+	}
+
+	public function test_init_test_drive_account_without_additional_data_leaves_account_data_unchanged() {
+		// Arrange.
+		$this->mock_api_client
+			->method( 'is_server_connected' )
+			->willReturn( true );
+
+		$captured_account_data = null;
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_onboarding_data' )
+			->willReturnCallback(
+				function ( $collect_payout_requirements, $return_url, $site_data, $user_data, $account_data ) use ( &$captured_account_data ) {
+					$captured_account_data = $account_data;
+					return [
+						'url' => false,
+					];
+				}
+			);
+
+		// Act.
+		$this->onboarding_service->init_test_drive_account( 'US', [] );
+
+		// Assert: No extra_bootstrapping key should be present.
+		$this->assertArrayNotHasKey( 'extra_bootstrapping', $captured_account_data );
+		// The base account data should still contain the expected keys.
+		$this->assertArrayHasKey( 'setup_mode', $captured_account_data );
+		$this->assertSame( 'test_drive', $captured_account_data['setup_mode'] );
+	}
+
 	public function test_add_woocommerce_store_id_to_request_adds_store_id() {
 		$store_id = 'test-store-uuid-1234';
 		update_option( 'woocommerce_store_id', $store_id );


### PR DESCRIPTION
Fixes WOOPRD-3245

#### Changes proposed in this Pull Request

The `test_drive_account/init` REST endpoint currently ignores any `account_data` passed in the request body. This means callers (e.g., CIAB's commerce-garden provisioning) cannot control platform behavior like `extra_bootstrapping` during test-drive account creation.

The Transact Platform seeds a $1.00 test charge and payout when `extra_bootstrapping` defaults to `true`. This programmatic data pollutes WooPayments analytics events on test-drive accounts.

This PR:
- Registers `account_data` as an accepted object parameter on the `test_drive_account/init` route
- Forwards it from the controller to `WC_Payments_Onboarding_Service::init_test_drive_account()`
- Merges it into the internally-built account data via `array_merge_recursive_distinct` before sending to the platform API

#### Testing instructions

1. Set up a site connected to WordPress.com with WooPayments active
2. Send a POST request to `/wc/v3/payments/onboarding/test_drive_account/init` with body:
   ```json
   {
     "country": "US",
     "capabilities": { "card_payments": true },
     "account_data": { "extra_bootstrapping": false }
   }
   ```
3. Verify the request succeeds and the `account_data` fields are forwarded to the platform (check logs or platform side)
4. Verify that omitting `account_data` still works as before (backwards compatible)

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_