### PR TITLE
fix: resolve WooPay header color for nested and cross-theme template parts

### DIFF
--- a/changelog/agent-woopmnt-6095
+++ b/changelog/agent-woopmnt-6095
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay themed checkout header color not applied when template part is nested inside a wrapper block

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -644,6 +644,7 @@ class WC_Payments_Styles_Cache {
 
 		$blocks   = parse_blocks( $template->content );
 		$blocks   = self::resolve_pattern_blocks( $blocks );
+		$blocks   = self::flatten_blocks( $blocks );
 		$sections = [];
 
 		foreach ( $blocks as $block ) {
@@ -822,6 +823,9 @@ class WC_Payments_Styles_Cache {
 
 		foreach ( $blocks as $block ) {
 			if ( 'core/pattern' !== $block['blockName'] || empty( $block['attrs']['slug'] ) ) {
+				if ( ! empty( $block['innerBlocks'] ) ) {
+					$block['innerBlocks'] = self::resolve_pattern_blocks( $block['innerBlocks'] );
+				}
 				$resolved[] = $block;
 				continue;
 			}
@@ -842,6 +846,26 @@ class WC_Payments_Styles_Cache {
 		}
 
 		return $resolved;
+	}
+
+	/**
+	 * Recursively flattens a block tree into a single-level array.
+	 *
+	 * Parent blocks appear before their children, so the first classified
+	 * block for a given area is always the outermost one.
+	 *
+	 * @param array $blocks Parsed blocks (possibly nested via innerBlocks).
+	 * @return array Flat array of all blocks at every depth.
+	 */
+	private static function flatten_blocks( array $blocks ): array {
+		$flat = [];
+		foreach ( $blocks as $block ) {
+			$flat[] = $block;
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$flat = array_merge( $flat, self::flatten_blocks( $block['innerBlocks'] ) );
+			}
+		}
+		return $flat;
 	}
 
 	/**

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -659,7 +659,7 @@ class WC_Payments_Styles_Cache {
 			}
 
 			if ( 'core/template-part' === $block_name && ! empty( $block['attrs']['slug'] ) ) {
-				$colors = self::get_template_part_colors( $block['attrs']['slug'] );
+				$colors = self::get_template_part_colors( $block['attrs']['slug'], $block['attrs']['theme'] ?? '' );
 			} else {
 				$colors = self::extract_block_colors( $block );
 			}
@@ -691,6 +691,9 @@ class WC_Payments_Styles_Cache {
 			$area = $block['attrs']['area'] ?? null;
 			if ( ! $area ) {
 				$part = get_block_template( get_stylesheet() . '//' . $block['attrs']['slug'], 'wp_template_part' );
+				if ( ! $part && ! empty( $block['attrs']['theme'] ) ) {
+					$part = get_block_template( $block['attrs']['theme'] . '//' . $block['attrs']['slug'], 'wp_template_part' );
+				}
 				$area = $part ? $part->area : null;
 			}
 			if ( in_array( $area, [ 'header', 'footer' ], true ) ) {
@@ -724,11 +727,17 @@ class WC_Payments_Styles_Cache {
 	 * Extracts background and text colors from a template part (header/footer)
 	 * by parsing its outermost block attributes.
 	 *
-	 * @param string $slug The template part slug (e.g. 'header', 'footer').
+	 * @param string $slug  The template part slug (e.g. 'header', 'checkout-header').
+	 * @param string $theme The theme attribute from the template-part block (e.g. 'woocommerce/woocommerce').
 	 * @return array Associative array with 'background' and/or 'text' keys, or empty.
 	 */
-	private static function get_template_part_colors( string $slug ): array {
+	private static function get_template_part_colors( string $slug, string $theme = '' ): array {
 		$template = get_block_template( get_stylesheet() . '//' . $slug, 'wp_template_part' );
+
+		if ( ( ! $template || empty( $template->content ) ) && '' !== $theme ) {
+			$template = get_block_template( $theme . '//' . $slug, 'wp_template_part' );
+		}
+
 		if ( ! $template || empty( $template->content ) ) {
 			return [];
 		}

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -877,6 +877,64 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_classify_block_area_falls_back_to_theme_attr() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'classify_block_area' );
+		$method->setAccessible( true );
+
+		// Template part with no area attr, slug not in active theme,
+		// but theme attr points to a theme that has it registered.
+		// Since we can't easily register a cross-theme template part in
+		// unit tests, we test the branch by providing a theme attr with
+		// a non-existent theme — the lookup returns null, so area stays null.
+		// The important thing is the code doesn't fatal and returns null.
+		$block = [
+			'blockName'    => 'core/template-part',
+			'attrs'        => [
+				'slug'  => 'nonexistent-part',
+				'theme' => 'fake-theme/fake-theme',
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$this->assertNull( $method->invoke( null, $block ) );
+	}
+
+	public function test_classify_block_area_uses_area_attr_before_theme_lookup() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'classify_block_area' );
+		$method->setAccessible( true );
+
+		// When area attr is present, the theme lookup is skipped entirely.
+		$block = [
+			'blockName'    => 'core/template-part',
+			'attrs'        => [
+				'slug'  => 'checkout-header',
+				'area'  => 'header',
+				'theme' => 'woocommerce/woocommerce',
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$this->assertSame( 'header', $method->invoke( null, $block ) );
+	}
+
+	public function test_get_template_part_colors_falls_back_to_theme_attr() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'get_template_part_colors' );
+		$method->setAccessible( true );
+
+		// With a slug not in the active theme and no valid theme fallback,
+		// the method should return an empty array without errors.
+		$result = $method->invoke( null, 'nonexistent-checkout-header', 'fake-theme/fake-theme' );
+		$this->assertSame( [], $result );
+
+		// With no theme arg, same behavior.
+		$result = $method->invoke( null, 'nonexistent-checkout-header' );
+		$this->assertSame( [], $result );
+	}
+
 	public function test_compute_woopay_appearance_maps_input_element_styles() {
 		// WooPay requires WP 6.5+. The textInput element key and proper
 		// elements.link resolution require WP 6.1+. Skip on older versions

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -786,6 +786,97 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		$this->assertNull( $method->invoke( null, $block ) );
 	}
 
+	public function test_flatten_blocks_finds_nested_blocks() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'flatten_blocks' );
+		$method->setAccessible( true );
+
+		$blocks = [
+			[
+				'blockName'    => 'core/group',
+				'attrs'        => [],
+				'innerBlocks'  => [
+					[
+						'blockName'    => 'core/template-part',
+						'attrs'        => [
+							'slug' => 'header',
+							'area' => 'header',
+						],
+						'innerBlocks'  => [],
+						'innerHTML'    => '',
+						'innerContent' => [],
+					],
+				],
+				'innerHTML'    => '',
+				'innerContent' => [],
+			],
+			[
+				'blockName'    => 'core/template-part',
+				'attrs'        => [
+					'slug' => 'footer',
+					'area' => 'footer',
+				],
+				'innerBlocks'  => [],
+				'innerHTML'    => '',
+				'innerContent' => [],
+			],
+		];
+
+		$flat = $method->invoke( null, $blocks );
+
+		$this->assertCount( 3, $flat );
+		// Parent appears before child.
+		$this->assertSame( 'core/group', $flat[0]['blockName'] );
+		$this->assertSame( 'core/template-part', $flat[1]['blockName'] );
+		$this->assertSame( 'header', $flat[1]['attrs']['slug'] );
+		$this->assertSame( 'core/template-part', $flat[2]['blockName'] );
+		$this->assertSame( 'footer', $flat[2]['attrs']['slug'] );
+	}
+
+	public function test_resolve_pattern_blocks_recurses_into_inner_blocks() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'resolve_pattern_blocks' );
+		$method->setAccessible( true );
+
+		$pattern_slug    = 'test-theme/nested-pattern';
+		$pattern_content = '<!-- wp:template-part {"slug":"header","area":"header"} /-->';
+
+		register_block_pattern(
+			$pattern_slug,
+			[
+				'title'   => 'Test nested pattern',
+				'content' => $pattern_content,
+			]
+		);
+
+		try {
+			$blocks = [
+				[
+					'blockName'    => 'core/group',
+					'attrs'        => [],
+					'innerBlocks'  => [
+						[
+							'blockName'    => 'core/pattern',
+							'attrs'        => [ 'slug' => $pattern_slug ],
+							'innerBlocks'  => [],
+							'innerHTML'    => '',
+							'innerContent' => [],
+						],
+					],
+					'innerHTML'    => '',
+					'innerContent' => [],
+				],
+			];
+
+			$resolved = $method->invoke( null, $blocks );
+
+			$this->assertCount( 1, $resolved );
+			$inner = $resolved[0]['innerBlocks'];
+			$this->assertSame( 'core/template-part', $inner[0]['blockName'] );
+			$this->assertSame( 'header', $inner[0]['attrs']['slug'] );
+		} finally {
+			unregister_block_pattern( $pattern_slug );
+		}
+	}
+
 	public function test_compute_woopay_appearance_maps_input_element_styles() {
 		// WooPay requires WP 6.5+. The textInput element key and proper
 		// elements.link resolution require WP 6.1+. Skip on older versions


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOPMNT-6095

#### Changes proposed in this Pull Request

PR #11545 introduced two regressions in how `get_checkout_section_colors()` extracts header/footer colors from the checkout template:

1. **Missing `innerBlocks` recursion:** When `collect_template_part_slugs()` was rewritten to `get_checkout_section_colors()` to handle Assembler inline blocks (commit `c0aff3176`), the recursive walk into `innerBlocks` was dropped. Template parts nested inside wrapper groups (e.g., for layout) were no longer found.

2. **Cross-theme template part lookup:** The checkout template references `checkout-header` from `woocommerce/woocommerce`, but the lookup only tried the active theme stylesheet (`twentytwentyfour//checkout-header` → NULL). The block's `theme` attribute was ignored.

Both bugs caused the header to silently fall back to the main page background color. The footer was unaffected because it was either top-level or an Assembler-style inline block.

**Fix:**
- Add `flatten_blocks()` to recursively walk the full block tree before classification
- Make `resolve_pattern_blocks()` recursive into `innerBlocks`
- Fall back to the block's `theme` attribute in both `classify_block_area()` and `get_template_part_colors()` when the active theme lookup returns null

#### Testing instructions

1. Activate a block theme (e.g., Twenty Twenty-Four) with WooCommerce and WooPayments
2. Go to **WooPayments → Settings → Express checkout → WooPay**
3. Verify the WooPay preview header shows the correct header background color (not the main page background)
4. Verify the footer color is also correct
5. Try customizing the checkout template in the Site Editor to wrap the header in a Group block — the header color should still be extracted correctly

---

- [x] Run `npm run changelog` to add a changelog file
- [x] Covered with tests
- [x] Tested on mobile (does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here_

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
☢️ Powered by [Gamma AI Tools](https://github.a8c.com/Automattic/gamma-ai-tools/)

Prior the Header was not picking up the Checkout head color.

After TT24:
<img width="1158" height="1408" alt="image" src="https://github.com/user-attachments/assets/a042e25d-9e73-4e37-8e22-54a9c57ab01e" />


<img width="1173" height="988" alt="image" src="https://github.com/user-attachments/assets/f134e244-653a-40c7-b471-2af604698a48" />

<img width="555" height="381" alt="image" src="https://github.com/user-attachments/assets/d74cfd10-e969-4d9f-b610-1e243e1f2143" />

Assembler, footer, no header:
<img width="1166" height="1486" alt="image" src="https://github.com/user-attachments/assets/cd8f8d62-949d-44b8-8a4d-67ab8c33f411" />

<img width="1166" height="1016" alt="image" src="https://github.com/user-attachments/assets/8a72d9f3-0873-45eb-99f4-905c2515a7cc" />

Assembler, no footer, header
<img width="1152" height="898" alt="image" src="https://github.com/user-attachments/assets/e552c134-84b4-45ae-8f1a-5faafe315252" />

<img width="1141" height="1015" alt="image" src="https://github.com/user-attachments/assets/19b2595d-fc56-4e36-b195-226b914028e4" />
