### PR TITLE
Clear cached account data when Jetpack site is disconnected

### DIFF
--- a/changelog/2026-04-13-11-20-00-314863
+++ b/changelog/2026-04-13-11-20-00-314863
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clear cached account data when Jetpack site is disconnected

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -132,6 +132,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 		// Add all other hooks.
 		add_filter( 'allowed_redirect_hosts', [ $this, 'allowed_redirect_hosts' ] );
 		add_action( 'jetpack_site_registered', [ $this, 'clear_cache' ] );
+		add_action( 'jetpack_site_disconnected', [ $this, 'clear_cache' ] );
 		add_action( 'updated_option', [ $this, 'possibly_update_wcpay_account_locale' ], 10, 3 );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ $this, 'clear_cache' ] );
 		// Hook into the recurring store setup sync action and do the store setup sync.

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -124,6 +124,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertNotFalse( has_action( 'wcpay_instant_deposit_reminder', [ $this->wcpay_account, 'handle_instant_deposits_inbox_reminder' ] ), 'handle_instant_deposits_inbox_reminder action does not exist.' );
 		$this->assertNotFalse( has_filter( 'allowed_redirect_hosts', [ $this->wcpay_account, 'allowed_redirect_hosts' ] ), 'allowed_redirect_hooks filter does not exist.' );
 		$this->assertNotFalse( has_action( 'jetpack_site_registered', [ $this->wcpay_account, 'clear_cache' ] ), 'jetpack_site_registered action does not exist.' );
+		$this->assertNotFalse( has_action( 'jetpack_site_disconnected', [ $this->wcpay_account, 'clear_cache' ] ), 'jetpack_site_disconnected action does not exist.' );
 		$this->assertNotFalse( has_action( 'updated_option', [ $this->wcpay_account, 'possibly_update_wcpay_account_locale' ] ), 'updated_option action does not exist.' );
 		$this->assertNotFalse( has_action( 'woocommerce_woocommerce_payments_updated', [ $this->wcpay_account, 'clear_cache' ] ), 'woocommerce_woocommerce_payments_updated action does not exist.' );
 		$this->assertNotFalse( has_action( WC_Payments_Account::STORE_SETUP_SYNC_ACTION, [ $this->wcpay_account, 'store_setup_sync' ] ), 'store_setup_sync action does not exist.' );


### PR DESCRIPTION
Fixes #632 

#### Changes proposed in this Pull Request

Clear cached account data when Jetpack site is disconnected
<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

  Prerequisites                                                                                                                                                                
                                                                                                                                                                               
  - Docker environment running (npm run up)                                                                                                                                    
  - WooPayments plugin active with Jetpack connected and an account set up (so account data is cached)
                                                                                                                                                                               
  ---                                                       
  Option A — Quick smoke test (no full account needed)                                                                                                                         
                                                                                                                                                                               
  This verifies the hook is wired and fires correctly without needing a real Stripe account.
                                                                                                                                                                               
  1. Confirm the cache can be written and read:
  ```
  wp --allow-root eval 'WC_Payments::get_account_service()->refresh_account_data();'
  wp --allow-root option get wcpay_account_data
  ```
  2. You should see a serialized value (even an error response counts — just something non-empty). Notice the `fetched` timestamp if present.
  3. Fire the Jetpack disconnect action manually:
  ```
  wp --allow-root eval 'do_action( "jetpack_site_disconnected" );'
  ```
  4. Confirm the cache was cleared:
  ```
  wp --allow-root option get wcpay_account_data
  ```
  5. Should either return empty data or the serialized data with an updated `fetched` timestamp.
  6. Retrieve the option data again (step 4). `fetched` timestamp should remain unchanged.
                                                                                                                                                                               
  ---                                                       
  Option B — Full end-to-end flow                                                                                                                                              
                                                                                                                                                                               
  1. Connect Jetpack and set up a WooPayments test account.
  2. Visit the WooPayments overview page — confirm it loads account data normally.
  3. Disconnect Jetpack: Jetpack → Settings → Disconnect (or via WP-CLI: `wp jetpack disconnect blog`). _Optional:_ Try to change the external site URL, e.g., by using a different alias with JT.
  5. Reload the WooPayments overview page.
  7. Expected: The plugin prompts to reconnect / set up a new account rather than displaying the stale cached account details.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
