### PR TITLE
feat: enable dispute additional evidence types by default

### DIFF
--- a/changelog/enable-dispute-additional-evidence-types-by-default
+++ b/changelog/enable-dispute-additional-evidence-types-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable dispute additional evidence types feature by default

--- a/client/disputes/new-evidence/__tests__/evidence-matrix-spec-validation.test.ts
+++ b/client/disputes/new-evidence/__tests__/evidence-matrix-spec-validation.test.ts
@@ -1,64 +1,14 @@
 /**
  * Spec-Driven Evidence Matrix Validation Tests
  *
- * This file validates the implementation against the specification document:
- * "Reason Code x Product Type Logic"
- *
- * The tests ensure that for each implemented Reason × Product Type combination:
+ * Validates the implementation against the "Reason Code x Product Type Logic"
+ * specification. For each Reason × Product Type combination in the matrix,
+ * asserts that:
  * 1. UI shows the correct document fields (getRecommendedDocumentFields)
  * 2. Cover letter includes the correct attachments (generateAttachments)
  *
- * IMPLEMENTATION STATUS (from evidence-matrix.ts):
- * ✅ Implemented combinations:
- *   - fraudulent × booking_reservation
- *   - fraudulent × physical_product
- *   - fraudulent × digital_product_or_service
- *   - product_not_received × booking_reservation
- *   - product_not_received × physical_product
- *   - product_not_received × digital_product_or_service
- *   - product_unacceptable × booking_reservation
- *   - product_unacceptable × physical_product
- *   - product_unacceptable × digital_product_or_service
- *   - subscription_canceled × booking_reservation
- *   - subscription_canceled × physical_product
- *   - subscription_canceled × digital_product_or_service
- *   - subscription_canceled × other
- *   - subscription_canceled × multiple
- *   - duplicate × booking_reservation (is_duplicate scenario)
- *   - duplicate × booking_reservation (is_not_duplicate scenario)
- *   - duplicate × physical_product (is_duplicate scenario)
- *   - duplicate × physical_product (is_not_duplicate scenario)
- *   - duplicate × digital_product_or_service (is_duplicate scenario)
- *   - duplicate × digital_product_or_service (is_not_duplicate scenario)
- *   - credit_not_processed × booking_reservation (refund_has_been_issued scenario)
- *   - credit_not_processed × booking_reservation (refund_was_not_owed scenario)
- *   - credit_not_processed × physical_product (refund_has_been_issued scenario)
- *   - credit_not_processed × physical_product (refund_was_not_owed scenario)
- *   - credit_not_processed × digital_product_or_service (refund_has_been_issued scenario)
- *   - credit_not_processed × digital_product_or_service (refund_was_not_owed scenario)
- *   - fraudulent × offline_service
- *   - product_not_received × offline_service
- *   - product_unacceptable × offline_service
- *   - subscription_canceled × offline_service
- *   - credit_not_processed × offline_service (refund_has_been_issued scenario)
- *   - credit_not_processed × offline_service (refund_was_not_owed scenario)
- *   - duplicate × offline_service (is_duplicate scenario)
- *   - duplicate × offline_service (is_not_duplicate scenario)
- *   - fraudulent × event
- *   - product_not_received × event
- *   - product_unacceptable × event
- *   - subscription_canceled × event
- *   - credit_not_processed × event (refund_has_been_issued scenario)
- *   - credit_not_processed × event (refund_was_not_owed scenario)
- *   - duplicate × event (is_duplicate scenario)
- *   - duplicate × event (is_not_duplicate scenario)
- *   - fraudulent × other
- *   - product_not_received × other
- *   - product_unacceptable × other
- *   - credit_not_processed × other (refund_has_been_issued scenario)
- *   - credit_not_processed × other (refund_was_not_owed scenario)
- *   - duplicate × other (is_duplicate scenario)
- *   - duplicate × other (is_not_duplicate scenario)
+ * The matrix in evidence-matrix.ts is the source of truth for which
+ * combinations are covered.
  */
 
 /**
@@ -2059,18 +2009,19 @@ describe( 'Evidence Matrix Specification Validation', () => {
 			}
 		);
 
-		describe( 'Non-implemented combinations should return undefined', () => {
-			const notImplemented = [
-				// Status-less call for credit_not_processed × other should return undefined
-				// (only composite keys other__refund_has_been_issued / other__refund_was_not_owed exist)
+		describe( 'Status-dependent reasons require a status argument', () => {
+			// credit_not_processed and duplicate use composite keys
+			// (e.g. other__refund_has_been_issued). A status-less lookup has
+			// no plain productType key in the matrix and must return undefined.
+			const statusDependentLookups = [
 				{
 					reason: 'credit_not_processed',
 					productType: 'other',
 				},
 			];
 
-			it.each( notImplemented )(
-				'should return undefined for $reason × $productType',
+			it.each( statusDependentLookups )(
+				'should return undefined for $reason × $productType without a status',
 				( { reason, productType } ) => {
 					const fields = getMatrixFields( reason, productType );
 					expect( fields ).toBeUndefined();

--- a/client/disputes/new-evidence/__tests__/evidence-matrix-spec-validation.test.ts
+++ b/client/disputes/new-evidence/__tests__/evidence-matrix-spec-validation.test.ts
@@ -2,13 +2,13 @@
  * Spec-Driven Evidence Matrix Validation Tests
  *
  * Validates the implementation against the "Reason Code x Product Type Logic"
- * specification. For each Reason × Product Type combination in the matrix,
+ * specification. For each entry in the `implementedCombinations` array below,
  * asserts that:
  * 1. UI shows the correct document fields (getRecommendedDocumentFields)
  * 2. Cover letter includes the correct attachments (generateAttachments)
  *
- * The matrix in evidence-matrix.ts is the source of truth for which
- * combinations are covered.
+ * `implementedCombinations` is hand-maintained and must be kept in sync with
+ * `evidence-matrix.ts` when new reason × product type entries are added.
  */
 
 /**

--- a/client/disputes/new-evidence/__tests__/evidence-matrix-spec-validation.test.ts
+++ b/client/disputes/new-evidence/__tests__/evidence-matrix-spec-validation.test.ts
@@ -2018,6 +2018,10 @@ describe( 'Evidence Matrix Specification Validation', () => {
 					reason: 'credit_not_processed',
 					productType: 'other',
 				},
+				{
+					reason: 'duplicate',
+					productType: 'other',
+				},
 			];
 
 			it.each( statusDependentLookups )(

--- a/client/disputes/new-evidence/__tests__/index.test.tsx
+++ b/client/disputes/new-evidence/__tests__/index.test.tsx
@@ -935,3 +935,96 @@ describe( 'NewEvidence - Payment Intent Cache Invalidation', () => {
 		} );
 	} );
 } );
+
+describe( 'NewEvidence - multiple → other product type mapping', () => {
+	const disputeWithMultipleSuggestedType = {
+		id: 'dp_test_multiple',
+		amount: 1000,
+		currency: 'usd',
+		created: 1609459200,
+		reason: 'fraudulent' as DisputeReason,
+		status: 'needs_response',
+		evidence_details: {
+			due_by: 1610064000,
+		},
+		evidence: {},
+		metadata: {},
+		order: {
+			id: 123,
+			number: '123',
+			ip_address: '192.168.1.1',
+			suggested_product_type: 'multiple',
+		},
+		charge: {
+			id: 'ch_test_multiple',
+			payment_method_details: {
+				type: 'card',
+				card: { issuer: 'Test Bank' },
+			},
+		},
+		enhanced_eligibility_types: [],
+		balance_transactions: [],
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockApiFetch.mockResolvedValue( disputeWithMultipleSuggestedType );
+		mockUseGetSettings.mockReturnValue( {
+			account_country: 'US',
+			account_business_name: 'Test Store',
+			account_business_support_email: 'support@test.com',
+			account_business_support_phone: '1234567890',
+		} );
+		mockUseDisputeEvidence.mockReturnValue( { updateDispute: jest.fn() } );
+		( mockUseDispatch as jest.Mock ).mockReturnValue( {
+			createSuccessNotice: jest.fn(),
+			createErrorNotice: jest.fn(),
+			createInfoNotice: jest.fn(),
+		} );
+	} );
+
+	afterEach( () => {
+		global.wcpaySettings.featureFlags.isDisputeAdditionalEvidenceTypesEnabled =
+			true;
+	} );
+
+	it( 'remaps multiple → other when the feature flag is enabled', async () => {
+		global.wcpaySettings.featureFlags.isDisputeAdditionalEvidenceTypesEnabled =
+			true;
+
+		render( <NewEvidence query={ { id: 'dp_test_multiple' } } /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getByText( 'Product or service details' )
+			).toBeInTheDocument();
+		} );
+
+		const productTypeSelect = screen
+			.getByText( 'Product or service details' )
+			.closest( 'section' )
+			?.querySelector( 'select' ) as HTMLSelectElement;
+
+		expect( productTypeSelect ).not.toBeNull();
+		expect( productTypeSelect ).toHaveValue( 'other' );
+	} );
+
+	it( 'preserves multiple when the feature flag is disabled', async () => {
+		global.wcpaySettings.featureFlags.isDisputeAdditionalEvidenceTypesEnabled =
+			false;
+
+		render( <NewEvidence query={ { id: 'dp_test_multiple' } } /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Product details' ) ).toBeInTheDocument();
+		} );
+
+		const productTypeSelect = screen
+			.getByText( 'Product details' )
+			.closest( 'section' )
+			?.querySelector( 'select' ) as HTMLSelectElement;
+
+		expect( productTypeSelect ).not.toBeNull();
+		expect( productTypeSelect ).toHaveValue( 'multiple' );
+	} );
+} );

--- a/client/disputes/new-evidence/index.tsx
+++ b/client/disputes/new-evidence/index.tsx
@@ -156,10 +156,20 @@ export default ( { query }: { query: { id: string } } ) => {
 					isVisaComplianceDispute( d );
 				// Prefer the saved metadata value for product type, as it will be empty on the merchant's first visit.
 				// After the merchant saves the dispute challenge, this metadata will be populated and should be used.
-				const suggestedProductType =
+				const rawSuggestedProductType =
 					d.metadata?.__product_type ||
 					d.order?.suggested_product_type ||
 					'';
+				// `multiple` is no longer a selectable option when the new form is active
+				// (see product-details.tsx), so mixed-product orders coming back from the
+				// backend or from legacy drafts get normalized to `other` to avoid an
+				// unselected dropdown. `subscription_canceled × multiple` still has a
+				// matrix entry for the legacy path.
+				const suggestedProductType =
+					isFeatureFlagEnabled &&
+					rawSuggestedProductType === 'multiple'
+						? 'other'
+						: rawSuggestedProductType;
 				setProductType( suggestedProductType );
 				// Load saved product description from evidence or level3 line items
 				const level3ProductNames = d.charge?.level3?.line_items

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -316,14 +316,14 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Checks whether Dispute Additional Evidence Types feature should be enabled. Disabled by default.
+	 * Checks whether Dispute Additional Evidence Types feature should be enabled. Enabled by default.
 	 *
 	 * This gates the new evidence form types (event, booking_reservation, other) for dispute challenges.
 	 *
 	 * @return bool
 	 */
 	public static function is_dispute_additional_evidence_types_enabled(): bool {
-		return '1' === get_option( self::DISPUTE_ADDITIONAL_EVIDENCE_TYPES, '0' );
+		return '1' === get_option( self::DISPUTE_ADDITIONAL_EVIDENCE_TYPES, '1' );
 	}
 
 	/**

--- a/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-disputes-respond.spec.ts
@@ -193,7 +193,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 				).toBeVisible();
 
 				await merchantPage
-					.getByLabel( 'PRODUCT DESCRIPTION' )
+					.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 					.fill( 'my product description' );
 			} );
 
@@ -520,16 +520,16 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 			// so we retry the fill+verify cycle until the value sticks.
 			await expect( async () => {
 				await merchantPage
-					.getByLabel( 'PRODUCT DESCRIPTION' )
+					.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 					.fill( 'my product description' );
 
 				// Blur the field to ensure value is committed to state
 				await merchantPage
-					.getByLabel( 'PRODUCT DESCRIPTION' )
+					.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 					.press( 'Tab' );
 
 				await expect(
-					merchantPage.getByLabel( 'PRODUCT DESCRIPTION' )
+					merchantPage.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 				).toHaveValue( 'my product description', {
 					timeout: 2000,
 				} );
@@ -601,7 +601,7 @@ test.describe( 'Disputes > Respond to a dispute', () => {
 				).toBeVisible();
 
 				await expect(
-					merchantPage.getByLabel( 'PRODUCT DESCRIPTION' )
+					merchantPage.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 				).toHaveValue( 'my product description', {
 					timeout: 5000,
 				} );

--- a/tests/qit/test-package/tests/woopayments/merchant/merchant-disputes-respond.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/merchant/merchant-disputes-respond.spec.ts
@@ -159,7 +159,7 @@ test.describe( 'Disputes > Respond to a dispute', { tag: '@merchant' }, () => {
 					).toBeVisible();
 
 					await adminPage
-						.getByLabel( 'PRODUCT DESCRIPTION' )
+						.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 						.fill( 'my product description' );
 				}
 			);
@@ -543,16 +543,16 @@ test.describe( 'Disputes > Respond to a dispute', { tag: '@merchant' }, () => {
 				// so we retry the fill+verify cycle until the value sticks.
 				await expect( async () => {
 					await adminPage
-						.getByLabel( 'PRODUCT DESCRIPTION' )
+						.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 						.fill( 'my product description' );
 
 					// Blur the field to ensure value is committed to state
 					await adminPage
-						.getByLabel( 'PRODUCT DESCRIPTION' )
+						.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 						.press( 'Tab' );
 
 					await expect(
-						adminPage.getByLabel( 'PRODUCT DESCRIPTION' )
+						adminPage.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 					).toHaveValue( 'my product description', {
 						timeout: 2000,
 					} );
@@ -632,7 +632,7 @@ test.describe( 'Disputes > Respond to a dispute', { tag: '@merchant' }, () => {
 					).toBeVisible();
 
 					await expect(
-						adminPage.getByLabel( 'PRODUCT DESCRIPTION' )
+						adminPage.getByLabel( 'PRODUCT OR SERVICE DESCRIPTION' )
 					).toHaveValue( 'my product description', {
 						timeout: 5000,
 					} );

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -26,8 +26,7 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	private $mock_wcpay_account;
 
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
-		'_wcpay_feature_customer_multi_currency'           => 'multiCurrency',
-		'_wcpay_feature_dispute_additional_evidence_types' => 'isDisputeAdditionalEvidenceTypesEnabled',
+		'_wcpay_feature_customer_multi_currency' => 'multiCurrency',
 	];
 
 	public function set_up() {
@@ -73,6 +72,10 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	 */
 	public function test_it_returns_expected_to_array_result( array $enabled_flags ) {
 		$this->setup_enabled_flags( $enabled_flags );
+
+		// Explicitly disable flags that default to ON so they don't appear
+		// in to_array() output unless included in $enabled_flags above.
+		$this->set_feature_flag_option( WC_Payments_Features::DISPUTE_ADDITIONAL_EVIDENCE_TYPES, '0' );
 
 		$expected = [];
 		foreach ( $enabled_flags as $flag ) {

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -99,6 +99,15 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Features::is_customer_multi_currency_enabled() );
 	}
 
+	public function test_is_dispute_additional_evidence_types_enabled_by_default() {
+		$this->assertTrue( WC_Payments_Features::is_dispute_additional_evidence_types_enabled() );
+	}
+
+	public function test_is_dispute_additional_evidence_types_can_be_disabled() {
+		$this->set_feature_flag_option( WC_Payments_Features::DISPUTE_ADDITIONAL_EVIDENCE_TYPES, '0' );
+		$this->assertFalse( WC_Payments_Features::is_dispute_additional_evidence_types_enabled() );
+	}
+
 	public function test_is_woopay_eligible_returns_true() {
 		$this->mock_cache->method( 'get' )->willReturn( [ 'platform_checkout_eligible' => true ] );
 		$this->assertTrue( WC_Payments_Features::is_woopay_eligible() );

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -26,7 +26,8 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	private $mock_wcpay_account;
 
 	const FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING = [
-		'_wcpay_feature_customer_multi_currency' => 'multiCurrency',
+		'_wcpay_feature_customer_multi_currency'           => 'multiCurrency',
+		'_wcpay_feature_dispute_additional_evidence_types' => 'isDisputeAdditionalEvidenceTypesEnabled',
 	];
 
 	public function set_up() {


### PR DESCRIPTION
Fixes #WOOPMNT-6103

#### Changes proposed in this Pull Request

Flips `_wcpay_feature_dispute_additional_evidence_types` to be enabled by default now that all reason × product type combinations have shipped. The flag is kept in place as a rollback escape hatch for one release of observation — full flag removal will follow in a separate PR.

Additional changes in this PR:

- **`multiple` → `other` normalization in `index.tsx`.**  The load path now normalizes `'multiple'` to `'other'` when the flag is enabled, so the dropdown selects "Other" instead of rendering in an invalid-selected state.
- **E2E test label updates.** `product-details.tsx` renders "PRODUCT OR SERVICE DESCRIPTION" when the flag is ON and "PRODUCT DESCRIPTION" when it isn't. 

**Rollback:** `wp option update _wcpay_feature_dispute_additional_evidence_types 0` — instant revert to the legacy form, evidence data untouched.

#### Testing instructions

The feature itself is already covered by PRs #11403, #11420, #11424, #11443, #11475. These steps specifically verify the flag default flip, the legacy-draft migration path, and the new `multiple → other` normalization.

**1. Default is ON for a fresh install**

- `wp option delete _wcpay_feature_dispute_additional_evidence_types`
- Reload WP admin → Payments → Disputes
- Open any dispute's challenge page
- Expected: the product type selector is visible (new form is rendered)
- Expected: `window.wcpaySettings.featureFlags.isDisputeAdditionalEvidenceTypesEnabled === true` in the browser console

**2. Legacy drafts survive the flag flip**

- `wp option update _wcpay_feature_dispute_additional_evidence_types 0`
- Open a dispute, start a challenge in the legacy form, upload a file to each visible field, save as draft
- `wp option delete _wcpay_feature_dispute_additional_evidence_types` (back to new default)
- Reopen the same dispute
- Expected: uploaded files are still present under their respective fields
- Expected: the product type selector falls back to `suggested_product_type` from the API (or legacy fields if none resolves)

**3. Mixed-product orders normalize to "Other"**

- Create a dispute on an order that contains more than one product type (backend returns `suggested_product_type = 'multiple'`) — or manually save a draft with the legacy form and `multiple` selected, then re-enable the flag default.
- Open the challenge page with the flag ON.
- Expected: the product type dropdown is pre-selected to **Other**, not rendered unselected.
- Expected: saved description, uploaded files, and cover letter content are preserved across the remap.

**4. Rollback is instant**

- With the new form visible, run `wp option update _wcpay_feature_dispute_additional_evidence_types 0`
- Reload the challenge page
- Expected: legacy form is shown, no product type selector, previously uploaded files still load

-------------------

- [x] Run \`npm run changelog\` to add a changelog file, choose \`patch\` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description)
- [x] Tested on mobile (or does not apply) — admin-only UI, no mobile surface

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.