### PR TITLE
fix: amazon pay fee calculations

### DIFF
--- a/changelog/fix-amazon-pay-fee-calculations
+++ b/changelog/fix-amazon-pay-fee-calculations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: Amazon Pay fee display on order details page and timeline view when the payment was processed with non-card instrument

--- a/client/data/timeline/types.d.ts
+++ b/client/data/timeline/types.d.ts
@@ -34,6 +34,7 @@ export interface TimelineFeeRates {
 	fee_exchange_rate?: TimelineFeeExchangeRate;
 	tax?: TimelineFeeTax;
 	before_tax?: TimelineFeeTax;
+	fee_refunded?: boolean;
 }
 
 export interface TimelineTransactionDetails {

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -846,10 +846,7 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 				stripeProcessingFee > 0
 					? sprintf(
 							/* translators: %s is a monetary amount */
-							__(
-								'Stripe processing fee: -%s',
-								'woocommerce-payments'
-							),
+							__( 'Processing fee: -%s', 'woocommerce-payments' ),
 							formatExplicitCurrency(
 								stripeProcessingFee,
 								stripeProcessingFeeCurrency

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -838,13 +838,12 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 				composeFXString( event ),
 				isFeeRefunded ? null : composeFeeString( event ),
 				isFeeRefunded ? null : composeFeeBreakdown( event ),
-				! isFeeRefunded && event?.fee_rates?.tax?.amount !== 0
+				event?.fee_rates?.tax?.amount !== 0
 					? composeTaxString( event )
 					: null,
-				// When our fee was refunded but Stripe still charges a processing
-				// fee (balance transaction has settled), display it and show net.
-				// When store_fee is 0 the BT hasn't settled yet — skip both.
-				isFeeRefunded && stripeProcessingFee > 0
+				// Server only populates stripe_processing_fee once the balance
+				// transaction has settled on a refunded-fee event.
+				stripeProcessingFee > 0
 					? sprintf(
 							/* translators: %s is a monetary amount */
 							__(
@@ -857,6 +856,8 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 							)
 					  )
 					: null,
+				// For refunded events, skip the net line until Stripe's fee is
+				// known — otherwise it would use stale (pre-settlement) values.
 				isFeeRefunded && stripeProcessingFee <= 0
 					? null
 					: composeNetString( event ),

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -282,7 +282,9 @@ const formatNetString = ( event ) => {
 		},
 	} = event;
 
-	if ( ! isFXEvent( event ) ) {
+	const isFeeRefunded = event.fee_rates?.fee_refunded;
+
+	if ( ! isFXEvent( event ) && ! isFeeRefunded ) {
 		return formatExplicitCurrency(
 			amountCaptured - fee,
 			currency,
@@ -291,7 +293,9 @@ const formatNetString = ( event ) => {
 		);
 	}
 
-	// We need to use the store amount and currency for the net amount calculation in the case of a FX event.
+	// For FX events and refunded-fee events, use store amounts.
+	// When the fee was refunded, store_fee holds only Stripe's processing
+	// fee while the event fee was zeroed out, so store values are correct.
 	return formatExplicitCurrency(
 		storeAmountCaptured - storeFee,
 		storeCurrency,
@@ -824,14 +828,40 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 			];
 		case 'captured':
 			const formattedNet = formatNetString( event );
+			const isFeeRefunded = !! event.fee_rates?.fee_refunded;
+			const stripeProcessingFee =
+				event.fee_rates?.stripe_processing_fee || 0;
+			const stripeProcessingFeeCurrency =
+				event.fee_rates?.stripe_processing_fee_currency ||
+				event.transaction_details?.store_currency;
 			const body = [
 				composeFXString( event ),
-				composeFeeString( event ),
-				composeFeeBreakdown( event ),
-				event?.fee_rates?.tax?.amount !== 0
+				isFeeRefunded ? null : composeFeeString( event ),
+				isFeeRefunded ? null : composeFeeBreakdown( event ),
+				isFeeRefunded
+					? null
+					: event?.fee_rates?.tax?.amount !== 0
 					? composeTaxString( event )
 					: null,
-				composeNetString( event ),
+				// When our fee was refunded but Stripe still charges a processing
+				// fee (balance transaction has settled), display it and show net.
+				// When store_fee is 0 the BT hasn't settled yet — skip both.
+				isFeeRefunded && stripeProcessingFee > 0
+					? sprintf(
+							/* translators: %s is a monetary amount */
+							__(
+								'Stripe processing fee: -%s',
+								'woocommerce-payments'
+							),
+							formatExplicitCurrency(
+								stripeProcessingFee,
+								stripeProcessingFeeCurrency
+							)
+					  )
+					: null,
+				isFeeRefunded && stripeProcessingFee <= 0
+					? null
+					: composeNetString( event ),
 			].filter( Boolean );
 			return [
 				getStatusChangeTimelineItem(
@@ -1195,6 +1225,26 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 			return getAutomaticFraudOutcomeTimelineItem( event, 'review' );
 		case 'fraud_outcome_block':
 			return getAutomaticFraudOutcomeTimelineItem( event, 'block' );
+		case 'application_fee_refunded': {
+			const formattedRefundedFee = formatExplicitCurrency(
+				event.amount_refunded,
+				event.currency
+			);
+			return [
+				getMainTimelineItem(
+					event,
+					sprintf(
+						/* translators: %s is a monetary amount */
+						__(
+							'Application fee refunded: +%s',
+							'woocommerce-payments'
+						),
+						formattedRefundedFee
+					),
+					<CheckmarkIcon className="is-success" />
+				),
+			];
+		}
 		default:
 			return [];
 	}

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -838,9 +838,7 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 				composeFXString( event ),
 				isFeeRefunded ? null : composeFeeString( event ),
 				isFeeRefunded ? null : composeFeeBreakdown( event ),
-				isFeeRefunded
-					? null
-					: event?.fee_rates?.tax?.amount !== 0
+				! isFeeRefunded && event?.fee_rates?.tax?.amount !== 0
 					? composeTaxString( event )
 					: null,
 				// When our fee was refunded but Stripe still charges a processing
@@ -1225,26 +1223,6 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 			return getAutomaticFraudOutcomeTimelineItem( event, 'review' );
 		case 'fraud_outcome_block':
 			return getAutomaticFraudOutcomeTimelineItem( event, 'block' );
-		case 'application_fee_refunded': {
-			const formattedRefundedFee = formatExplicitCurrency(
-				event.amount_refunded,
-				event.currency
-			);
-			return [
-				getMainTimelineItem(
-					event,
-					sprintf(
-						/* translators: %s is a monetary amount */
-						__(
-							'Application fee refunded: +%s',
-							'woocommerce-payments'
-						),
-						formattedRefundedFee
-					),
-					<CheckmarkIcon className="is-success" />
-				),
-			];
-		}
 		default:
 			return [];
 	}

--- a/client/payment-details/transaction-breakdown/fees-breakdown/index.tsx
+++ b/client/payment-details/transaction-breakdown/fees-breakdown/index.tsx
@@ -18,6 +18,14 @@ const FeesBreakdown: React.FC< {
 		return null;
 	}
 
+	if ( event.fee_rates.fee_refunded ) {
+		return (
+			<div className="wcpay-transaction-breakdown__fees-container">
+				<p>{ __( 'Fee refunded', 'woocommerce-payments' ) }</p>
+			</div>
+		);
+	}
+
 	const storeCurrency = event.transaction_details.store_currency;
 	const feeExchangeRate = event.fee_rates.fee_exchange_rate?.rate || 1;
 	const discountFee = event.fee_rates.history

--- a/client/payment-details/transaction-breakdown/fees-breakdown/index.tsx
+++ b/client/payment-details/transaction-breakdown/fees-breakdown/index.tsx
@@ -19,11 +19,7 @@ const FeesBreakdown: React.FC< {
 	}
 
 	if ( event.fee_rates.fee_refunded ) {
-		return (
-			<div className="wcpay-transaction-breakdown__fees-container">
-				<p>{ __( 'Fee refunded', 'woocommerce-payments' ) }</p>
-			</div>
-		);
+		return null;
 	}
 
 	const storeCurrency = event.transaction_details.store_currency;

--- a/includes/class-wc-payments-captured-event-note.php
+++ b/includes/class-wc-payments-captured-event-note.php
@@ -67,7 +67,7 @@ class WC_Payments_Captured_Event_Note {
 			if ( $store_fee > 0 ) {
 				$lines[] = sprintf(
 					/* translators: %s is a monetary amount */
-					__( 'Stripe processing fee: -%s', 'woocommerce-payments' ),
+					__( 'Processing fee: -%s', 'woocommerce-payments' ),
 					WC_Payments_Utils::format_explicit_currency(
 						WC_Payments_Utils::interpret_stripe_amount( (int) $store_fee, $store_currency ),
 						$store_currency

--- a/includes/class-wc-payments-captured-event-note.php
+++ b/includes/class-wc-payments-captured-event-note.php
@@ -55,18 +55,42 @@ class WC_Payments_Captured_Event_Note {
 			$lines[] = $fx_string;
 		}
 
-		$lines[] = $this->compose_fee_string();
+		$fee_rates    = $this->captured_event['fee_rates'] ?? [];
+		$fee_refunded = ! empty( $fee_rates['fee_refunded'] );
 
-		$fee_breakdown_lines = $this->compose_fee_break_down();
-		if ( null !== $fee_breakdown_lines ) {
-			$lines = array_merge( $lines, $fee_breakdown_lines );
+		if ( $fee_refunded ) {
+			$lines[] = __( 'Application fee refunded', 'woocommerce-payments' );
+
+			// When the balance transaction has settled, Stripe's processing fee
+			// is available as store_fee. Show it and include the net payout.
+			// When store_fee is 0 the BT hasn't settled — skip both lines.
+			$store_fee      = $this->captured_event['transaction_details']['store_fee'] ?? 0;
+			$store_currency = $this->captured_event['transaction_details']['store_currency'] ?? '';
+			if ( $store_fee > 0 ) {
+				$lines[] = sprintf(
+					/* translators: %s is a monetary amount */
+					__( 'Stripe processing fee: -%s', 'woocommerce-payments' ),
+					WC_Payments_Utils::format_explicit_currency(
+						WC_Payments_Utils::interpret_stripe_amount( (int) $store_fee, $store_currency ),
+						$store_currency
+					)
+				);
+				$lines[] = $this->compose_net_string();
+			}
+		} else {
+			$lines[] = $this->compose_fee_string();
+
+			$fee_breakdown_lines = $this->compose_fee_break_down();
+			if ( null !== $fee_breakdown_lines ) {
+				$lines = array_merge( $lines, $fee_breakdown_lines );
+			}
+
+			if ( $this->has_tax() ) {
+				$lines[] = $this->compose_tax_string();
+			}
+
+			$lines[] = $this->compose_net_string();
 		}
-
-		if ( $this->has_tax() ) {
-			$lines[] = $this->compose_tax_string();
-		}
-
-		$lines[] = $this->compose_net_string();
 
 		$html = '';
 		foreach ( $lines as $line ) {
@@ -186,12 +210,15 @@ class WC_Payments_Captured_Event_Note {
 	 * @return string
 	 */
 	public function compose_net_string(): string {
-		$data = $this->captured_event['transaction_details'];
+		$data         = $this->captured_event['transaction_details'];
+		$fee_rates    = $this->captured_event['fee_rates'] ?? [];
+		$fee_refunded = ! empty( $fee_rates['fee_refunded'] );
 
 		// Determine the type of payment and select the appropriate amounts and currencies.
-		if ( $this->is_fx_event() ) {
-			// For fx events, we need the store amount and currency to display the net amount
-			// in the store currency.
+		if ( $this->is_fx_event() || $fee_refunded ) {
+			// For fx events and refunded-fee events, use store amounts.
+			// When the fee was refunded, store_fee holds only Stripe's processing
+			// fee while customer_fee was zeroed out, so store values are correct.
 			$amount          = $data['store_amount'];
 			$captured_amount = $data['store_amount_captured'];
 			$fee             = $data['store_fee'];

--- a/includes/class-wc-payments-captured-event-note.php
+++ b/includes/class-wc-payments-captured-event-note.php
@@ -59,8 +59,6 @@ class WC_Payments_Captured_Event_Note {
 		$fee_refunded = ! empty( $fee_rates['fee_refunded'] );
 
 		if ( $fee_refunded ) {
-			$lines[] = __( 'Application fee refunded', 'woocommerce-payments' );
-
 			// When the balance transaction has settled, Stripe's processing fee
 			// is available as store_fee. Show it and include the net payout.
 			// When store_fee is 0 the BT hasn't settled — skip both lines.

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -2329,8 +2329,11 @@ class WC_Payments_Order_Service {
 	 * @return void
 	 */
 	private function enqueue_add_fee_breakdown_to_order_notes( WC_Order $order, string $intent_id ) {
+		// Delay by 15 seconds to allow the server to process webhooks and
+		// adjust fee data (e.g., Amazon Pay non-card fee refunds) before the
+		// timeline is fetched for the order note.
 		WC_Payments::get_action_scheduler_service()->schedule_job(
-			time(),
+			time() + 15,
 			self::ADD_FEE_BREAKDOWN_TO_ORDER_NOTES,
 			[
 				'order_id'     => $order->get_id(),

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -593,6 +593,20 @@ class WC_Payments_Order_Service {
 				return;
 			}
 
+			// For refunded Amazon Pay application fees, the captured event's
+			// store_fee carries the Stripe processing fee that the merchant
+			// actually pays. Use it to backfill the transaction-fee meta so
+			// the order page shows the real fee instead of hiding the row.
+			$fee_refunded    = ! empty( $captured_event['fee_rates']['fee_refunded'] );
+			$store_fee_cents = $captured_event['transaction_details']['store_fee'] ?? 0;
+			$store_currency  = $captured_event['transaction_details']['store_currency'] ?? $order->get_currency();
+			if ( $fee_refunded && $store_fee_cents > 0 ) {
+				$order->update_meta_data(
+					self::WCPAY_TRANSACTION_FEE_META_KEY,
+					WC_Payments_Utils::interpret_stripe_amount( (int) $store_fee_cents, $store_currency )
+				);
+			}
+
 			$details = ( new WC_Payments_Captured_Event_Note( $captured_event ) )->generate_html_note();
 
 			// Add fee breakdown details to the note.
@@ -1409,9 +1423,21 @@ class WC_Payments_Order_Service {
 			// Only set transaction fee if the charge was actually captured.
 			// Canceled authorizations should not have fees since no payment was processed.
 			if ( $charge && null !== $charge->get_application_fee_amount() && $charge->is_captured() ) {
+				// Non-card Amazon Pay transactions have the application fee refunded
+				// server-side; record 0 up front so the order page never displays a
+				// pre-refund fee while waiting for the forwarded webhook to arrive.
+				$pm_details  = $charge->get_payment_method_details() ?? [];
+				$pm_type     = $pm_details['type'] ?? null;
+				$funding     = $pm_details['amazon_pay']['funding']['type'] ?? null;
+				$is_refunded = 'amazon_pay' === $pm_type && 'card' !== $funding;
+
+				$fee_amount = $is_refunded
+					? 0
+					: WC_Payments_Utils::interpret_stripe_amount( $charge->get_application_fee_amount(), $charge->get_currency() );
+
 				$order->update_meta_data(
 					self::WCPAY_TRANSACTION_FEE_META_KEY,
-					WC_Payments_Utils::interpret_stripe_amount( $charge->get_application_fee_amount(), $charge->get_currency() )
+					$fee_amount
 				);
 				$order->save_meta_data();
 			}

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -503,12 +503,13 @@ class WC_Payments_Webhook_Processing_Service {
 
 		$application_fee_amount = $charges_data[0]['application_fee_amount'] ?? null;
 
-		if ( $application_fee_amount ) {
-			$fee = WC_Payments_Utils::interpret_stripe_amount( $application_fee_amount, $currency );
-			$meta_data_to_update['_wcpay_transaction_fee'] = $fee;
-
-			$charge_amount                     = WC_Payments_Utils::interpret_stripe_amount( $charge_amount, $currency );
-			$meta_data_to_update['_wcpay_net'] = $charge_amount - $fee;
+		if ( null !== $application_fee_amount ) {
+			$fee = WC_Payments_Utils::interpret_stripe_amount( (int) $application_fee_amount, $currency );
+			$charge_amount = WC_Payments_Utils::interpret_stripe_amount( $charge_amount, $currency );
+			// Update fee and net directly — these can be 0 (e.g., refunded
+			// Amazon Pay fees) and must not be skipped by the falsy check below.
+			$order->update_meta_data( '_wcpay_transaction_fee', $fee );
+			$order->update_meta_data( '_wcpay_net', $charge_amount - $fee );
 		}
 
 		foreach ( $meta_data_to_update as $key => $value ) {

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -504,7 +504,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$application_fee_amount = $charges_data[0]['application_fee_amount'] ?? null;
 
 		if ( null !== $application_fee_amount ) {
-			$fee = WC_Payments_Utils::interpret_stripe_amount( (int) $application_fee_amount, $currency );
+			$fee           = WC_Payments_Utils::interpret_stripe_amount( (int) $application_fee_amount, $currency );
 			$charge_amount = WC_Payments_Utils::interpret_stripe_amount( $charge_amount, $currency );
 			// Update fee and net directly — these can be 0 (e.g., refunded
 			// Amazon Pay fees) and must not be skipped by the falsy check below.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -501,23 +501,23 @@ class WC_Payments_Webhook_Processing_Service {
 			$meta_data_to_update['_stripe_mandate_id'] = $mandate_id;
 		}
 
-		$application_fee_amount = $charges_data[0]['application_fee_amount'] ?? null;
-
-		if ( null !== $application_fee_amount ) {
-			$fee           = WC_Payments_Utils::interpret_stripe_amount( (int) $application_fee_amount, $currency );
-			$charge_amount = WC_Payments_Utils::interpret_stripe_amount( $charge_amount, $currency );
-			// Update fee and net directly — these can be 0 (e.g., refunded
-			// Amazon Pay fees) and must not be skipped by the falsy check below.
-			$order->update_meta_data( '_wcpay_transaction_fee', $fee );
-			$order->update_meta_data( '_wcpay_net', $charge_amount - $fee );
-		}
-
 		foreach ( $meta_data_to_update as $key => $value ) {
 			// Override existing meta data with incoming values, if present.
 			if ( $value ) {
 				$order->update_meta_data( $key, $value );
 			}
 		}
+
+		// Fee/net are written directly (not via the loop above) because they
+		// can legitimately be 0 — the loop's truthy check would drop those.
+		$application_fee_amount = $charges_data[0]['application_fee_amount'] ?? null;
+		if ( null !== $application_fee_amount ) {
+			$fee           = WC_Payments_Utils::interpret_stripe_amount( (int) $application_fee_amount, $currency );
+			$charge_amount = WC_Payments_Utils::interpret_stripe_amount( $charge_amount, $currency );
+			$order->update_meta_data( '_wcpay_transaction_fee', $fee );
+			$order->update_meta_data( '_wcpay_net', $charge_amount - $fee );
+		}
+
 		// Save the order after updating the meta data values.
 		$order->save();
 

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1494,6 +1494,60 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->order_service->attach_transaction_fee_to_order( $mock_order, $charge );
 	}
 
+	public function test_attach_transaction_fee_to_order_amazon_pay_non_card() {
+		$order  = WC_Helper_Order::create_order();
+		$charge = new WC_Payments_API_Charge(
+			'ch_mock',
+			1500,
+			new DateTime(),
+			[
+				'type'       => 'amazon_pay',
+				'amazon_pay' => [
+					'funding' => [ 'type' => null ],
+				],
+			],
+			null,
+			null,
+			null,
+			102,
+			[],
+			[],
+			'usd'
+		);
+		$charge->set_captured( true );
+		$this->order_service->attach_transaction_fee_to_order( $order, $charge );
+
+		// Fee should be recorded as 0 up front; the server refunds it async.
+		$this->assertEquals( 0, $order->get_meta( '_wcpay_transaction_fee', true ) );
+	}
+
+	public function test_attach_transaction_fee_to_order_amazon_pay_card_passthrough() {
+		$order  = WC_Helper_Order::create_order();
+		$charge = new WC_Payments_API_Charge(
+			'ch_mock',
+			1500,
+			new DateTime(),
+			[
+				'type'       => 'amazon_pay',
+				'amazon_pay' => [
+					'funding' => [ 'type' => 'card' ],
+				],
+			],
+			null,
+			null,
+			null,
+			102,
+			[],
+			[],
+			'usd'
+		);
+		$charge->set_captured( true );
+		$this->order_service->attach_transaction_fee_to_order( $order, $charge );
+
+		// Card-funded Amazon Pay keeps the application fee as normal.
+		$this->assertEquals( 1.02, $order->get_meta( '_wcpay_transaction_fee', true ) );
+	}
+
 	public function test_add_note_and_metadata_for_created_refund_successful_fully_refunded(): void {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
@@ -2100,5 +2154,40 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 
 		$notes_after = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
 		$this->assertCount( count( $notes_before ), $notes_after );
+	}
+
+	/**
+	 * Test that add_fee_breakdown_to_order_notes backfills the transaction-fee
+	 * meta with the Stripe processing fee once the application fee has been
+	 * refunded (Amazon Pay non-card) and the balance transaction has settled.
+	 */
+	public function test_add_fee_breakdown_backfills_stripe_fee_when_application_fee_refunded() {
+		$this->order->update_meta_data( '_wcpay_transaction_fee', 0 );
+		$this->order->save();
+
+		$mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$mock_api_client->expects( $this->once() )
+			->method( 'get_timeline' )
+			->willReturn(
+				[
+					'data' => [
+						[
+							'type'                => 'captured',
+							'fee_rates'           => [
+								'fee_refunded' => true,
+							],
+							'transaction_details' => [
+								'store_fee'      => 68,
+								'store_currency' => 'usd',
+							],
+						],
+					],
+				]
+			);
+
+		$order_service = new WC_Payments_Order_Service( $mock_api_client );
+		$order_service->add_fee_breakdown_to_order_notes( $this->order->get_id(), 'pi_test_123' );
+
+		$this->assertEquals( 0.68, $this->order->get_meta( '_wcpay_transaction_fee', true ) );
 	}
 }

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -2177,8 +2177,10 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 								'fee_refunded' => true,
 							],
 							'transaction_details' => [
-								'store_fee'      => 68,
-								'store_currency' => 'usd',
+								'store_amount'          => 1299,
+								'store_amount_captured' => 1299,
+								'store_fee'             => 68,
+								'store_currency'        => 'usd',
 							],
 						],
 					],
@@ -2188,6 +2190,9 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$order_service = new WC_Payments_Order_Service( $mock_api_client );
 		$order_service->add_fee_breakdown_to_order_notes( $this->order->get_id(), 'pi_test_123' );
 
-		$this->assertEquals( 0.68, $this->order->get_meta( '_wcpay_transaction_fee', true ) );
+		// Reload the order — the service operates on its own instance loaded
+		// via wc_get_order(), so $this->order's cached meta is stale.
+		$order = wc_get_order( $this->order->get_id() );
+		$this->assertEquals( 0.68, $order->get_meta( '_wcpay_transaction_fee', true ) );
 	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-6097

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

For non-card Amazon Pay transactions (SEPA, BNPL, etc.), the fee shown across the order and transaction surfaces didn't match the amount actually deducted from the merchant's payout. This PR updates the merchant-facing displays to show the correct fee.

- Order-page "Transaction Fee" row, timeline, fees-breakdown panel, and order notes now surface the accurate processing fee.
- Net payout uses store-side amounts when the timeline's captured event carries `fee_refunded: true`.
- Webhook processing writes `$0` fee/net meta values when the payload carries them (previously skipped by a truthy check, leaving stale values in place).
- The checkout redirect writes `$0` up front for non-card Amazon Pay so the order page doesn't briefly display a stale value.
- The fee-breakdown order note is scheduled 15 s after capture so the final fee data is available when the note is built.

Regular card payments and card-funded Amazon Pay should remain unaffected.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use in combination with the server-side PR (#211501 - or get it from the Linear issue)
 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
