### PR TITLE
Fix WOOPMNT-3978: order price rounding on block-based order pages

### DIFF
--- a/changelog/fix-order-currency-rounding-block-pages
+++ b/changelog/fix-order-currency-rounding-block-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix order price rounding when switching to a zero-decimal currency on block-based order pages

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -423,17 +423,30 @@ class FrontendCurrencies {
 		$pages = [ 'my-account', 'checkout' ];
 		$vars  = [ 'order-received', 'order-pay', 'orders', 'view-order' ];
 
-		if ( $this->utils->is_page_with_vars( $pages, $vars ) ) {
-			return $this->utils->is_call_in_backtrace(
-				[
-					'WC_Shortcode_My_Account::view_order',
-					'WC_Shortcode_Checkout::order_received',
-					'WC_Shortcode_Checkout::order_pay',
-					'WC_Order->get_formatted_order_total',
-				]
-			);
+		if ( ! $this->utils->is_page_with_vars( $pages, $vars ) ) {
+			return false;
 		}
 
-		return false;
+		// On single-order pages, always use the order currency without backtrace
+		// inspection. Block-based rendering (WooCommerce Checkout Blocks) does not
+		// include WC_Shortcode classes in the call stack, so the backtrace check
+		// fails and prices fall back to the selected currency's decimal rules.
+		global $wp;
+		if ( ! empty( $wp->query_vars['order-received'] )
+			|| ! empty( $wp->query_vars['order-pay'] )
+			|| ! empty( $wp->query_vars['view-order'] ) ) {
+			return true;
+		}
+
+		// On the orders list page, use backtrace inspection so each order row
+		// uses its own currency through the init/clear cycle.
+		return $this->utils->is_call_in_backtrace(
+			[
+				'WC_Shortcode_My_Account::view_order',
+				'WC_Shortcode_Checkout::order_received',
+				'WC_Shortcode_Checkout::order_pay',
+				'WC_Order->get_formatted_order_total',
+			]
+		);
 	}
 }

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -149,7 +149,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WCPAY_UnitTestCase 
 	public function test_get_price_decimals_uses_order_currency_on_single_order_page_without_backtrace() {
 		// Simulate being on the order-received page (block-based checkout).
 		global $wp;
-		$original_query_vars          = $wp->query_vars;
+		$original_query_vars              = $wp->query_vars;
 		$wp->query_vars['order-received'] = $this->mock_order->get_id();
 
 		$this->mock_utils

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -146,6 +146,32 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WCPAY_UnitTestCase 
 		$this->assertEquals( 3, $this->frontend_currencies->get_price_decimals( 2 ) );
 	}
 
+	public function test_get_price_decimals_uses_order_currency_on_single_order_page_without_backtrace() {
+		// Simulate being on the order-received page (block-based checkout).
+		global $wp;
+		$original_query_vars          = $wp->query_vars;
+		$wp->query_vars['order-received'] = $this->mock_order->get_id();
+
+		$this->mock_utils
+			->expects( $this->once() )
+			->method( 'is_page_with_vars' )
+			->willReturn( true );
+		// The backtrace check should NOT be called on single-order pages.
+		$this->mock_utils
+			->expects( $this->never() )
+			->method( 'is_call_in_backtrace' );
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'ISK' ) );
+
+		$this->mock_order->set_currency( 'USD' );
+		$this->frontend_currencies->init_order_currency( $this->mock_order );
+
+		// USD uses 2 decimals. Even though ISK (0 decimals) is the selected currency,
+		// the order currency should be used on single-order pages.
+		$this->assertEquals( 2, $this->frontend_currencies->get_price_decimals( 2 ) );
+
+		$wp->query_vars = $original_query_vars;
+	}
+
 	public function test_get_price_decimals_returns_original_when_the_currency_is_same() {
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'USD' ) );
 


### PR DESCRIPTION
## Summary

- Fix order price rounding when switching to a zero-decimal currency (e.g., ISK) on block-based Order Received and View Order pages
- On single-order pages, skip backtrace inspection in `should_use_order_currency()` — block-based rendering doesn't include `WC_Shortcode` classes in the call stack, causing the check to fail
- Preserve backtrace check on the orders list page where per-order currency switching is needed

## Bug

[WOOPMNT-3978](https://linear.app/a8c/issue/WOOPMNT-3978): Rounding applied on order received and view order pages when changing from 2-decimal currency to 0-decimal currency

**Reproduction:** Place an order in USD ($27.50), then on the Order Received page switch the currency widget to ISK (0-decimal). The total rounds to $28.00 instead of staying at $27.50.

## Changes

- `includes/multi-currency/FrontendCurrencies.php` — Modified `should_use_order_currency()` to return `true` on single-order pages (`order-received`, `order-pay`, `view-order`) without backtrace inspection. The backtrace check only applies to the `orders` list page.
- `tests/unit/multi-currency/test-class-frontend-currencies.php` — Added test verifying that on a single-order page, the order currency's decimals are used even when ISK is the selected currency, and `is_call_in_backtrace` is never invoked.
- `changelog/fix-order-currency-rounding-block-pages` — Changelog entry.

## Testing

- Unit test added for the new behavior (order currency used on single-order page without backtrace)
- Existing tests verify the orders list page behavior is unchanged
- QIT automated regression tests will run on this PR

## Notes

This PR was created during the [Woo Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/) via team Ceres' [`/bug-blitz` Claude skill](https://github.com/Automattic/public-resources-squad/blob/trunk/.claude/skills/bug-blitz/skill.md). The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.