### PR TITLE
Fix WooPay preview logo sizing on some themes

### DIFF
--- a/changelog/fix-woopay-preview-logo-sizing
+++ b/changelog/fix-woopay-preview-logo-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay preview logo rendering at full intrinsic size on some themes.

--- a/client/settings/express-checkout-settings/index.scss
+++ b/client/settings/express-checkout-settings/index.scss
@@ -252,6 +252,8 @@
 			&__woopay-logo {
 				display: flex;
 				align-items: center;
+				height: 0.375rem;
+				width: auto;
 
 				svg {
 					height: 0.375rem;


### PR DESCRIPTION
## Summary

- Fix WooPay preview logo rendering at full intrinsic size on certain themes
- The `WooPayLogo` component renders an `<img>`, but the SCSS only constrained the child `svg` selector — themes without their own `img` max-height rules showed the logo at full size
- Adds `height` and `width: auto` on the parent `&__woopay-logo` container so both `svg` and `img` children are sized correctly

Originally part of #11542 (closed), this fix was not carried over when #11545 was merged.

## Test plan

- [x] Open WooPayments > Settings > Express Checkout
- [x] Verify the WooPay preview logo renders at the expected small size
- [ ] Test with a theme that doesn't set `img { max-height }` (e.g. Flavor flavor flavor flavor flavor flavor flavor flavor Flavor flavor flavor flavor flavor flavor flavor flavor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This got dropped when PR 11542 was replaced by 11545. Needs to be in 10.7.

Before
<img width="809" height="421" alt="image" src="https://github.com/user-attachments/assets/cf052d2b-0bd7-4cb0-b43d-adc60934a11b" />

After
<img width="650" height="381" alt="image" src="https://github.com/user-attachments/assets/2df7ffbd-20db-4d9d-a5bc-c95beca24144" />

<img width="814" height="384" alt="image" src="https://github.com/user-attachments/assets/7da85ba7-5981-49d3-a2a3-5df4876caf22" />

