### PR TITLE
E2E: add test for the repeated checkout attempt after the card decline

### DIFF
--- a/changelog/dev-add-tests-for-repeated-checkout-attempts
+++ b/changelog/dev-add-tests-for-repeated-checkout-attempts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+E2E tests for the repeated checkout attempt after the card decline.

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.ts
@@ -187,3 +187,38 @@ test.describe(
 		} );
 	}
 );
+
+test.describe(
+	'Shopper > Checkout > Retry after failure without page refresh',
+	{ tag: '@critical' },
+	() => {
+		let shopperPage: Page;
+		let browser: Browser;
+
+		test.beforeAll( async ( { browser: b } ) => {
+			browser = b;
+			shopperPage = ( await getShopper( browser ) ).shopperPage;
+			await shopper.addToCartFromShopPage( shopperPage );
+		} );
+
+		test( 'should successfully complete order after retrying with a valid card without refreshing the page', async () => {
+			await shopper.setupCheckout( shopperPage );
+			await shopper.selectPaymentMethod( shopperPage );
+
+			// First attempt: declined card.
+			await shopper.fillCardDetails( shopperPage, config.cards.declined );
+			await shopper.placeOrder( shopperPage );
+			await expect(
+				shopperPage.getByText( 'Error: Your card was declined.' )
+			).toBeVisible();
+
+			// Second attempt: valid card, same page, no refresh.
+			// Regression scenario from issue #160 / PR #133.
+			await shopper.fillCardDetails( shopperPage, config.cards.basic );
+			await shopper.placeOrder( shopperPage );
+			await expect(
+				shopperPage.getByText( 'Order received' ).first()
+			).toBeVisible();
+		} );
+	}
+);

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.ts
@@ -198,6 +198,7 @@ test.describe(
 		test.beforeAll( async ( { browser: b } ) => {
 			browser = b;
 			shopperPage = ( await getShopper( browser ) ).shopperPage;
+			await shopper.emptyCart( shopperPage );
 			await shopper.addToCartFromShopPage( shopperPage );
 		} );
 

--- a/tests/e2e/specs/wcpay/shopper/shopper-wc-blocks-checkout-failures.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-wc-blocks-checkout-failures.spec.ts
@@ -120,5 +120,25 @@ describeif( shouldRunWCBlocksTests )(
 				}
 			} );
 		}
+
+		test( 'should successfully complete order after retrying with a valid card without refreshing the page', async () => {
+			// First attempt: declined card.
+			await shopper.fillCardDetailsWCB(
+				shopperPage,
+				config.cards.declined
+			);
+			await shopper.placeOrderWCB( shopperPage, false );
+
+			await expect(
+				shopperPage
+					.locator( '.wc-block-checkout__form' )
+					.getByText( 'Your card was declined.' )
+			).toBeVisible();
+
+			// Second attempt: valid card, same page, no refresh.
+			// Regression scenario from issue #160 / PR #133.
+			await shopper.fillCardDetailsWCB( shopperPage, config.cards.basic );
+			await shopper.placeOrderWCB( shopperPage, true );
+		} );
 	}
 );


### PR DESCRIPTION
Fixes #160 

### Changes proposed

Add tests for the scenario when checkout form is resubmitted after the card decline.

_Note:_ Copilot erased original PR description without asking 🤷‍♂️ 