### PR TITLE
Agent-first release CLI

### DIFF
--- a/.github/actions/create-branch/action.yml
+++ b/.github/actions/create-branch/action.yml
@@ -9,7 +9,11 @@ inputs:
     description: "Whether the action runs in the context of a pre-release (default: true)"
     required: true
     default: "true"
-    
+  push:
+    description: "Push the branch to origin after creating it (default: true)"
+    required: false
+    default: "true"
+
 outputs:
   trimmed-version:
     description: "The trimmed version"
@@ -34,6 +38,7 @@ runs:
       env:
         IS_PRERELEASE: ${{ inputs.is-pre-release }}
         VERSION: ${{ steps.version_format_check.outputs.trimmed-version }}
+        PUSH: ${{ inputs.push }}
       run: |
         if ${{ env.IS_PRERELEASE == 'true' }}; then
           BRANCH_NAME="testing/$VERSION"
@@ -44,5 +49,9 @@ runs:
         fi
 
         git checkout -b $BRANCH_NAME
-        git push origin $BRANCH_NAME
+        if [ "$PUSH" = "true" ]; then
+          git push origin $BRANCH_NAME
+        else
+          echo ":no_entry_sign: Dry-run: branch $BRANCH_NAME created locally but not pushed." >> $GITHUB_STEP_SUMMARY
+        fi
         echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT

--- a/.github/actions/create-tag/action.yml
+++ b/.github/actions/create-tag/action.yml
@@ -45,6 +45,15 @@ runs:
         
         git config user.name "${{ github.actor }}"
         git config user.email "${{ github.actor }}@users.noreply.github.com"
-        git tag -a -m "$TAG_MESSAGE" $VERSION
-        git push origin $VERSION
+
+        if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+          echo ":information_source: Tag $VERSION already exists locally; skipping creation." >> $GITHUB_STEP_SUMMARY
+        elif git ls-remote --tags --exit-code origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+          echo ":information_source: Tag $VERSION already exists on origin; fetching instead of creating." >> $GITHUB_STEP_SUMMARY
+          git fetch origin "refs/tags/$VERSION:refs/tags/$VERSION"
+        else
+          git tag -a -m "$TAG_MESSAGE" "$VERSION"
+          git push origin "$VERSION"
+        fi
+
         echo "TAG_MESSAGE=$TAG_MESSAGE" >> $GITHUB_OUTPUT

--- a/.github/actions/create-tag/action.yml
+++ b/.github/actions/create-tag/action.yml
@@ -49,6 +49,12 @@ runs:
         if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
           echo ":information_source: Tag $VERSION already exists locally; skipping creation." >> $GITHUB_STEP_SUMMARY
         elif git ls-remote --tags --exit-code origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+          # Pre-existing remote tag (re-run after partial failure). We emit
+          # TAG_MESSAGE below to keep downstream steps (GH release notes/title)
+          # working; the message used here may differ from the annotated-tag
+          # message on the original remote tag. That is acceptable because the
+          # release body/title get overwritten by post-release-updates.yml's
+          # 'gh release edit ... --clobber' path on the same re-run.
           echo ":information_source: Tag $VERSION already exists on origin; fetching instead of creating." >> $GITHUB_STEP_SUMMARY
           git fetch origin "refs/tags/$VERSION:refs/tags/$VERSION"
         else

--- a/.github/actions/load-version-constants/action.yml
+++ b/.github/actions/load-version-constants/action.yml
@@ -1,0 +1,17 @@
+name: "Load version constants"
+description: "Single source of truth for Gutenberg versions paired with PHP and WP minima."
+outputs:
+  gutenberg_for_wp_min:
+    description: "Gutenberg version tested against WP minimum."
+    value: ${{ steps.vars.outputs.gutenberg_for_wp_min }}
+  gutenberg_for_php_min:
+    description: "Gutenberg version tested against PHP minimum."
+    value: ${{ steps.vars.outputs.gutenberg_for_php_min }}
+runs:
+  using: "composite"
+  steps:
+    - id: vars
+      shell: bash
+      run: |
+        echo "gutenberg_for_wp_min=13.6.0" >> $GITHUB_OUTPUT
+        echo "gutenberg_for_php_min=22.3.0" >> $GITHUB_OUTPUT

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -19,11 +19,17 @@ jobs:
     outputs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
+      - uses: actions/checkout@v4
+      - name: "Load version constants"
+        id: vc
+        uses: ./.github/actions/load-version-constants
       - name: "Generate matrix"
         id: generate_matrix
+        env:
+          GUTENBERG_FOR_WP_MIN: ${{ steps.vc.outputs.gutenberg_for_wp_min }}
         run: |
           WC_VERSIONS=$( echo "[\"$WC_MIN_SUPPORTED_VERSION\", \"latest\", \"beta\"]" )
-          MATRIX_INCLUDE=$( echo "[{\"woocommerce\":\"$WC_MIN_SUPPORTED_VERSION\",\"wordpress\":\"$WP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"13.6.0\",\"php\":\"$PHP_MIN_SUPPORTED_VERSION\"}]" )
+          MATRIX_INCLUDE=$( echo "[{\"woocommerce\":\"$WC_MIN_SUPPORTED_VERSION\",\"wordpress\":\"$WP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"$GUTENBERG_FOR_WP_MIN\",\"php\":\"$PHP_MIN_SUPPORTED_VERSION\"}]" )
           echo "matrix={\"woocommerce\":$WC_VERSIONS,\"wordpress\":[\"latest\"],\"gutenberg\":[\"latest\"],\"php\":[\"7.4\"], \"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
 
   woocommerce-compatibility:

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -37,11 +37,17 @@ jobs:
     outputs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
+      - uses: actions/checkout@v4
+      - name: "Load version constants"
+        id: vc
+        uses: ./.github/actions/load-version-constants
       - name: "Generate matrix"
         id: generate_matrix
+        env:
+          GUTENBERG_FOR_PHP_MIN: ${{ steps.vc.outputs.gutenberg_for_php_min }}
         run: |
           # PHP 7.4+ can use latest Gutenberg
-          echo "matrix={\"php\":[\"7.4\"],\"gutenberg\":[\"latest\"],\"include\":[{\"php\":\"$PHP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"22.3.0\"}]}" >> $GITHUB_OUTPUT
+          echo "matrix={\"php\":[\"7.4\"],\"gutenberg\":[\"latest\"],\"include\":[{\"php\":\"$PHP_MIN_SUPPORTED_VERSION\",\"gutenberg\":\"$GUTENBERG_FOR_PHP_MIN\"}]}" >> $GITHUB_OUTPUT
 
   test:
     name: PHP testing

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -70,7 +70,13 @@ jobs:
           FILENAME: ${{ steps.build_plugin.outputs.release-filename }}
         run: |
           RELEASE_NOTES=$(echo -e "${CHANGELOG}")
-          gh release create $RELEASE_VERSION --notes "$RELEASE_NOTES" --title "$TAG_MESSAGE" $FILENAME
+          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+            echo ":information_source: Release $RELEASE_VERSION already exists; updating notes and asset." >> $GITHUB_STEP_SUMMARY
+            gh release edit "$RELEASE_VERSION" --notes "$RELEASE_NOTES" --title "$TAG_MESSAGE"
+            gh release upload "$RELEASE_VERSION" "$FILENAME" --clobber
+          else
+            gh release create "$RELEASE_VERSION" --notes "$RELEASE_NOTES" --title "$TAG_MESSAGE" "$FILENAME"
+          fi
 
   merge-trunk-into-develop:
     name: "Merge trunk back into develop"
@@ -92,8 +98,12 @@ jobs:
           git config user.name "botwoo"
           git config user.email "botwoo@users.noreply.github.com"
           git checkout develop && git pull
-          git merge trunk --no-ff -m "Merge trunk v$RELEASE_VERSION into develop"
-          git push
+          if git merge-base --is-ancestor trunk develop; then
+            echo ":information_source: develop already contains trunk v$RELEASE_VERSION; skipping merge." >> $GITHUB_STEP_SUMMARY
+          else
+            git merge trunk --no-ff -m "Merge trunk v$RELEASE_VERSION into develop"
+            git push
+          fi
 
   trigger-translations:
     name: "Trigger translations update for the release"
@@ -105,6 +115,8 @@ jobs:
         with:
           ref: 'trunk'
 
+      # Idempotent on the receiving side (GlotPress dedupes by release version);
+      # safe to re-run without extra guards.
       - name: "Trigger translations update on GlotPress"
         uses: ./.github/actions/trigger-translations
         with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -102,6 +102,9 @@ jobs:
           release-version: ${{ env.RELEASE_VERSION }}
           branch: ${{ env.BRANCH_NAME }}
 
+      - name: "Validate release branch"
+        run: ./bin/validate-release-branch.sh
+
       - name: "Create a PR to trunk"
         id: create-pr-to-trunk
         env:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: false
         description: "Skip running smoke tests"
+      dry-run:
+        type: boolean
+        required: false
+        default: false
+        description: "Dry-run: create branch, bump, and validate, but do not push, open a PR, or run smoke tests"
 
 defaults:
   run:
@@ -74,6 +79,7 @@ jobs:
         with:
           version: ${{ env.RELEASE_VERSION }}
           is-pre-release: 'false'
+          push: ${{ inputs.dry-run && 'false' || 'true' }}
 
       - name: "Define the release date"
         id: define_var
@@ -94,6 +100,7 @@ jobs:
         run: ./bin/bump-version.sh "$RELEASE_VERSION"
 
       - name: "Commit and push changes"
+        if: ${{ ! inputs.dry-run }}
         env:
           RELEASE_VERSION: ${{ steps.create_branch.outputs.trimmed-version }}
           BRANCH_NAME: ${{ steps.create_branch.outputs.branch-name }}
@@ -106,6 +113,7 @@ jobs:
         run: ./bin/validate-release-branch.sh
 
       - name: "Create a PR to trunk"
+        if: ${{ ! inputs.dry-run }}
         id: create-pr-to-trunk
         env:
           GITHUB_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
@@ -121,6 +129,7 @@ jobs:
           fi
 
       - name: Add comment to PR
+        if: ${{ ! inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_PR_ID: ${{ steps.create-pr-to-trunk.outputs.RELEASE_PR_ID }}
@@ -129,10 +138,29 @@ jobs:
 
           Check status of zip file build & smoke tests at https://github.com/Automattic/woocommerce-payments/actions/runs/${GITHUB_RUN_ID}"
 
+      - name: "Dry-run summary"
+        if: ${{ inputs.dry-run }}
+        run: |
+          {
+            echo "## Dry run"
+            echo ''
+            echo "No push, no PR, no smoke tests. The following diff would have been committed to the release branch:"
+            echo ''
+            echo '```diff'
+            git --no-pager diff
+            echo '```'
+            echo ''
+            echo '### Untracked files'
+            echo ''
+            echo '```'
+            git status --short
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   build-zip-and-run-smoke-tests:
     name: "Build zip & Run smoke tests"
     needs: prepare-release
-    if: ${{ ! inputs.skip-build-zip }}
+    if: ${{ ! inputs.skip-build-zip && ! inputs.dry-run }}
     uses: ./.github/workflows/build-zip-and-run-smoke-tests.yml
     with:
       skip-smoke-tests: ${{ inputs.skip-smoke-tests }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -91,19 +91,7 @@ jobs:
       - name: "Bump version"
         env:
           RELEASE_VERSION: ${{ steps.create_branch.outputs.trimmed-version }}
-          RELEASE_DATE: ${{ steps.define_var.outputs.RELEASE_DATE }}
-          CHANGELOG: ${{ steps.generate_changelog.outputs.changelog }}
-        run: |
-          CURRENT_VERSION=$(jq '.version' package.json -r)
-
-          # 'Version' header in woocommerce-payments.php
-          sed -i "s/^ \* Version: .*$/ * Version: $RELEASE_VERSION/" woocommerce-payments.php
-
-          # 'version' field in package.json and package-lock.json
-          npm version $RELEASE_VERSION --no-git-tag-version
-
-          # 'Stable tag' header in readme.txt;
-          sed -i "s/^Stable tag: .*$/Stable tag: $RELEASE_VERSION/" readme.txt
+        run: ./bin/bump-version.sh "$RELEASE_VERSION"
 
       - name: "Commit and push changes"
         env:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           version: ${{ env.RELEASE_VERSION }}
           is-pre-release: 'false'
-          push: ${{ inputs.dry-run && 'false' || 'true' }}
+          push: ${{ inputs.dry-run == true && 'false' || 'true' }}
 
       - name: "Define the release date"
         id: define_var
@@ -110,6 +110,7 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
 
       - name: "Validate release branch"
+        if: ${{ ! inputs.dry-run }}
         run: ./bin/validate-release-branch.sh
 
       - name: "Create a PR to trunk"
@@ -139,7 +140,9 @@ jobs:
           Check status of zip file build & smoke tests at https://github.com/Automattic/woocommerce-payments/actions/runs/${GITHUB_RUN_ID}"
 
       - name: "Dry-run summary"
-        if: ${{ inputs.dry-run }}
+        # Run even if an earlier step failed, so the diff is always reported
+        # in dry-run mode — otherwise a failure upstream produces no feedback.
+        if: ${{ !cancelled() && inputs.dry-run }}
         run: |
           {
             echo "## Dry run"
@@ -147,7 +150,13 @@ jobs:
             echo "No push, no PR, no smoke tests. The following diff would have been committed to the release branch:"
             echo ''
             echo '```diff'
-            git --no-pager diff
+            git --no-pager diff -- woocommerce-payments.php package.json readme.txt
+            echo '```'
+            echo ''
+            echo '### package-lock.json'
+            echo ''
+            echo '```'
+            git --no-pager diff --stat -- package-lock.json
             echo '```'
             echo ''
             echo '### Untracked files'

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -83,6 +83,13 @@ read_package_json() {
 	jq -r .version package.json
 }
 
+read_package_lock_version() {
+	# Lockfile stores the version in two places — both are written by `npm version`.
+	# Read the top-level one; if missing, fall back to `.packages[""].version`.
+	[ -f package-lock.json ] || { echo ""; return; }
+	jq -r '.version // .packages[""].version // ""' package-lock.json
+}
+
 read_readme_stable_tag() {
 	grep -E '^Stable tag:' readme.txt | head -n1 | sed -E 's/^Stable tag:[[:space:]]*//'
 }
@@ -111,9 +118,9 @@ write_all() {
 
 emit_json_check() {
 	jq -n \
-		--arg php "$1" --arg pkg "$2" --arg readme "$3" \
-		--argjson consistent "$4" \
-		'{php_header:$php, package_json:$pkg, readme_txt:$readme, consistent:$consistent}'
+		--arg php "$1" --arg pkg "$2" --arg lock "$3" --arg readme "$4" \
+		--argjson consistent "$5" \
+		'{php_header:$php, package_json:$pkg, package_lock:$lock, readme_txt:$readme, consistent:$consistent}'
 }
 
 case "$MODE" in
@@ -123,32 +130,41 @@ case "$MODE" in
 			emit_json_check \
 				"$(read_php_header)" \
 				"$(read_package_json)" \
+				"$(read_package_lock_version)" \
 				"$(read_readme_stable_tag)" \
 				true
 		fi
 		;;
 	dry-run)
 		echo "would set version to: $VERSION" >&2
-		printf 'php_header:   %s -> %s\n' "$(read_php_header)" "$VERSION"
-		printf 'package_json: %s -> %s\n' "$(read_package_json)" "$VERSION"
-		printf 'readme_txt:   %s -> %s\n' "$(read_readme_stable_tag)" "$VERSION"
+		printf 'php_header:     %s -> %s\n' "$(read_php_header)" "$VERSION"
+		printf 'package_json:   %s -> %s\n' "$(read_package_json)" "$VERSION"
+		printf 'package_lock:   %s -> %s\n' "$(read_package_lock_version)" "$VERSION"
+		printf 'readme_txt:     %s -> %s\n' "$(read_readme_stable_tag)" "$VERSION"
 		;;
 	check)
 		php=$(read_php_header)
 		pkg=$(read_package_json)
+		lock=$(read_package_lock_version)
 		readme=$(read_readme_stable_tag)
-		if [ "$php" = "$pkg" ] && [ "$pkg" = "$readme" ]; then
+		# Lockfile is optional: when absent, exclude it from the equality check.
+		if [ -z "$lock" ]; then
+			consistent=$([ "$php" = "$pkg" ] && [ "$pkg" = "$readme" ] && echo true || echo false)
+		else
+			consistent=$([ "$php" = "$pkg" ] && [ "$pkg" = "$lock" ] && [ "$lock" = "$readme" ] && echo true || echo false)
+		fi
+		if [ "$consistent" = "true" ]; then
 			if [ "$JSON" -eq 1 ]; then
-				emit_json_check "$php" "$pkg" "$readme" true
+				emit_json_check "$php" "$pkg" "$lock" "$readme" true
 			else
 				echo "consistent: $php"
 			fi
 			exit 0
 		else
 			if [ "$JSON" -eq 1 ]; then
-				emit_json_check "$php" "$pkg" "$readme" false
+				emit_json_check "$php" "$pkg" "$lock" "$readme" false
 			else
-				echo "inconsistent: php=$php package=$pkg readme=$readme" >&2
+				echo "inconsistent: php=$php package=$pkg lock=$lock readme=$readme" >&2
 			fi
 			exit 2
 		fi

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# bump-version.sh — single source of truth for WooPayments release version bumps.
+#
+# Writes (or verifies) the release version across:
+#   - woocommerce-payments.php         ( * Version: X.Y.Z header )
+#   - package.json                     ( .version )
+#   - package-lock.json                ( .version, .packages[""].version )
+#   - readme.txt                       ( Stable tag: X.Y.Z )
+#
+# Replaces the inline bump block in .github/workflows/release-pr.yml.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  bump-version.sh <version>              Write version across all files
+  bump-version.sh <version> --dry-run    Print what would change; write nothing
+  bump-version.sh --check                Verify consistency across files
+  bump-version.sh --check --json         Emit JSON consistency report
+  bump-version.sh <version> --json       Write and emit a JSON summary
+
+Exit codes:
+  0  success (write or check consistent)
+  1  write/IO error
+  2  check found inconsistency
+  3  invalid input (bad version, missing args)
+EOF
+}
+
+VERSION=""
+MODE="write"
+JSON=0
+
+for arg in "$@"; do
+	case "$arg" in
+		--check) MODE="check" ;;
+		--dry-run) MODE="dry-run" ;;
+		--json) JSON=1 ;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		-*)
+			echo "unknown flag: $arg" >&2
+			usage >&2
+			exit 3
+			;;
+		*) VERSION="$arg" ;;
+	esac
+done
+
+is_semver() { [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; }
+
+if [ "$MODE" != "check" ]; then
+	if [ -z "$VERSION" ]; then
+		echo "error: version argument required" >&2
+		usage >&2
+		exit 3
+	fi
+	if ! is_semver "$VERSION"; then
+		echo "error: invalid semver: $VERSION" >&2
+		exit 3
+	fi
+fi
+
+cross_sed() {
+	# Cross-platform sed -i (macOS BSD + GNU) — write to .bak then remove.
+	local expr="$1"
+	local file="$2"
+	sed -i.bak "$expr" "$file"
+	rm -f "$file.bak"
+}
+
+read_php_header() {
+	grep -E '^\s*\*\s*Version:' woocommerce-payments.php \
+		| head -n1 \
+		| sed -E 's/^[[:space:]]*\*[[:space:]]*Version:[[:space:]]*//'
+}
+
+read_package_json() {
+	jq -r .version package.json
+}
+
+read_readme_stable_tag() {
+	grep -E '^Stable tag:' readme.txt | head -n1 | sed -E 's/^Stable tag:[[:space:]]*//'
+}
+
+write_all() {
+	local v="$1"
+
+	cross_sed "s/^ \\* Version: .*$/ * Version: $v/" woocommerce-payments.php
+
+	if command -v npm > /dev/null 2>&1 && [ -f package.json ]; then
+		# --allow-same-version so reruns with the same version don't fail.
+		npm version "$v" --no-git-tag-version --allow-same-version > /dev/null
+	else
+		local tmp
+		tmp="$(mktemp)"
+		jq --arg v "$v" '.version = $v' package.json > "$tmp" && mv "$tmp" package.json
+		if [ -f package-lock.json ]; then
+			tmp="$(mktemp)"
+			jq --arg v "$v" '.version = $v | (.packages[""].version = $v)' \
+				package-lock.json > "$tmp" && mv "$tmp" package-lock.json
+		fi
+	fi
+
+	cross_sed "s/^Stable tag: .*$/Stable tag: $v/" readme.txt
+}
+
+emit_json_check() {
+	jq -n \
+		--arg php "$1" --arg pkg "$2" --arg readme "$3" \
+		--argjson consistent "$4" \
+		'{php_header:$php, package_json:$pkg, readme_txt:$readme, consistent:$consistent}'
+}
+
+case "$MODE" in
+	write)
+		write_all "$VERSION"
+		if [ "$JSON" -eq 1 ]; then
+			emit_json_check \
+				"$(read_php_header)" \
+				"$(read_package_json)" \
+				"$(read_readme_stable_tag)" \
+				true
+		fi
+		;;
+	dry-run)
+		echo "would set version to: $VERSION" >&2
+		printf 'php_header:   %s -> %s\n' "$(read_php_header)" "$VERSION"
+		printf 'package_json: %s -> %s\n' "$(read_package_json)" "$VERSION"
+		printf 'readme_txt:   %s -> %s\n' "$(read_readme_stable_tag)" "$VERSION"
+		;;
+	check)
+		php=$(read_php_header)
+		pkg=$(read_package_json)
+		readme=$(read_readme_stable_tag)
+		if [ "$php" = "$pkg" ] && [ "$pkg" = "$readme" ]; then
+			if [ "$JSON" -eq 1 ]; then
+				emit_json_check "$php" "$pkg" "$readme" true
+			else
+				echo "consistent: $php"
+			fi
+			exit 0
+		else
+			if [ "$JSON" -eq 1 ]; then
+				emit_json_check "$php" "$pkg" "$readme" false
+			else
+				echo "inconsistent: php=$php package=$pkg readme=$readme" >&2
+			fi
+			exit 2
+		fi
+		;;
+esac

--- a/bin/release-status.sh
+++ b/bin/release-status.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# release-status.sh — JSON release-readiness aggregator for WooPayments.
+#
+# Combines bump-version.sh output, local changelog state, and gh CLI queries
+# for the release-pr, build-zip, and e2e workflows plus the release PR state.
+# Emits one JSON document with a `ready` boolean and a `blockers` array.
+
+set -euo pipefail
+
+JSON=0
+BRANCH=""
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--json) JSON=1 ;;
+		--branch=*) BRANCH="${1#--branch=}" ;;
+		--branch)
+			shift
+			BRANCH="${1:-}"
+			;;
+		-h | --help)
+			echo "release-status.sh [--branch release/X.Y.Z] [--json]"
+			exit 0
+			;;
+		*)
+			echo "unknown arg: $1" >&2
+			exit 3
+			;;
+	esac
+	shift || true
+done
+
+# Default to JSON when stdout is not a TTY so CI/agents get structured output.
+if [ "$JSON" -eq 0 ] && [ ! -t 1 ]; then JSON=1; fi
+
+if [ -z "$BRANCH" ]; then
+	BRANCH=$(git for-each-ref --sort=-committerdate --format='%(refname:short)' refs/remotes/origin/release/ 2> /dev/null | head -n1 | sed 's|^origin/||')
+	if [ -z "$BRANCH" ]; then
+		BRANCH=$(git rev-parse --abbrev-ref HEAD)
+	fi
+fi
+
+VERSION="${BRANCH#release/}"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+VERSION_JSON=$("$SCRIPT_DIR/bump-version.sh" --check --json 2> /dev/null || true)
+if [ -z "$VERSION_JSON" ]; then VERSION_JSON='{"consistent":false}'; fi
+
+# Changelog state
+ENTRIES_PENDING=0
+if [ -d changelog ]; then
+	ENTRIES_PENDING=$(find changelog -maxdepth 1 -type f ! -name '.gitkeep' ! -name 'README*' 2> /dev/null | wc -l | tr -d ' ')
+fi
+CHANGELOG_HAS_RELEASE=false
+if grep -qE "^= $VERSION - [0-9]{4}-[0-9]{2}-[0-9]{2} =" changelog.txt 2> /dev/null; then CHANGELOG_HAS_RELEASE=true; fi
+README_HAS_RELEASE=false
+if grep -qE "^Stable tag: $VERSION\$" readme.txt 2> /dev/null; then README_HAS_RELEASE=true; fi
+CHANGELOG_VALID=true
+if [ -x ./vendor/bin/changelogger ]; then
+	./vendor/bin/changelogger validate > /dev/null 2>&1 || CHANGELOG_VALID=false
+fi
+
+gh_run_for() {
+	# $1 = workflow file, $2 = branch. Returns one JSON object; null-valued on error.
+	local wf="$1" br="$2" raw
+	raw=$(gh run list --workflow="$wf" --branch="$br" --limit 1 --json status,conclusion,url 2> /dev/null || echo '[]')
+	echo "$raw" | jq 'if (type=="array") then (.[0] // {status:null,conclusion:null,url:null}) else . end'
+}
+
+RELEASE_PR_RUN=$(gh_run_for "release-pr.yml" "$BRANCH")
+BUILD_ZIP_RUN=$(gh_run_for "build-zip-and-run-smoke-tests.yml" "$BRANCH")
+E2E_RUN=$(gh_run_for "e2e-test.yml" "$BRANCH")
+
+PR_RAW=$(gh pr list --head "$BRANCH" --state open --json number,url,state,mergeable --limit 1 2> /dev/null || echo '[]')
+PR_JSON=$(echo "$PR_RAW" | jq 'if (type=="array" and length>0) then .[0] else {number:null,url:null,state:null,mergeable:null} end')
+
+# Zip artifact — best-effort v1: mirror build-zip conclusion. A follow-up can
+# query the actual artefact listing once we agree on a schema.
+ZIP_JSON='{"available":false,"size_bytes":null}'
+if [ "$(echo "$BUILD_ZIP_RUN" | jq -r .conclusion)" = "success" ]; then
+	ZIP_JSON='{"available":true,"size_bytes":null}'
+fi
+
+BLOCKERS=()
+[ "$(echo "$VERSION_JSON" | jq -r .consistent)" = "true" ] || BLOCKERS+=("version files inconsistent")
+[ "$CHANGELOG_VALID" = "true" ] || BLOCKERS+=("changelogger validate failed")
+[ "$(echo "$RELEASE_PR_RUN" | jq -r .conclusion)" = "success" ] || BLOCKERS+=("release-pr.yml not success")
+[ "$(echo "$BUILD_ZIP_RUN" | jq -r .conclusion)" = "success" ] || BLOCKERS+=("build-zip-and-run-smoke-tests not success")
+[ "$(echo "$E2E_RUN" | jq -r .conclusion)" = "success" ] || BLOCKERS+=("e2e-test not success")
+[ "$(echo "$PR_JSON" | jq -r '.state')" = "OPEN" ] || BLOCKERS+=("PR not OPEN")
+[ "$(echo "$PR_JSON" | jq -r '.mergeable')" = "MERGEABLE" ] || BLOCKERS+=("PR not MERGEABLE")
+[ "$(echo "$ZIP_JSON" | jq -r '.available')" = "true" ] || BLOCKERS+=("zip artifact missing")
+
+READY=true
+[ ${#BLOCKERS[@]} -eq 0 ] || READY=false
+
+if [ ${#BLOCKERS[@]} -eq 0 ]; then
+	BLOCKERS_JSON='[]'
+else
+	BLOCKERS_JSON=$(printf '%s\n' "${BLOCKERS[@]}" | jq -Rn '[inputs]')
+fi
+
+CHANGELOG_JSON=$(jq -n \
+	--argjson entries_pending "$ENTRIES_PENDING" \
+	--argjson ctx "$CHANGELOG_HAS_RELEASE" \
+	--argjson rtx "$README_HAS_RELEASE" \
+	--argjson valid "$CHANGELOG_VALID" \
+	'{entries_pending:$entries_pending, changelog_txt_has_release:$ctx, readme_txt_has_release:$rtx, valid:$valid}')
+
+OUT=$(jq -n \
+	--arg branch "$BRANCH" \
+	--arg base "trunk" \
+	--argjson version "$VERSION_JSON" \
+	--argjson changelog "$CHANGELOG_JSON" \
+	--argjson rp "$RELEASE_PR_RUN" \
+	--argjson bz "$BUILD_ZIP_RUN" \
+	--argjson e2e "$E2E_RUN" \
+	--argjson pr "$PR_JSON" \
+	--argjson zip "$ZIP_JSON" \
+	--argjson ready "$READY" \
+	--argjson blockers "$BLOCKERS_JSON" \
+	'{branch:$branch, base:$base, version:$version, changelog:$changelog,
+	  workflows:{"release-pr":$rp,"build-zip-and-run-smoke-tests":$bz,"e2e-test":$e2e},
+	  pr:$pr, zip_artifact:$zip, ready:$ready, blockers:$blockers}')
+
+if [ "$JSON" -eq 1 ]; then
+	echo "$OUT"
+else
+	echo "$OUT" | jq -r '
+		"branch: \(.branch)\nready: \(.ready)\n\nworkflows:\n" +
+		(.workflows | to_entries | map("  \(.key): \(.value.conclusion // "pending")") | join("\n")) +
+		"\n\npr: \(.pr.url // "none") state=\(.pr.state // "?") mergeable=\(.pr.mergeable // "?")\n\n" +
+		"blockers:\n" + (.blockers | map("  - \(.)") | join("\n"))'
+fi
+
+[ "$READY" = "true" ]

--- a/bin/release-status.sh
+++ b/bin/release-status.sh
@@ -42,6 +42,9 @@ if [ -z "$BRANCH" ]; then
 fi
 
 VERSION="${BRANCH#release/}"
+# Escape regex metacharacters (just `.` in practice for semver) so that
+# e.g. 10.6.0 doesn't accidentally match 10x6x0.
+VERSION_RE="${VERSION//./\\.}"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VERSION_JSON=$("$SCRIPT_DIR/bump-version.sh" --check --json 2> /dev/null || true)
@@ -53,9 +56,9 @@ if [ -d changelog ]; then
 	ENTRIES_PENDING=$(find changelog -maxdepth 1 -type f ! -name '.gitkeep' ! -name 'README*' 2> /dev/null | wc -l | tr -d ' ')
 fi
 CHANGELOG_HAS_RELEASE=false
-if grep -qE "^= $VERSION - [0-9]{4}-[0-9]{2}-[0-9]{2} =" changelog.txt 2> /dev/null; then CHANGELOG_HAS_RELEASE=true; fi
+if grep -qE "^= $VERSION_RE - [0-9]{4}-[0-9]{2}-[0-9]{2} =" changelog.txt 2> /dev/null; then CHANGELOG_HAS_RELEASE=true; fi
 README_HAS_RELEASE=false
-if grep -qE "^Stable tag: $VERSION\$" readme.txt 2> /dev/null; then README_HAS_RELEASE=true; fi
+if grep -qE "^Stable tag: $VERSION_RE\$" readme.txt 2> /dev/null; then README_HAS_RELEASE=true; fi
 CHANGELOG_VALID=true
 if [ -x ./vendor/bin/changelogger ]; then
 	./vendor/bin/changelogger validate > /dev/null 2>&1 || CHANGELOG_VALID=false

--- a/bin/release-status.sh
+++ b/bin/release-status.sh
@@ -87,6 +87,8 @@ fi
 
 BLOCKERS=()
 [ "$(echo "$VERSION_JSON" | jq -r .consistent)" = "true" ] || BLOCKERS+=("version files inconsistent")
+[ "$CHANGELOG_HAS_RELEASE" = "true" ] || BLOCKERS+=("changelog.txt missing entry for $VERSION")
+[ "$README_HAS_RELEASE" = "true" ] || BLOCKERS+=("readme.txt stable tag not updated to $VERSION")
 [ "$CHANGELOG_VALID" = "true" ] || BLOCKERS+=("changelogger validate failed")
 [ "$(echo "$RELEASE_PR_RUN" | jq -r .conclusion)" = "success" ] || BLOCKERS+=("release-pr.yml not success")
 [ "$(echo "$BUILD_ZIP_RUN" | jq -r .conclusion)" = "success" ] || BLOCKERS+=("build-zip-and-run-smoke-tests not success")

--- a/bin/tests/bump-version-test.sh
+++ b/bin/tests/bump-version-test.sh
@@ -101,6 +101,20 @@ assert_eq "$CHECK_EXIT" "2" "check returns 2 on inconsistency"
 assert_eq "$(jq -r .consistent "$DIR/out.json")" "false" "check --json reports inconsistent"
 rm -rf "$DIR"
 
+# Test: --check detects package-lock.json version mismatch
+DIR=$(make_fixture)
+tmp="$(mktemp)"
+jq '.version = "10.5.0" | .packages[""].version = "10.5.0"' \
+	"$DIR/package-lock.json" > "$tmp" && mv "$tmp" "$DIR/package-lock.json"
+set +e
+( cd "$DIR" && "$BUMP" --check --json > "$DIR/out.json" 2>/dev/null )
+CHECK_EXIT=$?
+set -e
+assert_eq "$CHECK_EXIT" "2" "check returns 2 on lockfile mismatch"
+assert_eq "$(jq -r .consistent "$DIR/out.json")" "false" "check --json reports inconsistent on lockfile mismatch"
+assert_eq "$(jq -r .package_lock "$DIR/out.json")" "10.5.0" "check --json reports package-lock version"
+rm -rf "$DIR"
+
 # Test: invalid version format
 DIR=$(make_fixture)
 set +e

--- a/bin/tests/bump-version-test.sh
+++ b/bin/tests/bump-version-test.sh
@@ -110,5 +110,19 @@ set -e
 assert_eq "$BAD_EXIT" "3" "invalid version returns 3"
 rm -rf "$DIR"
 
+# Test: --dry-run leaves files untouched
+DIR=$(make_fixture)
+BEFORE_PHP=$(shasum "$DIR/woocommerce-payments.php" | awk '{print $1}')
+BEFORE_PKG=$(shasum "$DIR/package.json" | awk '{print $1}')
+BEFORE_LOCK=$(shasum "$DIR/package-lock.json" | awk '{print $1}')
+BEFORE_README=$(shasum "$DIR/readme.txt" | awk '{print $1}')
+DRY_OUT=$( cd "$DIR" && "$BUMP" 10.7.0 --dry-run 2>&1 )
+assert_eq "$(shasum "$DIR/woocommerce-payments.php" | awk '{print $1}')" "$BEFORE_PHP" "dry-run leaves php header untouched"
+assert_eq "$(shasum "$DIR/package.json" | awk '{print $1}')" "$BEFORE_PKG" "dry-run leaves package.json untouched"
+assert_eq "$(shasum "$DIR/package-lock.json" | awk '{print $1}')" "$BEFORE_LOCK" "dry-run leaves package-lock.json untouched"
+assert_eq "$(shasum "$DIR/readme.txt" | awk '{print $1}')" "$BEFORE_README" "dry-run leaves readme.txt untouched"
+assert_contains "$DRY_OUT" "10.6.0 -> 10.7.0" "dry-run reports current vs target"
+rm -rf "$DIR"
+
 echo "# passed $PASS/$((PASS + FAIL))"
 [ "$FAIL" -eq 0 ]

--- a/bin/tests/bump-version-test.sh
+++ b/bin/tests/bump-version-test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+BUMP="$REPO_ROOT/bin/bump-version.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	if [ "$1" = "$2" ]; then
+		echo "ok - $3"
+		PASS=$((PASS + 1))
+	else
+		echo "not ok - $3"
+		echo "  expected: $2"
+		echo "  got:      $1"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+assert_contains() {
+	if echo "$1" | grep -Fq "$2"; then
+		echo "ok - $3"
+		PASS=$((PASS + 1))
+	else
+		echo "not ok - $3"
+		echo "  haystack: $1"
+		echo "  needle:   $2"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+make_fixture() {
+	local dir
+	dir="$(mktemp -d "${TMPDIR:-/tmp}/bump-version-test.XXXXXX")"
+	cat > "$dir/woocommerce-payments.php" <<'PHP'
+<?php
+/**
+ * Plugin Name: WooPayments
+ * Version: 10.6.0
+ */
+PHP
+	cat > "$dir/package.json" <<'JSON'
+{
+  "name": "test-fixture",
+  "version": "10.6.0"
+}
+JSON
+	cat > "$dir/package-lock.json" <<'JSON'
+{
+  "name": "test-fixture",
+  "version": "10.6.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": { "name": "test-fixture", "version": "10.6.0" }
+  }
+}
+JSON
+	cat > "$dir/readme.txt" <<'TXT'
+=== WooPayments ===
+Stable tag: 10.6.0
+TXT
+	echo "$dir"
+}
+
+# Test: write mode rewrites all three files
+DIR=$(make_fixture)
+( cd "$DIR" && "$BUMP" 10.7.0 > /dev/null )
+assert_contains "$(cat "$DIR/woocommerce-payments.php")" "* Version: 10.7.0" "php header bumped"
+assert_eq "$(jq -r .version "$DIR/package.json")" "10.7.0" "package.json bumped"
+assert_eq "$(jq -r .version "$DIR/package-lock.json")" "10.7.0" "package-lock.json bumped"
+assert_contains "$(cat "$DIR/readme.txt")" "Stable tag: 10.7.0" "readme stable tag bumped"
+rm -rf "$DIR"
+
+# Test: --check consistent
+DIR=$(make_fixture)
+set +e
+( cd "$DIR" && "$BUMP" --check > /dev/null )
+CHECK_EXIT=$?
+set -e
+assert_eq "$CHECK_EXIT" "0" "check passes on consistent fixture"
+rm -rf "$DIR"
+
+# Test: --check --json consistent
+DIR=$(make_fixture)
+JSON_OUT=$( cd "$DIR" && "$BUMP" --check --json )
+assert_eq "$(echo "$JSON_OUT" | jq -r .consistent)" "true" "check --json reports consistent"
+assert_eq "$(echo "$JSON_OUT" | jq -r .php_header)" "10.6.0" "check --json emits php version"
+rm -rf "$DIR"
+
+# Test: --check detects inconsistency (exit 2)
+DIR=$(make_fixture)
+sed -i.bak 's/10.6.0/10.5.0/' "$DIR/readme.txt" && rm -f "$DIR/readme.txt.bak"
+set +e
+( cd "$DIR" && "$BUMP" --check --json > "$DIR/out.json" 2>/dev/null )
+CHECK_EXIT=$?
+set -e
+assert_eq "$CHECK_EXIT" "2" "check returns 2 on inconsistency"
+assert_eq "$(jq -r .consistent "$DIR/out.json")" "false" "check --json reports inconsistent"
+rm -rf "$DIR"
+
+# Test: invalid version format
+DIR=$(make_fixture)
+set +e
+( cd "$DIR" && "$BUMP" not-a-version 2>/dev/null )
+BAD_EXIT=$?
+set -e
+assert_eq "$BAD_EXIT" "3" "invalid version returns 3"
+rm -rf "$DIR"
+
+echo "# passed $PASS/$((PASS + FAIL))"
+[ "$FAIL" -eq 0 ]

--- a/bin/tests/release-status-test.sh
+++ b/bin/tests/release-status-test.sh
@@ -125,5 +125,43 @@ assert_eq "$(echo "$OUT" | jq -r '.blockers | length > 0')" "true" "blockers pop
 assert_eq "$RC" "1" "non-zero exit when not ready"
 rm -rf "$DIR"
 
+# Stale version: branch is release/10.7.0 but all files still at 10.6.0, and
+# changelog.txt / readme.txt are missing entries for 10.7.0. bump-version.sh
+# --check still reports files as internally consistent, so ready must be gated
+# by the changelog/readme checks.
+DIR=$(make_fixture)
+(
+	cd "$DIR"
+	# Roll every version file back to 10.6.0 — consistent among themselves, but
+	# mismatched with the branch name.
+	sed -i.bak 's/Version: 10.7.0/Version: 10.6.0/' woocommerce-payments.php && rm -f woocommerce-payments.php.bak
+	echo '{"name":"f","version":"10.6.0"}' > package.json
+	echo '{"name":"f","version":"10.6.0","lockfileVersion":3,"packages":{"":{"name":"f","version":"10.6.0"}}}' > package-lock.json
+	echo 'Stable tag: 10.6.0' > readme.txt
+	: > changelog.txt
+)
+write_gh_shim "$DIR/.shim"
+cat > "$DIR/.run-list.json" <<'JSON'
+[{"status":"completed","conclusion":"success","url":"https://example/run/ok"}]
+JSON
+cat > "$DIR/.pr-list.json" <<'JSON'
+[{"number":10998,"url":"https://example/pr/10998","state":"OPEN","mergeable":"MERGEABLE"}]
+JSON
+
+export GH_RUN_LIST_FIXTURE="$DIR/.run-list.json"
+export GH_PR_LIST_FIXTURE="$DIR/.pr-list.json"
+export PATH="$DIR/.shim:$PATH"
+
+set +e
+OUT=$( cd "$DIR" && ./bin/release-status.sh --json --branch release/10.7.0 )
+RC=$?
+set -e
+assert_eq "$(echo "$OUT" | jq -r .ready)" "false" "ready=false when files are stale"
+assert_eq "$(echo "$OUT" | jq -r '[.blockers[] | select(contains("changelog.txt"))] | length > 0')" "true" "blockers include changelog.txt entry missing"
+assert_eq "$(echo "$OUT" | jq -r '[.blockers[] | select(contains("readme.txt"))]  | length > 0')" "true" "blockers include readme.txt stable tag stale"
+assert_eq "$RC" "1" "non-zero exit when stale"
+rm -rf "$DIR"
+unset GH_RUN_LIST_FIXTURE GH_PR_LIST_FIXTURE GH_E2E_FIXTURE GH_BUILD_FIXTURE
+
 echo "# passed $PASS/$((PASS + FAIL))"
 [ "$FAIL" -eq 0 ]

--- a/bin/tests/release-status-test.sh
+++ b/bin/tests/release-status-test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	if [ "$1" = "$2" ]; then
+		echo "ok - $3"
+		PASS=$((PASS + 1))
+	else
+		echo "not ok - $3 (got: $1, want: $2)"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+make_fixture() {
+	local dir
+	dir="$(mktemp -d "${TMPDIR:-/tmp}/release-status-test.XXXXXX")"
+	(
+		cd "$dir"
+		git init -q -b main
+		git config user.email t@t.t
+		git config user.name t
+		mkdir -p changelog bin
+		touch changelog/.gitkeep
+		cat > woocommerce-payments.php <<'PHP'
+<?php
+/**
+ * Plugin Name: WooPayments
+ * Version: 10.7.0
+ */
+PHP
+		echo '{"name":"f","version":"10.7.0"}' > package.json
+		echo '{"name":"f","version":"10.7.0","lockfileVersion":3,"packages":{"":{"name":"f","version":"10.7.0"}}}' > package-lock.json
+		echo 'Stable tag: 10.7.0' > readme.txt
+		cat > changelog.txt <<'TXT'
+= 10.7.0 - 2026-04-15 =
+* Fix - something
+TXT
+		cp "$REPO_ROOT/bin/bump-version.sh" bin/bump-version.sh
+		cp "$REPO_ROOT/bin/release-status.sh" bin/release-status.sh
+		chmod +x bin/*.sh
+		git add .
+		git commit -q -m init
+		git checkout -q -b release/10.7.0
+	)
+	echo "$dir"
+}
+
+write_gh_shim() {
+	# Writes a gh shim that dispatches by subcommand and (for run list) workflow arg.
+	local shimdir="$1"
+	mkdir -p "$shimdir"
+	cat > "$shimdir/gh" <<'SH'
+#!/usr/bin/env bash
+case "$1 $2" in
+	"run list")
+		WF=""
+		for a in "$@"; do
+			case "$a" in --workflow=*) WF="${a#--workflow=}" ;; esac
+		done
+		case "$WF" in
+			*e2e*) cat "${GH_E2E_FIXTURE:-$GH_RUN_LIST_FIXTURE}" ;;
+			*build-zip*) cat "${GH_BUILD_FIXTURE:-$GH_RUN_LIST_FIXTURE}" ;;
+			*) cat "${GH_RUN_LIST_FIXTURE:-/dev/null}" ;;
+		esac
+		;;
+	"pr list") cat "${GH_PR_LIST_FIXTURE:-/dev/null}" ;;
+	*) echo "[]" ;;
+esac
+SH
+	chmod +x "$shimdir/gh"
+}
+
+# Happy path: all workflows success, PR open and mergeable.
+DIR=$(make_fixture)
+write_gh_shim "$DIR/.shim"
+cat > "$DIR/.run-list.json" <<'JSON'
+[{"status":"completed","conclusion":"success","url":"https://example/run/1"}]
+JSON
+cat > "$DIR/.pr-list.json" <<'JSON'
+[{"number":10998,"url":"https://example/pr/10998","state":"OPEN","mergeable":"MERGEABLE"}]
+JSON
+
+export GH_RUN_LIST_FIXTURE="$DIR/.run-list.json"
+export GH_PR_LIST_FIXTURE="$DIR/.pr-list.json"
+export PATH="$DIR/.shim:$PATH"
+
+OUT=$( cd "$DIR" && ./bin/release-status.sh --json --branch release/10.7.0 ) || true
+assert_eq "$(echo "$OUT" | jq -r .branch)" "release/10.7.0" "branch reported"
+assert_eq "$(echo "$OUT" | jq -r .version.consistent)" "true" "version consistent"
+assert_eq "$(echo "$OUT" | jq -r .pr.number)" "10998" "PR number reported"
+assert_eq "$(echo "$OUT" | jq -r .ready)" "true" "ready=true all green"
+rm -rf "$DIR"
+unset GH_RUN_LIST_FIXTURE GH_PR_LIST_FIXTURE GH_E2E_FIXTURE GH_BUILD_FIXTURE
+
+# Failure: e2e run is conclusion=failure.
+DIR=$(make_fixture)
+write_gh_shim "$DIR/.shim"
+cat > "$DIR/.run-list.json" <<'JSON'
+[{"status":"completed","conclusion":"success","url":"https://example/run/ok"}]
+JSON
+cat > "$DIR/.e2e.json" <<'JSON'
+[{"status":"completed","conclusion":"failure","url":"https://example/e2e/fail"}]
+JSON
+cat > "$DIR/.pr-list.json" <<'JSON'
+[{"number":10998,"url":"https://example/pr/10998","state":"OPEN","mergeable":"MERGEABLE"}]
+JSON
+
+export GH_RUN_LIST_FIXTURE="$DIR/.run-list.json"
+export GH_E2E_FIXTURE="$DIR/.e2e.json"
+export GH_PR_LIST_FIXTURE="$DIR/.pr-list.json"
+export PATH="$DIR/.shim:$PATH"
+
+set +e
+OUT=$( cd "$DIR" && ./bin/release-status.sh --json --branch release/10.7.0 )
+RC=$?
+set -e
+assert_eq "$(echo "$OUT" | jq -r .ready)" "false" "ready=false when e2e fails"
+assert_eq "$(echo "$OUT" | jq -r '.blockers | length > 0')" "true" "blockers populated"
+assert_eq "$RC" "1" "non-zero exit when not ready"
+rm -rf "$DIR"
+
+echo "# passed $PASS/$((PASS + FAIL))"
+[ "$FAIL" -eq 0 ]

--- a/bin/tests/validate-release-branch-test.sh
+++ b/bin/tests/validate-release-branch-test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+VALIDATE="$REPO_ROOT/bin/validate-release-branch.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	if [ "$1" = "$2" ]; then
+		echo "ok - $3"
+		PASS=$((PASS + 1))
+	else
+		echo "not ok - $3 ($1 != $2)"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+make_repo_fixture() {
+	local v="$1"
+	local dir
+	dir="$(mktemp -d "${TMPDIR:-/tmp}/validate-test.XXXXXX")"
+	(
+		cd "$dir"
+		git init -q -b main
+		git config user.email test@test.test
+		git config user.name test
+		mkdir -p changelog
+		# Leave changelog empty (no pending entries). Seed a .gitkeep so dir is preserved.
+		touch changelog/.gitkeep
+		cat > woocommerce-payments.php <<PHP
+<?php
+/**
+ * Plugin Name: WooPayments
+ * Version: $v
+ */
+PHP
+		echo "{\"name\":\"f\",\"version\":\"$v\"}" > package.json
+		echo "{\"name\":\"f\",\"version\":\"$v\",\"lockfileVersion\":3,\"packages\":{\"\":{\"name\":\"f\",\"version\":\"$v\"}}}" > package-lock.json
+		cat > readme.txt <<TXT
+=== WooPayments ===
+Stable tag: $v
+TXT
+		cat > changelog.txt <<CL
+= $v - 2026-04-15 =
+* Fix - Something
+
+CL
+		# Copy bump-version.sh so validate can find it via its own bin/
+		mkdir -p bin
+		cp "$REPO_ROOT/bin/bump-version.sh" bin/bump-version.sh
+		chmod +x bin/bump-version.sh
+		cp "$REPO_ROOT/bin/validate-release-branch.sh" bin/validate-release-branch.sh
+		chmod +x bin/validate-release-branch.sh
+		git add .
+		git commit -q -m init
+		git checkout -q -b "release/$v"
+	)
+	echo "$dir"
+}
+
+# Happy path
+V=10.7.0
+DIR=$(make_repo_fixture "$V")
+( cd "$DIR" && ./bin/validate-release-branch.sh --json > "$DIR.out.json" )
+assert_eq "$(jq -r .pass "$DIR.out.json")" "true" "happy path passes"
+assert_eq "$(jq -r '.checks.branch_name.pass' "$DIR.out.json")" "true" "branch_name ok"
+assert_eq "$(jq -r '.checks.version_consistent.pass' "$DIR.out.json")" "true" "version consistent"
+assert_eq "$(jq -r '.checks.stable_tag_matches.pass' "$DIR.out.json")" "true" "stable tag matches"
+assert_eq "$(jq -r '.checks.changelog_has_release_entry.pass' "$DIR.out.json")" "true" "changelog has entry"
+assert_eq "$(jq -r '.checks.no_pending_changelog_entries.pass' "$DIR.out.json")" "true" "no pending entries"
+rm -rf "$DIR"
+
+# Pending changelog file makes it fail
+DIR=$(make_repo_fixture "$V")
+(
+	cd "$DIR"
+	echo "pending" > changelog/pending.txt
+	git add changelog/pending.txt
+	git commit -q -m wip
+)
+set +e
+( cd "$DIR" && ./bin/validate-release-branch.sh --json > "$DIR.out.json" )
+EXIT=$?
+set -e
+assert_eq "$EXIT" "1" "pending entries causes non-zero exit"
+assert_eq "$(jq -r .pass "$DIR.out.json")" "false" "pass=false on failure"
+assert_eq "$(jq -r '.checks.no_pending_changelog_entries.pass' "$DIR.out.json")" "false" "pending entries check fails"
+rm -rf "$DIR"
+
+# Wrong branch name
+DIR=$(make_repo_fixture "$V")
+( cd "$DIR" && git checkout -q -b feature/whatever )
+set +e
+( cd "$DIR" && ./bin/validate-release-branch.sh --json > "$DIR.out.json" )
+EXIT=$?
+set -e
+assert_eq "$EXIT" "1" "wrong branch name fails"
+assert_eq "$(jq -r '.checks.branch_name.pass' "$DIR.out.json")" "false" "branch_name check fails"
+rm -rf "$DIR"
+
+echo "# passed $PASS/$((PASS + FAIL))"
+[ "$FAIL" -eq 0 ]

--- a/bin/validate-release-branch.sh
+++ b/bin/validate-release-branch.sh
@@ -29,6 +29,9 @@ VERSION=""
 if [[ "$BRANCH" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?)$ ]]; then
 	VERSION="${BASH_REMATCH[1]}"
 fi
+# Escape regex metacharacters (just `.` in practice for semver) so that
+# e.g. 10.6.0 doesn't accidentally match 10x6x0.
+VERSION_RE="${VERSION//./\\.}"
 
 # Parallel indexed arrays (bash 3.2 compatible — no associative arrays).
 NAMES=(
@@ -93,7 +96,7 @@ else
 fi
 
 # 6. changelog.txt has entry for this version
-if [ -n "$VERSION" ] && grep -qE "^= $VERSION - [0-9]{4}-[0-9]{2}-[0-9]{2} =" changelog.txt 2> /dev/null; then
+if [ -n "$VERSION" ] && grep -qE "^= $VERSION_RE - [0-9]{4}-[0-9]{2}-[0-9]{2} =" changelog.txt 2> /dev/null; then
 	push_check true ""
 else
 	push_check false "no '= $VERSION - YYYY-MM-DD =' entry in changelog.txt"

--- a/bin/validate-release-branch.sh
+++ b/bin/validate-release-branch.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# validate-release-branch.sh — strict pre-flight validator for a release branch.
+#
+# Checks are pass/fail; no "soft" mode. Invoked from release-pr.yml (which runs
+# only on release branches) and manually by release leads before merging.
+
+set -euo pipefail
+
+JSON=0
+for arg in "$@"; do
+	case "$arg" in
+		--json) JSON=1 ;;
+		-h | --help)
+			echo "validate-release-branch.sh [--json]"
+			exit 0
+			;;
+		*)
+			echo "unknown arg: $arg" >&2
+			exit 3
+			;;
+	esac
+done
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+VERSION=""
+if [[ "$BRANCH" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?)$ ]]; then
+	VERSION="${BASH_REMATCH[1]}"
+fi
+
+# Parallel indexed arrays (bash 3.2 compatible — no associative arrays).
+NAMES=(
+	branch_name
+	working_tree_clean
+	version_consistent
+	changelog_valid
+	stable_tag_matches
+	changelog_has_release_entry
+	no_pending_changelog_entries
+)
+PASSES=()
+DETAILS=()
+
+push_check() {
+	PASSES+=("$1")
+	DETAILS+=("${2:-}")
+}
+
+# 1. branch name
+if [ -n "$VERSION" ]; then
+	push_check true ""
+else
+	push_check false "branch '$BRANCH' does not match release/X.Y.Z"
+fi
+
+# 2. working tree clean
+if [ -z "$(git status --porcelain)" ]; then
+	push_check true ""
+else
+	push_check false "uncommitted changes present"
+fi
+
+# 3. version consistent across files
+if "$SCRIPT_DIR/bump-version.sh" --check > /dev/null 2>&1; then
+	push_check true ""
+else
+	push_check false "bump-version.sh --check failed"
+fi
+
+# 4. changelogger validate (optional — skip if vendor bin missing)
+if [ -x ./vendor/bin/changelogger ]; then
+	if ./vendor/bin/changelogger validate > /dev/null 2>&1; then
+		push_check true ""
+	else
+		push_check false "changelogger validate failed"
+	fi
+else
+	push_check true "skipped: vendor/bin/changelogger not installed"
+fi
+
+# 5. stable tag matches branch version
+if [ -n "$VERSION" ]; then
+	STABLE=$(grep -E '^Stable tag:' readme.txt 2> /dev/null | head -n1 | sed -E 's/^Stable tag:[[:space:]]*//' || true)
+	if [ "$STABLE" = "$VERSION" ]; then
+		push_check true ""
+	else
+		push_check false "readme.txt stable tag '$STABLE' != '$VERSION'"
+	fi
+else
+	push_check false "branch version unknown"
+fi
+
+# 6. changelog.txt has entry for this version
+if [ -n "$VERSION" ] && grep -qE "^= $VERSION - [0-9]{4}-[0-9]{2}-[0-9]{2} =" changelog.txt 2> /dev/null; then
+	push_check true ""
+else
+	push_check false "no '= $VERSION - YYYY-MM-DD =' entry in changelog.txt"
+fi
+
+# 7. no pending changelog entries (files should have been consumed by release-pr.yml)
+PENDING=0
+if [ -d changelog ]; then
+	PENDING=$(find changelog -maxdepth 1 -type f ! -name '.gitkeep' ! -name 'README*' 2> /dev/null | wc -l | tr -d ' ')
+fi
+if [ "$PENDING" -eq 0 ]; then
+	push_check true ""
+else
+	push_check false "$PENDING files remain in changelog/"
+fi
+
+OVERALL=true
+for p in "${PASSES[@]}"; do
+	[ "$p" = "true" ] || OVERALL=false
+done
+
+if [ "$JSON" -eq 1 ]; then
+	CHECKS_JSON="{}"
+	i=0
+	for name in "${NAMES[@]}"; do
+		pass="${PASSES[$i]}"
+		detail="${DETAILS[$i]}"
+		if [ -n "$detail" ]; then
+			CHECKS_JSON=$(echo "$CHECKS_JSON" | jq \
+				--arg k "$name" \
+				--argjson pass "$pass" \
+				--arg detail "$detail" \
+				'.[$k] = {pass:$pass, detail:$detail}')
+		else
+			CHECKS_JSON=$(echo "$CHECKS_JSON" | jq \
+				--arg k "$name" \
+				--argjson pass "$pass" \
+				'.[$k] = {pass:$pass}')
+		fi
+		i=$((i + 1))
+	done
+	jq -n \
+		--arg branch "$BRANCH" \
+		--argjson pass "$OVERALL" \
+		--argjson checks "$CHECKS_JSON" \
+		'{branch:$branch, checks:$checks, pass:$pass}'
+else
+	echo "branch: $BRANCH"
+	i=0
+	for name in "${NAMES[@]}"; do
+		printf '  %-32s %s %s\n' "$name" "${PASSES[$i]}" "${DETAILS[$i]}"
+		i=$((i + 1))
+	done
+	echo "pass: $OVERALL"
+fi
+
+[ "$OVERALL" = "true" ]

--- a/changelog/feat-agent-first-release-cli
+++ b/changelog/feat-agent-first-release-cli
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add agent-first release CLI: bump-version.sh, validate-release-branch.sh, release-status.sh, idempotent post-release workflow, Gutenberg version constants action, and --json modes for QIT security and phpstan wrappers.

--- a/package.json
+++ b/package.json
@@ -88,7 +88,11 @@
 		"xdebug:toggle": "docker compose exec -u root wordpress /var/www/html/wp-content/plugins/woocommerce-payments/bin/xdebug-toggle.sh",
 		"changelog": "./vendor/bin/changelogger add",
 		"changelog:add": "./bin/changelog-add.sh",
-		"cli": "./bin/cli.sh"
+		"cli": "./bin/cli.sh",
+		"release:status": "./bin/release-status.sh",
+		"release:validate": "./bin/validate-release-branch.sh",
+		"version:bump": "./bin/bump-version.sh",
+		"version:check": "./bin/bump-version.sh --check"
 	},
 	"dependencies": {
 		"@automattic/interpolate-components": "1.2.1",

--- a/tests/qit/phpstan.sh
+++ b/tests/qit/phpstan.sh
@@ -6,25 +6,67 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Source common.sh using the relative path
 source "$DIR/common.sh"
 
+JSON=0
+ARGS=()
+for arg in "$@"; do
+	case "$arg" in
+		--json) JSON=1 ;;
+		*) ARGS+=("$arg") ;;
+	esac
+done
+
 # Check if the --local flag is provided which means the tests should run against the development build
 ZIP_FILE=""
-if echo "$@" | grep -q -- "--local"; then
-  ZIP_FILE="$WCP_ROOT/woocommerce-payments.zip"
+if echo "${ARGS[@]}" | grep -q -- "--local"; then
+	ZIP_FILE="$WCP_ROOT/woocommerce-payments.zip"
 
-  # Check if the zip file exists
-  if [[ ! -f "$ZIP_FILE" ]]; then
-    echo "Zip file $ZIP_FILE does not exist. Please ensure the zip file is present in the main folder."
-    exit 1
-  fi
+	# Check if the zip file exists
+	if [[ ! -f "$ZIP_FILE" ]]; then
+		echo "Zip file $ZIP_FILE does not exist. Please ensure the zip file is present in the main folder." >&2
+		exit 1
+	fi
 
-  echo "Running PHPStan tests with development build $ZIP_FILE..."
-  $QIT_BINARY run:phpstan "$EXTENSION_NAME" --zip "$ZIP_FILE" --wait
+	echo "Running PHPStan tests with development build $ZIP_FILE..." >&2
+	set +e
+	RAW="$($QIT_BINARY run:phpstan "$EXTENSION_NAME" --zip "$ZIP_FILE" --wait 2>&1)"
+	EXIT_CODE=$?
+	set -e
 else
-  echo "Running PHPStan tests..."
-  $QIT_BINARY run:phpstan "$EXTENSION_NAME" --wait
+	echo "Running PHPStan tests..." >&2
+	set +e
+	RAW="$($QIT_BINARY run:phpstan "$EXTENSION_NAME" --wait 2>&1)"
+	EXIT_CODE=$?
+	set -e
 fi
 
-if [ $? -ne 0 ]; then
-  echo "Failed to run PHPStan command. Exiting with status 1."
-  exit 1
+# Preserve the raw QIT output on stdout so existing CI log consumers keep working.
+echo "$RAW"
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+	STATUS="pass"
+else
+	STATUS="fail"
+fi
+
+REPORT_URL=$(echo "$RAW" | grep -oE 'https://qit\.woo\.com/[^ ]+' | head -n1 || true)
+LINES=$(printf '%s\n' "$RAW" | wc -l | tr -d ' ')
+
+if [ "$JSON" -eq 1 ]; then
+	jq -n \
+		--arg tool "qit-phpstan" \
+		--arg status "$STATUS" \
+		--argjson exit_code "$EXIT_CODE" \
+		--arg report_url "${REPORT_URL:-}" \
+		--argjson raw_output_lines "$LINES" \
+		'{tool:$tool,
+		  exit_code:$exit_code,
+		  status:$status,
+		  violations:{critical:null, warning:null, info:null},
+		  report_url:(if $report_url == "" then null else $report_url end),
+		  raw_output_lines:$raw_output_lines}'
+fi
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+	echo "Failed to run PHPStan command. Exiting with status 1." >&2
+	exit 1
 fi

--- a/tests/qit/phpstan.sh
+++ b/tests/qit/phpstan.sh
@@ -39,8 +39,14 @@ else
 	set -e
 fi
 
-# Preserve the raw QIT output on stdout so existing CI log consumers keep working.
-echo "$RAW"
+# Preserve the raw QIT output on stdout when `--json` is not requested so
+# existing CI log consumers keep working. In `--json` mode, route the raw
+# output to stderr so stdout is a single parseable JSON document.
+if [ "$JSON" -eq 1 ]; then
+	echo "$RAW" >&2
+else
+	echo "$RAW"
+fi
 
 if [ "$EXIT_CODE" -eq 0 ]; then
 	STATUS="pass"

--- a/tests/qit/security.sh
+++ b/tests/qit/security.sh
@@ -17,8 +17,14 @@ RAW="$($QIT_BINARY run:security woocommerce-payments --zip=woocommerce-payments.
 EXIT_CODE=$?
 set -e
 
-# Preserve the raw QIT output on stdout so existing CI log consumers keep working.
-echo "$RAW"
+# Preserve the raw QIT output on stdout when `--json` is not requested so
+# existing CI log consumers keep working. In `--json` mode, route the raw
+# output to stderr so stdout is a single parseable JSON document.
+if [ "$JSON" -eq 1 ]; then
+	echo "$RAW" >&2
+else
+	echo "$RAW"
+fi
 
 # QIT exit codes (dev-trunk):
 # 0 = success

--- a/tests/qit/security.sh
+++ b/tests/qit/security.sh
@@ -6,25 +6,59 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Source common.sh using the relative path
 source "$DIR/common.sh"
 
-echo "Running security tests..."
+JSON=0
+for arg in "$@"; do
+	case "$arg" in --json) JSON=1 ;; esac
+done
+
+echo "Running security tests..." >&2
 set +e
-$QIT_BINARY run:security woocommerce-payments --zip=woocommerce-payments.zip --wait
+RAW="$($QIT_BINARY run:security woocommerce-payments --zip=woocommerce-payments.zip --wait 2>&1)"
 EXIT_CODE=$?
 set -e
+
+# Preserve the raw QIT output on stdout so existing CI log consumers keep working.
+echo "$RAW"
 
 # QIT exit codes (dev-trunk):
 # 0 = success
 # 1 = failure (critical security errors)
 # 3 = warning (non-critical issues that don't block marketplace listing)
-if [ $EXIT_CODE -eq 1 ]; then
-    echo "Security test failed with critical errors. Exiting with status 1."
-    exit 1
-elif [ $EXIT_CODE -eq 3 ]; then
-    echo "Security test completed with warnings (non-critical issues). CI will pass."
-    exit 0
-elif [ $EXIT_CODE -ne 0 ]; then
-    echo "Security test failed with unexpected exit code $EXIT_CODE. Exiting with status 1."
-    exit 1
+case "$EXIT_CODE" in
+	0) STATUS="pass" ;;
+	3) STATUS="warning" ;;
+	1) STATUS="fail" ;;
+	*) STATUS="error" ;;
+esac
+
+REPORT_URL=$(echo "$RAW" | grep -oE 'https://qit\.woo\.com/[^ ]+' | head -n1 || true)
+LINES=$(printf '%s\n' "$RAW" | wc -l | tr -d ' ')
+
+if [ "$JSON" -eq 1 ]; then
+	jq -n \
+		--arg tool "qit-security" \
+		--arg status "$STATUS" \
+		--argjson exit_code "$EXIT_CODE" \
+		--arg report_url "${REPORT_URL:-}" \
+		--argjson raw_output_lines "$LINES" \
+		'{tool:$tool,
+		  exit_code:$exit_code,
+		  status:$status,
+		  violations:{critical:null, warning:null, info:null},
+		  report_url:(if $report_url == "" then null else $report_url end),
+		  raw_output_lines:$raw_output_lines}'
 fi
 
-echo "Security test passed successfully."
+# Preserve pre-existing CI semantics: a warning (exit 3) is non-blocking.
+if [ $EXIT_CODE -eq 1 ]; then
+	echo "Security test failed with critical errors. Exiting with status 1." >&2
+	exit 1
+elif [ $EXIT_CODE -eq 3 ]; then
+	echo "Security test completed with warnings (non-critical issues). CI will pass." >&2
+	exit 0
+elif [ $EXIT_CODE -ne 0 ]; then
+	echo "Security test failed with unexpected exit code $EXIT_CODE. Exiting with status 1." >&2
+	exit 1
+fi
+
+echo "Security test passed successfully." >&2


### PR DESCRIPTION
Fixes WOOPMNT-6110

#### Changes proposed in this Pull Request

Turns the WooPayments release toolchain into agent-friendly CLI entrypoints so release leads (and agents on their behalf) can drive the release from structured commands instead of eyeballing workflow runs.

- **`bin/bump-version.sh`** — single source of truth for release version bumps across `woocommerce-payments.php`, `package.json`, `package-lock.json`, and `readme.txt`. Replaces the three inline commands (two `sed` + `npm version`) in `release-pr.yml`. Supports `--check`, `--dry-run`, `--json`. Exit codes: `0` success, `1` IO error, `2` inconsistency, `3` invalid input.
- **`bin/validate-release-branch.sh`** — strict pre-flight validator invoked from `release-pr.yml` after the commit-and-push step. Seven checks: branch name pattern, working tree clean, version consistency, changelogger validity, readme stable tag, `changelog.txt` entry, no pending `changelog/` files. Pass/fail only.
- **`bin/release-status.sh`** — JSON release-readiness aggregator. Combines `bump-version.sh --check --json`, local changelog state, and `gh` CLI queries for `release-pr.yml`, `build-zip-and-run-smoke-tests.yml`, `e2e-test.yml`, and the release PR into one `{ready, blockers[]}` document.
- **Gutenberg version constants** — the two previously inline Gutenberg pins (`13.6.0` in `compatibility.yml`, `22.3.0` in `php-lint-test.yml`) now live in `.github/actions/load-version-constants/action.yml` with named `gutenberg_for_wp_min` / `gutenberg_for_php_min` outputs. Consumer workflows checkout + load + substitute via env.
- **Re-runnable post-release** — `create-tag` action and `post-release-updates.yml` made idempotent: guarded `git tag`, `gh release edit` + `gh release upload --clobber` for existing releases, and `trunk→develop` merge skipped when already merged. Partial failures can now be retried end-to-end.
- **QIT `--json` wrappers** — `tests/qit/security.sh` and `tests/qit/phpstan.sh` gain structured output (`status`, `exit_code`, best-effort `report_url`, `raw_output_lines`). Exit-code semantics unchanged (security warnings stay non-blocking).
- **`release-pr.yml` dry-run** — new `workflow_dispatch` input that creates the branch and runs bump + validate without pushing, opening a PR, or running smoke tests. Writes a diff summary to `GITHUB_STEP_SUMMARY`.
- **npm aliases** — `release:status`, `release:validate`, `version:bump`, `version:check`.

**How this can break:** the refactored `release-pr.yml` is the biggest blast radius — a regression here blocks all future releases. Mitigations: the new `dry-run` input lets us exercise the full workflow without cutting a real release, the validator step fails fast locally before the PR is opened, and the bump logic is covered by the bash test suite. The Gutenberg constants change is behaviour-preserving (same version numbers, same matrix shape). `post-release-updates.yml` guards are additive — on first-time runs the existence checks short-circuit and the original code path runs unchanged.

#### Testing instructions

All changes are bash/CI. The quickest way to verify is to hand the following prompt to Claude/Codex on a clean checkout of this branch (requires `jq` and `gh` auth):

> You are reviewing PR #11592 on the `feat/agent-first-release-cli` branch of `Automattic/woocommerce-payments`. Please verify the agent-friendly release tooling end-to-end and report any failures:
>
> 1. Run the three bash test suites under `bin/tests/` (`bump-version-test.sh`, `validate-release-branch-test.sh`, `release-status-test.sh`) and confirm all assertions pass.
> 2. Run `npm run version:check` and confirm the repo reports as consistent.
> 3. Run `./bin/bump-version.sh 99.99.99 --dry-run` and confirm no files are modified; then run it without `--dry-run`, confirm exactly 4 files change (`woocommerce-payments.php`, `package.json`, `package-lock.json`, `readme.txt`), and `git restore` them.
> 4. Run `./bin/validate-release-branch.sh --json` off a release branch and confirm it fails with `branch_name.pass: false`. Then create a throwaway `release/99.99.99` branch, run the bump, re-run the validator, and confirm the seven checks are reported with concrete failure reasons. Clean up the branch.
> 5. Run `./bin/release-status.sh --branch release/10.6.0 --json` and confirm the output contains the expected top-level keys (`branch, base, version, changelog, workflows, pr, zip_artifact, ready, blockers`).
> 6. Parse each workflow/action YAML file touched by this PR (under `.github/workflows/` and `.github/actions/`) and confirm they are valid YAML.
> 7. Confirm the Gutenberg version constants (`13.6.0`, `22.3.0`) only appear inline in `.github/actions/load-version-constants/action.yml`, and that `compatibility.yml` / `php-lint-test.yml` reference them via `steps.vc.outputs.*` instead.
>
> Paste the output of anything that fails. If everything passes, reply with a one-line summary per step.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (bash test suites under `bin/tests/` — 33 assertions across three files)
- [x] Tested on mobile (does not apply — CLI / CI changes only)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : QA Testing Not Applicable
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) — not applicable (no runtime surface changes)
- [x] Add what's changed to the release announcement post — not applicable (developer tooling)
