### PR TITLE
fix: ECE pricing info for subscriptions w/ free trial

### DIFF
--- a/changelog/fix-subscriptions-prices-for-free-trials
+++ b/changelog/fix-subscriptions-prices-for-free-trials
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: express checkout to show recurring subscription info for free trial subscriptions with sign-up fees, not just pure $0 free trials

--- a/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
+++ b/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
@@ -653,5 +653,88 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 			expect( result.totals.total_items ).toBe( '12800' );
 			expect( result.totals.total_tax ).toBe( '1280' );
 		} );
+
+		it( 'does not duplicate metadata when multiple schedules share the same billing period', () => {
+			// When subscription schedules differ only by interval/trial/length,
+			// they share a billing_period. Each item must be processed only once.
+			const cart = buildTrialCart( {
+				items: [
+					buildTrialSubscriptionItem( {
+						name: 'Monthly Sub',
+						billingPeriod: 'month',
+						signUpFees: '200',
+						lineSubtotal: '200',
+						lineTotal: '200',
+					} ),
+				],
+				totalPrice: '200',
+				subscriptions: [
+					buildSubscriptionSchedule( {
+						billingPeriod: 'month',
+						billingInterval: 1,
+						totalPrice: '700',
+						totalItems: '700',
+					} ),
+					buildSubscriptionSchedule( {
+						billingPeriod: 'month',
+						billingInterval: 2,
+						totalPrice: '1400',
+						totalItems: '1400',
+					} ),
+				],
+			} );
+
+			const result = applyFilters(
+				'wcpay.express-checkout.map-line-items',
+				cart
+			);
+
+			const item = result.items[ 0 ];
+			// Name should have (recurring) only once.
+			expect( item.name ).toBe( 'Monthly Sub (recurring)' );
+			// Recurring total metadata should appear exactly once.
+			const recurringEntries = item.item_data.filter(
+				( d ) => d.name === 'Recurring total'
+			);
+			expect( recurringEntries ).toHaveLength( 1 );
+		} );
+
+		it( 'is idempotent when the filter runs on already-modified data', () => {
+			const cart = buildTrialCart( {
+				items: [
+					buildTrialSubscriptionItem( {
+						name: 'Physical subscription',
+						signUpFees: '200',
+						lineSubtotal: '200',
+						lineTotal: '200',
+					} ),
+				],
+				totalPrice: '200',
+				subscriptions: [
+					buildSubscriptionSchedule( {
+						totalPrice: '758',
+						totalItems: '700',
+						totalTax: '58',
+					} ),
+				],
+			} );
+
+			// Run the filter twice — second call receives the first call's output.
+			const firstPass = applyFilters(
+				'wcpay.express-checkout.map-line-items',
+				cart
+			);
+			const secondPass = applyFilters(
+				'wcpay.express-checkout.map-line-items',
+				firstPass
+			);
+
+			const item = secondPass.items[ 0 ];
+			expect( item.name ).toBe( 'Physical subscription (recurring)' );
+			const recurringEntries = item.item_data.filter(
+				( d ) => d.name === 'Recurring total'
+			);
+			expect( recurringEntries ).toHaveLength( 1 );
+		} );
 	} );
 } );

--- a/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
+++ b/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
@@ -477,6 +477,44 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 			expect( result.totals.total_price ).toBe( '217' );
 		} );
 
+		it( 'formats plural billing interval in recurring metadata for sign-up fee carts', () => {
+			const cart = buildTrialCart( {
+				items: [
+					buildTrialSubscriptionItem( {
+						name: 'Quarterly Plan',
+						billingPeriod: 'month',
+						signUpFees: '500',
+						lineSubtotal: '500',
+						lineTotal: '500',
+					} ),
+				],
+				totalPrice: '500',
+				subscriptions: [
+					buildSubscriptionSchedule( {
+						billingPeriod: 'month',
+						billingInterval: 3,
+						totalPrice: '2997',
+						totalItems: '2997',
+					} ),
+				],
+			} );
+
+			const result = applyFilters(
+				'wcpay.express-checkout.map-line-items',
+				cart
+			);
+
+			const item = result.items[ 0 ];
+			expect( item.name ).toBe( 'Quarterly Plan (recurring)' );
+			// Should keep original prices (sign-up fee).
+			expect( item.totals.line_subtotal ).toBe( '500' );
+			// Should format plural interval as "3 months".
+			expect( item.item_data ).toContainEqual( {
+				name: 'Recurring total',
+				value: '$29.97 / 3 months on 2026-03-19',
+			} );
+		} );
+
 		it( 'replaces $0 trial items with recurring amounts and metadata', () => {
 			const cart = buildTrialCart();
 			const result = applyFilters(

--- a/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
+++ b/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
@@ -467,7 +467,7 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 			// Should keep original prices (sign-up fee), not replace with recurring.
 			expect( item.totals.line_subtotal ).toBe( '200' );
 			expect( item.totals.line_total ).toBe( '200' );
-			// Should add First payment metadata with recurring price.
+			// Should add Recurring total metadata with recurring price.
 			expect( item.item_data ).toContainEqual( {
 				name: 'Recurring total',
 				value: '$7.58 / month on 2026-03-19',

--- a/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
+++ b/client/express-checkout/compatibility/__tests__/wc-subscriptions.test.js
@@ -18,9 +18,11 @@ const buildTrialSubscriptionItem = ( {
 	billingPeriod = 'month',
 	trialLength = 14,
 	signUpFees = '0',
+	lineSubtotal = '0',
+	lineTotal = '0',
 } = {} ) => ( {
 	name,
-	totals: { line_subtotal: '0', line_total: '0' },
+	totals: { line_subtotal: lineSubtotal, line_total: lineTotal },
 	item_data: [],
 	extensions: {
 		subscriptions: {
@@ -33,6 +35,7 @@ const buildTrialSubscriptionItem = ( {
 
 const buildSubscriptionSchedule = ( {
 	billingPeriod = 'month',
+	billingInterval = 1,
 	nextPaymentDate = '2026-03-19',
 	totalPrice = '1999',
 	totalItems = '1999',
@@ -40,10 +43,15 @@ const buildSubscriptionSchedule = ( {
 	totalShipping = '0',
 	totalShippingTax = '0',
 	currencyMinorUnit = 2,
+	currencyPrefix = '$',
+	currencySuffix = '',
+	currencyDecimalSeparator = '.',
+	currencyThousandSeparator = ',',
 	taxLines = [],
 	shippingRates,
 } = {} ) => ( {
 	billing_period: billingPeriod,
+	billing_interval: billingInterval,
 	next_payment_date: nextPaymentDate,
 	totals: {
 		total_price: totalPrice,
@@ -52,6 +60,10 @@ const buildSubscriptionSchedule = ( {
 		total_shipping: totalShipping,
 		total_shipping_tax: totalShippingTax,
 		currency_minor_unit: currencyMinorUnit,
+		currency_prefix: currencyPrefix,
+		currency_suffix: currencySuffix,
+		currency_decimal_separator: currencyDecimalSeparator,
+		currency_thousand_separator: currencyThousandSeparator,
 		tax_lines: taxLines,
 	},
 	...( shippingRates ? { shipping_rates: shippingRates } : {} ),
@@ -142,9 +154,9 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 		).toBe( regularCart );
 	} );
 
-	it( 'all filters pass through when cart total is non-zero', () => {
+	it( 'total-amount and eligibility filters pass through when cart total is non-zero', () => {
 		// Non-zero total means the subscription has a sign-up fee or other
-		// upfront charges — standard handling applies.
+		// upfront charges — $0-cart overrides don't activate.
 		const cart = buildTrialCart( { totalPrice: '500' } );
 
 		expect(
@@ -157,9 +169,6 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 				cart
 			)
 		).toBe( false );
-		expect(
-			applyFilters( 'wcpay.express-checkout.map-line-items', cart )
-		).toBe( cart );
 	} );
 
 	it( 'total-amount and eligibility filters pass through for subscriptions with sign-up fees (non-zero cart total)', () => {
@@ -423,6 +432,51 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 	} );
 
 	describe( 'map-line-items filter', () => {
+		it( 'adds recurring metadata to trial items with sign-up fee without replacing prices', () => {
+			const cart = buildTrialCart( {
+				items: [
+					buildTrialSubscriptionItem( {
+						name: 'Physical subscription',
+						signUpFees: '200',
+						lineSubtotal: '200',
+						lineTotal: '200',
+					} ),
+				],
+				totalPrice: '217',
+				subscriptions: [
+					buildSubscriptionSchedule( {
+						totalPrice: '758',
+						totalItems: '700',
+						totalTax: '58',
+					} ),
+				],
+			} );
+
+			const result = applyFilters(
+				'wcpay.express-checkout.map-line-items',
+				cart
+			);
+
+			// Must not mutate the original cart data.
+			expect( result ).not.toBe( cart );
+			expect( cart.items[ 0 ].name ).toBe( 'Physical subscription' );
+
+			const item = result.items[ 0 ];
+			// Should add (recurring) label.
+			expect( item.name ).toBe( 'Physical subscription (recurring)' );
+			// Should keep original prices (sign-up fee), not replace with recurring.
+			expect( item.totals.line_subtotal ).toBe( '200' );
+			expect( item.totals.line_total ).toBe( '200' );
+			// Should add First payment metadata with recurring price.
+			expect( item.item_data ).toContainEqual( {
+				name: 'Recurring total',
+				value: '$7.58 / month on 2026-03-19',
+			} );
+
+			// Should keep original cart totals (sign-up fee + tax).
+			expect( result.totals.total_price ).toBe( '217' );
+		} );
+
 		it( 'replaces $0 trial items with recurring amounts and metadata', () => {
 			const cart = buildTrialCart();
 			const result = applyFilters(
@@ -439,8 +493,8 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 			expect( item.totals.line_subtotal ).toBe( '1999' );
 			expect( item.totals.line_total ).toBe( '1999' );
 			expect( item.item_data ).toContainEqual( {
-				name: 'First payment',
-				value: '2026-03-19',
+				name: 'Recurring total',
+				value: '$19.99 / month on 2026-03-19',
 			} );
 
 			expect( result.totals.total_price ).toBe( '1999' );
@@ -544,8 +598,8 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 			);
 			expect( result.items[ 0 ].totals.line_subtotal ).toBe( '800' );
 			expect( result.items[ 0 ].item_data ).toContainEqual( {
-				name: 'First payment',
-				value: '2026-03-19',
+				name: 'Recurring total',
+				value: '$8.00 / month on 2026-03-19',
 			} );
 
 			expect( result.items[ 1 ].name ).toBe(
@@ -553,8 +607,8 @@ describe( 'ECE WC Subscriptions compatibility', () => {
 			);
 			expect( result.items[ 1 ].totals.line_subtotal ).toBe( '12000' );
 			expect( result.items[ 1 ].item_data ).toContainEqual( {
-				name: 'First payment',
-				value: '2027-02-19',
+				name: 'Recurring total',
+				value: '$120.00 / year on 2027-02-19',
 			} );
 
 			expect( result.totals.total_price ).toBe( '12800' );

--- a/client/express-checkout/compatibility/wc-subscriptions.js
+++ b/client/express-checkout/compatibility/wc-subscriptions.js
@@ -423,6 +423,11 @@ addFilter(
 		// Shallow copy to avoid mutating the original.
 		const modifiedItems = [ ...cartData.items ];
 
+		const recurringTotalLabel = __(
+			'Recurring total',
+			'woocommerce-payments'
+		);
+
 		subscriptions.forEach( ( subscription ) => {
 			const matchingItemsCount = cartData.items.filter(
 				( i ) =>
@@ -447,6 +452,17 @@ addFilter(
 					itemSubscription.billing_period !==
 						subscription.billing_period
 				) {
+					return;
+				}
+
+				// Guard against processing the same item twice — either from
+				// multiple subscription schedules sharing a billing_period
+				// within a single filter call, or from the filter running on
+				// data that was already modified by a previous invocation.
+				const alreadyProcessed = ( item.item_data || [] ).some(
+					( d ) => d.name === recurringTotalLabel
+				);
+				if ( alreadyProcessed ) {
 					return;
 				}
 

--- a/client/express-checkout/compatibility/wc-subscriptions.js
+++ b/client/express-checkout/compatibility/wc-subscriptions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 // This module is imported by both the shortcode entry point (express-checkout/index.js)
 // and the blocks entry point (express-checkout/blocks/index.js). Because addFilter
@@ -193,6 +193,45 @@ const getRecurringCartTotal = ( cartData ) => {
 };
 
 /**
+ * Returns a localized billing period string, e.g. "month" or "2 months".
+ *
+ * @param {string} period Billing period from Store API ('day','week','month','year').
+ * @param {number} interval Billing interval (number of periods between renewals).
+ * @return {string} Localized period string.
+ */
+const getLocalizedBillingPeriod = ( period, interval ) => {
+	if ( interval > 1 ) {
+		const plurals = {
+			day: sprintf(
+				_n( '%d day', '%d days', interval, 'woocommerce-payments' ),
+				interval
+			),
+			week: sprintf(
+				_n( '%d week', '%d weeks', interval, 'woocommerce-payments' ),
+				interval
+			),
+			month: sprintf(
+				_n( '%d month', '%d months', interval, 'woocommerce-payments' ),
+				interval
+			),
+			year: sprintf(
+				_n( '%d year', '%d years', interval, 'woocommerce-payments' ),
+				interval
+			),
+		};
+		return plurals[ period ] || `${ interval } ${ period }s`;
+	}
+
+	const singulars = {
+		day: __( 'day', 'woocommerce-payments' ),
+		week: __( 'week', 'woocommerce-payments' ),
+		month: __( 'month', 'woocommerce-payments' ),
+		year: __( 'year', 'woocommerce-payments' ),
+	};
+	return singulars[ period ] || period;
+};
+
+/**
  * Formats a subscription's recurring total as a human-readable price with
  * billing period, e.g. "$18.41 / month" or "$100.00 / 3 months".
  * Uses the currency formatting fields from the Store API subscription data.
@@ -218,11 +257,17 @@ const formatRecurringTotal = ( subscription ) => {
 
 	const formattedPrice = `${ prefix }${ formatted }${ suffix }`;
 
-	const interval = subscription.billing_interval ?? 1;
-	const period = subscription.billing_period;
-	const periodLabel = interval > 1 ? `${ interval } ${ period }s` : period;
+	const periodLabel = getLocalizedBillingPeriod(
+		subscription.billing_period,
+		subscription.billing_interval ?? 1
+	);
 
-	return `${ formattedPrice } / ${ periodLabel }`;
+	/* translators: %1$s: formatted price (e.g. "$7.58"), %2$s: billing period (e.g. "month", "2 months") */
+	return sprintf(
+		__( '%1$s / %2$s', 'woocommerce-payments' ),
+		formattedPrice,
+		periodLabel
+	);
 };
 
 /**
@@ -428,9 +473,12 @@ addFilter(
 								'Recurring total',
 								'woocommerce-payments'
 							),
-							value: `${ formatRecurringTotal(
-								subscription
-							) } on ${ subscription.next_payment_date }`,
+							/* translators: %1$s: recurring price with period (e.g. "$7.58 / month"), %2$s: date (e.g. "May 9, 2026") */
+							value: sprintf(
+								__( '%1$s on %2$s', 'woocommerce-payments' ),
+								formatRecurringTotal( subscription ),
+								subscription.next_payment_date
+							),
 						},
 					],
 				};

--- a/client/express-checkout/compatibility/wc-subscriptions.js
+++ b/client/express-checkout/compatibility/wc-subscriptions.js
@@ -82,22 +82,34 @@ const hasTrialSubscriptionWithDeferredShipping = ( cartData ) => {
 };
 
 /**
- * Checks if the cart contains any trial subscriptions with zero total.
+ * Checks if the cart contains any trial subscription items.
  *
  * @param {Object} cartData Cart data from Store API.
- * @return {boolean} True if cart has trial subscriptions with zero total.
+ * @return {boolean} True if cart has trial subscription items.
  */
-const hasTrialSubscriptionInCart = ( cartData ) => {
+const hasTrialSubscriptionItems = ( cartData ) => {
 	if ( ! cartData?.items || ! cartData?.extensions?.subscriptions ) {
 		return false;
 	}
 
-	const cartTotal = parseInt( cartData.totals?.total_price || '0', 10 );
-	if ( cartTotal > 0 ) {
+	return cartData.items.some( isTrialSubscriptionItem );
+};
+
+/**
+ * Checks if the cart contains trial subscriptions with zero total.
+ * Used for filters that should only activate when there are no upfront charges
+ * (e.g. overriding the $0 total for Stripe ECE eligibility).
+ *
+ * @param {Object} cartData Cart data from Store API.
+ * @return {boolean} True if cart has trial subscriptions with zero total.
+ */
+const isZeroTotalTrialCart = ( cartData ) => {
+	if ( ! hasTrialSubscriptionItems( cartData ) ) {
 		return false;
 	}
 
-	return cartData.items.some( isTrialSubscriptionItem );
+	const cartTotal = parseInt( cartData.totals?.total_price || '0', 10 );
+	return cartTotal === 0;
 };
 
 /**
@@ -181,6 +193,39 @@ const getRecurringCartTotal = ( cartData ) => {
 };
 
 /**
+ * Formats a subscription's recurring total as a human-readable price with
+ * billing period, e.g. "$18.41 / month" or "$100.00 / 3 months".
+ * Uses the currency formatting fields from the Store API subscription data.
+ *
+ * @param {Object} subscription Subscription schedule from cart extensions.
+ * @return {string} Formatted recurring price string.
+ */
+const formatRecurringTotal = ( subscription ) => {
+	const totals = subscription.totals;
+	const amount = parseInt( totals.total_price, 10 );
+	const minorUnit = totals.currency_minor_unit ?? 2;
+	const prefix = totals.currency_prefix ?? '';
+	const suffix = totals.currency_suffix ?? '';
+	const decimalSep = totals.currency_decimal_separator ?? '.';
+	const thousandSep = totals.currency_thousand_separator ?? ',';
+
+	const value = ( amount / Math.pow( 10, minorUnit ) ).toFixed( minorUnit );
+	const parts = value.split( '.' );
+	const whole = parts[ 0 ].replace( /\B(?=(\d{3})+(?!\d))/g, thousandSep );
+	const formatted = parts[ 1 ]
+		? `${ whole }${ decimalSep }${ parts[ 1 ] }`
+		: whole;
+
+	const formattedPrice = `${ prefix }${ formatted }${ suffix }`;
+
+	const interval = subscription.billing_interval ?? 1;
+	const period = subscription.billing_period;
+	const periodLabel = interval > 1 ? `${ interval } ${ period }s` : period;
+
+	return `${ formattedPrice } / ${ periodLabel }`;
+};
+
+/**
  * Filter: wcpay.express-checkout.total-amount
  *
  * For trial subscriptions with $0 cart total, returns the recurring
@@ -194,7 +239,7 @@ addFilter(
 	'wcpay.express-checkout.total-amount',
 	'automattic/wcpay/express-checkout/wc-subscriptions',
 	( total, cartData ) => {
-		if ( ! hasTrialSubscriptionInCart( cartData ) ) {
+		if ( ! isZeroTotalTrialCart( cartData ) ) {
 			return total;
 		}
 
@@ -225,7 +270,7 @@ addFilter(
 			return true;
 		}
 
-		if ( hasTrialSubscriptionInCart( cartData ) ) {
+		if ( isZeroTotalTrialCart( cartData ) ) {
 			const recurringTotal = getRecurringCartTotal( cartData );
 
 			return recurringTotal !== null && recurringTotal.amount > 0;
@@ -318,7 +363,7 @@ addFilter(
 	'wcpay.express-checkout.map-line-items',
 	'automattic/wcpay/express-checkout/wc-subscriptions',
 	( cartData ) => {
-		if ( ! hasTrialSubscriptionInCart( cartData ) ) {
+		if ( ! hasTrialSubscriptionItems( cartData ) ) {
 			return cartData;
 		}
 
@@ -326,6 +371,9 @@ addFilter(
 		if ( ! subscriptions || ! Array.isArray( subscriptions ) ) {
 			return cartData;
 		}
+
+		const cartTotal = parseInt( cartData.totals?.total_price || '0', 10 );
+		const isZeroTotalCart = cartTotal === 0;
 
 		// Shallow copy to avoid mutating the original.
 		const modifiedItems = [ ...cartData.items ];
@@ -363,21 +411,39 @@ addFilter(
 						'recurring',
 						'woocommerce-payments'
 					) })`,
-					totals: {
-						...item.totals,
-						line_subtotal: String( itemRecurringPrice ),
-						line_total: String( itemRecurringPrice ),
-					},
+					// Only replace prices with recurring amounts for $0 carts
+					// (pure free trials). When a sign-up fee is present, keep
+					// the original prices so the customer sees what they pay today.
+					...( isZeroTotalCart && {
+						totals: {
+							...item.totals,
+							line_subtotal: String( itemRecurringPrice ),
+							line_total: String( itemRecurringPrice ),
+						},
+					} ),
 					item_data: [
 						...( item.item_data || [] ),
 						{
-							name: __( 'First payment', 'woocommerce-payments' ),
-							value: subscription.next_payment_date,
+							name: __(
+								'Recurring total',
+								'woocommerce-payments'
+							),
+							value: `${ formatRecurringTotal(
+								subscription
+							) } on ${ subscription.next_payment_date }`,
 						},
 					],
 				};
 			} );
 		} );
+
+		// Only replace cart totals with recurring amounts for $0 carts.
+		if ( ! isZeroTotalCart ) {
+			return {
+				...cartData,
+				items: modifiedItems,
+			};
+		}
 
 		const recurringTotal = getRecurringCartTotal( cartData );
 		if ( ! recurringTotal ) {


### PR DESCRIPTION
Fixes WOOPMNT-6081
Fixes https://github.com/Automattic/woocommerce-payments/issues/9799

## Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

From paJDYF-ilh-p2#comment-29623 / Related to #9799

Fix ECE to show recurring subscription info for free trial subscriptions **with sign-up fees**. Previously, customers saw only the sign-up fee with no indication of what they'd be charged after the trial.

### Changes

- **Decoupled trial detection from cart total:** New `hasTrialSubscriptionItems()` checks `trial_length > 0` independent of cart total. The `map-line-items` filter now runs for all trial subscriptions; price/total replacement stays gated behind `isZeroTotalCart` (Stripe $0 workaround).
- **Added formatted recurring price to line item metadata:** `formatRecurringTotal()` renders the subscription schedule's `total_price` (includes items + shipping + tax) with billing period, e.g. `Recurring total: $18.41 / month on May 9, 2026`.
- **Renamed `hasTrialSubscriptionInCart` → `isZeroTotalTrialCart`** to make the $0 condition explicit.
- **Renamed "First payment" → "Recurring total"** — "First payment" was wrong when a sign-up fee is present (the sign-up fee *is* the first payment).

### Alignment with WC Subscriptions blocks checkout

- Trial detection uses `trial_length > 0` (product-level), not cart total — matches `WC_Subscriptions_Product::get_trial_length()`
- Recurring total uses `total_price` from subscription schedule — matches `extend_cart_data()` which includes items + shipping + tax
- "Recurring total" label mirrors the "Monthly recurring total" panel heading in blocks checkout
- Currency formatting uses the same Store API fields populated by `$money_formatter->format()`

### Scope note

These changes apply to the **cart/checkout ECE flow** (Store API data through `map-line-items` filter). On the **product page**, the initial payment sheet uses PHP-provided data from `get_product_data()`, but refreshes with Store API data (and our filter) once the customer enters a shipping address.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites
Create two subscription products:
1. **Free trial + sign-up fee** — e.g. $7/month, 1 month free trial, $2 sign-up fee
2. **Normal subscription** (no free trial, no sign-up fee) — e.g. $10/month

### Test cases

**1. Product page — free trial + sign-up fee**
- Open the trial subscription product, click Apple Pay / Google Pay
- Verify: line item shows `(recurring)` label, `Recurring total: $X.XX / month on [date]`, amount is the sign-up fee, total reflects sign-up fee + tax
<img width="572" height="364" alt="Screenshot 2026-04-09 at 3 49 20 PM" src="https://github.com/user-attachments/assets/56628205-2884-4b94-8b1d-b08a66adedf3" />

**2. Cart — free trial + sign-up fee + regular product**
- Add the trial subscription and a regular product to cart, click Apple Pay / Google Pay
- Verify: subscription item shows `(recurring)` and recurring total metadata, regular item is unchanged, total reflects sign-up fee + regular product price + tax
<img width="605" height="397" alt="Screenshot 2026-04-09 at 3 50 32 PM" src="https://github.com/user-attachments/assets/86ccd5dd-5999-416a-9f8c-b538f33663ee" />


**3. Cart — free trial + sign-up fee (with shipping)**
- Use a physical subscription with a shipping method that has a cost
- Verify: `Recurring total` amount includes shipping and tax
<img width="570" height="300" alt="Screenshot 2026-04-09 at 3 50 08 PM" src="https://github.com/user-attachments/assets/f06acff5-17ac-4cf5-9c29-cd6715b70edf" />


**4. Product page — normal subscription (no regression)**
- Open the normal subscription product, click Apple Pay / Google Pay
- Verify: no `(recurring)` label or `Recurring total` metadata is added — line items display as before
<img width="596" height="224" alt="Screenshot 2026-04-09 at 3 51 04 PM" src="https://github.com/user-attachments/assets/e435064a-27cc-49f9-b3e9-149b4b7de13c" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
