### PR TITLE
fix: add auth guard to shopper appearance endpoint

### DIFF
--- a/changelog/fix-add-auth-guard-shopper-appearance
+++ b/changelog/fix-add-auth-guard-shopper-appearance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add authentication guard to shopper WooPay appearance endpoint

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -1253,9 +1253,7 @@ class WooPay_Session {
 	 * @return void
 	 */
 	public static function ajax_shopper_set_woopay_appearance() {
-		$is_nonce_valid = check_ajax_referer( 'woopay_session_nonce', false, false );
-
-		if ( ! $is_nonce_valid ) {
+		if ( ! is_user_logged_in() || ! check_ajax_referer( 'woopay_session_nonce', false, false ) ) {
 			wp_send_json_error(
 				__( 'You aren\'t authorized to do that.', 'woocommerce-payments' ),
 				403


### PR DESCRIPTION
## Summary

- Add `is_user_logged_in()` guard to `ajax_shopper_set_woopay_appearance()` to block unauthenticated writes to the persistent WooPay appearance option

See paJDYF-ilh-p2 for full analysis.

Verified locally that unauthenticated requests are blocked and authenticated requests pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)