### PR TITLE
fix: resolve WC version instead of passing "latest" to QIT CLI

### DIFF
--- a/.github/scripts/generate-wc-matrix.sh
+++ b/.github/scripts/generate-wc-matrix.sh
@@ -83,16 +83,18 @@ echo "Latest beta version: $LATEST_BETA_VERSION" >&2
 # Build the version array
 VERSIONS=("7.7.0")  # Keep for business reasons (significant TPV)
 
-# Add major versions latest stable (excluding current major since we'll use 'latest')
+# Add major versions latest stable (excluding current major since it's added below)
 for version in "${MAJOR_VERSIONS[@]}"; do
-    # Skip the current major version since we'll use 'latest' instead
+    # Skip the current major version since it's added as LATEST_WC_VERSION below
     if [[ "$version" != "$LATEST_WC_VERSION" ]]; then
         VERSIONS+=("$version")
     fi
 done
 
-# Add latest, beta, rc (with actual versions)
-VERSIONS+=("latest")
+# Add latest stable, beta, rc (with actual versions)
+# Use the resolved version number instead of "latest" to avoid QIT CLI
+# constructing invalid wporg download URLs (woocommerce.latest.zip → 404).
+VERSIONS+=("$LATEST_WC_VERSION")
 if [[ -n "$LATEST_BETA_VERSION" && "$LATEST_BETA_VERSION" != "null" ]]; then
     VERSIONS+=("$LATEST_BETA_VERSION")
     echo "Including beta version: $LATEST_BETA_VERSION" >&2

--- a/.github/scripts/generate-wc-matrix.sh
+++ b/.github/scripts/generate-wc-matrix.sh
@@ -144,12 +144,14 @@ fi
 # Output a single JSON object with both versions and metadata
 RESULT=$(jq -n \
     --argjson versions "$(printf '%s\n' "${VERSIONS[@]}" | jq -R . | jq -s .)" \
+    --arg latest_wc_version "$LATEST_WC_VERSION" \
     --arg l1_version "$L1_VERSION" \
     --arg rc_version "${INCLUDED_RC_VERSION}" \
     --arg beta_version "${LATEST_BETA_VERSION}" \
     '{
         versions: $versions,
         metadata: {
+            latest_wc_version: $latest_wc_version,
             l1_version: $l1_version,
             rc_version: (if ($rc_version // "") == "" or ($rc_version == "null") then null else $rc_version end),
             beta_version: (if ($beta_version // "") == "" or ($beta_version == "null") then null else $beta_version end)

--- a/.github/workflows/qit-e2e-pr.yml
+++ b/.github/workflows/qit-e2e-pr.yml
@@ -48,9 +48,7 @@ jobs:
           SCRIPT_RESULT=$(.github/scripts/generate-wc-matrix.sh)
           L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l1_version')
 
-          # Resolve "latest" to actual version number to avoid QIT CLI
-          # constructing invalid wporg download URLs (woocommerce.latest.zip → 404).
-          LATEST_WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.version')
+          LATEST_WC_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.latest_wc_version')
           echo "L-1 version: $L1_VERSION, Latest WC: $LATEST_WC_VERSION" >&2
 
           # Build PR matrix: L-1 + latest stable, PHP 8.3 only, all projects

--- a/.github/workflows/qit-e2e-pr.yml
+++ b/.github/workflows/qit-e2e-pr.yml
@@ -48,11 +48,14 @@ jobs:
           SCRIPT_RESULT=$(.github/scripts/generate-wc-matrix.sh)
           L1_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.l1_version')
 
-          echo "L-1 version: $L1_VERSION" >&2
+          # Resolve "latest" to actual version number to avoid QIT CLI
+          # constructing invalid wporg download URLs (woocommerce.latest.zip → 404).
+          LATEST_WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.version')
+          echo "L-1 version: $L1_VERSION, Latest WC: $LATEST_WC_VERSION" >&2
 
-          # Build PR matrix: L-1 + latest, PHP 8.3 only, all projects
+          # Build PR matrix: L-1 + latest stable, PHP 8.3 only, all projects
           MATRIX_ENTRIES=()
-          for wc_version in "$L1_VERSION" "latest"; do
+          for wc_version in "$L1_VERSION" "$LATEST_WC_VERSION"; do
             for project in "shopper" "merchant" "subscriptions"; do
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$wc_version\",\"wordpress\":\"latest\",\"php\":\"8.3\",\"project\":\"$project\"}")
             done

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -57,8 +57,9 @@ jobs:
           coverage: none
 
       - name: Install QIT CLI
-        # Use dev-trunk because test packages feature is not yet in stable releases
-        run: composer global require woocommerce/qit-cli:dev-trunk
+        # Pin to a stable release to avoid regressions from dev-trunk.
+        # Test packages feature is available since 1.1.0.
+        run: composer global require woocommerce/qit-cli:1.1.8
 
       - name: Authenticate QIT
         run: qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -50,14 +50,18 @@ jobs:
           [[ "$BETA_VERSION" == "null" ]] && BETA_VERSION=""
           [[ "$RC_VERSION" == "null" ]] && RC_VERSION=""
 
-          echo "L-1 version: $L1_VERSION" >&2
+          # Resolve "latest" to actual version number to avoid QIT CLI
+          # constructing invalid wporg download URLs (woocommerce.latest.zip → 404).
+          LATEST_WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.version')
+
+          echo "L-1 version: $L1_VERSION, Latest WC: $LATEST_WC_VERSION" >&2
           [[ -n "$BETA_VERSION" ]] && echo "Beta version: $BETA_VERSION" >&2 || echo "No beta version available" >&2
           [[ -n "$RC_VERSION" ]] && echo "RC version: $RC_VERSION" >&2 || echo "No RC version available" >&2
 
-          # Build scheduled matrix: L-1 + latest + nightly WC, PHP 8.3, all projects
+          # Build scheduled matrix: L-1 + latest stable + nightly WC, PHP 8.3, all projects
           # All combinations use WP latest by default
           MATRIX_ENTRIES=()
-          for wc_version in "$L1_VERSION" "latest" "nightly"; do
+          for wc_version in "$L1_VERSION" "$LATEST_WC_VERSION" "nightly"; do
             for project in "shopper" "merchant" "subscriptions"; do
               MATRIX_ENTRIES+=("{\"woocommerce\":\"$wc_version\",\"wordpress\":\"latest\",\"php\":\"8.3\",\"project\":\"$project\"}")
             done

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -50,9 +50,7 @@ jobs:
           [[ "$BETA_VERSION" == "null" ]] && BETA_VERSION=""
           [[ "$RC_VERSION" == "null" ]] && RC_VERSION=""
 
-          # Resolve "latest" to actual version number to avoid QIT CLI
-          # constructing invalid wporg download URLs (woocommerce.latest.zip → 404).
-          LATEST_WC_VERSION=$(curl -s https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.version')
+          LATEST_WC_VERSION=$(echo "$SCRIPT_RESULT" | jq -r '.metadata.latest_wc_version')
 
           echo "L-1 version: $L1_VERSION, Latest WC: $LATEST_WC_VERSION" >&2
           [[ -n "$BETA_VERSION" ]] && echo "Beta version: $BETA_VERSION" >&2 || echo "No beta version available" >&2
@@ -81,9 +79,9 @@ jobs:
             done
           fi
 
-          # Add WP nightly tests (WP nightly + WC latest + PHP 8.3 only)
+          # Add WP nightly tests (WP nightly + WC latest stable + PHP 8.3 only)
           for project in "shopper" "merchant" "subscriptions"; do
-            MATRIX_ENTRIES+=("{\"woocommerce\":\"latest\",\"wordpress\":\"nightly\",\"php\":\"8.3\",\"project\":\"$project\"}")
+            MATRIX_ENTRIES+=("{\"woocommerce\":\"$LATEST_WC_VERSION\",\"wordpress\":\"nightly\",\"php\":\"8.3\",\"project\":\"$project\"}")
           done
 
           # Add PHP 8.4 tests (WC nightly + PHP 8.4 to catch newest PHP compatibility issues)

--- a/changelog/fix-qit-wc-latest-version-resolution
+++ b/changelog/fix-qit-wc-latest-version-resolution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Resolve WC version number instead of passing 'latest' to QIT CLI to work around invalid download URL construction.

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "cweagans/composer-patches": "1.7.1",
         "automattic/jetpack-changelogger": "3.3.2",
         "spatie/phpunit-watcher": "1.23.6",
-        "woocommerce/qit-cli": "dev-trunk",
+        "woocommerce/qit-cli": "1.1.8",
         "slevomat/coding-standard": "^8.15",
         "dg/bypass-finals": "1.5.1",
         "sirbrillig/phpcs-variable-analysis": "^2.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b58e44f39d45cbcc950226f1149a5ce",
+    "content-hash": "0d367ae57ca9268b4f43af1ca1ed519d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -5696,23 +5696,22 @@
         },
         {
             "name": "woocommerce/qit-cli",
-            "version": "dev-trunk",
+            "version": "1.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/qit-cli.git",
-                "reference": "276968bd88e83be1fa861c3d85212c5a3328eb47"
+                "reference": "86756685410ebbbe20a7341e980629b48f8920c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/qit-cli/zipball/276968bd88e83be1fa861c3d85212c5a3328eb47",
-                "reference": "276968bd88e83be1fa861c3d85212c5a3328eb47",
+                "url": "https://api.github.com/repos/woocommerce/qit-cli/zipball/86756685410ebbbe20a7341e980629b48f8920c8",
+                "reference": "86756685410ebbbe20a7341e980629b48f8920c8",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "php": "^7.4 | ^8"
             },
-            "default-branch": true,
             "bin": [
                 "qit"
             ],
@@ -5724,9 +5723,9 @@
             "description": "A command line interface for WooCommerce Quality Insights Toolkit (QIT).",
             "support": {
                 "issues": "https://github.com/woocommerce/qit-cli/issues",
-                "source": "https://github.com/woocommerce/qit-cli/tree/trunk"
+                "source": "https://github.com/woocommerce/qit-cli/tree/1.1.8"
             },
-            "time": "2026-01-27T04:47:04+00:00"
+            "time": "2026-04-03T16:28:34+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",
@@ -5957,8 +5956,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "kalessil/production-dependencies-guard": 20,
-        "woocommerce/qit-cli": 20
+        "kalessil/production-dependencies-guard": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
Fixes WOOPMNT-6059 

## Summary

QIT CLI dev-trunk (`dbdbe368`) constructs download URLs using the literal version string. When `--woo=latest` is passed, it generates `woocommerce.latest.zip` — which returns a **404** from `downloads.wordpress.org`, causing all QIT E2E `WC latest` jobs to fail across every PR.

### Verification

```bash
# This returns 404 (the bug):
curl -sI "https://downloads.wordpress.org/plugin/woocommerce.latest.zip" | head -1
# HTTP/2 404

# This works (the fix):
curl -sI "https://downloads.wordpress.org/plugin/woocommerce.10.6.2.zip" | head -1
# HTTP/2 200
```

### Testing instructions

- CI QIT E2E jobs targeting WC latest should now pass 
- Check that the matrix shows an actual version like `10.6.2` instead of `latest`
- Verified locally: `qit run:e2e` downloads `woocommerce.10.6.2.zip` successfully with QIT CLI 1.1.8

---

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)