### PR TITLE
Optimize order_from_intent_id() to use HPOS transaction_id column

### DIFF
--- a/changelog/woopmnt-6055-optimize-order-from-intent-id
+++ b/changelog/woopmnt-6055-optimize-order-from-intent-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Optimize order lookup by intent ID to use the HPOS transaction_id column instead of _intent_id meta query, improving webhook processing performance for high-volume stores.

--- a/includes/class-wc-payments-db.php
+++ b/includes/class-wc-payments-db.php
@@ -68,6 +68,23 @@ class WC_Payments_DB {
 	 * @return boolean|WC_Order|WC_Order_Refund
 	 */
 	public function order_from_intent_id( $intent_id ) {
+		if ( ! $intent_id ) {
+			return false;
+		}
+
+		// Try the HPOS transaction_id column first — avoids a slow meta table JOIN.
+		$orders = wc_get_orders(
+			[
+				'limit'          => 1,
+				'transaction_id' => $intent_id,
+			]
+		);
+
+		if ( ! empty( $orders ) ) {
+			return $orders[0];
+		}
+
+		// Fallback to _intent_id meta for historical orders where transaction_id may not be populated.
 		$order_id = $this->order_id_from_meta_key_value( self::META_KEY_INTENT_ID, $intent_id );
 
 		if ( $order_id ) {

--- a/tests/unit/test-class-wc-payments-db.php
+++ b/tests/unit/test-class-wc-payments-db.php
@@ -68,6 +68,48 @@ class WC_Payments_DB_Test extends WCPAY_UnitTestCase {
 		$result = $this->wcpay_db->order_from_charge_id( $charge_id );
 		$this->assertSame( $order->get_id(), $result->get_id() );
 	}
+	public function test_order_from_intent_id_uses_transaction_id() {
+		$intent_id = 'pi_123';
+		$order     = WC_Helper_Order::create_order();
+		$order->set_transaction_id( $intent_id );
+		$order->save();
+
+		$result = $this->wcpay_db->order_from_intent_id( $intent_id );
+		$this->assertSame( $order->get_id(), $result->get_id() );
+	}
+
+	public function test_order_from_intent_id_falls_back_to_meta() {
+		$intent_id = 'pi_456';
+		$order     = WC_Helper_Order::create_order();
+		// Only set the meta, not the transaction_id — simulates a historical order.
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->save();
+
+		$result = $this->wcpay_db->order_from_intent_id( $intent_id );
+		$this->assertSame( $order->get_id(), $result->get_id() );
+	}
+
+	public function test_order_from_intent_id_returns_false_if_empty() {
+		$result = $this->wcpay_db->order_from_intent_id( '' );
+		$this->assertFalse( $result );
+
+		$result = $this->wcpay_db->order_from_intent_id( null );
+		$this->assertFalse( $result );
+	}
+
+	public function test_order_from_intent_id_prefers_transaction_id_over_meta() {
+		$intent_id = 'pi_789';
+
+		// Create an order with both transaction_id and _intent_id set (normal case).
+		$order = WC_Helper_Order::create_order();
+		$order->set_transaction_id( $intent_id );
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->save();
+
+		$result = $this->wcpay_db->order_from_intent_id( $intent_id );
+		$this->assertSame( $order->get_id(), $result->get_id() );
+	}
+
 	public function test_order_from_charge_id_will_return_false_if_value_is_empty() {
 		$charge_id = 'ch_123';
 		$order     = WC_Helper_Order::create_order();


### PR DESCRIPTION
Fixes #11552

#### Changes proposed in this Pull Request

Optimizes `order_from_intent_id()` in `WC_Payments_DB` to query the HPOS `transaction_id` column first, avoiding a slow meta table JOIN on `_intent_id`. Falls back to the meta query for historical orders where `transaction_id` may not be populated.

**Why:** The `payment_intent.succeeded` webhook — the highest-volume webhook for any store — resolves orders via `order_from_intent_id()`. On HPOS stores, this currently JOINs against `wc_orders_meta`, which degrades as order count grows. This is especially impactful for HVMs during BFCM webhook surges.

**What:** Instead of `wc_get_orders(['meta_key' => '_intent_id', 'meta_value' => $id])` (meta JOIN), we first try `wc_get_orders(['transaction_id' => $id])` (direct column comparison on `wc_orders`). The data is already there — `attach_intent_info_to_order__legacy` writes the intent ID to both `transaction_id` and `_intent_id` meta on every order.

**Fallback cost:** In the worst case (historical order without `transaction_id`), two queries run instead of one. However, `set_transaction_id($intent_id)` was introduced in WooPayments 5.6.0 (February 2023, PR #5321) — over 3 years ago. The fallback only fires for orders created before that version, which would require a webhook for a 3+ year old order (e.g., a very late dispute). For all orders since v5.6.0, and all current webhook traffic including BFCM surges, it's a single faster query.

**How can this break?** Historical orders from plugin versions before 5.6.0 may have `_intent_id` meta but no `transaction_id` populated. The fallback to the meta query handles this case.

#### Testing instructions

* Create an order via WooPayments checkout
* Verify the order is found correctly in WP Admin → WooPayments → Transactions
* Verify webhooks process correctly (check order notes for payment confirmation)
* For historical order testing: create an order, remove its `transaction_id` via DB, verify it's still found via the `_intent_id` meta fallback

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.