### PR TITLE
refactor: move ECE title into gateway

### DIFF
--- a/changelog/refactor-move-express-checkout-title-to-gateway
+++ b/changelog/refactor-move-express-checkout-title-to-gateway
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+refactor: extract payment method detection to gateway

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2412,10 +2412,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
+		// Detect express checkout type: first from metadata that may have been set earlier in the flow,
+		// then fall back to Stripe's wallet info (authoritative for Apple Pay, Google Pay, Link).
+		$express_checkout_type = $order->get_meta( '_wcpay_express_checkout_payment_method' );
+		if ( ! $express_checkout_type && ! empty( $payment_method_details['card']['wallet']['type'] ) ) {
+			$express_checkout_type = sanitize_text_field( $payment_method_details['card']['wallet']['type'] );
+			$order->update_meta_data( '_wcpay_express_checkout_payment_method', $express_checkout_type );
+		}
+
 		// express checkout can be Amazon Pay/Google Pay/Apple Pay/Link,
 		// but Google Pay/Apple Pay/Link use the `card` gateway; Amazon Pay has its own gateway.
-		$express_checkout_type = $order->get_meta( '_wcpay_express_checkout_payment_method' );
-		$effective_type        = $express_checkout_type ? $express_checkout_type : $payment_method_type;
+		$effective_type = $express_checkout_type ? $express_checkout_type : $payment_method_type;
 
 		$payment_methods_using_card = [ Payment_Method::CARD, Payment_Method::LINK, Payment_Method::GOOGLE_PAY, Payment_Method::APPLE_PAY ];
 		$payment_gateway            = in_array( $effective_type, $payment_methods_using_card, true )
@@ -2425,8 +2432,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// this will ensure that the refunds are handled by the correct split gateway class.
 		$order->set_payment_method( $payment_gateway );
 
-		// the Express Checkout handler already set the method's title in `tokenized_cart_set_payment_method_type`, earlier in the flow.
-		if ( ! $express_checkout_type ) {
+		if ( $express_checkout_type ) {
+			$express_method = WC_Payments::get_payment_method_by_id( $express_checkout_type );
+			$title          = $express_method ? $express_method->get_title() : null;
+			if ( $title ) {
+				$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
+				if ( ! empty( $suffix ) ) {
+					$suffix = " ($suffix)";
+				}
+				$order->set_payment_method_title( $title . $suffix );
+			}
+		} else {
 			$order->set_payment_method_title( $payment_method->get_title( $this->get_account_country(), $payment_method_details ) );
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2415,8 +2415,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Detect express checkout type: first from metadata that may have been set earlier in the flow,
 		// then fall back to Stripe's wallet info (authoritative for Apple Pay, Google Pay, Link).
 		$express_checkout_type = $order->get_meta( '_wcpay_express_checkout_payment_method' );
-		if ( ! $express_checkout_type && ! empty( $payment_method_details['card']['wallet']['type'] ) ) {
-			$express_checkout_type = sanitize_text_field( $payment_method_details['card']['wallet']['type'] );
+		$wallet_type           = is_array( $payment_method_details ) ? $payment_method_details['card']['wallet']['type'] ?? null : null;
+		if ( ! $express_checkout_type && $wallet_type ) {
+			$express_checkout_type = sanitize_text_field( $wallet_type );
 			$order->update_meta_data( '_wcpay_express_checkout_payment_method', $express_checkout_type );
 		}
 
@@ -2434,14 +2435,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		if ( $express_checkout_type ) {
 			$express_method = WC_Payments::get_payment_method_by_id( $express_checkout_type );
-			$title          = $express_method ? $express_method->get_title() : null;
-			if ( $title ) {
-				$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
-				if ( ! empty( $suffix ) ) {
-					$suffix = " ($suffix)";
-				}
-				$order->set_payment_method_title( $title . $suffix );
+			$title          = $express_method ? $express_method->get_title() : 'Payment Request';
+			$suffix         = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
+			if ( ! empty( $suffix ) ) {
+				$suffix = " ($suffix)";
 			}
+			$order->set_payment_method_title( $title . $suffix );
 		} else {
 			$order->set_payment_method_title( $payment_method->get_title( $this->get_account_country(), $payment_method_details ) );
 		}

--- a/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-ajax-handler.php
@@ -49,15 +49,6 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 			);
 		}
 
-		add_action(
-			'woocommerce_store_api_checkout_update_order_from_request',
-			[
-				$this,
-				'tokenized_cart_set_payment_method_type',
-			],
-			10,
-			2
-		);
 		add_filter( 'rest_pre_dispatch', [ $this, 'tokenized_cart_store_api_address_normalization' ], 10, 3 );
 		add_filter( 'woocommerce_get_country_locale', [ $this, 'modify_country_locale_for_express_checkout' ], 20 );
 	}
@@ -153,63 +144,6 @@ class WC_Payments_Express_Checkout_Ajax_Handler {
 		}
 
 		wp_send_json( $data );
-	}
-
-	/**
-	 * Updates the checkout order based on the request, to set the Apple Pay/Google Pay payment method title.
-	 *
-	 * @param \WC_Order        $order The order to be updated.
-	 * @param \WP_REST_Request $request Store API request to update the order.
-	 */
-	public function tokenized_cart_set_payment_method_type( \WC_Order $order, \WP_REST_Request $request ) {
-		if ( ! isset( $request['payment_method'] ) || 'woocommerce_payments' !== $request['payment_method'] ) {
-			return;
-		}
-
-		if ( empty( $request['payment_data'] ) ) {
-			return;
-		}
-
-		$payment_data = [];
-		foreach ( $request['payment_data'] as $data ) {
-			$payment_data[ sanitize_key( $data['key'] ) ] = wc_clean( $data['value'] );
-		}
-
-		if ( empty( $payment_data['express_payment_type'] ) ) {
-			return;
-		}
-
-		$express_payment_type = wc_clean( wp_unslash( $payment_data['express_payment_type'] ) );
-
-		$payment_method_title = $this->get_payment_method_title_from_definition( $express_payment_type );
-		// fallback, just in case.
-		if ( ! $payment_method_title ) {
-			$payment_method_title = 'Payment Request';
-		}
-
-		$suffix = apply_filters( 'wcpay_payment_request_payment_method_title_suffix', 'WooPayments' );
-		if ( ! empty( $suffix ) ) {
-			$suffix = " ($suffix)";
-		}
-
-		$order->set_payment_method_title( $payment_method_title . $suffix );
-		$order->update_meta_data( '_wcpay_express_checkout_payment_method', $express_payment_type );
-	}
-
-	/**
-	 * Get the payment method title from the definition.
-	 *
-	 * @param string $payment_method_id The payment method ID (e.g., 'apple_pay', 'google_pay').
-	 * @return string|null The payment method title or null if not found.
-	 */
-	private function get_payment_method_title_from_definition( $payment_method_id ) {
-		$payment_method = WC_Payments::get_payment_method_by_id( $payment_method_id );
-
-		if ( $payment_method && method_exists( $payment_method, 'get_title' ) ) {
-			return $payment_method->get_title();
-		}
-
-		return null;
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -580,7 +580,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 						],
 					],
 				],
-				'expected_title'   => 'Link',
+				'expected_title'   => 'Link (WooPayments)',
 				'expected_gateway' => 'woocommerce_payments',
 			],
 		];
@@ -659,26 +659,183 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Test that Express Checkout payments set the correct gateway ID and preserve title.
+	 * Test that Express Checkout payments set the correct gateway ID and title
+	 * when the express checkout type is already stored in order meta (e.g. set by JS earlier in the flow).
 	 *
 	 * @dataProvider express_checkout_payment_method_provider
 	 *
 	 * @param string $express_type     The express checkout type stored in order meta.
 	 * @param string $stripe_type      The Stripe payment method type.
-	 * @param string $expected_title   The expected payment method title to be preserved.
+	 * @param string $expected_title   The expected payment method title.
 	 * @param string $expected_gateway The expected gateway ID.
 	 * @param array  $payment_details  The payment method details from Stripe.
 	 */
 	public function test_express_checkout_payment_method_for_order( $express_type, $stripe_type, $expected_title, $expected_gateway, $payment_details ) {
 		$order = WC_Helper_Order::create_order();
-		$order->set_payment_method_title( $expected_title );
 		$order->update_meta_data( '_wcpay_express_checkout_payment_method', $express_type );
 		$order->save();
 
 		$this->card_gateway->set_payment_method_title_for_order( $order, $stripe_type, $payment_details );
 
 		$this->assertEquals( $expected_gateway, $order->get_payment_method(), "$express_type should use correct gateway" );
-		$this->assertEquals( $expected_title, $order->get_payment_method_title(), "$express_type title should be preserved" );
+		$this->assertEquals( $expected_title, $order->get_payment_method_title(), "$express_type title should be set by the gateway" );
+	}
+
+	/**
+	 * Data provider for wallet-based express checkout detection tests.
+	 *
+	 * These test the scenario where no `_wcpay_express_checkout_payment_method` meta
+	 * exists on the order, and the gateway detects the express type from Stripe's
+	 * `card.wallet.type` field.
+	 *
+	 * @return array[]
+	 */
+	public function wallet_detection_provider() {
+		return [
+			'Google Pay detected from wallet' => [
+				'wallet_type'      => 'google_pay',
+				'expected_title'   => 'Google Pay (WooPayments)',
+				'expected_gateway' => 'woocommerce_payments',
+			],
+			'Apple Pay detected from wallet'  => [
+				'wallet_type'      => 'apple_pay',
+				'expected_title'   => 'Apple Pay (WooPayments)',
+				'expected_gateway' => 'woocommerce_payments',
+			],
+		];
+	}
+
+	/**
+	 * Test that express checkout type is detected from Stripe's card.wallet.type
+	 * when no meta is pre-set on the order, and the title and meta are set correctly.
+	 *
+	 * @dataProvider wallet_detection_provider
+	 *
+	 * @param string $wallet_type      The Stripe wallet type.
+	 * @param string $expected_title   The expected payment method title.
+	 * @param string $expected_gateway The expected gateway ID.
+	 */
+	public function test_wallet_detection_sets_title_and_meta( $wallet_type, $expected_title, $expected_gateway ) {
+		$order           = WC_Helper_Order::create_order();
+		$payment_details = [
+			'type' => 'card',
+			'card' => [
+				'network' => 'visa',
+				'wallet'  => [
+					'type' => $wallet_type,
+				],
+			],
+		];
+
+		$this->card_gateway->set_payment_method_title_for_order( $order, 'card', $payment_details );
+
+		$this->assertEquals( $expected_title, $order->get_payment_method_title(), "$wallet_type title should be set from wallet detection" );
+		$this->assertEquals( $expected_gateway, $order->get_payment_method(), "$wallet_type should use correct gateway" );
+		$this->assertEquals( $wallet_type, $order->get_meta( '_wcpay_express_checkout_payment_method' ), "$wallet_type meta should be persisted" );
+	}
+
+	/**
+	 * Test that the express checkout title suffix can be customized via filter.
+	 */
+	public function test_express_checkout_title_suffix_filter() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_express_checkout_payment_method', 'google_pay' );
+		$order->save();
+
+		add_filter(
+			'wcpay_payment_request_payment_method_title_suffix',
+			function () {
+				return 'Custom Suffix';
+			}
+		);
+
+		$payment_details = [
+			'type' => 'card',
+			'card' => [
+				'network' => 'visa',
+				'funding' => 'credit',
+			],
+		];
+
+		$this->card_gateway->set_payment_method_title_for_order( $order, 'card', $payment_details );
+
+		$this->assertEquals( 'Google Pay (Custom Suffix)', $order->get_payment_method_title() );
+
+		// Clean up.
+		remove_all_filters( 'wcpay_payment_request_payment_method_title_suffix' );
+	}
+
+	/**
+	 * Test that an empty suffix filter produces a title without parentheses.
+	 */
+	public function test_express_checkout_title_empty_suffix() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_express_checkout_payment_method', 'apple_pay' );
+		$order->save();
+
+		add_filter( 'wcpay_payment_request_payment_method_title_suffix', '__return_empty_string' );
+
+		$payment_details = [
+			'type' => 'card',
+			'card' => [
+				'network' => 'visa',
+				'funding' => 'credit',
+			],
+		];
+
+		$this->card_gateway->set_payment_method_title_for_order( $order, 'card', $payment_details );
+
+		$this->assertEquals( 'Apple Pay', $order->get_payment_method_title() );
+
+		// Clean up.
+		remove_all_filters( 'wcpay_payment_request_payment_method_title_suffix' );
+	}
+
+	/**
+	 * Test that pre-existing meta takes precedence over wallet detection.
+	 * If JS already set the meta earlier in the flow, the gateway should use that
+	 * rather than detecting from Stripe's wallet info.
+	 */
+	public function test_existing_meta_takes_precedence_over_wallet_detection() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wcpay_express_checkout_payment_method', 'google_pay' );
+		$order->save();
+
+		// Stripe wallet says apple_pay, but meta says google_pay — meta wins.
+		$payment_details = [
+			'type' => 'card',
+			'card' => [
+				'network' => 'visa',
+				'wallet'  => [
+					'type' => 'apple_pay',
+				],
+			],
+		];
+
+		$this->card_gateway->set_payment_method_title_for_order( $order, 'card', $payment_details );
+
+		$this->assertEquals( 'Google Pay (WooPayments)', $order->get_payment_method_title() );
+		$this->assertEquals( 'google_pay', $order->get_meta( '_wcpay_express_checkout_payment_method' ), 'Meta should remain unchanged' );
+	}
+
+	/**
+	 * Test that a regular card payment (no wallet, no meta) sets the standard card title,
+	 * not an express checkout title.
+	 */
+	public function test_regular_card_payment_not_detected_as_express() {
+		$order           = WC_Helper_Order::create_order();
+		$payment_details = [
+			'type' => 'card',
+			'card' => [
+				'network' => 'visa',
+				'funding' => 'credit',
+			],
+		];
+
+		$this->card_gateway->set_payment_method_title_for_order( $order, 'card', $payment_details );
+
+		$this->assertEmpty( $order->get_meta( '_wcpay_express_checkout_payment_method' ), 'Regular card should not have express meta' );
+		$this->assertEquals( 'woocommerce_payments', $order->get_payment_method() );
 	}
 
 	public function test_payment_methods_show_correct_default_outputs() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -742,12 +742,10 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data( '_wcpay_express_checkout_payment_method', 'google_pay' );
 		$order->save();
 
-		add_filter(
-			'wcpay_payment_request_payment_method_title_suffix',
-			function () {
-				return 'Custom Suffix';
-			}
-		);
+		$callback = function () {
+			return 'Custom Suffix';
+		};
+		add_filter( 'wcpay_payment_request_payment_method_title_suffix', $callback );
 
 		$payment_details = [
 			'type' => 'card',
@@ -761,8 +759,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$this->assertEquals( 'Google Pay (Custom Suffix)', $order->get_payment_method_title() );
 
-		// Clean up.
-		remove_all_filters( 'wcpay_payment_request_payment_method_title_suffix' );
+		remove_filter( 'wcpay_payment_request_payment_method_title_suffix', $callback );
 	}
 
 	/**
@@ -787,8 +784,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 		$this->assertEquals( 'Apple Pay', $order->get_payment_method_title() );
 
-		// Clean up.
-		remove_all_filters( 'wcpay_payment_request_payment_method_title_suffix' );
+		remove_filter( 'wcpay_payment_request_payment_method_title_suffix', '__return_empty_string' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOPMNT-6102


#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Trying to split the larger "dynamic 'place order' button" PR into more manageable chunks.

In this PR, I'm extracting the payment method title logic from the ECE-specific handler into the gateway.
The method was in the ECE handler because we assumed that all ECE payment methods would be using the Store API to place orders.
With the "dynamic 'place order' button", we're rendering ECE buttons within the payment methods list (both on shortcode and cart-based checkouts), and the processing is done through the "normal" `process_payment` path (skipping the `woocommerce_store_api_checkout_update_order_from_request` hook for the shortcode checkout).

So this logic wouldn't work anymore.
Instead of duplicating, I am moving the logic into the main gateway class, so that it can be consistently applied.
The only drawback is that this logic is triggered later than it was before. It's triggered when we process the payment. Previously, it was triggered before we were processing the payment. 

This discrepancy can create some minor issues, where, for example, if the payment fails or is pending, the payment method title might not always be reported correctly (but that is happening also for "normal" card payments). 

With ECE (when processing -> after processing):
<img width="708" height="97" alt="Screenshot 2026-04-14 at 3 36 24 PM" src="https://github.com/user-attachments/assets/d86bf1b0-91ff-4adb-ac37-e8a77b03ac38" />
<img width="702" height="88" alt="Screenshot 2026-04-14 at 3 36 31 PM" src="https://github.com/user-attachments/assets/151d4787-8ef9-427e-8800-8f5bc3b81ea4" />

With card (when processing -> after processing):
<img width="711" height="98" alt="Screenshot 2026-04-14 at 3 37 53 PM" src="https://github.com/user-attachments/assets/377a9844-975b-4f37-a8b7-6dcfa2fdb4ae" />
<img width="704" height="81" alt="Screenshot 2026-04-14 at 3 38 00 PM" src="https://github.com/user-attachments/assets/33a74965-cde5-42bf-ab3e-3b5cf6d524c6" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There should be no regressions:

1. Google Pay title (product page)
  - As a customer, navigate to a product page
  - Pay with Google Pay via the ECE
  - As a merchant, navigate to WP Admin → WooCommerce → Orders → open the latest order
  - The payment method title should show "Google Pay (WooPayments)"

Product page:
<img width="844" height="414" alt="Screenshot 2026-04-14 at 3 33 33 PM" src="https://github.com/user-attachments/assets/96ca394d-7bd6-4495-a5ae-8de989a0be1e" />

Order success:
<img width="264" height="160" alt="Screenshot 2026-04-14 at 3 34 11 PM" src="https://github.com/user-attachments/assets/0aba1fa3-b906-4237-ac79-53a303e24f95" />
<img width="188" height="144" alt="Screenshot 2026-04-14 at 3 33 51 PM" src="https://github.com/user-attachments/assets/817e9d5a-824b-42c7-bb21-7b220e005aa0" />

Orders list:
<img width="381" height="177" alt="Screenshot 2026-04-14 at 3 34 16 PM" src="https://github.com/user-attachments/assets/1376fcac-2756-44bb-a51f-d6d375575ec4" />

Order details:
<img width="298" height="65" alt="Screenshot 2026-04-14 at 3 34 31 PM" src="https://github.com/user-attachments/assets/11caedfe-737e-4131-a9ad-35d016c5be6d" />
<img width="199" height="70" alt="Screenshot 2026-04-14 at 3 34 27 PM" src="https://github.com/user-attachments/assets/a9a40566-04bd-4c18-bc0f-608fe9c691ff" />


2. Google Pay title (checkout page)
  - Go to checkout (blocks) with an item in the cart
  - Pay with Google Pay via the ECE
  - As a merchant, navigate to WP Admin → WooCommerce → Orders → open the latest order
  - The payment method title should show "Google Pay (WooPayments)"
3. Regular card payment is unaffected
  - As a customer, add a product to the cart, checkout with a regular card
  - As a merchant, navigate to WP Admin → WooCommerce → Orders → open the latest order
  - The payment method title should show "Payment via Card"
4. Refunds still work
  - Attempt a refund on an Apple Pay / Google Pay order
  - The refund should process correctly

Amazon Pay refund:
<img width="405" height="437" alt="Screenshot 2026-04-14 at 3 40 43 PM" src="https://github.com/user-attachments/assets/0867d371-3cd6-4203-936c-93fee216d024" />
<img width="362" height="247" alt="Screenshot 2026-04-14 at 3 40 35 PM" src="https://github.com/user-attachments/assets/2ad2ba0c-72d3-4c4b-94ca-5725180c1743" />

Google Pay refund (notice it says "Card" on the button - that's expected):
<img width="518" height="302" alt="Screenshot 2026-04-14 at 3 40 27 PM" src="https://github.com/user-attachments/assets/2940226f-2dbb-41de-9c67-40fd51bfed8b" />
<img width="386" height="277" alt="Screenshot 2026-04-14 at 3 40 16 PM" src="https://github.com/user-attachments/assets/28c4f920-a840-4216-ab36-35edfe7fa625" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
