### PR TITLE
Dedupe React package versions

### DIFF
--- a/changelog/dev-dedupe-react-packages
+++ b/changelog/dev-dedupe-react-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Developer side changes, deduping npm packages to align on versions used across the codebase.
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -281,21 +281,12 @@
 				"react-dom": "^18.2.0"
 			}
 		},
-		"node_modules/@automattic/components/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-			"dependencies": {
-				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
-			}
-		},
 		"node_modules/@automattic/components/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@automattic/components/node_modules/@wordpress/base-styles": {
@@ -572,16 +563,18 @@
 			}
 		},
 		"node_modules/@automattic/components/node_modules/framer-motion": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.6.tgz",
-			"integrity": "sha512-olpX48qfoSIDjhw0RbolhOGBQmdMAXHHpSI0PFdTj5LeXChcf5F4ApShs0mQ6FPEPOj7dnEvSyB07UgRK5G9Jw==",
+			"version": "11.18.2",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+			"integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
 			"dependencies": {
+				"motion-dom": "^11.18.1",
+				"motion-utils": "^11.18.1",
 				"tslib": "^2.4.0"
 			},
 			"peerDependencies": {
 				"@emotion/is-prop-valid": "*",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@emotion/is-prop-valid": {
@@ -596,14 +589,14 @@
 			}
 		},
 		"node_modules/@automattic/components/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@automattic/components/node_modules/path-to-regexp": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
 		},
 		"node_modules/@automattic/components/node_modules/remove-accents": {
 			"version": "0.5.0",
@@ -663,38 +656,36 @@
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/compose": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-			"integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.3.0",
-				"@wordpress/dom": "^4.3.0",
-				"@wordpress/element": "^6.3.0",
-				"@wordpress/is-shallow-equal": "^5.3.0",
-				"@wordpress/keycodes": "^4.3.0",
-				"@wordpress/priority-queue": "^3.3.0",
-				"@wordpress/undo-manager": "^1.3.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -707,12 +698,11 @@
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/deprecated": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-			"integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^4.3.0"
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -720,12 +710,11 @@
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/dom": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-			"integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^4.3.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -733,14 +722,13 @@
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/element": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-			"integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.3.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -752,36 +740,30 @@
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/escape-html": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-			"integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0"
-			},
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/hooks": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-			"integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/i18n": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-			"integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
+			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^4.3.0",
+				"@babel/runtime": "7.25.7",
+				"@wordpress/hooks": "^4.26.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -796,24 +778,39 @@
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-			"integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-			"dependencies": {
-				"@babel/runtime": "^7.16.0"
-			},
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/keycodes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-			"integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.3.0"
+				"@wordpress/i18n": "^6.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -821,11 +818,10 @@
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/priority-queue": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-			"integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -834,9 +830,9 @@
 			}
 		},
 		"node_modules/@automattic/i18n-utils/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@automattic/interpolate-components": {
 			"version": "1.2.1",
@@ -910,21 +906,12 @@
 				"redux": "^4.2.1"
 			}
 		},
-		"node_modules/@automattic/tour-kit/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-			"dependencies": {
-				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
-			}
-		},
 		"node_modules/@automattic/tour-kit/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@automattic/tour-kit/node_modules/@wordpress/base-styles": {
@@ -1201,16 +1188,18 @@
 			}
 		},
 		"node_modules/@automattic/tour-kit/node_modules/framer-motion": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.6.tgz",
-			"integrity": "sha512-olpX48qfoSIDjhw0RbolhOGBQmdMAXHHpSI0PFdTj5LeXChcf5F4ApShs0mQ6FPEPOj7dnEvSyB07UgRK5G9Jw==",
+			"version": "11.18.2",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+			"integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
 			"dependencies": {
+				"motion-dom": "^11.18.1",
+				"motion-utils": "^11.18.1",
 				"tslib": "^2.4.0"
 			},
 			"peerDependencies": {
 				"@emotion/is-prop-valid": "*",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@emotion/is-prop-valid": {
@@ -1225,14 +1214,14 @@
 			}
 		},
 		"node_modules/@automattic/tour-kit/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@automattic/tour-kit/node_modules/path-to-regexp": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
 		},
 		"node_modules/@automattic/tour-kit/node_modules/remove-accents": {
 			"version": "0.5.0",
@@ -1262,21 +1251,21 @@
 			}
 		},
 		"node_modules/@automattic/viewport-react/node_modules/@types/react": {
-			"version": "16.14.60",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.60.tgz",
-			"integrity": "sha512-wIFmnczGsTcgwCBeIYOuy2mdXEiKZ5znU/jNOnMZPQyCcIxauMGWlX0TNG4lZ7NxRKj7YUIZRneJQSSdB2jKgg==",
+			"version": "16.14.69",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.69.tgz",
+			"integrity": "sha512-NdnAamzkxLX9LBssSdt9Q0tQ3LR94hYxotI4/sRUs1vHKFXaDx9xDbK8S4wuw5bwrxiiXbTYyhKeITtFnwDvEA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@automattic/viewport-react/node_modules/@types/react-dom": {
-			"version": "16.9.24",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.24.tgz",
-			"integrity": "sha512-Gcmq2JTDheyWn/1eteqyzzWKSqDjYU6KYsIvH7thb7CR5OYInAWOX+7WnKf6PaU/cbdOc4szJItcDEJO7UGmfA==",
-			"dependencies": {
-				"@types/react": "^16"
+			"version": "16.9.25",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.25.tgz",
+			"integrity": "sha512-ZK//eAPhwft9Ul2/Zj+6O11YR6L4JX0J2sVeBC9Ft7x7HFN7xk7yUV/zDxqV6rjvqgl6r8Dq7oQImxtyf/Mzcw==",
+			"peerDependencies": {
+				"@types/react": "^16.0.0"
 			}
 		},
 		"node_modules/@automattic/viewport-react/node_modules/@wordpress/compose": {
@@ -1996,12 +1985,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+			"integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -3323,6 +3312,46 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
+		"node_modules/@cacheable/memory": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+			"integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+			"dev": true,
+			"dependencies": {
+				"@cacheable/utils": "^2.4.0",
+				"@keyv/bigmap": "^1.3.1",
+				"hookified": "^1.15.1",
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/memory/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"dev": true,
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/@cacheable/utils": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+			"integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+			"dev": true,
+			"dependencies": {
+				"hashery": "^1.5.1",
+				"keyv": "^5.6.0"
+			}
+		},
+		"node_modules/@cacheable/utils/node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"dev": true,
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
 		"node_modules/@csstools/css-parser-algorithms": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
@@ -3343,6 +3372,30 @@
 			},
 			"peerDependencies": {
 				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+			"integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
@@ -3409,6 +3462,16 @@
 				"postcss-selector-parser": "^7.0.0"
 			}
 		},
+		"node_modules/@date-fns/tz": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+			"integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="
+		},
+		"node_modules/@date-fns/utc": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+			"integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA=="
+		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -3419,25 +3482,25 @@
 			}
 		},
 		"node_modules/@dual-bundle/import-meta-resolve": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-			"integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
+			"integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
 			"dev": true,
 			"funding": {
 				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
+				"url": "https://github.com/sponsors/JounQin"
 			}
 		},
 		"node_modules/@emotion/babel-plugin": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-			"integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+			"integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.16.7",
 				"@babel/runtime": "^7.18.3",
-				"@emotion/hash": "^0.9.1",
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/serialize": "^1.1.2",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/serialize": "^1.3.3",
 				"babel-plugin-macros": "^3.1.0",
 				"convert-source-map": "^1.5.0",
 				"escape-string-regexp": "^4.0.0",
@@ -3460,32 +3523,32 @@
 			}
 		},
 		"node_modules/@emotion/cache": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-			"integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+			"integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
 			"dependencies": {
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/sheet": "^1.2.2",
-				"@emotion/utils": "^1.2.1",
-				"@emotion/weak-memoize": "^0.3.1",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
 				"stylis": "4.2.0"
 			}
 		},
 		"node_modules/@emotion/cache/node_modules/@emotion/utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-			"integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
 		},
 		"node_modules/@emotion/css": {
-			"version": "11.11.2",
-			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.11.2.tgz",
-			"integrity": "sha512-VJxe1ucoMYMS7DkiMdC2T7PWNbrEI0a39YRiyDvK2qq4lXwjRbVP/z4lpG+odCsRzadlR+1ywwrTzhdm5HNdew==",
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+			"integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
 			"dependencies": {
-				"@emotion/babel-plugin": "^11.11.0",
-				"@emotion/cache": "^11.11.0",
-				"@emotion/serialize": "^1.1.2",
-				"@emotion/sheet": "^1.2.2",
-				"@emotion/utils": "^1.2.1"
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.13.5",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2"
 			}
 		},
 		"node_modules/@emotion/css-prettifier": {
@@ -3498,28 +3561,22 @@
 				"stylis": "4.2.0"
 			}
 		},
-		"node_modules/@emotion/css-prettifier/node_modules/@emotion/memoize": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-			"dev": true
-		},
 		"node_modules/@emotion/css/node_modules/@emotion/utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-			"integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
 		},
 		"node_modules/@emotion/hash": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
 		},
 		"node_modules/@emotion/is-prop-valid": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-			"integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
 			"dependencies": {
-				"@emotion/memoize": "^0.8.1"
+				"@emotion/memoize": "^0.9.0"
 			}
 		},
 		"node_modules/@emotion/jest": {
@@ -3548,22 +3605,22 @@
 			}
 		},
 		"node_modules/@emotion/memoize": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-			"integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
 		},
 		"node_modules/@emotion/react": {
-			"version": "11.11.4",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
-			"integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
-				"@emotion/babel-plugin": "^11.11.0",
-				"@emotion/cache": "^11.11.0",
-				"@emotion/serialize": "^1.1.3",
-				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-				"@emotion/utils": "^1.2.1",
-				"@emotion/weak-memoize": "^0.3.1",
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
 				"hoist-non-react-statics": "^3.3.1"
 			},
 			"peerDependencies": {
@@ -3576,43 +3633,43 @@
 			}
 		},
 		"node_modules/@emotion/react/node_modules/@emotion/utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-			"integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
 		},
 		"node_modules/@emotion/serialize": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
-			"integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+			"integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
 			"dependencies": {
-				"@emotion/hash": "^0.9.1",
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/unitless": "^0.8.1",
-				"@emotion/utils": "^1.2.1",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/unitless": "^0.10.0",
+				"@emotion/utils": "^1.4.2",
 				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@emotion/serialize/node_modules/@emotion/utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-			"integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
 		},
 		"node_modules/@emotion/sheet": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-			"integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
 		},
 		"node_modules/@emotion/styled": {
-			"version": "11.11.5",
-			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
-			"integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
+			"version": "11.14.1",
+			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+			"integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
-				"@emotion/babel-plugin": "^11.11.0",
-				"@emotion/is-prop-valid": "^1.2.2",
-				"@emotion/serialize": "^1.1.4",
-				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-				"@emotion/utils": "^1.2.1"
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/is-prop-valid": "^1.3.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+				"@emotion/utils": "^1.4.2"
 			},
 			"peerDependencies": {
 				"@emotion/react": "^11.0.0-rc.0",
@@ -3625,19 +3682,19 @@
 			}
 		},
 		"node_modules/@emotion/styled/node_modules/@emotion/utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-			"integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
 		},
 		"node_modules/@emotion/unitless": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-			"integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
 		},
 		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-			"integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
 			"peerDependencies": {
 				"react": ">=16.8.0"
 			}
@@ -3648,9 +3705,9 @@
 			"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
 		},
 		"node_modules/@emotion/weak-memoize": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-			"integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
 		},
 		"node_modules/@es-joy/jsdoccomment": {
 			"version": "0.41.0",
@@ -3788,28 +3845,28 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
-			"integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.4"
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.7.tgz",
-			"integrity": "sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==",
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
 			"dependencies": {
-				"@floating-ui/core": "^1.6.0",
-				"@floating-ui/utils": "^0.2.4"
+				"@floating-ui/core": "^1.7.5",
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
-			"integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
 			"dependencies": {
-				"@floating-ui/dom": "^1.0.0"
+				"@floating-ui/dom": "^1.6.1"
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0",
@@ -3817,9 +3874,9 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
-			"integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA=="
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
 			"version": "2.3.4",
@@ -4025,6 +4082,97 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@jest/core": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/console": "^29.7.0",
+				"@jest/reporters": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.9",
+				"jest-changed-files": "^29.7.0",
+				"jest-config": "^29.7.0",
+				"jest-haste-map": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-regex-util": "^29.6.3",
+				"jest-resolve": "^29.7.0",
+				"jest-resolve-dependencies": "^29.7.0",
+				"jest-runner": "^29.7.0",
+				"jest-runtime": "^29.7.0",
+				"jest-snapshot": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-validate": "^29.7.0",
+				"jest-watcher": "^29.7.0",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/core/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@jest/core/node_modules/pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/core/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true
+		},
+		"node_modules/@jest/core/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@jest/environment": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -4065,69 +4213,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@jest/expect/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/react-is": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true
-		},
 		"node_modules/@jest/fake-timers": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
@@ -4145,6 +4230,92 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@jest/globals": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/reporters": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+			"dev": true,
+			"dependencies": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "^29.7.0",
+				"@jest/test-result": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.9",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^6.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.1.3",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jest-worker": "^29.7.0",
+				"slash": "^3.0.0",
+				"string-length": "^4.0.1",
+				"strip-ansi": "^6.0.0",
+				"v8-to-istanbul": "^9.0.1"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@jest/schemas": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -4152,6 +4323,20 @@
 			"dev": true,
 			"dependencies": {
 				"@sinclair/typebox": "^0.27.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/source-map": {
+			"version": "29.6.3",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.2.9"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4312,16 +4497,351 @@
 				"tslib": "2"
 			}
 		},
-		"node_modules/@jsonjoy.com/json-pack": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.2.0.tgz",
-			"integrity": "sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==",
+		"node_modules/@jsonjoy.com/buffers": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+			"integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/codegen": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+			"integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-core": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.1.tgz",
+			"integrity": "sha512-YrEi/ZPmgc+GfdO0esBF04qv8boK9Dg9WpRQw/+vM8Qt3nnVIJWIa8HwZ/LXVZ0DB11XUROM8El/7yYTJX+WtA==",
 			"dev": true,
 			"dependencies": {
-				"@jsonjoy.com/base64": "^1.1.1",
-				"@jsonjoy.com/util": "^1.1.2",
+				"@jsonjoy.com/fs-node-builtins": "4.57.1",
+				"@jsonjoy.com/fs-node-utils": "4.57.1",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-fsa": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.1.tgz",
+			"integrity": "sha512-ooEPvSW/HQDivPDPZMibHGKZf/QS4WRir1czGZmXmp3MsQqLECZEpN0JobrD8iV9BzsuwdIv+PxtWX9WpPLsIA==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/fs-core": "4.57.1",
+				"@jsonjoy.com/fs-node-builtins": "4.57.1",
+				"@jsonjoy.com/fs-node-utils": "4.57.1",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.1.tgz",
+			"integrity": "sha512-3YaKhP8gXEKN+2O49GLNfNb5l2gbnCFHyAaybbA2JkkbQP3dpdef7WcUaHAulg/c5Dg4VncHsA3NWAUSZMR5KQ==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/fs-core": "4.57.1",
+				"@jsonjoy.com/fs-node-builtins": "4.57.1",
+				"@jsonjoy.com/fs-node-utils": "4.57.1",
+				"@jsonjoy.com/fs-print": "4.57.1",
+				"@jsonjoy.com/fs-snapshot": "4.57.1",
+				"glob-to-regex.js": "^1.0.0",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-builtins": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.1.tgz",
+			"integrity": "sha512-XHkFKQ5GSH3uxm8c3ZYXVrexGdscpWKIcMWKFQpMpMJc8gA3AwOMBJXJlgpdJqmrhPyQXxaY9nbkNeYpacC0Og==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-to-fsa": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.1.tgz",
+			"integrity": "sha512-pqGHyWWzNck4jRfaGV39hkqpY5QjRUQ/nRbNT7FYbBa0xf4bDG+TE1Gt2KWZrSkrkZZDE3qZUjYMbjwSliX6pg==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/fs-fsa": "4.57.1",
+				"@jsonjoy.com/fs-node-builtins": "4.57.1",
+				"@jsonjoy.com/fs-node-utils": "4.57.1"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-node-utils": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.1.tgz",
+			"integrity": "sha512-vp+7ZzIB8v43G+GLXTS4oDUSQmhAsRz532QmmWBbdYA20s465JvwhkSFvX9cVTqRRAQg+vZ7zWDaIEh0lFe2gw==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/fs-node-builtins": "4.57.1"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-print": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.1.tgz",
+			"integrity": "sha512-Ynct7ZJmfk6qoXDOKfpovNA36ITUx8rChLmRQtW08J73VOiuNsU8PB6d/Xs7fxJC2ohWR3a5AqyjmLojfrw5yw==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/fs-node-utils": "4.57.1",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.1.tgz",
+			"integrity": "sha512-/oG8xBNFMbDXTq9J7vepSA1kerS5vpgd3p5QZSPd+nX59uwodGJftI51gDYyHRpP57P3WCQf7LHtBYPqwUg2Bg==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^17.65.0",
+				"@jsonjoy.com/fs-node-utils": "4.57.1",
+				"@jsonjoy.com/json-pack": "^17.65.0",
+				"@jsonjoy.com/util": "^17.65.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+			"integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+			"integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+			"integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/base64": "17.67.0",
+				"@jsonjoy.com/buffers": "17.67.0",
+				"@jsonjoy.com/codegen": "17.67.0",
+				"@jsonjoy.com/json-pointer": "17.67.0",
+				"@jsonjoy.com/util": "17.67.0",
 				"hyperdyperid": "^1.2.0",
-				"thingies": "^1.20.0"
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+			"integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/util": "17.67.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+			"version": "17.67.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+			"integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/buffers": "17.67.0",
+				"@jsonjoy.com/codegen": "17.67.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+			"integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.2",
+				"@jsonjoy.com/buffers": "^1.2.0",
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/json-pointer": "^1.0.2",
+				"@jsonjoy.com/util": "^1.9.0",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pointer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+			"integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/util": "^1.9.0"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -4335,9 +4855,29 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/util": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.6.0.tgz",
-			"integrity": "sha512-sw/RMbehRhN68WRtcKCpQOPfnH6lLP4GJfqzi3iYej8tnzpZUDr6UkZYJjcjjC0FWEJOJbyM3PTIwxucUmDG2A==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+			"integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+			"dev": true,
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^1.0.0",
+				"@jsonjoy.com/codegen": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0"
@@ -4350,14 +4890,27 @@
 				"tslib": "2"
 			}
 		},
-		"node_modules/@keyv/serialize": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
-			"integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+		"node_modules/@keyv/bigmap": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
 			"dev": true,
 			"dependencies": {
-				"buffer": "^6.0.3"
+				"hashery": "^1.4.0",
+				"hookified": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"keyv": "^5.6.0"
 			}
+		},
+		"node_modules/@keyv/serialize": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+			"dev": true
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
@@ -4518,6 +5071,315 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@parcel/watcher": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+			"integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^2.0.3",
+				"is-glob": "^4.0.3",
+				"node-addon-api": "^7.0.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher-android-arm64": "2.5.6",
+				"@parcel/watcher-darwin-arm64": "2.5.6",
+				"@parcel/watcher-darwin-x64": "2.5.6",
+				"@parcel/watcher-freebsd-x64": "2.5.6",
+				"@parcel/watcher-linux-arm-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm-musl": "2.5.6",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm64-musl": "2.5.6",
+				"@parcel/watcher-linux-x64-glibc": "2.5.6",
+				"@parcel/watcher-linux-x64-musl": "2.5.6",
+				"@parcel/watcher-win32-arm64": "2.5.6",
+				"@parcel/watcher-win32-ia32": "2.5.6",
+				"@parcel/watcher-win32-x64": "2.5.6"
+			}
+		},
+		"node_modules/@parcel/watcher-android-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+			"integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+			"integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+			"integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-freebsd-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+			"integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+			"integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+			"integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-glibc": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+			"integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-musl": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-arm64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+			"integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-ia32": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+			"integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-x64": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+			"integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/@paulirish/trace_engine": {
 			"version": "0.0.53",
 			"resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.53.tgz",
@@ -4629,29 +5491,6 @@
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
 		},
 		"node_modules/@radix-ui/primitive": {
 			"version": "1.1.2",
@@ -5250,26 +6089,20 @@
 			}
 		},
 		"node_modules/@slack/web-api/node_modules/axios": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-			"integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
 			"dev": true,
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
 			}
 		},
-		"node_modules/@slack/web-api/node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-			"dev": true
-		},
 		"node_modules/@slack/web-api/node_modules/follow-redirects": {
-			"version": "1.15.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5284,6 +6117,15 @@
 				"debug": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@slack/web-api/node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@stripe/connect-js": {
@@ -5386,9 +6228,9 @@
 			"dev": true
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
@@ -5412,53 +6254,36 @@
 			}
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
-		"node_modules/@stylistic/stylelint-plugin/node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/file-entry-cache": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.1.tgz",
-			"integrity": "sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==",
+			"version": "10.1.4",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
+			"integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
 			"dev": true,
 			"dependencies": {
-				"flat-cache": "^6.1.10"
+				"flat-cache": "^6.1.13"
 			}
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/flat-cache": {
-			"version": "6.1.10",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.10.tgz",
-			"integrity": "sha512-B6/v1f0NwjxzmeOhzfXPGWpKBVA207LS7lehaVKQnFrVktcFRfkzjZZ2gwj2i1TkEUMQht7ZMJbABUT5N+V1Nw==",
+			"version": "6.1.22",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+			"integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
 			"dev": true,
 			"dependencies": {
-				"cacheable": "^1.10.0",
-				"flatted": "^3.3.3",
-				"hookified": "^1.9.1"
+				"cacheable": "^2.3.4",
+				"flatted": "^3.4.2",
+				"hookified": "^1.15.0"
 			}
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/global-modules": {
@@ -5497,9 +6322,9 @@
 			}
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -5524,9 +6349,9 @@
 			"dev": true
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/meow": {
@@ -5541,16 +6366,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@stylistic/stylelint-plugin/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/postcss": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-			"integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+			"version": "8.5.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+			"integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5599,19 +6418,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4.31"
-			}
-		},
-		"node_modules/@stylistic/stylelint-plugin/node_modules/postcss-selector-parser": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-			"dev": true,
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/signal-exit": {
@@ -5721,9 +6527,9 @@
 			}
 		},
 		"node_modules/@stylistic/stylelint-plugin/node_modules/stylelint/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -5953,9 +6759,9 @@
 			}
 		},
 		"node_modules/@svgr/core/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -6057,9 +6863,9 @@
 			}
 		},
 		"node_modules/@svgr/plugin-svgo/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -6091,6 +6897,14 @@
 				"url": "https://github.com/sponsors/gregberge"
 			}
 		},
+		"node_modules/@tabby_ai/hijri-converter": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+			"integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/@tannin/compile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -6119,9 +6933,9 @@
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"node_modules/@tannin/sprintf": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.1.tgz",
-			"integrity": "sha512-3auu6Wqm4TR6gvOh1Dgh1d2k9+arNmu3T0JLiUJoJMgayeHr450OuWeZIMTE4CUuq51rwn/NI9S5InT0JuTxQw=="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.3.tgz",
+			"integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA=="
 		},
 		"node_modules/@testing-library/dom": {
 			"version": "9.3.4",
@@ -7005,12 +7819,13 @@
 			}
 		},
 		"node_modules/@types/wordpress__rich-text": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__rich-text/-/wordpress__rich-text-6.10.0.tgz",
-			"integrity": "sha512-NrG+000/kI0ltUe1uT750E/YuHzDceAFbrcEG7AY81BoqUBNhjUE8QNOwt07V6QXZ/tPcKEdhGOGMs9K9SrHKg==",
-			"deprecated": "This is a stub types definition. @wordpress/rich-text provides its own type definitions, so you do not need this installed.",
+			"version": "3.4.6",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__rich-text/-/wordpress__rich-text-3.4.6.tgz",
+			"integrity": "sha512-MeLSATBHrcN3fp8cVylbpx+BKRJ1aootPNtbTblcUAHcuRo6avKu1kaDLxIZb/8YbsD+/3Wm8d1uldeNz9/lhw==",
 			"dependencies": {
-				"@wordpress/rich-text": "*"
+				"@types/react": "*",
+				"@types/wordpress__data": "*",
+				"@types/wordpress__rich-text": "*"
 			}
 		},
 		"node_modules/@types/ws": {
@@ -7036,6 +7851,16 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
 			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
 			"dev": true
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.62.0",
@@ -7072,69 +7897,6 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "5.62.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
@@ -7163,12 +7925,11 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.62.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
 			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/types": "5.62.0",
 				"@typescript-eslint/visitor-keys": "5.62.0"
@@ -7179,79 +7940,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
@@ -7282,12 +7970,11 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/types": {
 			"version": "5.62.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
 			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -7296,12 +7983,11 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "5.62.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
 			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@typescript-eslint/types": "5.62.0",
 				"@typescript-eslint/visitor-keys": "5.62.0",
@@ -7322,37 +8008,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"eslint-visitor-keys": "^3.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
@@ -7382,72 +8037,11 @@
 				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "5.62.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
 			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/types": "5.62.0",
 				"eslint-visitor-keys": "^3.3.0"
@@ -7460,12 +8054,11 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
 			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -7776,13 +8369,13 @@
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@types/react-dom": {
@@ -7791,16 +8384,6 @@
 			"integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
 			"peerDependencies": {
 				"@types/react": "^17.0.0"
-			}
-		},
-		"node_modules/@woocommerce/components/node_modules/@types/wordpress__rich-text": {
-			"version": "3.4.6",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__rich-text/-/wordpress__rich-text-3.4.6.tgz",
-			"integrity": "sha512-MeLSATBHrcN3fp8cVylbpx+BKRJ1aootPNtbTblcUAHcuRo6avKu1kaDLxIZb/8YbsD+/3Wm8d1uldeNz9/lhw==",
-			"dependencies": {
-				"@types/react": "*",
-				"@types/wordpress__data": "*",
-				"@types/wordpress__rich-text": "*"
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/api-fetch": {
@@ -8089,9 +8672,9 @@
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/icons": {
 			"version": "9.49.0",
@@ -8107,20 +8690,20 @@
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/icons/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/icons/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
@@ -8155,20 +8738,20 @@
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/notices/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/notices/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
@@ -8257,20 +8840,20 @@
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/primitives/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/primitives/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
@@ -8376,9 +8959,9 @@
 			}
 		},
 		"node_modules/@woocommerce/components/node_modules/core-js": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-			"integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -8489,13 +9072,13 @@
 			}
 		},
 		"node_modules/@woocommerce/data/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/data/node_modules/@types/react-dom": {
@@ -8700,9 +9283,9 @@
 			}
 		},
 		"node_modules/@woocommerce/data/node_modules/@wordpress/i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@woocommerce/data/node_modules/@wordpress/url": {
 			"version": "3.59.0",
@@ -8864,14 +9447,14 @@
 			}
 		},
 		"node_modules/@woocommerce/experimental/node_modules/@types/react": {
-			"version": "17.0.87",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.87.tgz",
-			"integrity": "sha512-wpg9AbtJ6agjA+BKYmhG6dRWEU/2DHYwMzCaBzsz137ft6IyuqZ5fI4ic1DWL4DrI03Zy78IyVE6ucrXl0mu4g==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/experimental/node_modules/@types/react-dom": {
@@ -8939,13 +9522,13 @@
 			}
 		},
 		"node_modules/@woocommerce/experimental/node_modules/@wordpress/components/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/experimental/node_modules/@wordpress/components/node_modules/@types/react-dom": {
@@ -9112,9 +9695,9 @@
 			}
 		},
 		"node_modules/@woocommerce/experimental/node_modules/@wordpress/i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
 			"dev": true
 		},
 		"node_modules/@woocommerce/experimental/node_modules/@wordpress/icons": {
@@ -9146,13 +9729,13 @@
 			}
 		},
 		"node_modules/@woocommerce/experimental/node_modules/@wordpress/primitives/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/experimental/node_modules/@wordpress/primitives/node_modules/@types/react-dom": {
@@ -9295,11 +9878,11 @@
 			}
 		},
 		"node_modules/@woocommerce/navigation/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@woocommerce/navigation/node_modules/@wordpress/components": {
@@ -9461,13 +10044,13 @@
 			}
 		},
 		"node_modules/@woocommerce/navigation/node_modules/@wordpress/element/node_modules/@types/react": {
-			"version": "17.0.87",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.87.tgz",
-			"integrity": "sha512-wpg9AbtJ6agjA+BKYmhG6dRWEU/2DHYwMzCaBzsz137ft6IyuqZ5fI4ic1DWL4DrI03Zy78IyVE6ucrXl0mu4g==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/navigation/node_modules/@wordpress/element/node_modules/@types/react-dom": {
@@ -9534,9 +10117,9 @@
 			}
 		},
 		"node_modules/@woocommerce/navigation/node_modules/@wordpress/i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@woocommerce/navigation/node_modules/@wordpress/icons": {
 			"version": "9.49.0",
@@ -9917,12 +10500,12 @@
 			}
 		},
 		"node_modules/@woocommerce/onboarding/node_modules/@wordpress/components/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/onboarding/node_modules/@wordpress/components/node_modules/@types/react-dom": {
@@ -10078,9 +10661,9 @@
 			}
 		},
 		"node_modules/@woocommerce/onboarding/node_modules/@wordpress/i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@woocommerce/onboarding/node_modules/@wordpress/icons": {
 			"version": "8.4.0",
@@ -10109,12 +10692,12 @@
 			}
 		},
 		"node_modules/@woocommerce/onboarding/node_modules/@wordpress/primitives/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@woocommerce/onboarding/node_modules/@wordpress/primitives/node_modules/@types/react-dom": {
@@ -10187,9 +10770,9 @@
 			}
 		},
 		"node_modules/@woocommerce/onboarding/node_modules/core-js": {
-			"version": "3.43.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-			"integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -10297,9 +10880,9 @@
 			}
 		},
 		"node_modules/@wordpress/a11y/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/api-fetch": {
 			"version": "6.3.1",
@@ -10480,6 +11063,16 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/block-editor/node_modules/@types/react": {
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+			"dev": true,
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
+			}
+		},
 		"node_modules/@wordpress/block-editor/node_modules/@types/react-dom": {
 			"version": "18.3.7",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
@@ -10507,15 +11100,13 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.0.0.tgz",
-			"integrity": "sha512-ItvO/E3v39VX+5nZacyzwulhzRukiB2+1zqndWgOSNnERYnK/0hLHIWWthRFxYEPF13H54orXg68n17MZQ8whA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.27.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -10529,15 +11120,13 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/api-fetch": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.27.0.tgz",
-			"integrity": "sha512-YoYWIJg087pXSWaiiNAKixUB70l1gbvZi0VEj6SrqdAItuTfYelG6hJtYxF2xPhBWVGbTXaq8nJMVRB8EcutAg==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.43.0.tgz",
+			"integrity": "sha512-1Tetm4VIEKDIwrCsvDY0KjjrHvkEaSa2Qvld5gguY2ofcIszL3mR0tGezFaaaB14FHd7Zl0MpfpQY3KeQ+BatQ==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^6.0.0",
-				"@wordpress/url": "^4.27.0"
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/url": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10545,15 +11134,13 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/api-fetch/node_modules/@wordpress/i18n": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.0.0.tgz",
-			"integrity": "sha512-ItvO/E3v39VX+5nZacyzwulhzRukiB2+1zqndWgOSNnERYnK/0hLHIWWthRFxYEPF13H54orXg68n17MZQ8whA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.27.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -10567,42 +11154,30 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/autop": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.27.0.tgz",
-			"integrity": "sha512-UY1bxt8aJcZfG0U7y28QiHJAt6ZEv5gk7by9IZQ8VJ4bUEdNAafyWr9ysJlERDsca+CK2xNIR/JwQb7CAaXNjw==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.43.0.tgz",
+			"integrity": "sha512-ODEGv8CZmL12DRKyYCCUXwTHS8aI2/K1C4WuVLeQ5uhPmFk0QHAHQ2sGga509K9F0Nj/DY7fgkD0YlE9T1stbA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/blob": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.27.0.tgz",
-			"integrity": "sha512-dOXMP3xR6nJMGsDQbQ+IbJBjyVZq9RK0e7jA6elbkuspEQmRkbyiyfWTuscSEusJydW6NDRaQl9rzQsbLy7UeA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.43.0.tgz",
+			"integrity": "sha512-wNYpE1DMabI9wDIVBcwsakbnVnvskAj0eJ+7A1njEdmJFYEQ0wc6kTqJ6ma4pLYYPrgw2svWl8vI3HIIB50qhg==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/block-serialization-default-parser": {
-			"version": "5.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.27.0.tgz",
-			"integrity": "sha512-OTGiQMjailRi4KEM/9WNdUcZqUK2YRXf4Zd1VfsOPGI6RaZbYwW/5p0KuWOKYAVNF2ALAhssOoqxjKCvBs0kwg==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.43.0.tgz",
+			"integrity": "sha512-1P2eujRuY9VmhFT8Kp7hghxbxbw6dIcHWGLlo/V3YVaHor1WZ3P5p6k+ELQRJTyrbWYV+qu/zYWGYCGGDtEvsA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -10652,23 +11227,20 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/compose": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.27.0.tgz",
-			"integrity": "sha512-87/V/hyyg2Fojfk0hDVR4U3vdDdbNWoVdf17QnAORYt35lWWTxwMBKlZqIhFEuoLrPTvMQvu6ecjhxFNYB+ALg==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.27.0",
-				"@wordpress/dom": "^4.27.0",
-				"@wordpress/element": "^6.27.0",
-				"@wordpress/is-shallow-equal": "^5.27.0",
-				"@wordpress/keycodes": "^4.27.0",
-				"@wordpress/priority-queue": "^3.27.0",
-				"@wordpress/undo-manager": "^1.27.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -10681,20 +11253,18 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/data": {
-			"version": "10.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.27.0.tgz",
-			"integrity": "sha512-+7S4GgAEBi87qNPN/Jl3sr3xuBnjHIaA7Vzfn3UqoCQ469JkyB65kbgfJOOGDz94sMhYZ4OoeQT3lpGsPBxnVA==",
+			"version": "10.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.43.0.tgz",
+			"integrity": "sha512-LKjxBrub1qkMm8Oyj6ynHAGix5eJcJqN9Pq0aX9UYLPjc1T/zkhhAopFL7It2S4muKMNcAHizR+e1eZNA3k4fQ==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.27.0",
-				"@wordpress/deprecated": "^4.27.0",
-				"@wordpress/element": "^6.27.0",
-				"@wordpress/is-shallow-equal": "^5.27.0",
-				"@wordpress/priority-queue": "^3.27.0",
-				"@wordpress/private-apis": "^1.27.0",
-				"@wordpress/redux-routine": "^5.27.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/redux-routine": "^5.43.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -10729,14 +11299,12 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/deprecated": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.27.0.tgz",
-			"integrity": "sha512-1rJTK7iy0oSE6eFUCBqCGG/wYuF62WoNDLF1G1Do+TdFGB4WxckHwTr5TuwtIG4CdoMjsPYIh2EnI3ziFOsHkA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.27.0"
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10744,14 +11312,12 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dom": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.27.0.tgz",
-			"integrity": "sha512-uXcJslbSpxXX7EyMF4wtj+cydDyalapvu8HQ4QZleAAwJavhdNT+xpr/ai0XeApcxgIGHq1W05sYVN38lwVioQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.27.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10759,30 +11325,24 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dom-ready": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.27.0.tgz",
-			"integrity": "sha512-L1hZ1g1mMyt06tuMWt72uAJjlkjGOpR2Vxbo72ZZgO28PqQc1WLrvWN/W3LVViar9OQrR0yn/REYRd258iaNQw==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.43.0.tgz",
+			"integrity": "sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/element": {
-			"version": "6.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.27.0.tgz",
-			"integrity": "sha512-gHk4B0J0f7bEsDoUBdTm22vPQwmEWLZxyaojgRyx1ncE2IyktfmubD/q2NIcMEKh7p+Jq3ZUwzPcpchpvkH2mA==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.27.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -10794,42 +11354,30 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/escape-html": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.27.0.tgz",
-			"integrity": "sha512-1LBB/xOFBUySSmVpd2nFwIZ8fVnP8dLNFl0wLprHVLtW6ZcdykO2ITY9bkaHu2lZ9HLRgHL7A/3R7MsJ1azYkg==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/hooks": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.27.0.tgz",
-			"integrity": "sha512-sGaNVZKMxwnhGSge0tZZsGfImLPimiulUkM7hivQ2CSCgibTpgxFRBJ1r7gbNLDF+qHQK9a26K8fGfKnAal6Cg==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/html-entities": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.27.0.tgz",
-			"integrity": "sha512-4MfLS3k6+dlPSPbccnCloIFdbWjT6x0sRLNcVNWAI7I+nov7A34/cI/xjXFPcQaeewBE+24Q2TWsyFhcX2r89Q==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.43.0.tgz",
+			"integrity": "sha512-z7C782VfH3E5dWYO4VOtN8EEhzfID2kiJmGTINiVPD8kywxp5BsBU2KJSSPvkUjqOCMNJ2XhkYPgADKi9O1U7A==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -10874,14 +11422,10 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.27.0.tgz",
-			"integrity": "sha512-sYlAuNgEwQHioKSx3jyV6ZJlBR19sEvIdkBVoGF82OAxbXFzRvoD6V4zy+kZzY6V99FE12L93I0t5jh4qOn2lg==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -10908,14 +11452,12 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.27.0.tgz",
-			"integrity": "sha512-fWyEcLI2rAZn6FwVBITGFxo8aS7EQrt8icOdxS5Es3Ii8DneQUl2gtXs3tq9viX4cWCno7cEt+dpuuv2gPxwoQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^6.0.0"
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10923,15 +11465,13 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.0.0.tgz",
-			"integrity": "sha512-ItvO/E3v39VX+5nZacyzwulhzRukiB2+1zqndWgOSNnERYnK/0hLHIWWthRFxYEPF13H54orXg68n17MZQ8whA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.27.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -10945,14 +11485,12 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/primitives": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.27.0.tgz",
-			"integrity": "sha512-ZIhpB4ZmZwMSsrELx4mzhRvxAoqgk8sSE3PaRt/ue4GXFoRRQgI3RVCwEdiNPcsQXId9lOQIhAJNDt5Wa0Fbgg==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.43.0.tgz",
+			"integrity": "sha512-lU1vBSDyRkAYFEfbLyzjophDvIVCeQ7uuEXv5dBAbxkSLSsCcX6oLbWSwjkCEHp1R+9UtukLvbmXDdAbDYiEOA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.27.0",
+				"@wordpress/element": "^6.43.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -10964,13 +11502,11 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/priority-queue": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.27.0.tgz",
-			"integrity": "sha512-RpIaX59sji45x9oUYrkbTHbagJuHC05oZOjJDzLj2Qv12bGeq0QWI2+e59yl3wONLpVla7f3TfNsFapkgOhOAw==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -10979,13 +11515,11 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/redux-routine": {
-			"version": "5.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.27.0.tgz",
-			"integrity": "sha512-6eulRxrF40yKtGjzHKsY2pzD5/sbWaNjXRrFQZY+wMNsYV6AWYacgn3r+2r51Uhlut6zZl6x8YJtCcqGOHnKEQ==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.43.0.tgz",
+			"integrity": "sha512-3QIt7jBhhwhE1AybMeYfeo5Vj7Rn+7l7QBYiqXiWHWBYGEJtI0VXiEjcC34ctTZKdVGBPvYJZUhBbNHOjLtgMw==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
@@ -10999,13 +11533,11 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/shortcode": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.27.0.tgz",
-			"integrity": "sha512-7UyI2Exqt789MrWO4LQWtvfdBisAVDUfHgTj8Rqq3QJ6dE5zlxM1UJwaxIQArFv39gS1hOibfNUxigKFQ+IW9A==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.43.0.tgz",
+			"integrity": "sha512-mSpGnX6Wlzd8wx5GED2D188Mxvtc2FrflDPI39Tlysz4OW+9PNAKueRzvcQ7QLwZhIzaDQ8pvonyal5i8PryIQ==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"memize": "^2.0.1"
 			},
 			"engines": {
@@ -11057,13 +11589,11 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/url": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.27.0.tgz",
-			"integrity": "sha512-7+WJ2g5xvfRjsnLRixXDVZzEg7jQUYRNPOBbjO95D9kJ3Sm63Lu4xc3FOikeojOUJv5/Z9c2zKOsaotNkWHexg==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.43.0.tgz",
+			"integrity": "sha512-FFq/KZUlhAszI9y232BpQ83+58CtRV5M0SFuv7pQq+DxNDuWNHp8gjdX9WOnHkO/MrKAyVTI0jX9YoWF2RNEZw==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -11086,11 +11616,10 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg==",
-			"dev": true,
-			"license": "MIT"
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
+			"dev": true
 		},
 		"node_modules/@wordpress/block-editor/node_modules/postcss": {
 			"version": "8.5.6",
@@ -11230,13 +11759,13 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@types/react-dom": {
@@ -11564,9 +12093,9 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/icons": {
 			"version": "9.49.0",
@@ -11582,20 +12111,20 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/icons/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/icons/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
@@ -11630,20 +12159,20 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/notices/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/notices/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
@@ -11732,20 +12261,20 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/primitives/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/primitives/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
@@ -11972,18 +12501,20 @@
 			}
 		},
 		"node_modules/@wordpress/commands": {
-			"version": "1.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.25.0.tgz",
-			"integrity": "sha512-guWyoJPwWIw148fS2YpM+iEFuq9HMBOnSY5XPxpOQOTsQlRqolKlyiPp8D1SI5R2zdBHvEGAkpzcMo2woRRUcQ==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.43.0.tgz",
+			"integrity": "sha512-oD2uurR7HYgQ3lXhukcWX0/mc+PHEFEfB2lu/mi5IvX8xYMV8e/l/uoP6BJ+Krm7EqtOkSwoaoGi6KcYoR4sMw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/components": "^29.11.0",
-				"@wordpress/data": "^10.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/icons": "^10.25.0",
-				"@wordpress/keyboard-shortcuts": "^5.25.0",
-				"@wordpress/private-apis": "^1.25.0",
+				"@wordpress/base-styles": "^6.19.0",
+				"@wordpress/components": "^32.5.0",
+				"@wordpress/data": "^10.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/icons": "^12.1.0",
+				"@wordpress/keyboard-shortcuts": "^5.43.0",
+				"@wordpress/preferences": "^4.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/warning": "^3.43.0",
 				"clsx": "^2.1.1",
 				"cmdk": "^1.0.0"
 			},
@@ -11997,16 +12528,16 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@ariakit/core": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.15.tgz",
-			"integrity": "sha512-vvxmZvkNhiisKM+Y1TbGMUfVVchV/sWu9F0xw0RYADXcimWPK31dd9JnIZs/OQ5pwAryAHmERHwuGQVESkSjwQ=="
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.19.tgz",
+			"integrity": "sha512-PUj/J1eX/b+DkcYwP6m7/tzDUiX1SVST89coljTN6BdQwLYMSkhg71jXcZwmTX19jQmqV9VqhVkKeabLnvciQQ=="
 		},
 		"node_modules/@wordpress/commands/node_modules/@ariakit/react": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.17.tgz",
-			"integrity": "sha512-HQaIboE2axtlncJz1hRTaiQfJ1GGjhdtNcAnPwdjvl2RybfmlHowIB+HTVBp36LzroKPs/M4hPCxk7XTaqRZGg==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.25.tgz",
+			"integrity": "sha512-Gs/YgXrz0gCj0k/AWD7Ia9bw5vLPAJpG0KRiv6T/5Tg/DTZYihtE9blWGWhgGu+bSrp1IratNbQLkAvQ4J99cQ==",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.17"
+				"@ariakit/react-core": "0.4.25"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -12018,26 +12549,36 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@ariakit/react-core": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.17.tgz",
-			"integrity": "sha512-kFF6n+gC/5CRQIyaMTFoBPio2xUe0k9rZhMNdUobWRmc/twfeLVkODx+8UVYaNyKilTge8G0JFqwvFKku/jKEw==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.25.tgz",
+			"integrity": "sha512-7seOOJ6N71lIKMS2jtNzxITCRIirt7yRrZLLWE8bp4+tQbov96BqSNX8fNCXmr/bDvKWz9PL07YrPrGjTXJXgA==",
 			"dependencies": {
-				"@ariakit/core": "0.4.15",
+				"@ariakit/core": "0.4.19",
 				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
+				"use-sync-external-store": "^1.6.0"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
+		"node_modules/@wordpress/commands/node_modules/@emotion/utils": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+		},
+		"node_modules/@wordpress/commands/node_modules/@types/gradient-parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+			"integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw=="
+		},
 		"node_modules/@wordpress/commands/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@types/react-dom": {
@@ -12049,67 +12590,79 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/a11y": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.25.0.tgz",
-			"integrity": "sha512-9wJZC7gWUrDN1Ybch6pgGZL73kSm2b4dm9YDJtNJuCa/6T7TkVRVdpjVtnTLhvATPSXNV81P/bLK8fWbI3ze0A==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.43.0.tgz",
+			"integrity": "sha512-AWNmSi+Cjx5m03JhG/XjDqgRufqCFcIpYddWw7/0vR6rMk/DK5O+Jx6yJcJOwgmz2KFSgjMnjFfqbh3EtX8rRg==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/dom-ready": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/dom-ready": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/commands/node_modules/@wordpress/base-styles": {
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.19.0.tgz",
+			"integrity": "sha512-SAZA6dhfC5X00s9PRrL9diY59WegiF0MuAWupkoKnYk3a2IAQbRUUTrh3j3wRyr08ljqefmifX5GR3hz/VwQaw==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/components": {
-			"version": "29.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-29.11.0.tgz",
-			"integrity": "sha512-p/hicoCxHo4uC5DeGsdLme/JcRwedFkNctKS7uo5dy05odWXWOPDLiSsWYz6F7uCKbmBJNucxdF3f42YTh6y1Q==",
+			"version": "32.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.5.0.tgz",
+			"integrity": "sha512-UEBNEqxHfOvTVbVepoLPS2wSzIjcZoCHMv6P2iN0om819x3aLIKAZqpxjNF8x0nz2z/gnj5Bj9GpXTW0+Bvfcw==",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@babel/runtime": "7.25.7",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^2.0.8",
-				"@types/gradient-parser": "0.1.3",
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.25.0",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/date": "^5.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/escape-html": "^3.25.0",
-				"@wordpress/hooks": "^4.25.0",
-				"@wordpress/html-entities": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/icons": "^10.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/primitives": "^4.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/rich-text": "^7.25.0",
-				"@wordpress/warning": "^3.25.0",
+				"@wordpress/a11y": "^4.43.0",
+				"@wordpress/base-styles": "^6.19.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/date": "^5.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/escape-html": "^3.43.0",
+				"@wordpress/hooks": "^4.43.0",
+				"@wordpress/html-entities": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/icons": "^12.1.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/primitives": "^4.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/rich-text": "^7.43.0",
+				"@wordpress/warning": "^3.43.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
 				"date-fns": "^3.6.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.1.9",
-				"gradient-parser": "1.0.2",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"
 			},
@@ -12123,21 +12676,19 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/compose": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.25.0.tgz",
-			"integrity": "sha512-nfjtMZgrhdHU8/zOLUyA5o8ShLot1vbHZ0I2+IxLyNskRMVyR9pm4BAJSYKJ9XqBUom2/N51gfeKg5uhd9Y0TQ==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/undo-manager": "^1.25.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -12150,18 +12701,17 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/data": {
-			"version": "10.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.25.0.tgz",
-			"integrity": "sha512-PHfF7S2jhgcH9D3Z9nskaQEDIbh0k0MX6KprzK4plT4Xu71YboMVWnBx78glzMMu17DOFoHJC25d+ymfGBM5rw==",
+			"version": "10.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.43.0.tgz",
+			"integrity": "sha512-LKjxBrub1qkMm8Oyj6ynHAGix5eJcJqN9Pq0aX9UYLPjc1T/zkhhAopFL7It2S4muKMNcAHizR+e1eZNA3k4fQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/redux-routine": "^5.25.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/redux-routine": "^5.43.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -12179,12 +12729,11 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/date": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.25.0.tgz",
-			"integrity": "sha512-w3De486/qx2/MbxCCjiW7KS8lGhJ00VvnrbXRlrY9l/6yqbz0iMVglmFKrlLPftgutyhe3OSOSZsXX/uCF6yOg==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.43.0.tgz",
+			"integrity": "sha512-8DiFlE7YzP7F/P59Hr6h5fWJxJlvt6eZgU1C7huM9XhANh8Y3dZfepsySL6K7h1yE66SQDSq07cEefFQgJW31g==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.25.0",
+				"@wordpress/deprecated": "^4.43.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -12194,12 +12743,11 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/deprecated": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.25.0.tgz",
-			"integrity": "sha512-NfVGSVfAESrgQRQu5QpyprTsDY0BLq6hJ2KrWlpscLetApxU5kSpP/wRzmjbtuuWSr5RsoopaeoTbiZNXb0QEA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0"
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12207,12 +12755,11 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/dom": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.25.0.tgz",
-			"integrity": "sha512-uyP8oTjSYjU+OXSvpPITqMaF9Dk50WH7fiQIVUcjC/9VmrzIiaYaZ4USmuoUBtbFjJsSyANHw/anYMFqby9iIA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.25.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12220,26 +12767,22 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/dom-ready": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.25.0.tgz",
-			"integrity": "sha512-HvGxncRhskqrkwyIPVsfznToFtSr6X0zBrIMHK7bgwGGiMr+yz5jYX3wnY1AsUDSr95ezhbCTdE2rNmvFkCD0g==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.43.0.tgz",
+			"integrity": "sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/element": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.25.0.tgz",
-			"integrity": "sha512-zxdaf2s/en5Y+DfiswRZtQ+P8SvQ18+l5I2WmHb66+bVkFg7jrN+AJqLk86k2zcalOEjx7Fg4cce1wWytp8Wsw==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.25.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -12251,51 +12794,41 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/escape-html": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.25.0.tgz",
-			"integrity": "sha512-sQ3graObu5K/RWrngk9bsULJ+9E7QLC6gMG34ja0Jm1LdeRjVgHv3FqP/uIkL36EvxEkjQ0LSbgbZsdV/E1q0w==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/hooks": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.25.0.tgz",
-			"integrity": "sha512-IWqgozRE+8PE96TIsf5bfS7ezZfvleSm1YZAuhAWYH7QUVm07WK7/yhhDYkj9QyTpWSZnGkmR7YYH/NJ8jaMDQ==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/html-entities": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.25.0.tgz",
-			"integrity": "sha512-SEf8nnLm85KH2fZiEzUgLuh4Nd53iW0rmA5k9xM7n0uM6BA6HMDidtT/5wxTlnMH8cxOSjL2IkCHwhuRFTibbg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.43.0.tgz",
+			"integrity": "sha512-z7C782VfH3E5dWYO4VOtN8EEhzfID2kiJmGTINiVPD8kywxp5BsBU2KJSSPvkUjqOCMNJ2XhkYPgADKi9O1U7A==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/i18n": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.25.0.tgz",
-			"integrity": "sha512-6MWkwmA9dwiLA+N4cj81JxxSqgJ+5HeLZHa3Sy2u7A2f4wgGCH+Bj2T6eQnZdky9fMy4vjvUpUZdv5sdmtYJlQ==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
@@ -12307,40 +12840,39 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
-			"version": "10.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.25.0.tgz",
-			"integrity": "sha512-CNAgZ0ZE6pPjLWxPLBdmIQlxpkQCNZ9Zv4wuUDSMqG0jJDdf+YCpklwIMLWbv9WVubmzgURo54qeCedbpXhCjA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-12.1.0.tgz",
+			"integrity": "sha512-JOEVd94kZQsGYyLhjq1edfaMOTPON/7qUDuzT74uSwSCJ6OiHf3yJHfxMlLOMoh12dQshWPciLVLagkYLCldag==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/primitives": "^4.25.0"
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/primitives": "^4.43.0",
+				"change-case": "4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.25.0.tgz",
-			"integrity": "sha512-/37IIoJz8/mp7TGZbdmakXr6YKqvpjYUHJx9LA9ibVVh6AsM72nI7N5V3AsGndan46vItfzhs0zpEWI7xF86Gw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/keyboard-shortcuts": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.25.0.tgz",
-			"integrity": "sha512-g78ZZnoQMmQ70rVcvnxkIZ0VpOaZH34CxC9QSBASRfmoVrM9pFZFZJPDE/KoUt8qEFQqgTOVMpn0GenT2NEPXA==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.43.0.tgz",
+			"integrity": "sha512-JJThUTTiJZgzzOIYHgK5CHPHwD6plK1O45e/0RpsOEe4vLCuLH0RoVAWoy/9Z4jIxXLGbwE5WdJIQkTStf+KMQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/data": "^10.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/keycodes": "^4.25.0"
+				"@wordpress/data": "^10.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/keycodes": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12351,12 +12883,11 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/keycodes": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.25.0.tgz",
-			"integrity": "sha512-cnV4/7RY4m+DNo3BF10pHdFITKyoYr4TqvcSmka5O7RulPQi/PTeLcFgTTM+LrULGSNfV5ZUgIuPwLpLA5pqGQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12364,12 +12895,11 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/primitives": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.25.0.tgz",
-			"integrity": "sha512-I8voo9KWDFOgVUzxO0n1UtaTGBwhA/MuYmh6Bpn4M33SQAm4K5aUFidnJOelILWSA4Ox4R7wskGhuItfyty1LA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.43.0.tgz",
+			"integrity": "sha512-lU1vBSDyRkAYFEfbLyzjophDvIVCeQ7uuEXv5dBAbxkSLSsCcX6oLbWSwjkCEHp1R+9UtukLvbmXDdAbDYiEOA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.25.0",
+				"@wordpress/element": "^6.43.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -12381,11 +12911,10 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/priority-queue": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.25.0.tgz",
-			"integrity": "sha512-HtN8G1o/TaUIhapJf6Kq2dy1OOpC1beGB7sJUvq5JrwKd3VRdrXx0K3HKoHe99EJoE9v6lgEIS5VtVIaW0u0cQ==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -12394,11 +12923,10 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/redux-routine": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.25.0.tgz",
-			"integrity": "sha512-0YZNyuL1QO3CbA6njHzoHMmYX+tnOSUIOpag5jeeNKzNE7iThKRmD07HtMo+hL5B3EFumvWDXlwOLpoi2xBJuw==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.43.0.tgz",
+			"integrity": "sha512-3QIt7jBhhwhE1AybMeYfeo5Vj7Rn+7l7QBYiqXiWHWBYGEJtI0VXiEjcC34ctTZKdVGBPvYJZUhBbNHOjLtgMw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
@@ -12438,17 +12966,17 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/gradient-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
-			"integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
+			"integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/commands/node_modules/path-to-regexp": {
 			"version": "6.3.0",
@@ -12464,6 +12992,14 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
 			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
+		},
+		"node_modules/@wordpress/commands/node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
 		},
 		"node_modules/@wordpress/components": {
 			"version": "29.5.4",
@@ -12528,20 +13064,18 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@ariakit/core": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.15.tgz",
-			"integrity": "sha512-vvxmZvkNhiisKM+Y1TbGMUfVVchV/sWu9F0xw0RYADXcimWPK31dd9JnIZs/OQ5pwAryAHmERHwuGQVESkSjwQ==",
-			"dev": true,
-			"license": "MIT"
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.19.tgz",
+			"integrity": "sha512-PUj/J1eX/b+DkcYwP6m7/tzDUiX1SVST89coljTN6BdQwLYMSkhg71jXcZwmTX19jQmqV9VqhVkKeabLnvciQQ==",
+			"dev": true
 		},
 		"node_modules/@wordpress/components/node_modules/@ariakit/react": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.17.tgz",
-			"integrity": "sha512-HQaIboE2axtlncJz1hRTaiQfJ1GGjhdtNcAnPwdjvl2RybfmlHowIB+HTVBp36LzroKPs/M4hPCxk7XTaqRZGg==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.25.tgz",
+			"integrity": "sha512-Gs/YgXrz0gCj0k/AWD7Ia9bw5vLPAJpG0KRiv6T/5Tg/DTZYihtE9blWGWhgGu+bSrp1IratNbQLkAvQ4J99cQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.17"
+				"@ariakit/react-core": "0.4.25"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -12553,33 +13087,28 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@ariakit/react-core": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.17.tgz",
-			"integrity": "sha512-kFF6n+gC/5CRQIyaMTFoBPio2xUe0k9rZhMNdUobWRmc/twfeLVkODx+8UVYaNyKilTge8G0JFqwvFKku/jKEw==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.25.tgz",
+			"integrity": "sha512-7seOOJ6N71lIKMS2jtNzxITCRIirt7yRrZLLWE8bp4+tQbov96BqSNX8fNCXmr/bDvKWz9PL07YrPrGjTXJXgA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@ariakit/core": "0.4.15",
+				"@ariakit/core": "0.4.19",
 				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
+				"use-sync-external-store": "^1.6.0"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/@wordpress/components/node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+		"node_modules/@wordpress/components/node_modules/@types/react": {
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@types/react-dom": {
@@ -12593,15 +13122,13 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/a11y": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.27.0.tgz",
-			"integrity": "sha512-wbZ7F4mA2VZKGkA30fivJwHT6OA+CXzhGokaaIVGWqjAygioFkaqb49u+eMWKTQoYEL6BdeUgDmViMUxva73Uw==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.43.0.tgz",
+			"integrity": "sha512-AWNmSi+Cjx5m03JhG/XjDqgRufqCFcIpYddWw7/0vR6rMk/DK5O+Jx6yJcJOwgmz2KFSgjMnjFfqbh3EtX8rRg==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/dom-ready": "^4.27.0",
-				"@wordpress/i18n": "^6.0.0"
+				"@wordpress/dom-ready": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12609,15 +13136,13 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.0.0.tgz",
-			"integrity": "sha512-ItvO/E3v39VX+5nZacyzwulhzRukiB2+1zqndWgOSNnERYnK/0hLHIWWthRFxYEPF13H54orXg68n17MZQ8whA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.27.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -12631,23 +13156,20 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/compose": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.27.0.tgz",
-			"integrity": "sha512-87/V/hyyg2Fojfk0hDVR4U3vdDdbNWoVdf17QnAORYt35lWWTxwMBKlZqIhFEuoLrPTvMQvu6ecjhxFNYB+ALg==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.27.0",
-				"@wordpress/dom": "^4.27.0",
-				"@wordpress/element": "^6.27.0",
-				"@wordpress/is-shallow-equal": "^5.27.0",
-				"@wordpress/keycodes": "^4.27.0",
-				"@wordpress/priority-queue": "^3.27.0",
-				"@wordpress/undo-manager": "^1.27.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -12660,14 +13182,12 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/date": {
-			"version": "5.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.27.0.tgz",
-			"integrity": "sha512-DZ5OJlU8OliLpDaGi0KHhlphCujbppzAfb3y34CpWydSnSRSfVgzjzc2R4p17RIa9Vj9C6Q8FsnNBAiywaz39g==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.43.0.tgz",
+			"integrity": "sha512-8DiFlE7YzP7F/P59Hr6h5fWJxJlvt6eZgU1C7huM9XhANh8Y3dZfepsySL6K7h1yE66SQDSq07cEefFQgJW31g==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.27.0",
+				"@wordpress/deprecated": "^4.43.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -12677,14 +13197,12 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/deprecated": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.27.0.tgz",
-			"integrity": "sha512-1rJTK7iy0oSE6eFUCBqCGG/wYuF62WoNDLF1G1Do+TdFGB4WxckHwTr5TuwtIG4CdoMjsPYIh2EnI3ziFOsHkA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.27.0"
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12692,14 +13210,12 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/dom": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.27.0.tgz",
-			"integrity": "sha512-uXcJslbSpxXX7EyMF4wtj+cydDyalapvu8HQ4QZleAAwJavhdNT+xpr/ai0XeApcxgIGHq1W05sYVN38lwVioQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.27.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12707,30 +13223,24 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/dom-ready": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.27.0.tgz",
-			"integrity": "sha512-L1hZ1g1mMyt06tuMWt72uAJjlkjGOpR2Vxbo72ZZgO28PqQc1WLrvWN/W3LVViar9OQrR0yn/REYRd258iaNQw==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.43.0.tgz",
+			"integrity": "sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/element": {
-			"version": "6.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.27.0.tgz",
-			"integrity": "sha512-gHk4B0J0f7bEsDoUBdTm22vPQwmEWLZxyaojgRyx1ncE2IyktfmubD/q2NIcMEKh7p+Jq3ZUwzPcpchpvkH2mA==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.27.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -12742,42 +13252,30 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/escape-html": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.27.0.tgz",
-			"integrity": "sha512-1LBB/xOFBUySSmVpd2nFwIZ8fVnP8dLNFl0wLprHVLtW6ZcdykO2ITY9bkaHu2lZ9HLRgHL7A/3R7MsJ1azYkg==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/hooks": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.27.0.tgz",
-			"integrity": "sha512-sGaNVZKMxwnhGSge0tZZsGfImLPimiulUkM7hivQ2CSCgibTpgxFRBJ1r7gbNLDF+qHQK9a26K8fGfKnAal6Cg==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/html-entities": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.27.0.tgz",
-			"integrity": "sha512-4MfLS3k6+dlPSPbccnCloIFdbWjT6x0sRLNcVNWAI7I+nov7A34/cI/xjXFPcQaeewBE+24Q2TWsyFhcX2r89Q==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.43.0.tgz",
+			"integrity": "sha512-z7C782VfH3E5dWYO4VOtN8EEhzfID2kiJmGTINiVPD8kywxp5BsBU2KJSSPvkUjqOCMNJ2XhkYPgADKi9O1U7A==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -12806,15 +13304,14 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/icons": {
-			"version": "10.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.27.0.tgz",
-			"integrity": "sha512-KeOz3aLtd7p+cA287gmGzpC9kIO1lxPBn/lDPkXfc8oz482XqNJKohdW/7ZMlEWx1uEcZUI+g3vfSA+gKDgjUQ==",
+			"version": "10.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.32.0.tgz",
+			"integrity": "sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.27.0",
-				"@wordpress/primitives": "^4.27.0"
+				"@wordpress/element": "^6.32.0",
+				"@wordpress/primitives": "^4.32.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12822,28 +13319,22 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.27.0.tgz",
-			"integrity": "sha512-sYlAuNgEwQHioKSx3jyV6ZJlBR19sEvIdkBVoGF82OAxbXFzRvoD6V4zy+kZzY6V99FE12L93I0t5jh4qOn2lg==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/keycodes": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.27.0.tgz",
-			"integrity": "sha512-fWyEcLI2rAZn6FwVBITGFxo8aS7EQrt8icOdxS5Es3Ii8DneQUl2gtXs3tq9viX4cWCno7cEt+dpuuv2gPxwoQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^6.0.0"
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12851,15 +13342,13 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.0.0.tgz",
-			"integrity": "sha512-ItvO/E3v39VX+5nZacyzwulhzRukiB2+1zqndWgOSNnERYnK/0hLHIWWthRFxYEPF13H54orXg68n17MZQ8whA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.27.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -12873,14 +13362,12 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/primitives": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.27.0.tgz",
-			"integrity": "sha512-ZIhpB4ZmZwMSsrELx4mzhRvxAoqgk8sSE3PaRt/ue4GXFoRRQgI3RVCwEdiNPcsQXId9lOQIhAJNDt5Wa0Fbgg==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.43.0.tgz",
+			"integrity": "sha512-lU1vBSDyRkAYFEfbLyzjophDvIVCeQ7uuEXv5dBAbxkSLSsCcX6oLbWSwjkCEHp1R+9UtukLvbmXDdAbDYiEOA==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.27.0",
+				"@wordpress/element": "^6.43.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -12892,13 +13379,11 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/priority-queue": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.27.0.tgz",
-			"integrity": "sha512-RpIaX59sji45x9oUYrkbTHbagJuHC05oZOjJDzLj2Qv12bGeq0QWI2+e59yl3wONLpVla7f3TfNsFapkgOhOAw==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
 			"dev": true,
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -12935,11 +13420,10 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg==",
-			"dev": true,
-			"license": "MIT"
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
+			"dev": true
 		},
 		"node_modules/@wordpress/components/node_modules/path-to-regexp": {
 			"version": "6.3.0",
@@ -12954,6 +13438,15 @@
 			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@wordpress/components/node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"dev": true,
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
 		},
 		"node_modules/@wordpress/compose": {
 			"version": "5.20.0",
@@ -12981,13 +13474,13 @@
 			}
 		},
 		"node_modules/@wordpress/compose/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/compose/node_modules/@types/react-dom": {
@@ -13088,16 +13581,16 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@ariakit/core": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.15.tgz",
-			"integrity": "sha512-vvxmZvkNhiisKM+Y1TbGMUfVVchV/sWu9F0xw0RYADXcimWPK31dd9JnIZs/OQ5pwAryAHmERHwuGQVESkSjwQ=="
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.19.tgz",
+			"integrity": "sha512-PUj/J1eX/b+DkcYwP6m7/tzDUiX1SVST89coljTN6BdQwLYMSkhg71jXcZwmTX19jQmqV9VqhVkKeabLnvciQQ=="
 		},
 		"node_modules/@wordpress/core-data/node_modules/@ariakit/react": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.17.tgz",
-			"integrity": "sha512-HQaIboE2axtlncJz1hRTaiQfJ1GGjhdtNcAnPwdjvl2RybfmlHowIB+HTVBp36LzroKPs/M4hPCxk7XTaqRZGg==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.25.tgz",
+			"integrity": "sha512-Gs/YgXrz0gCj0k/AWD7Ia9bw5vLPAJpG0KRiv6T/5Tg/DTZYihtE9blWGWhgGu+bSrp1IratNbQLkAvQ4J99cQ==",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.17"
+				"@ariakit/react-core": "0.4.25"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -13109,13 +13602,13 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@ariakit/react-core": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.17.tgz",
-			"integrity": "sha512-kFF6n+gC/5CRQIyaMTFoBPio2xUe0k9rZhMNdUobWRmc/twfeLVkODx+8UVYaNyKilTge8G0JFqwvFKku/jKEw==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.25.tgz",
+			"integrity": "sha512-7seOOJ6N71lIKMS2jtNzxITCRIirt7yRrZLLWE8bp4+tQbov96BqSNX8fNCXmr/bDvKWz9PL07YrPrGjTXJXgA==",
 			"dependencies": {
-				"@ariakit/core": "0.4.15",
+				"@ariakit/core": "0.4.19",
 				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
+				"use-sync-external-store": "^1.6.0"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -13123,12 +13616,12 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@types/react-dom": {
@@ -13140,13 +13633,31 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/a11y": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.25.0.tgz",
-			"integrity": "sha512-9wJZC7gWUrDN1Ybch6pgGZL73kSm2b4dm9YDJtNJuCa/6T7TkVRVdpjVtnTLhvATPSXNV81P/bLK8fWbI3ze0A==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.43.0.tgz",
+			"integrity": "sha512-AWNmSi+Cjx5m03JhG/XjDqgRufqCFcIpYddWw7/0vR6rMk/DK5O+Jx6yJcJOwgmz2KFSgjMnjFfqbh3EtX8rRg==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/dom-ready": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/dom-ready": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -13154,13 +13665,31 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/api-fetch": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.25.0.tgz",
-			"integrity": "sha512-UrZWfx62/NaTitn+1HqQ8IFe+D5Y7+R7AHs0ag8KKsoKi/7cczm9MK3jgXwtjBZ0X6vbwOzxrdcTbMuPyymc0g==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.43.0.tgz",
+			"integrity": "sha512-1Tetm4VIEKDIwrCsvDY0KjjrHvkEaSa2Qvld5gguY2ofcIszL3mR0tGezFaaaB14FHd7Zl0MpfpQY3KeQ+BatQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/url": "^4.25.0"
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/url": "^4.43.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/api-fetch/node_modules/@wordpress/i18n": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -13168,70 +13697,64 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/autop": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.25.0.tgz",
-			"integrity": "sha512-MCTZYyNkUSqyZFfi3UY+Piiyzp5p2y1rkT1FB3+8ZVbigpRid4AnwO5zfsFFAUbbPCK/Z5aP1J0WP1lxnmBRIg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.43.0.tgz",
+			"integrity": "sha512-ODEGv8CZmL12DRKyYCCUXwTHS8aI2/K1C4WuVLeQ5uhPmFk0QHAHQ2sGga509K9F0Nj/DY7fgkD0YlE9T1stbA==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/blob": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.25.0.tgz",
-			"integrity": "sha512-M89TPVhqgKXDKEmMB+DssC0CqGPOLOrKEtVI2tJQH4Br/HGgWJ7tAQF9rtYKuQVFALKX6vkNIPcX9WEd+7p/kw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.43.0.tgz",
+			"integrity": "sha512-wNYpE1DMabI9wDIVBcwsakbnVnvskAj0eJ+7A1njEdmJFYEQ0wc6kTqJ6ma4pLYYPrgw2svWl8vI3HIIB50qhg==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/block-editor": {
-			"version": "14.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-14.20.0.tgz",
-			"integrity": "sha512-OhgsU3zONY4FHH3O4e5SZrqZDPI2FZHt6bROUknSc3nvFyhEojuq6ELtcQFsywhJyiWg3wN9TTz97N1LvreF2g==",
+			"version": "14.21.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-14.21.0.tgz",
+			"integrity": "sha512-twVFO5I+go/S2a6xxuxxrWlC9G3AZKiLtSgeZ+R0kuCfeyZgw49vCwQixDzJWBmpCagAYTEeakFv3PAkbMLaMA==",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
 				"@emotion/react": "^11.7.1",
 				"@emotion/styled": "^11.6.0",
 				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^4.25.0",
-				"@wordpress/api-fetch": "^7.25.0",
-				"@wordpress/blob": "^4.25.0",
-				"@wordpress/block-serialization-default-parser": "^5.25.0",
-				"@wordpress/blocks": "^14.14.0",
-				"@wordpress/commands": "^1.25.0",
-				"@wordpress/components": "^29.11.0",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/data": "^10.25.0",
-				"@wordpress/date": "^5.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/escape-html": "^3.25.0",
-				"@wordpress/hooks": "^4.25.0",
-				"@wordpress/html-entities": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/icons": "^10.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keyboard-shortcuts": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/notices": "^5.25.0",
-				"@wordpress/preferences": "^4.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/rich-text": "^7.25.0",
-				"@wordpress/style-engine": "^2.25.0",
-				"@wordpress/token-list": "^3.25.0",
-				"@wordpress/upload-media": "^0.10.0",
-				"@wordpress/url": "^4.25.0",
-				"@wordpress/warning": "^3.25.0",
-				"@wordpress/wordcount": "^4.25.0",
+				"@wordpress/a11y": "^4.26.0",
+				"@wordpress/api-fetch": "^7.26.0",
+				"@wordpress/blob": "^4.26.0",
+				"@wordpress/block-serialization-default-parser": "^5.26.0",
+				"@wordpress/blocks": "^14.15.0",
+				"@wordpress/commands": "^1.26.0",
+				"@wordpress/components": "^29.12.0",
+				"@wordpress/compose": "^7.26.0",
+				"@wordpress/data": "^10.26.0",
+				"@wordpress/date": "^5.26.0",
+				"@wordpress/deprecated": "^4.26.0",
+				"@wordpress/dom": "^4.26.0",
+				"@wordpress/element": "^6.26.0",
+				"@wordpress/escape-html": "^3.26.0",
+				"@wordpress/hooks": "^4.26.0",
+				"@wordpress/html-entities": "^4.26.0",
+				"@wordpress/i18n": "^5.26.0",
+				"@wordpress/icons": "^10.26.0",
+				"@wordpress/is-shallow-equal": "^5.26.0",
+				"@wordpress/keyboard-shortcuts": "^5.26.0",
+				"@wordpress/keycodes": "^4.26.0",
+				"@wordpress/notices": "^5.26.0",
+				"@wordpress/preferences": "^4.26.0",
+				"@wordpress/priority-queue": "^3.26.0",
+				"@wordpress/private-apis": "^1.26.0",
+				"@wordpress/rich-text": "^7.26.0",
+				"@wordpress/style-engine": "^2.26.0",
+				"@wordpress/token-list": "^3.26.0",
+				"@wordpress/upload-media": "^0.11.0",
+				"@wordpress/url": "^4.26.0",
+				"@wordpress/warning": "^3.26.0",
+				"@wordpress/wordcount": "^4.26.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -13257,38 +13780,35 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/block-serialization-default-parser": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.25.0.tgz",
-			"integrity": "sha512-tQWAbTY/5Rsv5H544qV7JEq5sjVfXFWiZSrXdb4Tnhs2K40LbJEKuYBcnJXo99zh0UHcX3Gw2h3qIBLSCaLC4A==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.43.0.tgz",
+			"integrity": "sha512-1P2eujRuY9VmhFT8Kp7hghxbxbw6dIcHWGLlo/V3YVaHor1WZ3P5p6k+ELQRJTyrbWYV+qu/zYWGYCGGDtEvsA==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/blocks": {
-			"version": "14.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-14.14.0.tgz",
-			"integrity": "sha512-3SbR/wM7u7TyQLs+Bw98dL+T0Q4DX+JMY9NXNb5yPkm/K2tuvNzRm/9xQmbfU+xHvop+3mDA8uzf3ROQUaE9Dw==",
+			"version": "14.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-14.15.0.tgz",
+			"integrity": "sha512-Esy7gM2HG3iimcFHFnwtXnIw0TLcSxT8bAe/S48wxZCIqM3++xoRgrEGe55u/d6Oj0mRM9HRFdp9et92nEsGBQ==",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/autop": "^4.25.0",
-				"@wordpress/blob": "^4.25.0",
-				"@wordpress/block-serialization-default-parser": "^5.25.0",
-				"@wordpress/data": "^10.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/hooks": "^4.25.0",
-				"@wordpress/html-entities": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/rich-text": "^7.25.0",
-				"@wordpress/shortcode": "^4.25.0",
-				"@wordpress/warning": "^3.25.0",
+				"@wordpress/autop": "^4.26.0",
+				"@wordpress/blob": "^4.26.0",
+				"@wordpress/block-serialization-default-parser": "^5.26.0",
+				"@wordpress/data": "^10.26.0",
+				"@wordpress/deprecated": "^4.26.0",
+				"@wordpress/dom": "^4.26.0",
+				"@wordpress/element": "^6.26.0",
+				"@wordpress/hooks": "^4.26.0",
+				"@wordpress/html-entities": "^4.26.0",
+				"@wordpress/i18n": "^5.26.0",
+				"@wordpress/is-shallow-equal": "^5.26.0",
+				"@wordpress/private-apis": "^1.26.0",
+				"@wordpress/rich-text": "^7.26.0",
+				"@wordpress/shortcode": "^4.26.0",
+				"@wordpress/warning": "^3.26.0",
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
 				"fast-deep-equal": "^3.1.3",
@@ -13310,9 +13830,9 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/components": {
-			"version": "29.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-29.11.0.tgz",
-			"integrity": "sha512-p/hicoCxHo4uC5DeGsdLme/JcRwedFkNctKS7uo5dy05odWXWOPDLiSsWYz6F7uCKbmBJNucxdF3f42YTh6y1Q==",
+			"version": "29.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-29.12.0.tgz",
+			"integrity": "sha512-jE96pUj84OZya54VusRdEIdTiLjbe2Qst3GbHZcQpA5GiSkPBmGjKWpO6FxR7kRDT4GMnZoVxgtV6xJk4IaNQw==",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
 				"@babel/runtime": "7.25.7",
@@ -13326,23 +13846,23 @@
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.25.0",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/date": "^5.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/escape-html": "^3.25.0",
-				"@wordpress/hooks": "^4.25.0",
-				"@wordpress/html-entities": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/icons": "^10.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/primitives": "^4.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/rich-text": "^7.25.0",
-				"@wordpress/warning": "^3.25.0",
+				"@wordpress/a11y": "^4.26.0",
+				"@wordpress/compose": "^7.26.0",
+				"@wordpress/date": "^5.26.0",
+				"@wordpress/deprecated": "^4.26.0",
+				"@wordpress/dom": "^4.26.0",
+				"@wordpress/element": "^6.26.0",
+				"@wordpress/escape-html": "^3.26.0",
+				"@wordpress/hooks": "^4.26.0",
+				"@wordpress/html-entities": "^4.26.0",
+				"@wordpress/i18n": "^5.26.0",
+				"@wordpress/icons": "^10.26.0",
+				"@wordpress/is-shallow-equal": "^5.26.0",
+				"@wordpress/keycodes": "^4.26.0",
+				"@wordpress/primitives": "^4.26.0",
+				"@wordpress/private-apis": "^1.26.0",
+				"@wordpress/rich-text": "^7.26.0",
+				"@wordpress/warning": "^3.26.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -13370,21 +13890,19 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/compose": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.25.0.tgz",
-			"integrity": "sha512-nfjtMZgrhdHU8/zOLUyA5o8ShLot1vbHZ0I2+IxLyNskRMVyR9pm4BAJSYKJ9XqBUom2/N51gfeKg5uhd9Y0TQ==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/undo-manager": "^1.25.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -13397,18 +13915,17 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/data": {
-			"version": "10.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.25.0.tgz",
-			"integrity": "sha512-PHfF7S2jhgcH9D3Z9nskaQEDIbh0k0MX6KprzK4plT4Xu71YboMVWnBx78glzMMu17DOFoHJC25d+ymfGBM5rw==",
+			"version": "10.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.43.0.tgz",
+			"integrity": "sha512-LKjxBrub1qkMm8Oyj6ynHAGix5eJcJqN9Pq0aX9UYLPjc1T/zkhhAopFL7It2S4muKMNcAHizR+e1eZNA3k4fQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/redux-routine": "^5.25.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/redux-routine": "^5.43.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -13426,12 +13943,11 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/date": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.25.0.tgz",
-			"integrity": "sha512-w3De486/qx2/MbxCCjiW7KS8lGhJ00VvnrbXRlrY9l/6yqbz0iMVglmFKrlLPftgutyhe3OSOSZsXX/uCF6yOg==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.43.0.tgz",
+			"integrity": "sha512-8DiFlE7YzP7F/P59Hr6h5fWJxJlvt6eZgU1C7huM9XhANh8Y3dZfepsySL6K7h1yE66SQDSq07cEefFQgJW31g==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.25.0",
+				"@wordpress/deprecated": "^4.43.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -13441,12 +13957,11 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/deprecated": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.25.0.tgz",
-			"integrity": "sha512-NfVGSVfAESrgQRQu5QpyprTsDY0BLq6hJ2KrWlpscLetApxU5kSpP/wRzmjbtuuWSr5RsoopaeoTbiZNXb0QEA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0"
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -13454,12 +13969,11 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/dom": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.25.0.tgz",
-			"integrity": "sha512-uyP8oTjSYjU+OXSvpPITqMaF9Dk50WH7fiQIVUcjC/9VmrzIiaYaZ4USmuoUBtbFjJsSyANHw/anYMFqby9iIA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.25.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -13467,26 +13981,22 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/dom-ready": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.25.0.tgz",
-			"integrity": "sha512-HvGxncRhskqrkwyIPVsfznToFtSr6X0zBrIMHK7bgwGGiMr+yz5jYX3wnY1AsUDSr95ezhbCTdE2rNmvFkCD0g==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.43.0.tgz",
+			"integrity": "sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/element": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.25.0.tgz",
-			"integrity": "sha512-zxdaf2s/en5Y+DfiswRZtQ+P8SvQ18+l5I2WmHb66+bVkFg7jrN+AJqLk86k2zcalOEjx7Fg4cce1wWytp8Wsw==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.25.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -13498,48 +14008,39 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/escape-html": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.25.0.tgz",
-			"integrity": "sha512-sQ3graObu5K/RWrngk9bsULJ+9E7QLC6gMG34ja0Jm1LdeRjVgHv3FqP/uIkL36EvxEkjQ0LSbgbZsdV/E1q0w==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/hooks": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.25.0.tgz",
-			"integrity": "sha512-IWqgozRE+8PE96TIsf5bfS7ezZfvleSm1YZAuhAWYH7QUVm07WK7/yhhDYkj9QyTpWSZnGkmR7YYH/NJ8jaMDQ==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/html-entities": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.25.0.tgz",
-			"integrity": "sha512-SEf8nnLm85KH2fZiEzUgLuh4Nd53iW0rmA5k9xM7n0uM6BA6HMDidtT/5wxTlnMH8cxOSjL2IkCHwhuRFTibbg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.43.0.tgz",
+			"integrity": "sha512-z7C782VfH3E5dWYO4VOtN8EEhzfID2kiJmGTINiVPD8kywxp5BsBU2KJSSPvkUjqOCMNJ2XhkYPgADKi9O1U7A==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/i18n": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.25.0.tgz",
-			"integrity": "sha512-6MWkwmA9dwiLA+N4cj81JxxSqgJ+5HeLZHa3Sy2u7A2f4wgGCH+Bj2T6eQnZdky9fMy4vjvUpUZdv5sdmtYJlQ==",
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
+			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0",
+				"@wordpress/hooks": "^4.26.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -13554,13 +14055,13 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/icons": {
-			"version": "10.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.25.0.tgz",
-			"integrity": "sha512-CNAgZ0ZE6pPjLWxPLBdmIQlxpkQCNZ9Zv4wuUDSMqG0jJDdf+YCpklwIMLWbv9WVubmzgURo54qeCedbpXhCjA==",
+			"version": "10.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.32.0.tgz",
+			"integrity": "sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/primitives": "^4.25.0"
+				"@wordpress/element": "^6.32.0",
+				"@wordpress/primitives": "^4.32.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -13568,26 +14069,22 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.25.0.tgz",
-			"integrity": "sha512-/37IIoJz8/mp7TGZbdmakXr6YKqvpjYUHJx9LA9ibVVh6AsM72nI7N5V3AsGndan46vItfzhs0zpEWI7xF86Gw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/keyboard-shortcuts": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.25.0.tgz",
-			"integrity": "sha512-g78ZZnoQMmQ70rVcvnxkIZ0VpOaZH34CxC9QSBASRfmoVrM9pFZFZJPDE/KoUt8qEFQqgTOVMpn0GenT2NEPXA==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.43.0.tgz",
+			"integrity": "sha512-JJThUTTiJZgzzOIYHgK5CHPHwD6plK1O45e/0RpsOEe4vLCuLH0RoVAWoy/9Z4jIxXLGbwE5WdJIQkTStf+KMQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/data": "^10.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/keycodes": "^4.25.0"
+				"@wordpress/data": "^10.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/keycodes": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -13598,12 +14095,30 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/keycodes": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.25.0.tgz",
-			"integrity": "sha512-cnV4/7RY4m+DNo3BF10pHdFITKyoYr4TqvcSmka5O7RulPQi/PTeLcFgTTM+LrULGSNfV5ZUgIuPwLpLA5pqGQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/i18n": "^6.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -13611,12 +14126,11 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/primitives": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.25.0.tgz",
-			"integrity": "sha512-I8voo9KWDFOgVUzxO0n1UtaTGBwhA/MuYmh6Bpn4M33SQAm4K5aUFidnJOelILWSA4Ox4R7wskGhuItfyty1LA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.43.0.tgz",
+			"integrity": "sha512-lU1vBSDyRkAYFEfbLyzjophDvIVCeQ7uuEXv5dBAbxkSLSsCcX6oLbWSwjkCEHp1R+9UtukLvbmXDdAbDYiEOA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.25.0",
+				"@wordpress/element": "^6.43.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -13628,11 +14142,10 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/priority-queue": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.25.0.tgz",
-			"integrity": "sha512-HtN8G1o/TaUIhapJf6Kq2dy1OOpC1beGB7sJUvq5JrwKd3VRdrXx0K3HKoHe99EJoE9v6lgEIS5VtVIaW0u0cQ==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -13641,11 +14154,10 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/redux-routine": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.25.0.tgz",
-			"integrity": "sha512-0YZNyuL1QO3CbA6njHzoHMmYX+tnOSUIOpag5jeeNKzNE7iThKRmD07HtMo+hL5B3EFumvWDXlwOLpoi2xBJuw==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.43.0.tgz",
+			"integrity": "sha512-3QIt7jBhhwhE1AybMeYfeo5Vj7Rn+7l7QBYiqXiWHWBYGEJtI0VXiEjcC34ctTZKdVGBPvYJZUhBbNHOjLtgMw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
@@ -13659,11 +14171,10 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/shortcode": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.25.0.tgz",
-			"integrity": "sha512-KF217XFpIz40yOGyaH4jlM4O82Bkkj+D60/HLByGY5Q5ObB7NSeCuhrp7YDBlXKXE682r4Lep8+MfwaJ/MRLYw==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.43.0.tgz",
+			"integrity": "sha512-mSpGnX6Wlzd8wx5GED2D188Mxvtc2FrflDPI39Tlysz4OW+9PNAKueRzvcQ7QLwZhIzaDQ8pvonyal5i8PryIQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"memize": "^2.0.1"
 			},
 			"engines": {
@@ -13671,37 +14182,20 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/core-data/node_modules/@wordpress/style-engine": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.25.0.tgz",
-			"integrity": "sha512-myjrI1+7WIEjfto+APXVkiuGUpidM4d6dVjs/JhN58Yn5O3j+3o9N7Y+YAzBHcq9HofuH3zJDuo+mOppDyUriw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"change-case": "^4.1.2"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/token-list": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.25.0.tgz",
-			"integrity": "sha512-K3Edpzo6/jxcF4q8xa9vMJsgpTSNDUyrW0jFR7qPoJOng+ypS0uBwQHJjGS9eEgDrx/CNd06C5TRaWHPwUrgYg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.43.0.tgz",
+			"integrity": "sha512-hNbN9Mrt2F14BguLVxQ2AtoO1gTTZtOuKJJ7D4c/fHCNh7QiSV03A/Zc629WIPIfgfIt4diASMVQpJ3hvKaUbw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/url": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.25.0.tgz",
-			"integrity": "sha512-IQE/Ck4lEu65VhYcCoMedusIurc+oZtxWUZkn/SoMBJm2ft5zw8oHzHkyDdU/DcrYVKoqV+dAPRPZMHyVrGUTQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.43.0.tgz",
+			"integrity": "sha512-FFq/KZUlhAszI9y232BpQ83+58CtRV5M0SFuv7pQq+DxNDuWNHp8gjdX9WOnHkO/MrKAyVTI0jX9YoWF2RNEZw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -13710,12 +14204,9 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/@wordpress/wordcount": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.25.0.tgz",
-			"integrity": "sha512-5e5LjZGMOVDiRxT9rOZW2VnUyM6MuWFJTp31W6CeaP4p+1qeie7Gg5lyZXgePIk47HlRtfpjsv0KzuepDl+YhQ==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.43.0.tgz",
+			"integrity": "sha512-kz1qrK57bkyoPYKFVkHln09HCUH2D4YRxMrMT02VHypwdjUQBN23R/bkzxhIy/Vl5k1yLjeYTRB2pWSYyWle/A==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -13756,9 +14247,9 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/core-data/node_modules/path-to-regexp": {
 			"version": "6.3.0",
@@ -13766,9 +14257,9 @@
 			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
 		},
 		"node_modules/@wordpress/core-data/node_modules/postcss": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-			"integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+			"version": "8.5.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+			"integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -13793,9 +14284,9 @@
 			}
 		},
 		"node_modules/@wordpress/core-data/node_modules/react-easy-crop": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.4.2.tgz",
-			"integrity": "sha512-V+GQUTkNWD8gK0mbZQfwTvcDxyCB4GS0cM36is8dAcvnsHY7DMEDP2D5IqHju55TOiCHwElJPVOYDgiu8BEiHQ==",
+			"version": "5.5.7",
+			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+			"integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
 			"dependencies": {
 				"normalize-wheel": "^1.0.1",
 				"tslib": "^2.0.1"
@@ -13826,6 +14317,14 @@
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@wordpress/core-data/node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@wordpress/data": {
@@ -13986,13 +14485,13 @@
 			}
 		},
 		"node_modules/@wordpress/element/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/element/node_modules/@types/react-dom": {
@@ -14239,34 +14738,33 @@
 			}
 		},
 		"node_modules/@wordpress/icons/node_modules/@types/react": {
-			"version": "18.3.18",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-			"integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/icons/node_modules/@types/react-dom": {
-			"version": "18.3.5",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-			"integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/icons/node_modules/@wordpress/element": {
-			"version": "6.19.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.19.0.tgz",
-			"integrity": "sha512-11kWRNiHbDkm5uXxEQiVVcEmdUHzBUjzsgp7Ui1iT8yDp0Taf8F30GzqGlWiu0B1K9VxUYLgVCqXamNqo64Ahg==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.19.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -14278,13 +14776,10 @@
 			}
 		},
 		"node_modules/@wordpress/icons/node_modules/@wordpress/escape-html": {
-			"version": "3.19.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.19.0.tgz",
-			"integrity": "sha512-vG2h1e/+MmLupGzseeoveB+48wz+ZhB9FhJ+yl0B19H/n4PfcSBl3XD0EPw9iAM6y6KMST/2qqkdFGNwohdnmA==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -14373,13 +14868,13 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@types/react-dom": {
@@ -14512,9 +15007,9 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/media-utils": {
 			"version": "3.4.1",
@@ -14533,13 +15028,14 @@
 			}
 		},
 		"node_modules/@wordpress/notices": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.25.0.tgz",
-			"integrity": "sha512-BvgvvFPa9eA98Xiyb0NeTqfuVfD+5TMfBmWId+y6iwbplKHetW/Bj/36qRWzUGptPh3ae7NKc/ovi4KDO4t9og==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.43.0.tgz",
+			"integrity": "sha512-EvYerIJQ9wc5tT/ibfKhqP3Ja75JJpcSUc11zaQECdTpG3leXGIsUBgl9GDFbd70GpDj1ZCU7NmVcTYl+y0b7w==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.25.0",
-				"@wordpress/data": "^10.25.0"
+				"@wordpress/a11y": "^4.43.0",
+				"@wordpress/components": "^32.5.0",
+				"@wordpress/data": "^10.43.0",
+				"clsx": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -14549,13 +15045,58 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/notices/node_modules/@ariakit/core": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.19.tgz",
+			"integrity": "sha512-PUj/J1eX/b+DkcYwP6m7/tzDUiX1SVST89coljTN6BdQwLYMSkhg71jXcZwmTX19jQmqV9VqhVkKeabLnvciQQ=="
+		},
+		"node_modules/@wordpress/notices/node_modules/@ariakit/react": {
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.25.tgz",
+			"integrity": "sha512-Gs/YgXrz0gCj0k/AWD7Ia9bw5vLPAJpG0KRiv6T/5Tg/DTZYihtE9blWGWhgGu+bSrp1IratNbQLkAvQ4J99cQ==",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.25"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/@ariakit/react-core": {
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.25.tgz",
+			"integrity": "sha512-7seOOJ6N71lIKMS2jtNzxITCRIirt7yRrZLLWE8bp4+tQbov96BqSNX8fNCXmr/bDvKWz9PL07YrPrGjTXJXgA==",
+			"dependencies": {
+				"@ariakit/core": "0.4.19",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/@emotion/utils": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+		},
+		"node_modules/@wordpress/notices/node_modules/@types/gradient-parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+			"integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw=="
+		},
 		"node_modules/@wordpress/notices/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@types/react-dom": {
@@ -14567,35 +15108,105 @@
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/a11y": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.25.0.tgz",
-			"integrity": "sha512-9wJZC7gWUrDN1Ybch6pgGZL73kSm2b4dm9YDJtNJuCa/6T7TkVRVdpjVtnTLhvATPSXNV81P/bLK8fWbI3ze0A==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.43.0.tgz",
+			"integrity": "sha512-AWNmSi+Cjx5m03JhG/XjDqgRufqCFcIpYddWw7/0vR6rMk/DK5O+Jx6yJcJOwgmz2KFSgjMnjFfqbh3EtX8rRg==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/dom-ready": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/dom-ready": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.25.0.tgz",
-			"integrity": "sha512-nfjtMZgrhdHU8/zOLUyA5o8ShLot1vbHZ0I2+IxLyNskRMVyR9pm4BAJSYKJ9XqBUom2/N51gfeKg5uhd9Y0TQ==",
+		"node_modules/@wordpress/notices/node_modules/@wordpress/base-styles": {
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.19.0.tgz",
+			"integrity": "sha512-SAZA6dhfC5X00s9PRrL9diY59WegiF0MuAWupkoKnYk3a2IAQbRUUTrh3j3wRyr08ljqefmifX5GR3hz/VwQaw==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/@wordpress/components": {
+			"version": "32.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.5.0.tgz",
+			"integrity": "sha512-UEBNEqxHfOvTVbVepoLPS2wSzIjcZoCHMv6P2iN0om819x3aLIKAZqpxjNF8x0nz2z/gnj5Bj9GpXTW0+Bvfcw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/undo-manager": "^1.25.0",
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.43.0",
+				"@wordpress/base-styles": "^6.19.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/date": "^5.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/escape-html": "^3.43.0",
+				"@wordpress/hooks": "^4.43.0",
+				"@wordpress/html-entities": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/icons": "^12.1.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/primitives": "^4.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/rich-text": "^7.43.0",
+				"@wordpress/warning": "^3.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
+				"change-case": "^4.1.2",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -14608,18 +15219,17 @@
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/data": {
-			"version": "10.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.25.0.tgz",
-			"integrity": "sha512-PHfF7S2jhgcH9D3Z9nskaQEDIbh0k0MX6KprzK4plT4Xu71YboMVWnBx78glzMMu17DOFoHJC25d+ymfGBM5rw==",
+			"version": "10.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.43.0.tgz",
+			"integrity": "sha512-LKjxBrub1qkMm8Oyj6ynHAGix5eJcJqN9Pq0aX9UYLPjc1T/zkhhAopFL7It2S4muKMNcAHizR+e1eZNA3k4fQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/redux-routine": "^5.25.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/redux-routine": "^5.43.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -14636,13 +15246,26 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/deprecated": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.25.0.tgz",
-			"integrity": "sha512-NfVGSVfAESrgQRQu5QpyprTsDY0BLq6hJ2KrWlpscLetApxU5kSpP/wRzmjbtuuWSr5RsoopaeoTbiZNXb0QEA==",
+		"node_modules/@wordpress/notices/node_modules/@wordpress/date": {
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.43.0.tgz",
+			"integrity": "sha512-8DiFlE7YzP7F/P59Hr6h5fWJxJlvt6eZgU1C7huM9XhANh8Y3dZfepsySL6K7h1yE66SQDSq07cEefFQgJW31g==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0"
+				"@wordpress/deprecated": "^4.43.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/@wordpress/deprecated": {
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
+			"dependencies": {
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -14650,12 +15273,11 @@
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/dom": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.25.0.tgz",
-			"integrity": "sha512-uyP8oTjSYjU+OXSvpPITqMaF9Dk50WH7fiQIVUcjC/9VmrzIiaYaZ4USmuoUBtbFjJsSyANHw/anYMFqby9iIA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.25.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -14663,26 +15285,22 @@
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/dom-ready": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.25.0.tgz",
-			"integrity": "sha512-HvGxncRhskqrkwyIPVsfznToFtSr6X0zBrIMHK7bgwGGiMr+yz5jYX3wnY1AsUDSr95ezhbCTdE2rNmvFkCD0g==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.43.0.tgz",
+			"integrity": "sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/element": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.25.0.tgz",
-			"integrity": "sha512-zxdaf2s/en5Y+DfiswRZtQ+P8SvQ18+l5I2WmHb66+bVkFg7jrN+AJqLk86k2zcalOEjx7Fg4cce1wWytp8Wsw==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.25.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -14694,39 +15312,41 @@
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/escape-html": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.25.0.tgz",
-			"integrity": "sha512-sQ3graObu5K/RWrngk9bsULJ+9E7QLC6gMG34ja0Jm1LdeRjVgHv3FqP/uIkL36EvxEkjQ0LSbgbZsdV/E1q0w==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/hooks": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.25.0.tgz",
-			"integrity": "sha512-IWqgozRE+8PE96TIsf5bfS7ezZfvleSm1YZAuhAWYH7QUVm07WK7/yhhDYkj9QyTpWSZnGkmR7YYH/NJ8jaMDQ==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/@wordpress/html-entities": {
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.43.0.tgz",
+			"integrity": "sha512-z7C782VfH3E5dWYO4VOtN8EEhzfID2kiJmGTINiVPD8kywxp5BsBU2KJSSPvkUjqOCMNJ2XhkYPgADKi9O1U7A==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/i18n": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.25.0.tgz",
-			"integrity": "sha512-6MWkwmA9dwiLA+N4cj81JxxSqgJ+5HeLZHa3Sy2u7A2f4wgGCH+Bj2T6eQnZdky9fMy4vjvUpUZdv5sdmtYJlQ==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
@@ -14737,37 +15357,65 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.25.0.tgz",
-			"integrity": "sha512-/37IIoJz8/mp7TGZbdmakXr6YKqvpjYUHJx9LA9ibVVh6AsM72nI7N5V3AsGndan46vItfzhs0zpEWI7xF86Gw==",
+		"node_modules/@wordpress/notices/node_modules/@wordpress/icons": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-12.1.0.tgz",
+			"integrity": "sha512-JOEVd94kZQsGYyLhjq1edfaMOTPON/7qUDuzT74uSwSCJ6OiHf3yJHfxMlLOMoh12dQshWPciLVLagkYLCldag==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7"
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/primitives": "^4.43.0",
+				"change-case": "4.1.2"
 			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/@wordpress/is-shallow-equal": {
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/keycodes": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.25.0.tgz",
-			"integrity": "sha512-cnV4/7RY4m+DNo3BF10pHdFITKyoYr4TqvcSmka5O7RulPQi/PTeLcFgTTM+LrULGSNfV5ZUgIuPwLpLA5pqGQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/priority-queue": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.25.0.tgz",
-			"integrity": "sha512-HtN8G1o/TaUIhapJf6Kq2dy1OOpC1beGB7sJUvq5JrwKd3VRdrXx0K3HKoHe99EJoE9v6lgEIS5VtVIaW0u0cQ==",
+		"node_modules/@wordpress/notices/node_modules/@wordpress/primitives": {
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.43.0.tgz",
+			"integrity": "sha512-lU1vBSDyRkAYFEfbLyzjophDvIVCeQ7uuEXv5dBAbxkSLSsCcX6oLbWSwjkCEHp1R+9UtukLvbmXDdAbDYiEOA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
+				"@wordpress/element": "^6.43.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/@wordpress/priority-queue": {
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
+			"dependencies": {
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -14776,11 +15424,10 @@
 			}
 		},
 		"node_modules/@wordpress/notices/node_modules/@wordpress/redux-routine": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.25.0.tgz",
-			"integrity": "sha512-0YZNyuL1QO3CbA6njHzoHMmYX+tnOSUIOpag5jeeNKzNE7iThKRmD07HtMo+hL5B3EFumvWDXlwOLpoi2xBJuw==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.43.0.tgz",
+			"integrity": "sha512-3QIt7jBhhwhE1AybMeYfeo5Vj7Rn+7l7QBYiqXiWHWBYGEJtI0VXiEjcC34ctTZKdVGBPvYJZUhBbNHOjLtgMw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
@@ -14793,15 +15440,67 @@
 				"redux": ">=4"
 			}
 		},
+		"node_modules/@wordpress/notices/node_modules/framer-motion": {
+			"version": "11.18.2",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+			"integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+			"dependencies": {
+				"motion-dom": "^11.18.1",
+				"motion-utils": "^11.18.1",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/notices/node_modules/gradient-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
+			"integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/@wordpress/notices/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
+		},
+		"node_modules/@wordpress/notices/node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
 		},
 		"node_modules/@wordpress/notices/node_modules/redux": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+		},
+		"node_modules/@wordpress/notices/node_modules/remove-accents": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
+		},
+		"node_modules/@wordpress/notices/node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
 			"version": "5.25.0",
@@ -14838,14 +15537,14 @@
 			}
 		},
 		"node_modules/@wordpress/plugins/node_modules/@types/react": {
-			"version": "17.0.83",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
-			"integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/plugins/node_modules/@types/react-dom": {
@@ -14955,20 +15654,20 @@
 			}
 		},
 		"node_modules/@wordpress/preferences": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.25.0.tgz",
-			"integrity": "sha512-zKBqF7mLiONH3LqYuruDGF6K9yWJj2fRSvgNVkcftQr7jPDys8c6F29+YQWDf1trs5MaYxhoenZQSenqf1oljQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.43.0.tgz",
+			"integrity": "sha512-di93xiAo2IT0lnAzV6J+3d+HB1vkOKs3eAfo500STGx10akGN1NgOqSmu6O+tdzlViLzz8q1mkIZ0j3KraKkPA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.25.0",
-				"@wordpress/components": "^29.11.0",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/data": "^10.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/icons": "^10.25.0",
-				"@wordpress/private-apis": "^1.25.0",
+				"@wordpress/a11y": "^4.43.0",
+				"@wordpress/base-styles": "^6.19.0",
+				"@wordpress/components": "^32.5.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/data": "^10.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/icons": "^12.1.0",
+				"@wordpress/private-apis": "^1.43.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -14981,16 +15680,16 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@ariakit/core": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.15.tgz",
-			"integrity": "sha512-vvxmZvkNhiisKM+Y1TbGMUfVVchV/sWu9F0xw0RYADXcimWPK31dd9JnIZs/OQ5pwAryAHmERHwuGQVESkSjwQ=="
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.19.tgz",
+			"integrity": "sha512-PUj/J1eX/b+DkcYwP6m7/tzDUiX1SVST89coljTN6BdQwLYMSkhg71jXcZwmTX19jQmqV9VqhVkKeabLnvciQQ=="
 		},
 		"node_modules/@wordpress/preferences/node_modules/@ariakit/react": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.17.tgz",
-			"integrity": "sha512-HQaIboE2axtlncJz1hRTaiQfJ1GGjhdtNcAnPwdjvl2RybfmlHowIB+HTVBp36LzroKPs/M4hPCxk7XTaqRZGg==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.25.tgz",
+			"integrity": "sha512-Gs/YgXrz0gCj0k/AWD7Ia9bw5vLPAJpG0KRiv6T/5Tg/DTZYihtE9blWGWhgGu+bSrp1IratNbQLkAvQ4J99cQ==",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.17"
+				"@ariakit/react-core": "0.4.25"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -15002,26 +15701,36 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@ariakit/react-core": {
-			"version": "0.4.17",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.17.tgz",
-			"integrity": "sha512-kFF6n+gC/5CRQIyaMTFoBPio2xUe0k9rZhMNdUobWRmc/twfeLVkODx+8UVYaNyKilTge8G0JFqwvFKku/jKEw==",
+			"version": "0.4.25",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.25.tgz",
+			"integrity": "sha512-7seOOJ6N71lIKMS2jtNzxITCRIirt7yRrZLLWE8bp4+tQbov96BqSNX8fNCXmr/bDvKWz9PL07YrPrGjTXJXgA==",
 			"dependencies": {
-				"@ariakit/core": "0.4.15",
+				"@ariakit/core": "0.4.19",
 				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
+				"use-sync-external-store": "^1.6.0"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
+		"node_modules/@wordpress/preferences/node_modules/@emotion/utils": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+		},
+		"node_modules/@wordpress/preferences/node_modules/@types/gradient-parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+			"integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw=="
+		},
 		"node_modules/@wordpress/preferences/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@types/react-dom": {
@@ -15033,67 +15742,79 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/a11y": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.25.0.tgz",
-			"integrity": "sha512-9wJZC7gWUrDN1Ybch6pgGZL73kSm2b4dm9YDJtNJuCa/6T7TkVRVdpjVtnTLhvATPSXNV81P/bLK8fWbI3ze0A==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.43.0.tgz",
+			"integrity": "sha512-AWNmSi+Cjx5m03JhG/XjDqgRufqCFcIpYddWw7/0vR6rMk/DK5O+Jx6yJcJOwgmz2KFSgjMnjFfqbh3EtX8rRg==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/dom-ready": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/dom-ready": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/preferences/node_modules/@wordpress/base-styles": {
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.19.0.tgz",
+			"integrity": "sha512-SAZA6dhfC5X00s9PRrL9diY59WegiF0MuAWupkoKnYk3a2IAQbRUUTrh3j3wRyr08ljqefmifX5GR3hz/VwQaw==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
-			"version": "29.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-29.11.0.tgz",
-			"integrity": "sha512-p/hicoCxHo4uC5DeGsdLme/JcRwedFkNctKS7uo5dy05odWXWOPDLiSsWYz6F7uCKbmBJNucxdF3f42YTh6y1Q==",
+			"version": "32.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.5.0.tgz",
+			"integrity": "sha512-UEBNEqxHfOvTVbVepoLPS2wSzIjcZoCHMv6P2iN0om819x3aLIKAZqpxjNF8x0nz2z/gnj5Bj9GpXTW0+Bvfcw==",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@babel/runtime": "7.25.7",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "^2.0.8",
-				"@types/gradient-parser": "0.1.3",
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.25.0",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/date": "^5.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/escape-html": "^3.25.0",
-				"@wordpress/hooks": "^4.25.0",
-				"@wordpress/html-entities": "^4.25.0",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/icons": "^10.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/primitives": "^4.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/rich-text": "^7.25.0",
-				"@wordpress/warning": "^3.25.0",
+				"@wordpress/a11y": "^4.43.0",
+				"@wordpress/base-styles": "^6.19.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/date": "^5.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/escape-html": "^3.43.0",
+				"@wordpress/hooks": "^4.43.0",
+				"@wordpress/html-entities": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/icons": "^12.1.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/primitives": "^4.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/rich-text": "^7.43.0",
+				"@wordpress/warning": "^3.43.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
 				"date-fns": "^3.6.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.1.9",
-				"gradient-parser": "1.0.2",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"
 			},
@@ -15107,21 +15828,19 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/compose": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.25.0.tgz",
-			"integrity": "sha512-nfjtMZgrhdHU8/zOLUyA5o8ShLot1vbHZ0I2+IxLyNskRMVyR9pm4BAJSYKJ9XqBUom2/N51gfeKg5uhd9Y0TQ==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/undo-manager": "^1.25.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -15134,18 +15853,17 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/data": {
-			"version": "10.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.25.0.tgz",
-			"integrity": "sha512-PHfF7S2jhgcH9D3Z9nskaQEDIbh0k0MX6KprzK4plT4Xu71YboMVWnBx78glzMMu17DOFoHJC25d+ymfGBM5rw==",
+			"version": "10.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.43.0.tgz",
+			"integrity": "sha512-LKjxBrub1qkMm8Oyj6ynHAGix5eJcJqN9Pq0aX9UYLPjc1T/zkhhAopFL7It2S4muKMNcAHizR+e1eZNA3k4fQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/redux-routine": "^5.25.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/redux-routine": "^5.43.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -15163,12 +15881,11 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/date": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.25.0.tgz",
-			"integrity": "sha512-w3De486/qx2/MbxCCjiW7KS8lGhJ00VvnrbXRlrY9l/6yqbz0iMVglmFKrlLPftgutyhe3OSOSZsXX/uCF6yOg==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.43.0.tgz",
+			"integrity": "sha512-8DiFlE7YzP7F/P59Hr6h5fWJxJlvt6eZgU1C7huM9XhANh8Y3dZfepsySL6K7h1yE66SQDSq07cEefFQgJW31g==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.25.0",
+				"@wordpress/deprecated": "^4.43.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -15178,12 +15895,11 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/deprecated": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.25.0.tgz",
-			"integrity": "sha512-NfVGSVfAESrgQRQu5QpyprTsDY0BLq6hJ2KrWlpscLetApxU5kSpP/wRzmjbtuuWSr5RsoopaeoTbiZNXb0QEA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0"
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -15191,12 +15907,11 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/dom": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.25.0.tgz",
-			"integrity": "sha512-uyP8oTjSYjU+OXSvpPITqMaF9Dk50WH7fiQIVUcjC/9VmrzIiaYaZ4USmuoUBtbFjJsSyANHw/anYMFqby9iIA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.25.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -15204,26 +15919,22 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/dom-ready": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.25.0.tgz",
-			"integrity": "sha512-HvGxncRhskqrkwyIPVsfznToFtSr6X0zBrIMHK7bgwGGiMr+yz5jYX3wnY1AsUDSr95ezhbCTdE2rNmvFkCD0g==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.43.0.tgz",
+			"integrity": "sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/element": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.25.0.tgz",
-			"integrity": "sha512-zxdaf2s/en5Y+DfiswRZtQ+P8SvQ18+l5I2WmHb66+bVkFg7jrN+AJqLk86k2zcalOEjx7Fg4cce1wWytp8Wsw==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.25.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -15235,51 +15946,41 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/escape-html": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.25.0.tgz",
-			"integrity": "sha512-sQ3graObu5K/RWrngk9bsULJ+9E7QLC6gMG34ja0Jm1LdeRjVgHv3FqP/uIkL36EvxEkjQ0LSbgbZsdV/E1q0w==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/hooks": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.25.0.tgz",
-			"integrity": "sha512-IWqgozRE+8PE96TIsf5bfS7ezZfvleSm1YZAuhAWYH7QUVm07WK7/yhhDYkj9QyTpWSZnGkmR7YYH/NJ8jaMDQ==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/html-entities": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.25.0.tgz",
-			"integrity": "sha512-SEf8nnLm85KH2fZiEzUgLuh4Nd53iW0rmA5k9xM7n0uM6BA6HMDidtT/5wxTlnMH8cxOSjL2IkCHwhuRFTibbg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.43.0.tgz",
+			"integrity": "sha512-z7C782VfH3E5dWYO4VOtN8EEhzfID2kiJmGTINiVPD8kywxp5BsBU2KJSSPvkUjqOCMNJ2XhkYPgADKi9O1U7A==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/i18n": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.25.0.tgz",
-			"integrity": "sha512-6MWkwmA9dwiLA+N4cj81JxxSqgJ+5HeLZHa3Sy2u7A2f4wgGCH+Bj2T6eQnZdky9fMy4vjvUpUZdv5sdmtYJlQ==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
@@ -15291,38 +15992,37 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
-			"version": "10.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.25.0.tgz",
-			"integrity": "sha512-CNAgZ0ZE6pPjLWxPLBdmIQlxpkQCNZ9Zv4wuUDSMqG0jJDdf+YCpklwIMLWbv9WVubmzgURo54qeCedbpXhCjA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-12.1.0.tgz",
+			"integrity": "sha512-JOEVd94kZQsGYyLhjq1edfaMOTPON/7qUDuzT74uSwSCJ6OiHf3yJHfxMlLOMoh12dQshWPciLVLagkYLCldag==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/primitives": "^4.25.0"
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/primitives": "^4.43.0",
+				"change-case": "4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.25.0.tgz",
-			"integrity": "sha512-/37IIoJz8/mp7TGZbdmakXr6YKqvpjYUHJx9LA9ibVVh6AsM72nI7N5V3AsGndan46vItfzhs0zpEWI7xF86Gw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/keycodes": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.25.0.tgz",
-			"integrity": "sha512-cnV4/7RY4m+DNo3BF10pHdFITKyoYr4TqvcSmka5O7RulPQi/PTeLcFgTTM+LrULGSNfV5ZUgIuPwLpLA5pqGQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -15330,12 +16030,11 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/primitives": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.25.0.tgz",
-			"integrity": "sha512-I8voo9KWDFOgVUzxO0n1UtaTGBwhA/MuYmh6Bpn4M33SQAm4K5aUFidnJOelILWSA4Ox4R7wskGhuItfyty1LA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.43.0.tgz",
+			"integrity": "sha512-lU1vBSDyRkAYFEfbLyzjophDvIVCeQ7uuEXv5dBAbxkSLSsCcX6oLbWSwjkCEHp1R+9UtukLvbmXDdAbDYiEOA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.25.0",
+				"@wordpress/element": "^6.43.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -15347,11 +16046,10 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/priority-queue": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.25.0.tgz",
-			"integrity": "sha512-HtN8G1o/TaUIhapJf6Kq2dy1OOpC1beGB7sJUvq5JrwKd3VRdrXx0K3HKoHe99EJoE9v6lgEIS5VtVIaW0u0cQ==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -15360,11 +16058,10 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/redux-routine": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.25.0.tgz",
-			"integrity": "sha512-0YZNyuL1QO3CbA6njHzoHMmYX+tnOSUIOpag5jeeNKzNE7iThKRmD07HtMo+hL5B3EFumvWDXlwOLpoi2xBJuw==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.43.0.tgz",
+			"integrity": "sha512-3QIt7jBhhwhE1AybMeYfeo5Vj7Rn+7l7QBYiqXiWHWBYGEJtI0VXiEjcC34ctTZKdVGBPvYJZUhBbNHOjLtgMw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
@@ -15404,17 +16101,17 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/gradient-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
-			"integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
+			"integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/preferences/node_modules/path-to-regexp": {
 			"version": "6.3.0",
@@ -15430,6 +16127,14 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
 			"integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="
+		},
+		"node_modules/@wordpress/preferences/node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
 		},
 		"node_modules/@wordpress/prettier-config": {
 			"version": "2.25.13",
@@ -15457,23 +16162,13 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@wordpress/primitives/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-			"dev": true,
-			"dependencies": {
-				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
-			}
-		},
 		"node_modules/@wordpress/primitives/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
-			"dependencies": {
-				"@types/react": "*"
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
@@ -15508,12 +16203,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.27.0.tgz",
-			"integrity": "sha512-u5EqKxkE4BHKOSlLPW+o632t2YnzJkZTjwnNFolswWI9+g5SiXRpM8Q7+1CNquqcgDcSNKId7S9UCE1fw1FhAw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.43.0.tgz",
+			"integrity": "sha512-ADZB20UjyQgdL43uFkFE9tm49URMRphydi+ngaxbAJnT/3n5x7WSzfXMBqrdQOuBpdy44O9yHz7JtzLXRapkjQ==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -15534,11 +16226,11 @@
 			}
 		},
 		"node_modules/@wordpress/react-i18n/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/react-i18n/node_modules/@wordpress/element": {
@@ -15590,9 +16282,9 @@
 			}
 		},
 		"node_modules/@wordpress/react-i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/redux-routine": {
 			"version": "4.58.0",
@@ -15648,13 +16340,13 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@types/react-dom": {
@@ -15982,9 +16674,9 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons": {
 			"version": "9.49.0",
@@ -16000,20 +16692,20 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
@@ -16048,20 +16740,20 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
@@ -16150,20 +16842,20 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/primitives/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/primitives/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
@@ -16319,19 +17011,21 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.27.0.tgz",
-			"integrity": "sha512-khZm3EqCcI0abZZhNWn9EhwFbLEyCy8X4+7IcJNzyKSZiDsP7HS1ch7Zo3lVPJAMWFeeqwDQJ3zSZwCL24Eg8w==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.43.0.tgz",
+			"integrity": "sha512-qoCnzUFZVfWLg7iuaqVifPO+y92gRWX+yz3ILKFxxduTHc1Avy9woNsy3nLaS6xgQhxYIUjEgb8jFShb3eR3OQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/a11y": "^4.27.0",
-				"@wordpress/compose": "^7.27.0",
-				"@wordpress/data": "^10.27.0",
-				"@wordpress/deprecated": "^4.27.0",
-				"@wordpress/element": "^6.27.0",
-				"@wordpress/escape-html": "^3.27.0",
-				"@wordpress/i18n": "^6.0.0",
-				"@wordpress/keycodes": "^4.27.0",
+				"@wordpress/a11y": "^4.43.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/data": "^10.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/escape-html": "^3.43.0",
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"colord": "2.9.3",
 				"memize": "^2.1.0"
 			},
 			"engines": {
@@ -16340,6 +17034,15 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@types/react": {
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+			"dependencies": {
+				"@types/prop-types": "*",
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@types/react-dom": {
@@ -16351,13 +17054,12 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/a11y": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.27.0.tgz",
-			"integrity": "sha512-wbZ7F4mA2VZKGkA30fivJwHT6OA+CXzhGokaaIVGWqjAygioFkaqb49u+eMWKTQoYEL6BdeUgDmViMUxva73Uw==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.43.0.tgz",
+			"integrity": "sha512-AWNmSi+Cjx5m03JhG/XjDqgRufqCFcIpYddWw7/0vR6rMk/DK5O+Jx6yJcJOwgmz2KFSgjMnjFfqbh3EtX8rRg==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/dom-ready": "^4.27.0",
-				"@wordpress/i18n": "^6.0.0"
+				"@wordpress/dom-ready": "^4.43.0",
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16365,21 +17067,19 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.27.0.tgz",
-			"integrity": "sha512-87/V/hyyg2Fojfk0hDVR4U3vdDdbNWoVdf17QnAORYt35lWWTxwMBKlZqIhFEuoLrPTvMQvu6ecjhxFNYB+ALg==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.27.0",
-				"@wordpress/dom": "^4.27.0",
-				"@wordpress/element": "^6.27.0",
-				"@wordpress/is-shallow-equal": "^5.27.0",
-				"@wordpress/keycodes": "^4.27.0",
-				"@wordpress/priority-queue": "^3.27.0",
-				"@wordpress/undo-manager": "^1.27.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -16392,18 +17092,17 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
-			"version": "10.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.27.0.tgz",
-			"integrity": "sha512-+7S4GgAEBi87qNPN/Jl3sr3xuBnjHIaA7Vzfn3UqoCQ469JkyB65kbgfJOOGDz94sMhYZ4OoeQT3lpGsPBxnVA==",
+			"version": "10.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.43.0.tgz",
+			"integrity": "sha512-LKjxBrub1qkMm8Oyj6ynHAGix5eJcJqN9Pq0aX9UYLPjc1T/zkhhAopFL7It2S4muKMNcAHizR+e1eZNA3k4fQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.27.0",
-				"@wordpress/deprecated": "^4.27.0",
-				"@wordpress/element": "^6.27.0",
-				"@wordpress/is-shallow-equal": "^5.27.0",
-				"@wordpress/priority-queue": "^3.27.0",
-				"@wordpress/private-apis": "^1.27.0",
-				"@wordpress/redux-routine": "^5.27.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/redux-routine": "^5.43.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -16421,12 +17120,11 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/deprecated": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.27.0.tgz",
-			"integrity": "sha512-1rJTK7iy0oSE6eFUCBqCGG/wYuF62WoNDLF1G1Do+TdFGB4WxckHwTr5TuwtIG4CdoMjsPYIh2EnI3ziFOsHkA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.27.0"
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16434,12 +17132,11 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/dom": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.27.0.tgz",
-			"integrity": "sha512-uXcJslbSpxXX7EyMF4wtj+cydDyalapvu8HQ4QZleAAwJavhdNT+xpr/ai0XeApcxgIGHq1W05sYVN38lwVioQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.27.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16447,26 +17144,22 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/dom-ready": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.27.0.tgz",
-			"integrity": "sha512-L1hZ1g1mMyt06tuMWt72uAJjlkjGOpR2Vxbo72ZZgO28PqQc1WLrvWN/W3LVViar9OQrR0yn/REYRd258iaNQw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.43.0.tgz",
+			"integrity": "sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-			"version": "6.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.27.0.tgz",
-			"integrity": "sha512-gHk4B0J0f7bEsDoUBdTm22vPQwmEWLZxyaojgRyx1ncE2IyktfmubD/q2NIcMEKh7p+Jq3ZUwzPcpchpvkH2mA==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.27.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -16478,37 +17171,30 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/escape-html": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.27.0.tgz",
-			"integrity": "sha512-1LBB/xOFBUySSmVpd2nFwIZ8fVnP8dLNFl0wLprHVLtW6ZcdykO2ITY9bkaHu2lZ9HLRgHL7A/3R7MsJ1azYkg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/hooks": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.27.0.tgz",
-			"integrity": "sha512-sGaNVZKMxwnhGSge0tZZsGfImLPimiulUkM7hivQ2CSCgibTpgxFRBJ1r7gbNLDF+qHQK9a26K8fGfKnAal6Cg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.0.0.tgz",
-			"integrity": "sha512-ItvO/E3v39VX+5nZacyzwulhzRukiB2+1zqndWgOSNnERYnK/0hLHIWWthRFxYEPF13H54orXg68n17MZQ8whA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.27.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -16522,24 +17208,20 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.27.0.tgz",
-			"integrity": "sha512-sYlAuNgEwQHioKSx3jyV6ZJlBR19sEvIdkBVoGF82OAxbXFzRvoD6V4zy+kZzY6V99FE12L93I0t5jh4qOn2lg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/keycodes": {
-			"version": "4.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.27.0.tgz",
-			"integrity": "sha512-fWyEcLI2rAZn6FwVBITGFxo8aS7EQrt8icOdxS5Es3Ii8DneQUl2gtXs3tq9viX4cWCno7cEt+dpuuv2gPxwoQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^6.0.0"
+				"@wordpress/i18n": "^6.16.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16547,11 +17229,10 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/priority-queue": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.27.0.tgz",
-			"integrity": "sha512-RpIaX59sji45x9oUYrkbTHbagJuHC05oZOjJDzLj2Qv12bGeq0QWI2+e59yl3wONLpVla7f3TfNsFapkgOhOAw==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -16560,11 +17241,10 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/redux-routine": {
-			"version": "5.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.27.0.tgz",
-			"integrity": "sha512-6eulRxrF40yKtGjzHKsY2pzD5/sbWaNjXRrFQZY+wMNsYV6AWYacgn3r+2r51Uhlut6zZl6x8YJtCcqGOHnKEQ==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.43.0.tgz",
+			"integrity": "sha512-3QIt7jBhhwhE1AybMeYfeo5Vj7Rn+7l7QBYiqXiWHWBYGEJtI0VXiEjcC34ctTZKdVGBPvYJZUhBbNHOjLtgMw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
@@ -16578,9 +17258,9 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/rich-text/node_modules/redux": {
 			"version": "5.0.1",
@@ -16706,9 +17386,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-			"version": "0.5.15",
-			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.15.tgz",
-			"integrity": "sha512-LFWllMA55pzB9D34w/wXUCf8+c+IYKuJDgxiZ3qMhl64KRMBHYM1I3VdGaD2BV5FNPV2/S2596bppxHbv2ZydQ==",
+			"version": "0.5.17",
+			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
+			"integrity": "sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==",
 			"dev": true,
 			"dependencies": {
 				"ansi-html": "^0.0.9",
@@ -16798,19 +17478,19 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/babel-preset-default": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.25.0.tgz",
-			"integrity": "sha512-8Sf4pkH7/4pcKt/jOkVNLOoScypMOM2xEHtyiTE5tHgX4z7UZRNbXFKqJ9fxDDb/cniDdNyeG5QhOLIZbO7hlg==",
+			"version": "8.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.43.0.tgz",
+			"integrity": "sha512-L2EOVoc0EXlz/QJRW1KuJxiKtVntD5bqFzMTizPmNdwr6BIyVOWs7mDOCldTTCKcYcLSGMbTFj7F24rKNC4Cmw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "7.25.7",
+				"@babel/plugin-syntax-import-attributes": "7.26.0",
 				"@babel/plugin-transform-react-jsx": "7.25.7",
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@babel/runtime": "7.25.7",
-				"@wordpress/browserslist-config": "^6.25.0",
-				"@wordpress/warning": "^3.25.0",
+				"@wordpress/browserslist-config": "^6.43.0",
+				"@wordpress/warning": "^3.43.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -16821,9 +17501,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/browserslist-config": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.25.0.tgz",
-			"integrity": "sha512-pJdhs1KJES46Z7/EFA4clmXlc+BBMlDrtFjoBX1FC5Lqh4RfJ1YD7VGdMSSuQpCF2iIrU4AijR31AZQ8NOy5mQ==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.43.0.tgz",
+			"integrity": "sha512-W6Htq0S8g9RE02zwIB4HgbxwFeL9tijIleAIjp3pMuodP6ReRcWjvOX9O3DyfaRKrhl7JCFhT/M1RkKK3hQnYg==",
 			"dev": true,
 			"engines": {
 				"node": ">=18.12.0",
@@ -16831,9 +17511,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.25.0.tgz",
-			"integrity": "sha512-bAVve8ksBNfCcBq09IoTLCdF604UXtVh4Fb+/LBqyJc1kTTS02PsIv5aguSvCjcNSakQgvs7IJqEGJ2ZmP4JZg==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.43.0.tgz",
+			"integrity": "sha512-4u7AvCEISGv9Q/sLHnV1+msZMKvHrDJ+R52Ezn3x2chIiOWFZWvr109BctwyUxvcn6SZgz9l0Ag88ffzdsjbqA==",
 			"dev": true,
 			"dependencies": {
 				"json2php": "^0.0.7"
@@ -16852,13 +17532,30 @@
 			"integrity": "sha512-dnSoUiLAoVaMXxFsVi4CrPVYMKOuDBXTghXSmMINX44RZ8WM9cXlY7UqrQnlAcODCVO7FV3+8t/5nDKAjimLfg==",
 			"dev": true
 		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/jest-preset-default": {
-			"version": "12.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.25.0.tgz",
-			"integrity": "sha512-YLKfgQl5ZW63XuJh24Mzv1yXIO4otTXg9fTbSsEAHhZI8KQL9VuFJgNQ4hE8lZV2Wbmy6Njh8q4TY05/oMJ3KA==",
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/jest-console": {
+			"version": "8.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.43.0.tgz",
+			"integrity": "sha512-cKkbZGXAwRc9GkQ6U0QQs3aa6N/dV/F6QZdMdcObb3cg+jXSw1N6k86Q5ZFSlpzYXrBgqNl3I59xq1cRifAA4Q==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/jest-console": "^8.25.0",
+				"jest-matcher-utils": "^29.6.2",
+				"jest-mock": "^29.6.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"jest": ">=29"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/jest-preset-default": {
+			"version": "12.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.43.0.tgz",
+			"integrity": "sha512-PY5HoTa5oQ+oIzxh6f4J9h0P1mqNDC0MoJuLGaw4/Yu+zBSvQuW67B9D29pQcSuLsLMtaR6R1Um/HmU+M//3rw==",
+			"dev": true,
+			"dependencies": {
+				"@wordpress/jest-console": "^8.43.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -16871,9 +17568,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/@wordpress/prettier-config": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.25.0.tgz",
-			"integrity": "sha512-P18anKvMO9lEpr2827No0SFmeypX1A5Ce3DZ4NdNNnoJRGYkdlwRzwMpMoB9XpAQz5o45ystBrak2/OqzdBWLg==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.43.0.tgz",
+			"integrity": "sha512-l52vxzgp61vfWq6fLIbAZl2efFMbEQ+BLGoekcyHw7h0rmg3u6YWTPdRRnzIfKAkSiArF8K80uvJ1eHYWiTMUg==",
 			"dev": true,
 			"engines": {
 				"node": ">=18.12.0",
@@ -16881,6 +17578,18 @@
 			},
 			"peerDependencies": {
 				"prettier": ">=3"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/argparse": {
@@ -16922,9 +17631,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/core-js": {
-			"version": "3.43.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-			"integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -16933,9 +17642,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
@@ -16959,34 +17668,23 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
+		"node_modules/@wordpress/scripts/node_modules/es-module-lexer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"dev": true
 		},
 		"node_modules/@wordpress/scripts/node_modules/eslint": {
 			"version": "8.57.0",
@@ -17103,14 +17801,14 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/flat-cache": {
-			"version": "6.1.10",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.10.tgz",
-			"integrity": "sha512-B6/v1f0NwjxzmeOhzfXPGWpKBVA207LS7lehaVKQnFrVktcFRfkzjZZ2gwj2i1TkEUMQht7ZMJbABUT5N+V1Nw==",
+			"version": "6.1.22",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+			"integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
 			"dev": true,
 			"dependencies": {
-				"cacheable": "^1.10.0",
-				"flatted": "^3.3.3",
-				"hookified": "^1.9.1"
+				"cacheable": "^2.3.4",
+				"flatted": "^3.4.2",
+				"hookified": "^1.15.0"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/glob-parent": {
@@ -17194,9 +17892,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -17227,9 +17925,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/known-css-properties": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
-			"integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
 			"dev": true
 		},
 		"node_modules/@wordpress/scripts/node_modules/locate-path": {
@@ -17248,9 +17946,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true
 		},
 		"node_modules/@wordpress/scripts/node_modules/meow": {
@@ -17284,12 +17982,6 @@
 			"peerDependencies": {
 				"webpack": "^5.0.0"
 			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
 		},
 		"node_modules/@wordpress/scripts/node_modules/p-limit": {
 			"version": "4.0.0",
@@ -17362,9 +18054,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/postcss": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-			"integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+			"version": "8.5.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+			"integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
 			"dev": true,
 			"funding": [
 				{
@@ -17416,9 +18108,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -17504,13 +18196,13 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/sass": {
-			"version": "1.89.2",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
-			"integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
+			"version": "1.99.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+			"integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
-				"immutable": "^5.0.2",
+				"immutable": "^5.1.5",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
 			"bin": {
@@ -17524,9 +18216,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/sass-loader": {
-			"version": "16.0.5",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.5.tgz",
-			"integrity": "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw==",
+			"version": "16.0.7",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+			"integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
 			"dev": true,
 			"dependencies": {
 				"neo-async": "^2.6.2"
@@ -17539,7 +18231,7 @@
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"@rspack/core": "0.x || 1.x",
+				"@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
 				"node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
 				"sass": "^1.3.0",
 				"sass-embedded": "*",
@@ -17579,9 +18271,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/schema-utils": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
@@ -17598,9 +18290,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -17611,18 +18303,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/schema-utils/node_modules/ajv-keywords": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-			"dev": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3"
-			},
-			"peerDependencies": {
-				"ajv": "^8.8.2"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/signal-exit": {
@@ -17680,9 +18360,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/stylelint": {
-			"version": "16.20.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.20.0.tgz",
-			"integrity": "sha512-B5Myu9WRxrgKuLs3YyUXLP2H0mrbejwNxPmyADlACWwFsrL8Bmor/nTSh4OMae5sHjOz6gkSeccQH34gM4/nAw==",
+			"version": "16.26.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -17695,34 +18375,35 @@
 				}
 			],
 			"dependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.4",
-				"@csstools/css-tokenizer": "^3.0.3",
-				"@csstools/media-query-list-parser": "^4.0.2",
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
+				"@csstools/css-tokenizer": "^3.0.4",
+				"@csstools/media-query-list-parser": "^4.0.3",
 				"@csstools/selector-specificity": "^5.0.0",
-				"@dual-bundle/import-meta-resolve": "^4.1.0",
+				"@dual-bundle/import-meta-resolve": "^4.2.1",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
 				"cosmiconfig": "^9.0.0",
 				"css-functions-list": "^3.2.3",
 				"css-tree": "^3.1.0",
-				"debug": "^4.4.1",
+				"debug": "^4.4.3",
 				"fast-glob": "^3.3.3",
 				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^10.1.0",
+				"file-entry-cache": "^11.1.1",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
 				"html-tags": "^3.3.1",
-				"ignore": "^7.0.4",
+				"ignore": "^7.0.5",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.36.0",
+				"known-css-properties": "^0.37.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^13.2.0",
 				"micromatch": "^4.0.8",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.1.1",
-				"postcss": "^8.5.3",
+				"postcss": "^8.5.6",
 				"postcss-resolve-nested-selector": "^0.1.6",
 				"postcss-safe-parser": "^7.0.1",
 				"postcss-selector-parser": "^7.1.0",
@@ -17742,12 +18423,12 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.1.tgz",
-			"integrity": "sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
 			"dev": true,
 			"dependencies": {
-				"flat-cache": "^6.1.10"
+				"flat-cache": "^6.1.20"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/stylelint/node_modules/ignore": {
@@ -17772,35 +18453,36 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/webpack": {
-			"version": "5.99.9",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-			"integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+			"version": "5.106.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.1.tgz",
+			"integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
-				"@types/estree": "^1.0.6",
+				"@types/estree": "^1.0.8",
 				"@types/json-schema": "^7.0.15",
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.14.0",
-				"browserslist": "^4.24.0",
+				"acorn": "^8.16.0",
+				"acorn-import-phases": "^1.0.3",
+				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.1",
-				"es-module-lexer": "^1.2.1",
+				"enhanced-resolve": "^5.20.0",
+				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
 				"json-parse-even-better-errors": "^2.3.1",
-				"loader-runner": "^4.2.0",
+				"loader-runner": "^4.3.1",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^4.3.2",
-				"tapable": "^2.1.1",
-				"terser-webpack-plugin": "^5.3.11",
-				"watchpack": "^2.4.1",
-				"webpack-sources": "^3.2.3"
+				"schema-utils": "^4.3.3",
+				"tapable": "^2.3.0",
+				"terser-webpack-plugin": "^5.3.17",
+				"watchpack": "^2.5.1",
+				"webpack-sources": "^3.3.4"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -17958,9 +18640,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/yocto-queue": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-			"integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+			"integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.20"
@@ -18007,13 +18689,13 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@types/react-dom": {
@@ -18257,9 +18939,9 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/i18n/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons": {
 			"version": "9.49.0",
@@ -18275,20 +18957,20 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
@@ -18323,20 +19005,20 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/primitives/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/primitives/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
@@ -18451,18 +19133,15 @@
 			}
 		},
 		"node_modules/@wordpress/shortcode/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/style-engine": {
-			"version": "2.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.27.0.tgz",
-			"integrity": "sha512-boTPFzKuVxEiXpaKu7qFIa5MyPVp5f5BHCiEqcsppcjGOtwdhLv1sSHGJdtUzsbe43yZ0pyY7q8a5dCmk5rjIw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
+			"version": "2.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.43.0.tgz",
+			"integrity": "sha512-pP+HHwq8Rbv2vfXBO3aMcybxQnjX7nKqELGMzHDT3s3oRH8cyFzuuVbvkDTlfAF//MJx+Jg+zUzBFQu1mQfbeQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"change-case": "^4.1.2"
 			},
 			"engines": {
@@ -18511,11 +19190,10 @@
 			}
 		},
 		"node_modules/@wordpress/sync/node_modules/@wordpress/url": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.25.0.tgz",
-			"integrity": "sha512-IQE/Ck4lEu65VhYcCoMedusIurc+oZtxWUZkn/SoMBJm2ft5zw8oHzHkyDdU/DcrYVKoqV+dAPRPZMHyVrGUTQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.43.0.tgz",
+			"integrity": "sha512-FFq/KZUlhAszI9y232BpQ83+58CtRV5M0SFuv7pQq+DxNDuWNHp8gjdX9WOnHkO/MrKAyVTI0jX9YoWF2RNEZw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -18540,12 +19218,11 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.27.0.tgz",
-			"integrity": "sha512-ndGz3mW0fu7YM7vTuNKqxXBPrpWvrefScD8dmdqeIVs+yDZo8PNpEvrTVfb7FM/gujD6Dh95OSuW5TNpNN6EIw==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.43.0.tgz",
+			"integrity": "sha512-G1hP30a1iV6QaUQ+oouUgFN2VetBVcMPmL+zD04TO1Gs0Dq+4Dgego7/GFuOPBZWO2qiuXTMJUUmi1wO6FSh9A==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/is-shallow-equal": "^5.27.0"
+				"@wordpress/is-shallow-equal": "^5.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18553,32 +19230,29 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.27.0.tgz",
-			"integrity": "sha512-sYlAuNgEwQHioKSx3jyV6ZJlBR19sEvIdkBVoGF82OAxbXFzRvoD6V4zy+kZzY6V99FE12L93I0t5jh4qOn2lg==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/upload-media": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.10.0.tgz",
-			"integrity": "sha512-FqhUvGCUmM1E9d+ggtxNAXtB3G/NqWIW6Ib47oFI+7avb0m0N/XjkrLZgRZOIVWILd3YLpWF6lPTgVHLhJ28qw==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.11.0.tgz",
+			"integrity": "sha512-bzgwuupDWhx6mU93ShYTmFCTD2rhjHeHAJB5p/slx/sfEA13BxAYG7ZCKSKDNWrwxbA4i669BnhjW3h7PsGklg==",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "^7.25.0",
-				"@wordpress/blob": "^4.25.0",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/data": "^10.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/preferences": "^4.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/url": "^4.25.0",
+				"@wordpress/api-fetch": "^7.26.0",
+				"@wordpress/blob": "^4.26.0",
+				"@wordpress/compose": "^7.26.0",
+				"@wordpress/data": "^10.26.0",
+				"@wordpress/element": "^6.26.0",
+				"@wordpress/i18n": "^5.26.0",
+				"@wordpress/preferences": "^4.26.0",
+				"@wordpress/private-apis": "^1.26.0",
+				"@wordpress/url": "^4.26.0",
 				"uuid": "^9.0.1"
 			},
 			"engines": {
@@ -18591,12 +19265,12 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@types/react": {
-			"version": "18.3.23",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-			"integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@types/react-dom": {
@@ -18608,13 +19282,31 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/api-fetch": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.25.0.tgz",
-			"integrity": "sha512-UrZWfx62/NaTitn+1HqQ8IFe+D5Y7+R7AHs0ag8KKsoKi/7cczm9MK3jgXwtjBZ0X6vbwOzxrdcTbMuPyymc0g==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.43.0.tgz",
+			"integrity": "sha512-1Tetm4VIEKDIwrCsvDY0KjjrHvkEaSa2Qvld5gguY2ofcIszL3mR0tGezFaaaB14FHd7Zl0MpfpQY3KeQ+BatQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^5.25.0",
-				"@wordpress/url": "^4.25.0"
+				"@wordpress/i18n": "^6.16.0",
+				"@wordpress/url": "^4.43.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/upload-media/node_modules/@wordpress/api-fetch/node_modules/@wordpress/i18n": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18622,33 +19314,28 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/blob": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.25.0.tgz",
-			"integrity": "sha512-M89TPVhqgKXDKEmMB+DssC0CqGPOLOrKEtVI2tJQH4Br/HGgWJ7tAQF9rtYKuQVFALKX6vkNIPcX9WEd+7p/kw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.43.0.tgz",
+			"integrity": "sha512-wNYpE1DMabI9wDIVBcwsakbnVnvskAj0eJ+7A1njEdmJFYEQ0wc6kTqJ6ma4pLYYPrgw2svWl8vI3HIIB50qhg==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/compose": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.25.0.tgz",
-			"integrity": "sha512-nfjtMZgrhdHU8/zOLUyA5o8ShLot1vbHZ0I2+IxLyNskRMVyR9pm4BAJSYKJ9XqBUom2/N51gfeKg5uhd9Y0TQ==",
+			"version": "7.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.43.0.tgz",
+			"integrity": "sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/dom": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/keycodes": "^4.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/undo-manager": "^1.25.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/dom": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/keycodes": "^4.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/undo-manager": "^1.43.0",
 				"change-case": "^4.1.2",
-				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			},
@@ -18661,18 +19348,17 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/data": {
-			"version": "10.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.25.0.tgz",
-			"integrity": "sha512-PHfF7S2jhgcH9D3Z9nskaQEDIbh0k0MX6KprzK4plT4Xu71YboMVWnBx78glzMMu17DOFoHJC25d+ymfGBM5rw==",
+			"version": "10.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.43.0.tgz",
+			"integrity": "sha512-LKjxBrub1qkMm8Oyj6ynHAGix5eJcJqN9Pq0aX9UYLPjc1T/zkhhAopFL7It2S4muKMNcAHizR+e1eZNA3k4fQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/compose": "^7.25.0",
-				"@wordpress/deprecated": "^4.25.0",
-				"@wordpress/element": "^6.25.0",
-				"@wordpress/is-shallow-equal": "^5.25.0",
-				"@wordpress/priority-queue": "^3.25.0",
-				"@wordpress/private-apis": "^1.25.0",
-				"@wordpress/redux-routine": "^5.25.0",
+				"@wordpress/compose": "^7.43.0",
+				"@wordpress/deprecated": "^4.43.0",
+				"@wordpress/element": "^6.43.0",
+				"@wordpress/is-shallow-equal": "^5.43.0",
+				"@wordpress/priority-queue": "^3.43.0",
+				"@wordpress/private-apis": "^1.43.0",
+				"@wordpress/redux-routine": "^5.43.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -18690,12 +19376,11 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/deprecated": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.25.0.tgz",
-			"integrity": "sha512-NfVGSVfAESrgQRQu5QpyprTsDY0BLq6hJ2KrWlpscLetApxU5kSpP/wRzmjbtuuWSr5RsoopaeoTbiZNXb0QEA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.43.0.tgz",
+			"integrity": "sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0"
+				"@wordpress/hooks": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18703,12 +19388,11 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/dom": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.25.0.tgz",
-			"integrity": "sha512-uyP8oTjSYjU+OXSvpPITqMaF9Dk50WH7fiQIVUcjC/9VmrzIiaYaZ4USmuoUBtbFjJsSyANHw/anYMFqby9iIA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.43.0.tgz",
+			"integrity": "sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/deprecated": "^4.25.0"
+				"@wordpress/deprecated": "^4.43.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18716,14 +19400,13 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/element": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.25.0.tgz",
-			"integrity": "sha512-zxdaf2s/en5Y+DfiswRZtQ+P8SvQ18+l5I2WmHb66+bVkFg7jrN+AJqLk86k2zcalOEjx7Fg4cce1wWytp8Wsw==",
+			"version": "6.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
+			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.25.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.43.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -18735,36 +19418,30 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/escape-html": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.25.0.tgz",
-			"integrity": "sha512-sQ3graObu5K/RWrngk9bsULJ+9E7QLC6gMG34ja0Jm1LdeRjVgHv3FqP/uIkL36EvxEkjQ0LSbgbZsdV/E1q0w==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
+			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/hooks": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.25.0.tgz",
-			"integrity": "sha512-IWqgozRE+8PE96TIsf5bfS7ezZfvleSm1YZAuhAWYH7QUVm07WK7/yhhDYkj9QyTpWSZnGkmR7YYH/NJ8jaMDQ==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
+			"integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/i18n": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.25.0.tgz",
-			"integrity": "sha512-6MWkwmA9dwiLA+N4cj81JxxSqgJ+5HeLZHa3Sy2u7A2f4wgGCH+Bj2T6eQnZdky9fMy4vjvUpUZdv5sdmtYJlQ==",
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
+			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.25.0",
+				"@wordpress/hooks": "^4.26.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -18779,24 +19456,39 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.25.0.tgz",
-			"integrity": "sha512-/37IIoJz8/mp7TGZbdmakXr6YKqvpjYUHJx9LA9ibVVh6AsM72nI7N5V3AsGndan46vItfzhs0zpEWI7xF86Gw==",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.43.0.tgz",
+			"integrity": "sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/keycodes": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.25.0.tgz",
-			"integrity": "sha512-cnV4/7RY4m+DNo3BF10pHdFITKyoYr4TqvcSmka5O7RulPQi/PTeLcFgTTM+LrULGSNfV5ZUgIuPwLpLA5pqGQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.43.0.tgz",
+			"integrity": "sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/i18n": "^5.25.0"
+				"@wordpress/i18n": "^6.16.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/upload-media/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
+			"integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.43.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18804,11 +19496,10 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/priority-queue": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.25.0.tgz",
-			"integrity": "sha512-HtN8G1o/TaUIhapJf6Kq2dy1OOpC1beGB7sJUvq5JrwKd3VRdrXx0K3HKoHe99EJoE9v6lgEIS5VtVIaW0u0cQ==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.43.0.tgz",
+			"integrity": "sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"requestidlecallback": "^0.3.0"
 			},
 			"engines": {
@@ -18817,11 +19508,10 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/redux-routine": {
-			"version": "5.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.25.0.tgz",
-			"integrity": "sha512-0YZNyuL1QO3CbA6njHzoHMmYX+tnOSUIOpag5jeeNKzNE7iThKRmD07HtMo+hL5B3EFumvWDXlwOLpoi2xBJuw==",
+			"version": "5.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.43.0.tgz",
+			"integrity": "sha512-3QIt7jBhhwhE1AybMeYfeo5Vj7Rn+7l7QBYiqXiWHWBYGEJtI0VXiEjcC34ctTZKdVGBPvYJZUhBbNHOjLtgMw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
@@ -18835,11 +19525,10 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/@wordpress/url": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.25.0.tgz",
-			"integrity": "sha512-IQE/Ck4lEu65VhYcCoMedusIurc+oZtxWUZkn/SoMBJm2ft5zw8oHzHkyDdU/DcrYVKoqV+dAPRPZMHyVrGUTQ==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.43.0.tgz",
+			"integrity": "sha512-FFq/KZUlhAszI9y232BpQ83+58CtRV5M0SFuv7pQq+DxNDuWNHp8gjdX9WOnHkO/MrKAyVTI0jX9YoWF2RNEZw==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -18848,9 +19537,9 @@
 			}
 		},
 		"node_modules/@wordpress/upload-media/node_modules/memize": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
-			"integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+			"integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w=="
 		},
 		"node_modules/@wordpress/upload-media/node_modules/redux": {
 			"version": "5.0.1",
@@ -18891,13 +19580,13 @@
 			}
 		},
 		"node_modules/@wordpress/viewport/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
+			"version": "17.0.91",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
+			"integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@wordpress/viewport/node_modules/@types/react-dom": {
@@ -18988,9 +19677,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.27.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.27.0.tgz",
-			"integrity": "sha512-AGcCLU2urtV7C4i4Oji8tL9froFPDie+99A2N3tqjZU1v7Csw4UgDrptYRyENjhXLBe9ZzVlf1mZmgH/MQPAHA==",
+			"version": "3.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.43.0.tgz",
+			"integrity": "sha512-hZn++Njsops73oG2DHpjgriUkHTgk1ykvZtHEDllPSNx5Zf6S8KJ00kcToHjIj/4p1iiDjag2zSX5Yi9ySJHvg==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -19092,6 +19781,18 @@
 				"acorn": "^8"
 			}
 		},
+		"node_modules/acorn-import-phases": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+			"integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"peerDependencies": {
+				"acorn": "^8.14.0"
+			}
+		},
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -19188,9 +19889,9 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -19230,9 +19931,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -19410,15 +20111,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
-		},
-		"node_modules/archiver-utils/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
 		},
 		"node_modules/are-docs-informative": {
 			"version": "0.0.2",
@@ -19685,9 +20377,9 @@
 			}
 		},
 		"node_modules/asn1.js/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true
 		},
 		"node_modules/ast-types": {
@@ -20059,6 +20751,97 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/bare-events": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+			"integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+			"dev": true,
+			"peerDependencies": {
+				"bare-abort-controller": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-fs": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
+			"integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
+			"dev": true,
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-os": {
+			"version": "3.8.7",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+			"integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+			"dev": true,
+			"engines": {
+				"bare": ">=1.14.0"
+			}
+		},
+		"node_modules/bare-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+			"dev": true,
+			"dependencies": {
+				"bare-os": "^3.0.1"
+			}
+		},
+		"node_modules/bare-stream": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+			"integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+			"dev": true,
+			"dependencies": {
+				"streamx": "^2.25.0",
+				"teex": "^1.0.1"
+			},
+			"peerDependencies": {
+				"bare-abort-controller": "*",
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-url": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+			"integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+			"dev": true,
+			"dependencies": {
+				"bare-path": "^3.0.0"
+			}
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -20077,6 +20860,18 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.18",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+			"integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+			"dev": true,
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.5",
@@ -20156,9 +20951,9 @@
 			"dev": true
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+			"integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
 			"dev": true
 		},
 		"node_modules/body-parser": {
@@ -20243,9 +21038,9 @@
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -20375,25 +21170,10 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
-		"node_modules/browserify-sign/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
 		"node_modules/browserslist": {
-			"version": "4.25.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-			"integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"funding": [
 				{
@@ -20410,10 +21190,11 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001718",
-				"electron-to-chromium": "^1.5.160",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.3"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -20524,22 +21305,25 @@
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.0.tgz",
-			"integrity": "sha512-SSgQTAnhd7WlJXnGlIi4jJJOiHzgnM5wRMEPaXAU4kECTAMpBoYKoZ9i5zHmclIEZbxcu3j7yY/CF8DTmwIsHg==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
+			"integrity": "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==",
 			"dev": true,
 			"dependencies": {
-				"hookified": "^1.8.2",
-				"keyv": "^5.3.3"
+				"@cacheable/memory": "^2.0.8",
+				"@cacheable/utils": "^2.4.0",
+				"hookified": "^1.15.0",
+				"keyv": "^5.6.0",
+				"qified": "^0.9.0"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.4.tgz",
-			"integrity": "sha512-ypEvQvInNpUe+u+w8BIcPkQvEqXquyyibWE/1NB5T2BTzIpS5cGEV1LZskDzPSTvNAaT4+5FutvzlvnkxOSKlw==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"dependencies": {
-				"@keyv/serialize": "^1.0.3"
+				"@keyv/serialize": "^1.1.1"
 			}
 		},
 		"node_modules/call-bind": {
@@ -20654,9 +21438,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001787",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-			"integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+			"version": "1.0.30001788",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+			"integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -21400,9 +22184,9 @@
 			}
 		},
 		"node_modules/copy-webpack-plugin/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -21487,9 +22271,9 @@
 			"dev": true
 		},
 		"node_modules/copy-webpack-plugin/node_modules/schema-utils": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-			"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
@@ -21498,7 +22282,7 @@
 				"ajv-keywords": "^5.1.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 10.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -21621,9 +22405,9 @@
 			}
 		},
 		"node_modules/create-ecdh/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true
 		},
 		"node_modules/create-hash": {
@@ -21672,378 +22456,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/@jest/globals": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/@jest/source-map": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/@jest/test-sequencer": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-config": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-jest": "^29.7.0",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"parse-json": "^5.2.0",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@types/node": "*",
-				"ts-node": ">=9.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"ts-node": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-docblock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-			"dev": true,
-			"dependencies": {
-				"detect-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-leak-detector": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-			"dev": true,
-			"dependencies": {
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-resolve": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"resolve": "^1.20.0",
-				"resolve.exports": "^2.0.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-runner": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/environment": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"emittery": "^0.13.1",
-				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-leak-detector": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-resolve": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"p-limit": "^3.1.0",
-				"source-map-support": "0.5.13"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-runtime": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/globals": "^29.7.0",
-				"@jest/source-map": "^29.6.3",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^1.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-validate": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"leven": "^3.1.0",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-watcher": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
-			"dev": true,
-			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"emittery": "^0.13.1",
-				"jest-util": "^29.7.0",
-				"string-length": "^4.0.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/jest-worker": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"jest-util": "^29.7.0",
-				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/react-is": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true
-		},
-		"node_modules/create-jest/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/source-map-support": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-			"dev": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/create-jest/node_modules/string-length": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-			"dev": true,
-			"dependencies": {
-				"char-regex": "^1.0.2",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/create-jest/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/create-jest/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -22349,9 +22761,9 @@
 			"dev": true
 		},
 		"node_modules/csso/node_modules/source-map-js": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -22382,9 +22794,9 @@
 			"dev": true
 		},
 		"node_modules/csstype": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
 		},
 		"node_modules/cwd": {
 			"version": "0.10.0",
@@ -22571,6 +22983,11 @@
 				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
+		"node_modules/date-fns-jalali": {
+			"version": "4.1.0-0",
+			"resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+			"integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="
+		},
 		"node_modules/debounce": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -22578,11 +22995,11 @@
 			"dev": true
 		},
 		"node_modules/debug": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -22911,6 +23328,16 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -22966,9 +23393,9 @@
 			}
 		},
 		"node_modules/diffie-hellman/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true
 		},
 		"node_modules/dir-glob": {
@@ -23210,9 +23637,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.166",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.166.tgz",
-			"integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==",
+			"version": "1.5.336",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+			"integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
 			"dev": true
 		},
 		"node_modules/elliptic": {
@@ -23231,9 +23658,9 @@
 			}
 		},
 		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -23305,13 +23732,13 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-			"integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+			"integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.0"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -23547,9 +23974,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"dev": true
 		},
 		"node_modules/es-object-atoms": {
@@ -24401,12 +24828,27 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"dev": true
+		},
 		"node_modules/events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"engines": {
 				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/events-universal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+			"dev": true,
+			"dependencies": {
+				"bare-events": "^2.7.0"
 			}
 		},
 		"node_modules/evp_bytestokey": {
@@ -24809,18 +25251,18 @@
 			}
 		},
 		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/filelist/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -25023,9 +25465,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true
 		},
 		"node_modules/follow-redirects": {
@@ -25091,9 +25533,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
 			"dev": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -25206,6 +25648,20 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -25431,6 +25887,22 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/glob-to-regex.js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+			"integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/glob-to-regexp": {
@@ -25730,6 +26202,18 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"node_modules/hashery": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+			"integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+			"dev": true,
+			"dependencies": {
+				"hookified": "^1.15.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -25812,9 +26296,9 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.9.1.tgz",
-			"integrity": "sha512-u3pxtGhKjcSXnGm1CX6aXS9xew535j3lkOCegbA6jdyh0BaAjTbXI4aslKstCr6zUNtoCxFGFKwjbSHdGrMB8g==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+			"integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
 			"dev": true
 		},
 		"node_modules/hosted-git-info": {
@@ -25885,15 +26369,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
-		},
-		"node_modules/hpack.js/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
 		},
 		"node_modules/hpq": {
 			"version": "1.4.0",
@@ -26108,21 +26583,12 @@
 				"react": "^18.2.0"
 			}
 		},
-		"node_modules/i18n-calypso/node_modules/@types/react": {
-			"version": "18.3.3",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-			"integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-			"dependencies": {
-				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
-			}
-		},
 		"node_modules/i18n-calypso/node_modules/@types/react-dom": {
-			"version": "18.3.0",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-			"dependencies": {
-				"@types/react": "*"
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/i18n-calypso/node_modules/@wordpress/compose": {
@@ -26257,9 +26723,9 @@
 			"dev": true
 		},
 		"node_modules/immutable": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.2.tgz",
-			"integrity": "sha512-qHKXW1q6liAk1Oys6umoaZbDRqjcjgSrbnrifHsfsttza7zcvRAsL7mMV6xWcyhwQy7Xj5v4hhbr6b+iDYwlmQ==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
 			"dev": true
 		},
 		"node_modules/import-fresh": {
@@ -26426,6 +26892,15 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/interpret": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+			"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/intl-messageformat": {
 			"version": "10.7.16",
 			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
@@ -26457,9 +26932,9 @@
 			}
 		},
 		"node_modules/ipaddr.js": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
-			"integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+			"integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 10"
@@ -27292,9 +27767,9 @@
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
 			"dev": true,
 			"dependencies": {
 				"html-escaper": "^2.0.0",
@@ -27422,35 +27897,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-circus/node_modules/@jest/globals": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/@jest/source-map": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/jest-circus/node_modules/ansi-styles": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -27464,9 +27910,9 @@
 			}
 		},
 		"node_modules/jest-circus/node_modules/dedent": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-			"integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
 			"dev": true,
 			"peerDependencies": {
 				"babel-plugin-macros": "^3.1.0"
@@ -27487,107 +27933,6 @@
 				"chalk": "^4.0.0",
 				"jest-get-type": "^29.6.3",
 				"jest-util": "^29.7.0",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-resolve": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"resolve": "^1.20.0",
-				"resolve.exports": "^2.0.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-runtime": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/globals": "^29.7.0",
-				"@jest/source-map": "^29.6.3",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^1.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-validate": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"leven": "^3.1.0",
 				"pretty-format": "^29.7.0"
 			},
 			"engines": {
@@ -27647,169 +27992,7 @@
 				}
 			}
 		},
-		"node_modules/jest-cli/node_modules/@jest/core": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
-			"dev": true,
-			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/reporters": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-changed-files": "^29.7.0",
-				"jest-config": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-resolve-dependencies": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-cli/node_modules/@jest/globals": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/@jest/reporters": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-			"dev": true,
-			"dependencies": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^6.0.0",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"slash": "^3.0.0",
-				"string-length": "^4.0.1",
-				"strip-ansi": "^6.0.0",
-				"v8-to-istanbul": "^9.0.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-cli/node_modules/@jest/source-map": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/@jest/test-sequencer": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-cli/node_modules/istanbul-lib-instrument": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.23.9",
-				"@babel/parser": "^7.23.9",
-				"@istanbuljs/schema": "^0.1.3",
-				"istanbul-lib-coverage": "^3.2.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jest-cli/node_modules/jest-config": {
+		"node_modules/jest-config": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
 			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
@@ -27854,199 +28037,34 @@
 				}
 			}
 		},
-		"node_modules/jest-cli/node_modules/jest-docblock": {
+		"node_modules/jest-config/node_modules/@jest/test-sequencer": {
 			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
 			"dev": true,
 			"dependencies": {
-				"detect-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/jest-leak-detector": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-			"dev": true,
-			"dependencies": {
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/jest-resolve": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.0.0",
+				"@jest/test-result": "^29.7.0",
 				"graceful-fs": "^4.2.9",
 				"jest-haste-map": "^29.7.0",
-				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"resolve": "^1.20.0",
-				"resolve.exports": "^2.0.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-cli/node_modules/jest-runner": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+		"node_modules/jest-config/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
-			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/environment": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"emittery": "^0.13.1",
-				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-leak-detector": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-resolve": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"p-limit": "^3.1.0",
-				"source-map-support": "0.5.13"
-			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/jest-cli/node_modules/jest-runtime": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/globals": "^29.7.0",
-				"@jest/source-map": "^29.6.3",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^1.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/jest-validate": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"leven": "^3.1.0",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/jest-watcher": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
-			"dev": true,
-			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"emittery": "^0.13.1",
-				"jest-util": "^29.7.0",
-				"string-length": "^4.0.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/jest-worker": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"jest-util": "^29.7.0",
-				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/pretty-format": {
+		"node_modules/jest-config/node_modules/pretty-format": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
 			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
@@ -28060,84 +28078,11 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-cli/node_modules/react-is": {
+		"node_modules/jest-config/node_modules/react-is": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
 			"dev": true
-		},
-		"node_modules/jest-cli/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/source-map-support": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-			"dev": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/jest-cli/node_modules/string-length": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-			"dev": true,
-			"dependencies": {
-				"char-regex": "^1.0.2",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jest-cli/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-cli/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/jest-cli/node_modules/v8-to-istanbul": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.12",
-				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.12.0"
-			}
 		},
 		"node_modules/jest-dev-server": {
 			"version": "10.1.4",
@@ -28203,6 +28148,18 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
 			"dev": true
+		},
+		"node_modules/jest-docblock": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+			"dev": true,
+			"dependencies": {
+				"detect-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
 		},
 		"node_modules/jest-environment-jsdom": {
 			"version": "29.7.0",
@@ -28282,35 +28239,50 @@
 				"fsevents": "^2.3.2"
 			}
 		},
-		"node_modules/jest-haste-map/node_modules/jest-worker": {
+		"node_modules/jest-leak-detector": {
 			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*",
-				"jest-util": "^29.7.0",
-				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
+				"jest-get-type": "^29.6.3",
+				"pretty-format": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-haste-map/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+		"node_modules/jest-leak-detector/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
 			"engines": {
 				"node": ">=10"
 			},
 			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
+		},
+		"node_modules/jest-leak-detector/node_modules/pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-leak-detector/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true
 		},
 		"node_modules/jest-matcher-utils": {
 			"version": "29.7.0",
@@ -28451,332 +28423,7 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-resolve-dependencies": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
-			"dev": true,
-			"dependencies": {
-				"jest-regex-util": "^29.6.3",
-				"jest-snapshot": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-resolve-dependencies/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-resolve-dependencies/node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-resolve-dependencies/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-resolve-dependencies/node_modules/react-is": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true
-		},
-		"node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/@jest/core": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
-			"dev": true,
-			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/reporters": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-changed-files": "^29.7.0",
-				"jest-config": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-resolve-dependencies": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest/node_modules/@jest/globals": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/@jest/reporters": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-			"dev": true,
-			"dependencies": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^6.0.0",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"slash": "^3.0.0",
-				"string-length": "^4.0.1",
-				"strip-ansi": "^6.0.0",
-				"v8-to-istanbul": "^9.0.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest/node_modules/@jest/source-map": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/@jest/test-sequencer": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest/node_modules/istanbul-lib-instrument": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.23.9",
-				"@babel/parser": "^7.23.9",
-				"@istanbuljs/schema": "^0.1.3",
-				"istanbul-lib-coverage": "^3.2.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jest/node_modules/jest-config": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-jest": "^29.7.0",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"parse-json": "^5.2.0",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@types/node": "*",
-				"ts-node": ">=9.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"ts-node": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest/node_modules/jest-docblock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-			"dev": true,
-			"dependencies": {
-				"detect-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/jest-leak-detector": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-			"dev": true,
-			"dependencies": {
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/jest-resolve": {
+		"node_modules/jest-resolve": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
 			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
@@ -28796,7 +28443,20 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest/node_modules/jest-runner": {
+		"node_modules/jest-resolve-dependencies": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+			"dev": true,
+			"dependencies": {
+				"jest-regex-util": "^29.6.3",
+				"jest-snapshot": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runner": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
 			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
@@ -28828,7 +28488,26 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest/node_modules/jest-runtime": {
+		"node_modules/jest-runner/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/source-map-support": {
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/jest-runtime": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
 			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
@@ -28861,7 +28540,7 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest/node_modules/jest-snapshot": {
+		"node_modules/jest-snapshot": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
 			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
@@ -28892,7 +28571,56 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest/node_modules/jest-validate": {
+		"node_modules/jest-snapshot/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true
+		},
+		"node_modules/jest-util": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-validate": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
 			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
@@ -28909,7 +28637,39 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest/node_modules/jest-watcher": {
+		"node_modules/jest-validate/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-validate/node_modules/pretty-format": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.6.3",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-validate/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true
+		},
+		"node_modules/jest-watcher": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
 			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
@@ -28928,7 +28688,7 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest/node_modules/jest-worker": {
+		"node_modules/jest-worker": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
 			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
@@ -28943,71 +28703,7 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/react-is": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true
-		},
-		"node_modules/jest/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/jest/node_modules/source-map-support": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-			"dev": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/jest/node_modules/string-length": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-			"dev": true,
-			"dependencies": {
-				"char-regex": "^1.0.2",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jest/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/supports-color": {
+		"node_modules/jest-worker/node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
@@ -29020,20 +28716,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/jest/node_modules/v8-to-istanbul": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.12",
-				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.12.0"
 			}
 		},
 		"node_modules/joi": {
@@ -29086,9 +28768,9 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"dev": true,
 			"dependencies": {
 				"argparse": "^1.0.7",
@@ -29159,9 +28841,9 @@
 			}
 		},
 		"node_modules/jsesc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -29352,15 +29034,6 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
-		"node_modules/lazystream/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/legacy-javascript": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
@@ -29494,17 +29167,17 @@
 			"dev": true
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-			"version": "2.10.5",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
-			"integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+			"integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
 			"dev": true,
 			"dependencies": {
-				"debug": "^4.4.1",
+				"debug": "^4.4.3",
 				"extract-zip": "^2.0.1",
 				"progress": "^2.0.3",
 				"proxy-agent": "^6.5.0",
-				"semver": "^7.7.2",
-				"tar-fs": "^3.0.8",
+				"semver": "^7.7.4",
+				"tar-fs": "^3.1.1",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -29515,9 +29188,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -29527,9 +29200,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/chromium-bidi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
-			"integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+			"integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
 			"dev": true,
 			"dependencies": {
 				"mitt": "^3.0.1",
@@ -29539,56 +29212,34 @@
 				"devtools-protocol": "*"
 			}
 		},
-		"node_modules/lighthouse/node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/lighthouse/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
-		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.10.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.10.0.tgz",
-			"integrity": "sha512-xX0QJRc8t19iAwRDsAOR38Q/Zx/W6WVzJCEhKCAwp2XMsaWqfNtQ+rBfQW9PlF+Op24d7c8Zlgq9YNmbnA7hdQ==",
+			"version": "24.40.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
+			"integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
 			"dev": true,
 			"dependencies": {
-				"@puppeteer/browsers": "2.10.5",
-				"chromium-bidi": "5.1.0",
-				"debug": "^4.4.1",
-				"devtools-protocol": "0.0.1452169",
-				"typed-query-selector": "^2.12.0",
-				"ws": "^8.18.2"
+				"@puppeteer/browsers": "2.13.0",
+				"chromium-bidi": "14.0.0",
+				"debug": "^4.4.3",
+				"devtools-protocol": "0.0.1581282",
+				"typed-query-selector": "^2.12.1",
+				"webdriver-bidi-protocol": "0.4.1",
+				"ws": "^8.19.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1452169",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1452169.tgz",
-			"integrity": "sha512-FOFDVMGrAUNp0dDKsAU1TorWJUx2JOU1k9xdgBKKJF3IBh/Uhl2yswG5r3TEAOrCiGY2QRp1e6LVDQrCsTKO4g==",
+			"version": "0.0.1581282",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+			"integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
 			"dev": true
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.18.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-			"integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -29637,9 +29288,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/zod": {
-			"version": "3.25.61",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.61.tgz",
-			"integrity": "sha512-fzfJgUw78LTNnHujj9re1Ov/JJQkRZZGDMcYqSx7Hp4rPOkKywaFHq0S6GoHeXs0wGNE/sIOutkXgnwzrVOGCQ==",
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
@@ -29711,20 +29362,6 @@
 				"url": "https://opencollective.com/lint-staged"
 			}
 		},
-		"node_modules/lint-staged/node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/lint-staged/node_modules/execa": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -29746,21 +29383,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/lint-staged/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/listr2": {
@@ -29806,12 +29428,16 @@
 			}
 		},
 		"node_modules/loader-runner": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+			"integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.11.5"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/loader-utils": {
@@ -30331,9 +29957,9 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -30648,9 +30274,9 @@
 			}
 		},
 		"node_modules/miller-rabin/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true
 		},
 		"node_modules/mime": {
@@ -30726,11 +30352,10 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -30763,11 +30388,10 @@
 			"license": "MIT"
 		},
 		"node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ajv": "^8.9.0",
@@ -30794,9 +30418,9 @@
 			"dev": true
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -30933,9 +30557,9 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/msw": {
 			"version": "1.3.2",
@@ -31086,6 +30710,13 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
+			"optional": true
+		},
 		"node_modules/node-exports-info": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -31171,9 +30802,9 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"version": "2.0.37",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+			"integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
 			"dev": true
 		},
 		"node_modules/node-wp-i18n": {
@@ -31338,9 +30969,9 @@
 			}
 		},
 		"node_modules/npm-package-json-lint/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -31853,9 +31484,9 @@
 			}
 		},
 		"node_modules/pac-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 14"
@@ -32127,9 +31758,9 @@
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.6"
@@ -33055,9 +32686,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.1.tgz",
-			"integrity": "sha512-b4dlw/9V8A71rLIDsSwVmak9z2DuBUB7CA1/wSdelNEzqsjoSPeADTWNO09lpH49Diy3/JIZ2bSPB1dI3LJCHg==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
 			"dev": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -33304,9 +32935,9 @@
 			}
 		},
 		"node_modules/proxy-agent/node_modules/agent-base": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 14"
@@ -33379,9 +33010,9 @@
 			}
 		},
 		"node_modules/public-encrypt/node_modules/bn.js": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"version": "4.12.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true
 		},
 		"node_modules/pump": {
@@ -33420,33 +33051,10 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/puppeteer-core/node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/puppeteer-core/node_modules/devtools-protocol": {
 			"version": "0.0.1367902",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
 			"integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-			"dev": true
-		},
-		"node_modules/puppeteer-core/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
 		},
 		"node_modules/pure-rand": {
@@ -33464,6 +33072,24 @@
 					"url": "https://opencollective.com/fast-check"
 				}
 			]
+		},
+		"node_modules/qified": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/qified/-/qified-0.9.1.tgz",
+			"integrity": "sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==",
+			"dev": true,
+			"dependencies": {
+				"hookified": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/qified/node_modules/hookified": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-2.1.1.tgz",
+			"integrity": "sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==",
+			"dev": true
 		},
 		"node_modules/qrcode.react": {
 			"version": "3.1.0",
@@ -33663,6 +33289,36 @@
 				"react": "^0.14 || ^15.5.4 || ^16.1.1",
 				"react-dom": "^0.14 || ^15.5.4 || ^16.1.1",
 				"react-with-direction": "^1.3.1"
+			}
+		},
+		"node_modules/react-day-picker": {
+			"version": "9.14.0",
+			"resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+			"integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+			"dependencies": {
+				"@date-fns/tz": "^1.4.1",
+				"@tabby_ai/hijri-converter": "1.0.5",
+				"date-fns": "^4.1.0",
+				"date-fns-jalali": "4.1.0-0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/gpbl"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/react-day-picker/node_modules/date-fns": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/react-dom": {
@@ -34190,18 +33846,18 @@
 			}
 		},
 		"node_modules/readdir-glob/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/readdir-glob/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -34272,6 +33928,18 @@
 			},
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0"
+			}
+		},
+		"node_modules/rechoir": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+			"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+			"dev": true,
+			"dependencies": {
+				"resolve": "^1.9.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/redent": {
@@ -34408,18 +34076,6 @@
 				"regjsparser": "bin/parser"
 			}
 		},
-		"node_modules/regjsparser/node_modules/jsesc": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-			"dev": true,
-			"bin": {
-				"jsesc": "bin/jsesc"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/remark": {
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
@@ -34523,16 +34179,20 @@
 			"dev": true
 		},
 		"node_modules/resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
 			"dependencies": {
-				"is-core-module": "^2.13.0",
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
 			"bin": {
 				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -34679,9 +34339,9 @@
 			}
 		},
 		"node_modules/rtlcss/node_modules/postcss": {
-			"version": "8.4.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-			"integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+			"version": "8.5.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+			"integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
 			"dev": true,
 			"funding": [
 				{
@@ -34698,18 +34358,18 @@
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.7",
-				"picocolors": "^1.0.1",
-				"source-map-js": "^1.2.0"
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/rtlcss/node_modules/source-map-js": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -35064,12 +34724,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/send/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
 		},
 		"node_modules/sentence-case": {
 			"version": "3.0.4",
@@ -35748,21 +35402,21 @@
 			}
 		},
 		"node_modules/socks-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 14"
 			}
 		},
 		"node_modules/source-map": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
 			"dev": true,
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 12"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -36007,16 +35661,14 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-			"integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+			"integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
 			"dev": true,
 			"dependencies": {
+				"events-universal": "^1.0.0",
 				"fast-fifo": "^1.3.2",
 				"text-decoder": "^1.1.0"
-			},
-			"optionalDependencies": {
-				"bare-events": "^2.2.0"
 			}
 		},
 		"node_modules/strict-event-emitter": {
@@ -36027,12 +35679,17 @@
 			"license": "MIT"
 		},
 		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dependencies": {
-				"safe-buffer": "~5.2.0"
+				"safe-buffer": "~5.1.0"
 			}
+		},
+		"node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/string-argv": {
 			"version": "0.3.1",
@@ -36041,6 +35698,31 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.6.19"
+			}
+		},
+		"node_modules/string-length": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+			"dev": true,
+			"dependencies": {
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/string-length/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/string-similarity": {
@@ -36522,62 +36204,56 @@
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "6.12.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
-			"integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
+			"integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
 			"dev": true,
 			"dependencies": {
 				"css-tree": "^3.0.1",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.36.0",
-				"mdn-data": "^2.21.0",
+				"known-css-properties": "^0.37.0",
+				"mdn-data": "^2.25.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.6",
-				"postcss-selector-parser": "^7.1.0",
+				"postcss-selector-parser": "^7.1.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
 				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^16.0.2"
+				"stylelint": "^16.8.2"
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/css-tree": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
 			"dependencies": {
-				"mdn-data": "2.12.2",
-				"source-map-js": "^1.0.1"
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
-		"node_modules/stylelint-scss/node_modules/css-tree/node_modules/mdn-data": {
-			"version": "2.12.2",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-			"dev": true
-		},
 		"node_modules/stylelint-scss/node_modules/known-css-properties": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
-			"integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
 			"dev": true
 		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
-			"integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
 			"dev": true
 		},
 		"node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -36654,15 +36330,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/stylelint/node_modules/ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/stylelint/node_modules/kind-of": {
@@ -36884,9 +36551,9 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -36943,18 +36610,22 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+			"integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-			"integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+			"integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
 			"dev": true,
 			"dependencies": {
 				"pump": "^3.0.0",
@@ -36966,12 +36637,13 @@
 			}
 		},
 		"node_modules/tar-fs/node_modules/tar-stream": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+			"integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
 			"dev": true,
 			"dependencies": {
 				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
 				"fast-fifo": "^1.2.0",
 				"streamx": "^2.15.0"
 			}
@@ -36990,6 +36662,15 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"dev": true,
+			"dependencies": {
+				"streamx": "^2.12.5"
 			}
 		},
 		"node_modules/terser": {
@@ -37011,15 +36692,14 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-			"integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+			"integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
 				"terser": "^5.31.1"
 			},
 			"engines": {
@@ -37045,9 +36725,9 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -37093,9 +36773,9 @@
 			"dev": true
 		},
 		"node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
@@ -37162,12 +36842,16 @@
 			"dev": true
 		},
 		"node_modules/thingies": {
-			"version": "1.21.0",
-			"resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
-			"integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
+			"integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
 			},
 			"peerDependencies": {
 				"tslib": "^2"
@@ -37218,9 +36902,9 @@
 			}
 		},
 		"node_modules/tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.14"
@@ -37306,9 +36990,9 @@
 			}
 		},
 		"node_modules/tree-dump": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
-			"integrity": "sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+			"integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0"
@@ -37618,9 +37302,9 @@
 			}
 		},
 		"node_modules/typed-query-selector": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-			"integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+			"integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
 			"dev": true
 		},
 		"node_modules/typedarray-to-buffer": {
@@ -37884,9 +37568,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -38058,11 +37742,11 @@
 			}
 		},
 		"node_modules/use-sync-external-store": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-			"integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
 			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/util": {
@@ -38119,6 +37803,20 @@
 			"integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
 			"dev": true
 		},
+		"node_modules/v8-to-istanbul": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.12",
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.12.0"
+			}
+		},
 		"node_modules/validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -38161,14 +37859,6 @@
 				"react": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/valtio/node_modules/use-sync-external-store": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/vary": {
@@ -38265,20 +37955,20 @@
 			}
 		},
 		"node_modules/wait-on/node_modules/axios": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-			"integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
 			"dev": true,
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/wait-on/node_modules/follow-redirects": {
-			"version": "1.15.9",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"dev": true,
 			"funding": [
 				{
@@ -38293,6 +37983,15 @@
 				"debug": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/wait-on/node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/walker": {
@@ -38313,9 +38012,9 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
-			"integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+			"integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
 			"dev": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
@@ -38359,6 +38058,12 @@
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
 			"integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+			"dev": true
+		},
+		"node_modules/webdriver-bidi-protocol": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+			"integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
 			"dev": true
 		},
 		"node_modules/webidl-conversions": {
@@ -38529,56 +38234,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/webpack-cli/node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/webpack-cli/node_modules/interpret": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-			"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/webpack-cli/node_modules/rechoir": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-			"integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
-			"dev": true,
-			"dependencies": {
-				"resolve": "^1.9.0"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/webpack-cli/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/webpack-dev-middleware": {
 			"version": "5.3.4",
 			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
@@ -38603,9 +38258,9 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -38719,9 +38374,9 @@
 			"dev": true
 		},
 		"node_modules/webpack-dev-server/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -38758,21 +38413,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-			"dev": true,
-			"dependencies": {
-				"is-inside-container": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -38780,34 +38420,69 @@
 			"dev": true
 		},
 		"node_modules/webpack-dev-server/node_modules/memfs": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.2.tgz",
-			"integrity": "sha512-NgYhCOWgovOXSzvYgUW0LQ7Qy72rWQMGGFJDoWg4G30RHd3z77VbYdtJ4fembJXBy8pMIUA31XNAupobOQlwdg==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.1.tgz",
+			"integrity": "sha512-WvzrWPwMQT+PtbX2Et64R4qXKK0fj/8pO85MrUCzymX3twwCiJCdvntW3HdhG1teLJcHDDLIKx5+c3HckWYZtQ==",
 			"dev": true,
 			"dependencies": {
-				"@jsonjoy.com/json-pack": "^1.0.3",
-				"@jsonjoy.com/util": "^1.3.0",
-				"tree-dump": "^1.0.1",
+				"@jsonjoy.com/fs-core": "4.57.1",
+				"@jsonjoy.com/fs-fsa": "4.57.1",
+				"@jsonjoy.com/fs-node": "4.57.1",
+				"@jsonjoy.com/fs-node-builtins": "4.57.1",
+				"@jsonjoy.com/fs-node-to-fsa": "4.57.1",
+				"@jsonjoy.com/fs-node-utils": "4.57.1",
+				"@jsonjoy.com/fs-print": "4.57.1",
+				"@jsonjoy.com/fs-snapshot": "4.57.1",
+				"@jsonjoy.com/json-pack": "^1.11.0",
+				"@jsonjoy.com/util": "^1.9.0",
+				"glob-to-regex.js": "^1.0.1",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.0.3",
 				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 4.0.0"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/webpack-dev-server/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/open": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
-			"integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
 			"dev": true,
 			"dependencies": {
 				"default-browser": "^5.2.1",
 				"define-lazy-prop": "^3.0.0",
 				"is-inside-container": "^1.0.0",
-				"is-wsl": "^3.1.0"
+				"wsl-utils": "^0.1.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -38834,9 +38509,9 @@
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/schema-utils": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-			"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+			"integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
@@ -38845,7 +38520,7 @@
 				"ajv-keywords": "^5.1.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 10.13.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -38853,14 +38528,14 @@
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/webpack-dev-middleware": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
-			"integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+			"integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
 			"dev": true,
 			"dependencies": {
 				"colorette": "^2.0.10",
-				"memfs": "^4.6.0",
-				"mime-types": "^2.1.31",
+				"memfs": "^4.43.1",
+				"mime-types": "^3.0.1",
 				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^4.0.0"
@@ -38942,9 +38617,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.13.0"
@@ -39187,9 +38862,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"devOptional": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -39205,6 +38880,36 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"dev": true,
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wsl-utils/node_modules/is-wsl": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+			"dev": true,
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/xdg-basedir": {
@@ -39363,20 +39068,6 @@
 				"yarnhook": "index.js"
 			}
 		},
-		"node_modules/yarnhook/node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/yarnhook/node_modules/execa": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -39398,21 +39089,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/yarnhook/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/yauzl": {


### PR DESCRIPTION

#### Changes proposed in this Pull Request


I run `npm dedupe` in a loop until it couldn't dedupe.

The result: 

- `@types/react` deduplication. Multiple packages (`@automattic/components`, `@automattic/tour-kit`, `@wordpress/block-editor`, `@wordpress/primitives`, etc.) had their own nested copies of `@types/react` 18.3.3. Those nested copies are removed, and the packages now share the top-level one.

- **`@types/react-dom` structural fix** - The package changed from using `dependencies: { "@types/react": "*" }` to `peerDependencies`. The older pattern was technically incorrect; the new one is the right way to declare this relationship.

- **Minor patch bumps** (`memize` 2.1.0→2.1.1, `path-to-regexp` 6.2.2→6.3.0, etc.) - routine and safe.

**Changes worth noting (not harmful, but not just deduplication):**

- **`framer-motion` 11.3.6 → 11.18.2** — A big jump within the same major version. It pulls in two new packages (`motion-dom`, `motion-utils`) that were extracted from the main bundle. Should be fine but it's a real dependency update, not pure deduplication.

- **`@wordpress/*` nested packages** — Large jumps like `@wordpress/compose` 7.3.0 → 7.43.0 under `@automattic/i18n-utils`. WordPress packages use a weekly release cadence, so `.43` just means many weekly releases have passed. These are within the `^` semver range declared, so they're valid.

- **`@babel/plugin-syntax-import-attributes` 7.27.1 → 7.26.0** — A small downgrade. This happens when dedupe resolves a version that satisfies all consumers' ranges simultaneously; not a problem.

- **New packages added** (`@cacheable/memory`, `@cacheable/utils`, `@csstools/css-syntax-patches-for-csstree`) — These are transitive deps of the updated packages above, not direct additions.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All tests shall pass.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
