### PR TITLE
feat: Dispute Defender AI — draft evidence for fraudulent disputes

### DIFF
--- a/changelog/feat-dispute-defender-panel
+++ b/changelog/feat-dispute-defender-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Dispute Defender AI REST endpoint and merchant-facing panel skeleton for generating draft defense responses on fraudulent disputes.

--- a/changelog/feat-dispute-evidence-collector
+++ b/changelog/feat-dispute-evidence-collector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Dispute_Evidence_Collector service that assembles a normalized, PII-minimized DTO for AI-drafted dispute defenses.

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -112,6 +112,10 @@ export function updateIsMultiCurrencyEnabled( isEnabled ) {
 	return updateSettingsValues( { is_multi_currency_enabled: isEnabled } );
 }
 
+export function updateIsDisputeDefenderEnabled( isEnabled ) {
+	return updateSettingsValues( { is_dispute_defender_enabled: isEnabled } );
+}
+
 export function updateIsWCPaySubscriptionsEnabled( isEnabled ) {
 	return updateSettingsValues( {
 		is_wcpay_subscriptions_enabled: isEnabled,

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -138,6 +138,19 @@ export const useMultiCurrency = () => {
 	return [ isMultiCurrencyEnabled, updateIsMultiCurrencyEnabled ];
 };
 
+/**
+ * @return {import('wcpay/types/wcpay-data-settings-hooks').GenericSettingsHook<boolean>}
+ */
+export const useDisputeDefender = () => {
+	const { updateIsDisputeDefenderEnabled } = useDispatch( STORE_NAME );
+
+	const isDisputeDefenderEnabled = useSelect( ( select ) =>
+		select( STORE_NAME ).getIsDisputeDefenderEnabled()
+	);
+
+	return [ isDisputeDefenderEnabled, updateIsDisputeDefenderEnabled ];
+};
+
 export const useWCPaySubscriptions = () => {
 	const { updateIsWCPaySubscriptionsEnabled } = useDispatch( STORE_NAME );
 

--- a/client/data/settings/selectors.js
+++ b/client/data/settings/selectors.js
@@ -136,6 +136,10 @@ export const getIsMultiCurrencyEnabled = ( state ) => {
 	return getSettings( state ).is_multi_currency_enabled || false;
 };
 
+export const getIsDisputeDefenderEnabled = ( state ) => {
+	return getSettings( state ).is_dispute_defender_enabled || false;
+};
+
 export const getPaymentRequestButtonType = ( state ) => {
 	return getSettings( state ).payment_request_button_type || '';
 };

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -32,6 +32,7 @@ declare global {
 			paymentTimeline: boolean;
 			isDisputeIssuerEvidenceEnabled: boolean;
 			isDisputeAdditionalEvidenceTypesEnabled: boolean;
+			isDisputeDefenderEnabled: boolean;
 			multiCurrency?: boolean;
 			isFRTReviewFeatureActive: boolean;
 			isDynamicCheckoutPlaceOrderButtonEnabled: boolean;

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -31,6 +31,7 @@ import { useDisputeAccept } from 'wcpay/data';
 import { getDisputeFeeFormatted, isInquiry } from 'wcpay/disputes/utils';
 import { getAdminUrl } from 'wcpay/utils';
 import DisputeNotice from './dispute-notice';
+import DisputeDefenderPanel from './dispute-defender-panel';
 import IssuerEvidenceList from './evidence-list';
 import DisputeSummaryRow from './dispute-summary-row';
 import {
@@ -327,6 +328,8 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 				<DisputeSummaryRow dispute={ dispute } />
 
 				{ steps }
+
+				<DisputeDefenderPanel dispute={ dispute } />
 
 				{ isDisputeIssuerEvidenceEnabled && (
 					<IssuerEvidenceList

--- a/client/payment-details/dispute-details/dispute-defender-panel/__tests__/index.test.tsx
+++ b/client/payment-details/dispute-details/dispute-defender-panel/__tests__/index.test.tsx
@@ -390,4 +390,125 @@ describe( 'DisputeDefenderPanel', () => {
 		// Sanity touch to avoid unused-var lint on onUseDraft.
 		expect( onUseDraft ).not.toHaveBeenCalled();
 	} );
+
+	it( 'does not fire button_viewed when the panel is gated off', () => {
+		( window as any ).wcpaySettings = {
+			featureFlags: { isDisputeDefenderEnabled: false },
+		};
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+
+		const viewedCalls = ( recordEvent as jest.Mock ).mock.calls.filter(
+			( [ name ] ) => name === 'wcpay_dispute_defender_button_viewed'
+		);
+		expect( viewedCalls ).toHaveLength( 0 );
+	} );
+
+	it( 'fires wcpay_dispute_defender_button_viewed once on mount', () => {
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+
+		const viewedCalls = ( recordEvent as jest.Mock ).mock.calls.filter(
+			( [ name ] ) => name === 'wcpay_dispute_defender_button_viewed'
+		);
+		expect( viewedCalls ).toHaveLength( 1 );
+		expect( viewedCalls[ 0 ][ 1 ] ).toEqual(
+			expect.objectContaining( { dispute_id: 'dp_test_123' } )
+		);
+	} );
+
+	it( 'renders the friendly message for a known error code', async () => {
+		( apiFetch as unknown as jest.Mock ).mockRejectedValue( {
+			code: 'wcpay_dispute_defender_failure',
+			message: 'Upstream error',
+			data: { status: 502 },
+		} );
+
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /generate with ai/i } )
+			);
+		} );
+
+		await waitFor( () => {
+			expect(
+				screen.getAllByText( /couldn[’']t generate a draft right now/i )
+					.length
+			).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	it( 'renders a Retry button for transient errors', async () => {
+		( apiFetch as unknown as jest.Mock ).mockRejectedValue( {
+			code: 'wcpay_dispute_defender_failure',
+			message: 'Upstream error',
+			data: { status: 502 },
+		} );
+
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /generate with ai/i } )
+			);
+		} );
+
+		const retryButton = await screen.findByRole( 'button', {
+			name: /retry/i,
+		} );
+		expect( retryButton ).toBeInTheDocument();
+
+		( apiFetch as unknown as jest.Mock ).mockClear();
+		await act( async () => {
+			await userEvent.click( retryButton );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wc/v3/payments/disputes/dp_test_123/defense/draft',
+			method: 'POST',
+		} );
+	} );
+
+	it( 'does not render a Retry button for non-retryable errors', async () => {
+		( apiFetch as unknown as jest.Mock ).mockRejectedValue( {
+			code: 'wcpay_dispute_defender_unsupported_reason',
+			message: 'Unsupported',
+			data: { status: 400 },
+		} );
+
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /generate with ai/i } )
+			);
+		} );
+
+		await waitFor( () => {
+			expect(
+				screen.getAllByText( /not supported by dispute defender ai/i )
+					.length
+			).toBeGreaterThan( 0 );
+		} );
+
+		expect(
+			screen.queryByRole( 'button', { name: /retry/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'falls back to err.message when the code is unknown', async () => {
+		( apiFetch as unknown as jest.Mock ).mockRejectedValue(
+			new Error( 'oops' )
+		);
+
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /generate with ai/i } )
+			);
+		} );
+
+		await waitFor( () => {
+			expect( screen.getAllByText( /oops/i ).length ).toBeGreaterThan(
+				0
+			);
+		} );
+	} );
 } );

--- a/client/payment-details/dispute-details/dispute-defender-panel/__tests__/index.test.tsx
+++ b/client/payment-details/dispute-details/dispute-defender-panel/__tests__/index.test.tsx
@@ -1,0 +1,118 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { DisputeDefenderPanel } from '../index';
+
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( 'tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+const baseFraudulentDispute: any = {
+	id: 'dp_test_123',
+	reason: 'fraudulent',
+	amount: 10000,
+	currency: 'usd',
+};
+
+describe( 'DisputeDefenderPanel', () => {
+	beforeEach( () => {
+		( window as any ).wcpaySettings = {
+			featureFlags: { isDisputeDefenderEnabled: true },
+		};
+		( apiFetch as unknown as jest.Mock ).mockReset();
+	} );
+
+	it( 'renders the Generate button when the flag is on and reason is fraudulent', () => {
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+		expect(
+			screen.getByRole( 'button', { name: /generate with ai/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when the dispute reason is not fraudulent', () => {
+		const dispute = { ...baseFraudulentDispute, reason: 'duplicate' };
+		const { container } = render(
+			<DisputeDefenderPanel dispute={ dispute } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when the feature flag is off', () => {
+		( window as any ).wcpaySettings = {
+			featureFlags: { isDisputeDefenderEnabled: false },
+		};
+		const { container } = render(
+			<DisputeDefenderPanel dispute={ baseFraudulentDispute } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'calls the REST endpoint and renders the draft on click', async () => {
+		( apiFetch as unknown as jest.Mock ).mockResolvedValue( {
+			narrative: 'The charge is legitimate.',
+			gaps: [],
+			meta: {
+				model: 'claude-sonnet-4-5',
+				prompt_version: 'v1',
+				generated_at: '2026-04-16T00:00:00Z',
+			},
+		} );
+
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+
+		const button = screen.getByRole( 'button', {
+			name: /generate with ai/i,
+		} );
+		// Wrap the click + async resolution in act() so the second state
+		// update (fired after apiFetch resolves on a subsequent microtask)
+		// is captured inside the test boundary. Without this, React 18
+		// emits an act() warning that @wordpress/jest-console treats as a
+		// test failure.
+		await act( async () => {
+			await userEvent.click( button );
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wc/v3/payments/disputes/dp_test_123/defense/draft',
+			method: 'POST',
+		} );
+
+		await waitFor( () => {
+			expect(
+				screen.getByText( /The charge is legitimate/i )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'shows an error when the REST call fails', async () => {
+		( apiFetch as unknown as jest.Mock ).mockRejectedValue(
+			new Error( 'Upstream failure' )
+		);
+
+		render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /generate with ai/i } )
+			);
+		} );
+
+		await waitFor( () => {
+			// Notice renders the message in multiple wrappers for a11y — use
+			// getAllByText so the presence check doesn't fail on duplicates.
+			expect(
+				screen.getAllByText( /Upstream failure/i ).length
+			).toBeGreaterThan( 0 );
+		} );
+	} );
+} );

--- a/client/payment-details/dispute-details/dispute-defender-panel/__tests__/index.test.tsx
+++ b/client/payment-details/dispute-details/dispute-defender-panel/__tests__/index.test.tsx
@@ -12,6 +12,7 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { DisputeDefenderPanel } from '../index';
+import { recordEvent } from 'tracks';
 
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( 'tracks', () => ( {
@@ -25,12 +26,77 @@ const baseFraudulentDispute: any = {
 	currency: 'usd',
 };
 
+const withEvidenceSentence =
+	'We captured the AVS and CVC match on the original authorization.';
+const substitutedSentence =
+	'AVS and CVC data from the original authorization are not available for this charge.';
+
+const draftWithGap = {
+	narrative: `The charge is legitimate. ${ withEvidenceSentence } Thanks.`,
+	gaps: [
+		{
+			id: 'avs_cvc',
+			label: 'AVS / CVC match',
+			default_resolution: 'provide',
+			sentences: {
+				with_evidence: withEvidenceSentence,
+				substituted: substitutedSentence,
+			},
+		},
+	],
+	meta: {
+		model: 'claude-sonnet-4-5',
+		prompt_version: 'v1',
+		generated_at: '2026-04-16T00:00:00Z',
+	},
+};
+
+const draftWithTwoGaps = {
+	narrative: `Intro. ${ withEvidenceSentence } Middle sentence. Second gap evidence sentence.`,
+	gaps: [
+		{
+			id: 'avs_cvc',
+			label: 'AVS / CVC match',
+			default_resolution: 'provide',
+			sentences: {
+				with_evidence: withEvidenceSentence,
+				substituted: substitutedSentence,
+			},
+		},
+		{
+			id: 'ip_match',
+			label: 'IP address match',
+			default_resolution: 'provide',
+			sentences: {
+				with_evidence: 'Second gap evidence sentence.',
+				substituted: 'Second gap substituted sentence.',
+			},
+		},
+	],
+	meta: {
+		model: 'claude-sonnet-4-5',
+		prompt_version: 'v1',
+		generated_at: '2026-04-16T00:00:00Z',
+	},
+};
+
+const generateDraft = async ( draft: any ) => {
+	( apiFetch as unknown as jest.Mock ).mockResolvedValue( draft );
+	render( <DisputeDefenderPanel dispute={ baseFraudulentDispute } /> );
+	await act( async () => {
+		await userEvent.click(
+			screen.getByRole( 'button', { name: /generate with ai/i } )
+		);
+	} );
+};
+
 describe( 'DisputeDefenderPanel', () => {
 	beforeEach( () => {
 		( window as any ).wcpaySettings = {
 			featureFlags: { isDisputeDefenderEnabled: true },
 		};
 		( apiFetch as unknown as jest.Mock ).mockReset();
+		( recordEvent as jest.Mock ).mockReset();
 	} );
 
 	it( 'renders the Generate button when the flag is on and reason is fraudulent', () => {
@@ -90,7 +156,7 @@ describe( 'DisputeDefenderPanel', () => {
 
 		await waitFor( () => {
 			expect(
-				screen.getByText( /The charge is legitimate/i )
+				screen.getByDisplayValue( /The charge is legitimate/i )
 			).toBeInTheDocument();
 		} );
 	} );
@@ -114,5 +180,214 @@ describe( 'DisputeDefenderPanel', () => {
 				screen.getAllByText( /Upstream failure/i ).length
 			).toBeGreaterThan( 0 );
 		} );
+	} );
+
+	it( 'renders a textarea with the draft narrative after generate', async () => {
+		await generateDraft( draftWithGap );
+
+		const textarea = await screen.findByRole( 'textbox', {
+			name: /narrative/i,
+		} );
+		expect( textarea ).toBeInTheDocument();
+		expect( ( textarea as HTMLTextAreaElement ).value ).toContain(
+			withEvidenceSentence
+		);
+	} );
+
+	it( 'edits to the narrative persist in local state', async () => {
+		await generateDraft( draftWithGap );
+
+		const textarea = ( await screen.findByRole( 'textbox', {
+			name: /narrative/i,
+		} ) ) as HTMLTextAreaElement;
+
+		await act( async () => {
+			await userEvent.clear( textarea );
+			await userEvent.type( textarea, 'Edited narrative.' );
+		} );
+
+		expect( textarea.value ).toBe( 'Edited narrative.' );
+	} );
+
+	it( 'renders each gap as a toggle row', async () => {
+		await generateDraft( draftWithTwoGaps );
+
+		// Both gap labels should be visible.
+		expect(
+			await screen.findByText( /AVS \/ CVC match/i )
+		).toBeInTheDocument();
+		expect( screen.getByText( /IP address match/i ) ).toBeInTheDocument();
+
+		// Each gap has both a "Provide" and "Can't provide" option (radio inputs).
+		// The component renders the apostrophe as a Unicode right-single-quote
+		// so we match either form.
+		expect(
+			screen.getAllByRole( 'radio', { name: /provide/i } ).length
+		).toBeGreaterThanOrEqual( 2 );
+		expect(
+			screen.getAllByRole( 'radio', { name: /can[’']t provide/i } ).length
+		).toBeGreaterThanOrEqual( 2 );
+	} );
+
+	it( 'toggling a gap to "can\'t provide" replaces the sentence in the narrative', async () => {
+		await generateDraft( draftWithGap );
+
+		const textarea = ( await screen.findByRole( 'textbox', {
+			name: /narrative/i,
+		} ) ) as HTMLTextAreaElement;
+		expect( textarea.value ).toContain( withEvidenceSentence );
+		expect( textarea.value ).not.toContain( substitutedSentence );
+
+		const cantProvide = screen.getByRole( 'radio', {
+			name: /can[’']t provide/i,
+		} );
+		await act( async () => {
+			await userEvent.click( cantProvide );
+		} );
+
+		expect( textarea.value ).toContain( substitutedSentence );
+		expect( textarea.value ).not.toContain( withEvidenceSentence );
+	} );
+
+	it( 'toggling back to "provide" restores the with_evidence sentence', async () => {
+		await generateDraft( draftWithGap );
+
+		const textarea = ( await screen.findByRole( 'textbox', {
+			name: /narrative/i,
+		} ) ) as HTMLTextAreaElement;
+
+		const cantProvide = screen.getByRole( 'radio', {
+			name: /can[’']t provide/i,
+		} );
+		await act( async () => {
+			await userEvent.click( cantProvide );
+		} );
+		expect( textarea.value ).toContain( substitutedSentence );
+
+		const provide = screen.getByRole( 'radio', {
+			name: /^provide$/i,
+		} );
+		await act( async () => {
+			await userEvent.click( provide );
+		} );
+
+		expect( textarea.value ).toContain( withEvidenceSentence );
+		expect( textarea.value ).not.toContain( substitutedSentence );
+	} );
+
+	it( 'appends the substituted sentence with a warning when the original is absent', async () => {
+		await generateDraft( draftWithGap );
+
+		const textarea = ( await screen.findByRole( 'textbox', {
+			name: /narrative/i,
+		} ) ) as HTMLTextAreaElement;
+
+		// User edits out the with_evidence sentence entirely.
+		await act( async () => {
+			await userEvent.clear( textarea );
+			await userEvent.type(
+				textarea,
+				'Totally rewritten narrative with nothing matching.'
+			);
+		} );
+		expect( textarea.value ).not.toContain( withEvidenceSentence );
+
+		const cantProvide = screen.getByRole( 'radio', {
+			name: /can[’']t provide/i,
+		} );
+		await act( async () => {
+			await userEvent.click( cantProvide );
+		} );
+
+		// Warning banner visible. The component uses a Unicode right-single-
+		// quote for the apostrophe in "couldn't", so match either form.
+		// Notice renders the message in multiple wrappers for a11y — use
+		// getAllByText so the check doesn't fail on duplicates.
+		expect(
+			screen.getAllByText( /couldn[’']t find the original sentence/i )
+				.length
+		).toBeGreaterThan( 0 );
+		// Substituted sentence was appended.
+		expect( textarea.value ).toContain( substitutedSentence );
+	} );
+
+	it( 'fires wcpay_dispute_defender_gap_resolved on toggle', async () => {
+		await generateDraft( draftWithGap );
+
+		( recordEvent as jest.Mock ).mockClear();
+
+		const cantProvide = await screen.findByRole( 'radio', {
+			name: /can[’']t provide/i,
+		} );
+		await act( async () => {
+			await userEvent.click( cantProvide );
+		} );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcpay_dispute_defender_gap_resolved',
+			expect.objectContaining( {
+				gap_id: 'avs_cvc',
+				resolution: 'substituted',
+			} )
+		);
+	} );
+
+	it( '"Use this draft" button calls onUseDraft prop with the current narrative', async () => {
+		const onUseDraft = jest.fn();
+		( apiFetch as unknown as jest.Mock ).mockResolvedValue( draftWithGap );
+		render(
+			<DisputeDefenderPanel
+				dispute={ baseFraudulentDispute }
+				onUseDraft={ onUseDraft }
+			/>
+		);
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /generate with ai/i } )
+			);
+		} );
+
+		const textarea = ( await screen.findByRole( 'textbox', {
+			name: /narrative/i,
+		} ) ) as HTMLTextAreaElement;
+
+		await act( async () => {
+			await userEvent.clear( textarea );
+			await userEvent.type( textarea, 'My edited narrative.' );
+		} );
+
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /use this draft/i } )
+			);
+		} );
+
+		expect( onUseDraft ).toHaveBeenCalledWith( 'My edited narrative.' );
+	} );
+
+	it( '"Use this draft" button fires wcpay_dispute_defender_draft_submitted', async () => {
+		const onUseDraft = jest.fn();
+		await generateDraft( draftWithGap );
+
+		( recordEvent as jest.Mock ).mockClear();
+
+		// Re-render with prop because generateDraft doesn't pass it — we can
+		// instead just click without the prop and ensure the event still fires.
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /use this draft/i } )
+			);
+		} );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcpay_dispute_defender_draft_submitted',
+			expect.objectContaining( {
+				dispute_id: 'dp_test_123',
+				narrative_length: expect.any( Number ),
+			} )
+		);
+
+		// Sanity touch to avoid unused-var lint on onUseDraft.
+		expect( onUseDraft ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/payment-details/dispute-details/dispute-defender-panel/draft-editor.tsx
+++ b/client/payment-details/dispute-details/dispute-defender-panel/draft-editor.tsx
@@ -1,0 +1,142 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import {
+	Button,
+	Notice,
+	RadioControl,
+	TextareaControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { DefenseGap, GapResolution } from './types';
+
+interface DraftEditorProps {
+	narrative: string;
+	onNarrativeChange: ( value: string ) => void;
+	gaps: DefenseGap[];
+	resolutions: Record< string, GapResolution >;
+	onResolutionChange: ( gap: DefenseGap, next: GapResolution ) => void;
+	orphanWarning: boolean;
+	onDismissOrphanWarning: () => void;
+	clipboardNotice: boolean;
+	onDismissClipboardNotice: () => void;
+	onUseDraft: () => void;
+	isBusy: boolean;
+}
+
+/**
+ * Narrative editor + gap toggle list + "Use this draft" action. Kept as a
+ * pure sibling component so the parent panel stays focused on data fetching
+ * and state wiring.
+ */
+const DraftEditor: React.FC< DraftEditorProps > = ( {
+	narrative,
+	onNarrativeChange,
+	gaps,
+	resolutions,
+	onResolutionChange,
+	orphanWarning,
+	onDismissOrphanWarning,
+	clipboardNotice,
+	onDismissClipboardNotice,
+	onUseDraft,
+	isBusy,
+} ) => {
+	return (
+		<div className="dispute-defender-panel__editor">
+			<TextareaControl
+				__nextHasNoMarginBottom
+				className="dispute-defender-panel__narrative"
+				label={ __( 'Narrative', 'woocommerce-payments' ) }
+				help={ __(
+					'Review and edit the draft. Toggle individual pieces of evidence below if you can\u2019t provide them.',
+					'woocommerce-payments'
+				) }
+				value={ narrative }
+				onChange={ onNarrativeChange }
+				rows={ 10 }
+			/>
+			{ orphanWarning && (
+				<Notice
+					status="warning"
+					isDismissible={ true }
+					onRemove={ onDismissOrphanWarning }
+					className="dispute-defender-panel__orphan-warning"
+				>
+					{ __(
+						'We couldn\u2019t find the original sentence. The replacement was appended \u2014 please review.',
+						'woocommerce-payments'
+					) }
+				</Notice>
+			) }
+			{ gaps.length > 0 && (
+				<ul className="dispute-defender-panel__gaps">
+					{ gaps.map( ( gap ) => (
+						<li
+							key={ gap.id }
+							className="dispute-defender-panel__gap"
+						>
+							<RadioControl
+								label={ gap.label }
+								selected={ resolutions[ gap.id ] || 'provide' }
+								options={ [
+									{
+										label: __(
+											'Provide',
+											'woocommerce-payments'
+										),
+										value: 'provide',
+									},
+									{
+										label: __(
+											'Can\u2019t provide',
+											'woocommerce-payments'
+										),
+										value: 'substituted',
+									},
+								] }
+								onChange={ ( value: string ) =>
+									onResolutionChange(
+										gap,
+										value as GapResolution
+									)
+								}
+							/>
+						</li>
+					) ) }
+				</ul>
+			) }
+			<div className="dispute-defender-panel__actions">
+				<Button
+					variant="secondary"
+					onClick={ onUseDraft }
+					disabled={ isBusy }
+				>
+					{ __( 'Use this draft', 'woocommerce-payments' ) }
+				</Button>
+			</div>
+			{ clipboardNotice && (
+				<Notice
+					status="success"
+					isDismissible={ true }
+					onRemove={ onDismissClipboardNotice }
+					className="dispute-defender-panel__clipboard-notice"
+				>
+					{ __(
+						'Draft copied to clipboard.',
+						'woocommerce-payments'
+					) }
+				</Notice>
+			) }
+		</div>
+	);
+};
+
+export default DraftEditor;

--- a/client/payment-details/dispute-details/dispute-defender-panel/index.tsx
+++ b/client/payment-details/dispute-details/dispute-defender-panel/index.tsx
@@ -1,0 +1,127 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'tracks';
+import type { Dispute } from 'wcpay/types/disputes';
+import './style.scss';
+
+interface DefenseDraftMeta {
+	model: string;
+	prompt_version: string;
+	generated_at: string;
+}
+
+interface DefenseGap {
+	id: string;
+	label: string;
+	default_resolution: 'provide' | 'substituted';
+	sentences: {
+		with_evidence: string;
+		substituted: string;
+	};
+}
+
+interface DefenseDraft {
+	narrative: string;
+	gaps: DefenseGap[];
+	meta: DefenseDraftMeta;
+}
+
+interface Props {
+	dispute: Dispute;
+}
+
+interface PanelState {
+	isLoading: boolean;
+	draft: DefenseDraft | null;
+	error: string | null;
+}
+
+const initialState: PanelState = {
+	isLoading: false,
+	draft: null,
+	error: null,
+};
+
+export const DisputeDefenderPanel: React.FC< Props > = ( { dispute } ) => {
+	// All three pieces of state are collapsed into a single setState call so
+	// that completion updates (loading=false + draft/error) land in a single
+	// React commit, even after an `await` boundary where React 18 no longer
+	// auto-batches.
+	const [ state, setState ] = useState< PanelState >( initialState );
+	const { isLoading, draft, error } = state;
+
+	const isEnabled =
+		dispute.reason === 'fraudulent' &&
+		!! wcpaySettings?.featureFlags?.isDisputeDefenderEnabled;
+
+	if ( ! isEnabled ) {
+		return null;
+	}
+
+	const handleGenerate = async () => {
+		setState( { isLoading: true, draft: null, error: null } );
+		recordEvent( 'wcpay_dispute_defender_generate_clicked', {
+			dispute_id: dispute.id,
+		} );
+
+		try {
+			const response = await apiFetch< DefenseDraft >( {
+				path: `/wc/v3/payments/disputes/${ dispute.id }/defense/draft`,
+				method: 'POST',
+			} );
+			setState( { isLoading: false, draft: response, error: null } );
+		} catch ( err ) {
+			const message =
+				err instanceof Error
+					? err.message
+					: __(
+							'Failed to generate a draft.',
+							'woocommerce-payments'
+					  );
+			setState( { isLoading: false, draft: null, error: message } );
+		}
+	};
+
+	return (
+		<div className="dispute-defender-panel">
+			<h3>{ __( 'Dispute Defender AI', 'woocommerce-payments' ) }</h3>
+			<p>
+				{ __(
+					'Generate a draft response to this dispute based on the signals we already have. You always review before submitting.',
+					'woocommerce-payments'
+				) }
+			</p>
+			<Button
+				variant="primary"
+				onClick={ handleGenerate }
+				isBusy={ isLoading }
+				disabled={ isLoading }
+			>
+				{ __( 'Generate with AI', 'woocommerce-payments' ) }
+			</Button>
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
+			{ draft && (
+				<pre className="dispute-defender-panel__draft-preview">
+					{ JSON.stringify( draft, null, 2 ) }
+				</pre>
+			) }
+		</div>
+	);
+};
+
+export default DisputeDefenderPanel;

--- a/client/payment-details/dispute-details/dispute-defender-panel/index.tsx
+++ b/client/payment-details/dispute-details/dispute-defender-panel/index.tsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { Button, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -13,32 +13,13 @@ import { __ } from '@wordpress/i18n';
  */
 import { recordEvent } from 'tracks';
 import type { Dispute } from 'wcpay/types/disputes';
+import DraftEditor from './draft-editor';
+import type { DefenseDraft, DefenseGap, GapResolution } from './types';
 import './style.scss';
-
-interface DefenseDraftMeta {
-	model: string;
-	prompt_version: string;
-	generated_at: string;
-}
-
-interface DefenseGap {
-	id: string;
-	label: string;
-	default_resolution: 'provide' | 'substituted';
-	sentences: {
-		with_evidence: string;
-		substituted: string;
-	};
-}
-
-interface DefenseDraft {
-	narrative: string;
-	gaps: DefenseGap[];
-	meta: DefenseDraftMeta;
-}
 
 interface Props {
 	dispute: Dispute;
+	onUseDraft?: ( narrative: string ) => void;
 }
 
 interface PanelState {
@@ -53,7 +34,40 @@ const initialState: PanelState = {
 	error: null,
 };
 
-export const DisputeDefenderPanel: React.FC< Props > = ( { dispute } ) => {
+/**
+ * Roughly estimates how much the narrative has diverged from the original,
+ * expressed as a percentage. Uses a length-plus-common-prefix heuristic so
+ * the MVP avoids pulling in a Levenshtein dependency — we only need an
+ * order-of-magnitude signal for analytics.
+ */
+const computeEditDistancePercent = (
+	original: string,
+	current: string
+): number => {
+	if ( ! original ) {
+		return current.length > 0 ? 100 : 0;
+	}
+	let commonPrefix = 0;
+	const max = Math.min( original.length, current.length );
+	while (
+		commonPrefix < max &&
+		original[ commonPrefix ] === current[ commonPrefix ]
+	) {
+		commonPrefix++;
+	}
+	const divergence =
+		Math.abs( original.length - current.length ) +
+		( original.length - commonPrefix );
+	return Math.min(
+		100,
+		Math.round( ( divergence / original.length ) * 100 )
+	);
+};
+
+export const DisputeDefenderPanel: React.FC< Props > = ( {
+	dispute,
+	onUseDraft,
+} ) => {
 	// All three pieces of state are collapsed into a single setState call so
 	// that completion updates (loading=false + draft/error) land in a single
 	// React commit, even after an `await` boundary where React 18 no longer
@@ -61,9 +75,35 @@ export const DisputeDefenderPanel: React.FC< Props > = ( { dispute } ) => {
 	const [ state, setState ] = useState< PanelState >( initialState );
 	const { isLoading, draft, error } = state;
 
+	// Editor state. `narrative` is the working copy that reflects user edits
+	// and toggle-driven sentence swaps; `draft.narrative` stays frozen as the
+	// original so we can compute edit distance later.
+	const [ narrative, setNarrative ] = useState< string >( '' );
+	const [ resolutions, setResolutions ] = useState<
+		Record< string, GapResolution >
+	>( {} );
+	const [ orphanWarning, setOrphanWarning ] = useState< boolean >( false );
+	const [ clipboardNotice, setClipboardNotice ] =
+		useState< boolean >( false );
+
 	const isEnabled =
 		dispute.reason === 'fraudulent' &&
 		!! wcpaySettings?.featureFlags?.isDisputeDefenderEnabled;
+
+	// Seed the editor state whenever a fresh draft arrives.
+	useEffect( () => {
+		if ( ! draft ) {
+			return;
+		}
+		setNarrative( draft.narrative );
+		const initialResolutions: Record< string, GapResolution > = {};
+		draft.gaps.forEach( ( gap ) => {
+			initialResolutions[ gap.id ] = gap.default_resolution || 'provide';
+		} );
+		setResolutions( initialResolutions );
+		setOrphanWarning( false );
+		setClipboardNotice( false );
+	}, [ draft ] );
 
 	if ( ! isEnabled ) {
 		return null;
@@ -93,6 +133,83 @@ export const DisputeDefenderPanel: React.FC< Props > = ( { dispute } ) => {
 		}
 	};
 
+	const handleResolutionChange = (
+		gap: DefenseGap,
+		nextResolution: GapResolution
+	) => {
+		const currentResolution = resolutions[ gap.id ] || 'provide';
+		if ( currentResolution === nextResolution ) {
+			return;
+		}
+
+		recordEvent( 'wcpay_dispute_defender_gap_resolved', {
+			gap_id: gap.id,
+			resolution: nextResolution,
+		} );
+
+		setResolutions( ( prev ) => ( {
+			...prev,
+			[ gap.id ]: nextResolution,
+		} ) );
+
+		const oldSentence =
+			currentResolution === 'provide'
+				? gap.sentences.with_evidence
+				: gap.sentences.substituted;
+		const newSentence =
+			nextResolution === 'provide'
+				? gap.sentences.with_evidence
+				: gap.sentences.substituted;
+
+		// Attempt an in-place swap; if the user has edited the sentence out
+		// of existence we fall back to appending plus a visible warning.
+		if ( narrative.includes( oldSentence ) ) {
+			setNarrative( narrative.replace( oldSentence, newSentence ) );
+			return;
+		}
+
+		setNarrative(
+			narrative.endsWith( '\n' ) || narrative.length === 0
+				? narrative + newSentence
+				: `${ narrative } ${ newSentence }`
+		);
+		setOrphanWarning( true );
+	};
+
+	const handleUseDraft = () => {
+		const originalNarrative = draft?.narrative || '';
+		const editDistancePercent = computeEditDistancePercent(
+			originalNarrative,
+			narrative
+		);
+
+		recordEvent( 'wcpay_dispute_defender_draft_submitted', {
+			dispute_id: dispute.id,
+			narrative_length: narrative.length,
+			edit_distance_percent: editDistancePercent,
+		} );
+
+		if ( onUseDraft ) {
+			onUseDraft( narrative );
+			return;
+		}
+
+		// Fallback: copy to clipboard and surface a brief confirmation so
+		// the merchant still has a way to move the text into the existing
+		// evidence form while the wiring for that form lands.
+		if (
+			typeof navigator !== 'undefined' &&
+			navigator.clipboard &&
+			typeof navigator.clipboard.writeText === 'function'
+		) {
+			navigator.clipboard.writeText( narrative ).catch( () => {
+				// Clipboard can reject when the page isn't focused; we
+				// still flip the notice so the user knows the action ran.
+			} );
+		}
+		setClipboardNotice( true );
+	};
+
 	return (
 		<div className="dispute-defender-panel">
 			<h3>{ __( 'Dispute Defender AI', 'woocommerce-payments' ) }</h3>
@@ -116,9 +233,21 @@ export const DisputeDefenderPanel: React.FC< Props > = ( { dispute } ) => {
 				</Notice>
 			) }
 			{ draft && (
-				<pre className="dispute-defender-panel__draft-preview">
-					{ JSON.stringify( draft, null, 2 ) }
-				</pre>
+				<DraftEditor
+					narrative={ narrative }
+					onNarrativeChange={ setNarrative }
+					gaps={ draft.gaps }
+					resolutions={ resolutions }
+					onResolutionChange={ handleResolutionChange }
+					orphanWarning={ orphanWarning }
+					onDismissOrphanWarning={ () => setOrphanWarning( false ) }
+					clipboardNotice={ clipboardNotice }
+					onDismissClipboardNotice={ () =>
+						setClipboardNotice( false )
+					}
+					onUseDraft={ handleUseDraft }
+					isBusy={ isLoading }
+				/>
 			) }
 		</div>
 	);

--- a/client/payment-details/dispute-details/dispute-defender-panel/index.tsx
+++ b/client/payment-details/dispute-details/dispute-defender-panel/index.tsx
@@ -22,16 +22,96 @@ interface Props {
 	onUseDraft?: ( narrative: string ) => void;
 }
 
+interface PanelError {
+	message: string;
+	retryable: boolean;
+}
+
 interface PanelState {
 	isLoading: boolean;
 	draft: DefenseDraft | null;
-	error: string | null;
+	error: PanelError | null;
 }
 
 const initialState: PanelState = {
 	isLoading: false,
 	draft: null,
 	error: null,
+};
+
+// Map known REST error codes to short, merchant-friendly strings. Anything
+// outside this map falls through to `err.message` so upstream changes remain
+// visible rather than being silently swallowed.
+const friendlyErrorMessages: Record< string, string > = {
+	wcpay_dispute_defender_disabled: __(
+		'Dispute Defender AI is not enabled. Turn it on in WooPayments → Settings → Advanced.',
+		'woocommerce-payments'
+	),
+	wcpay_dispute_defender_unsupported_reason: __(
+		'This dispute is not supported by Dispute Defender AI.',
+		'woocommerce-payments'
+	),
+	wcpay_dispute_defender_failure: __(
+		"We couldn't generate a draft right now. Try again in a moment.",
+		'woocommerce-payments'
+	),
+	wcpay_dispute_defender_unparseable: __(
+		'The AI returned an unexpected response. Try generating again.',
+		'woocommerce-payments'
+	),
+	wcpay_dispute_defender_config_error: __(
+		'Dispute Defender AI is temporarily unavailable.',
+		'woocommerce-payments'
+	),
+	rest_too_many_requests: __(
+		'Too many requests. Please wait a moment and try again.',
+		'woocommerce-payments'
+	),
+};
+
+// Codes we consider safe to retry. Transient upstream failures, parsing
+// hiccups, config errors, and rate limits all fall into this bucket. Errors
+// that reflect a stable state of the world (feature flag off, dispute reason
+// not supported) are NOT retryable — retrying won't change the answer.
+const retryableErrorCodes = new Set( [
+	'wcpay_dispute_defender_failure',
+	'wcpay_dispute_defender_unparseable',
+	'wcpay_dispute_defender_config_error',
+	'rest_too_many_requests',
+] );
+
+// Transient HTTP statuses: upstream failures, config errors, rate limits.
+const retryableStatuses = new Set( [ 429, 502, 503 ] );
+
+const resolvePanelError = ( err: unknown ): PanelError => {
+	// apiFetch rejects with a plain object shaped like { code, message, data:
+	// { status } }, but raw Error instances (e.g. network abort) can also
+	// surface here. Handle both shapes before falling back.
+	if ( err && typeof err === 'object' ) {
+		const maybe = err as {
+			code?: string;
+			message?: string;
+			data?: { status?: number };
+		};
+		const code = maybe.code;
+		const status = maybe.data?.status;
+		const friendly = code ? friendlyErrorMessages[ code ] : undefined;
+		const retryable =
+			( !! code && retryableErrorCodes.has( code ) ) ||
+			( typeof status === 'number' && retryableStatuses.has( status ) );
+
+		if ( friendly ) {
+			return { message: friendly, retryable };
+		}
+		if ( maybe.message ) {
+			return { message: maybe.message, retryable };
+		}
+	}
+
+	return {
+		message: __( 'Failed to generate a draft.', 'woocommerce-payments' ),
+		retryable: false,
+	};
 };
 
 /**
@@ -105,6 +185,23 @@ export const DisputeDefenderPanel: React.FC< Props > = ( {
 		setClipboardNotice( false );
 	}, [ draft ] );
 
+	// Fire the panel-view event exactly once per mount, AFTER the gate check
+	// so we don't count renders where the panel is suppressed. `dispute.id`
+	// is the stable key — if the merchant switches disputes without
+	// unmounting the route we'd want a fresh view event for the new ID.
+	// NOTE: this hook must be declared before the `isEnabled` early return
+	// would run in a conditional render path, so we guard inside the effect
+	// itself instead of gating the hook (React requires stable hook order).
+	useEffect( () => {
+		if ( ! isEnabled ) {
+			return;
+		}
+		recordEvent( 'wcpay_dispute_defender_button_viewed', {
+			dispute_id: dispute.id,
+		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ dispute.id, isEnabled ] );
+
 	if ( ! isEnabled ) {
 		return null;
 	}
@@ -122,14 +219,11 @@ export const DisputeDefenderPanel: React.FC< Props > = ( {
 			} );
 			setState( { isLoading: false, draft: response, error: null } );
 		} catch ( err ) {
-			const message =
-				err instanceof Error
-					? err.message
-					: __(
-							'Failed to generate a draft.',
-							'woocommerce-payments'
-					  );
-			setState( { isLoading: false, draft: null, error: message } );
+			setState( {
+				isLoading: false,
+				draft: null,
+				error: resolvePanelError( err ),
+			} );
 		}
 	};
 
@@ -229,7 +323,19 @@ export const DisputeDefenderPanel: React.FC< Props > = ( {
 			</Button>
 			{ error && (
 				<Notice status="error" isDismissible={ false }>
-					{ error }
+					{ error.message }
+					{ error.retryable && (
+						<>
+							{ ' ' }
+							<Button
+								variant="link"
+								onClick={ handleGenerate }
+								disabled={ isLoading }
+							>
+								{ __( 'Retry', 'woocommerce-payments' ) }
+							</Button>
+						</>
+					) }
 				</Notice>
 			) }
 			{ draft && (

--- a/client/payment-details/dispute-details/dispute-defender-panel/style.scss
+++ b/client/payment-details/dispute-details/dispute-defender-panel/style.scss
@@ -18,4 +18,38 @@
 		white-space: pre-wrap;
 		background: #f0f0f0;
 	}
+
+	&__editor {
+		margin-top: 1em;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	&__narrative .components-base-control__field textarea {
+		font-family: inherit;
+		min-height: 200px;
+	}
+
+	&__gaps {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	&__gap {
+		padding: 8px 12px;
+		border: 1px solid #dcdcde;
+		border-radius: 2px;
+		background: #f6f7f7;
+	}
+
+	&__actions {
+		display: flex;
+		gap: 8px;
+		margin-top: 4px;
+	}
 }

--- a/client/payment-details/dispute-details/dispute-defender-panel/style.scss
+++ b/client/payment-details/dispute-details/dispute-defender-panel/style.scss
@@ -1,0 +1,21 @@
+.dispute-defender-panel {
+	margin: 16px 0;
+	padding: 16px;
+	background: #fff;
+	border: 1px solid #dcdcde;
+
+	h3 {
+		margin: 0 0 8px 0;
+	}
+
+	p {
+		margin: 0 0 12px 0;
+	}
+
+	&__draft-preview {
+		margin-top: 1em;
+		padding: 1em;
+		white-space: pre-wrap;
+		background: #f0f0f0;
+	}
+}

--- a/client/payment-details/dispute-details/dispute-defender-panel/types.ts
+++ b/client/payment-details/dispute-details/dispute-defender-panel/types.ts
@@ -1,0 +1,25 @@
+/** @format */
+
+export type GapResolution = 'provide' | 'substituted';
+
+export interface DefenseDraftMeta {
+	model: string;
+	prompt_version: string;
+	generated_at: string;
+}
+
+export interface DefenseGap {
+	id: string;
+	label: string;
+	default_resolution: GapResolution;
+	sentences: {
+		with_evidence: string;
+		substituted: string;
+	};
+}
+
+export interface DefenseDraft {
+	narrative: string;
+	gaps: DefenseGap[];
+	meta: DefenseDraftMeta;
+}

--- a/client/settings/advanced-settings/__tests__/dispute-defender-toggle.test.js
+++ b/client/settings/advanced-settings/__tests__/dispute-defender-toggle.test.js
@@ -1,0 +1,47 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import DisputeDefenderToggle from '../dispute-defender-toggle';
+import { useDisputeDefender } from 'wcpay/data';
+
+jest.mock( 'wcpay/data', () => ( {
+	useDisputeDefender: jest.fn(),
+} ) );
+
+describe( 'DisputeDefenderToggle', () => {
+	beforeEach( () => {
+		useDisputeDefender.mockReturnValue( [ false, jest.fn() ] );
+	} );
+
+	it( 'renders the checkbox with the correct label', () => {
+		render( <DisputeDefenderToggle /> );
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: /enable dispute defender ai/i,
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'reflects the current enabled state', () => {
+		useDisputeDefender.mockReturnValue( [ true, jest.fn() ] );
+		render( <DisputeDefenderToggle /> );
+		expect( screen.getByTestId( 'dispute-defender-toggle' ) ).toBeChecked();
+	} );
+
+	it( 'calls update when toggled', async () => {
+		const update = jest.fn();
+		useDisputeDefender.mockReturnValue( [ false, update ] );
+		render( <DisputeDefenderToggle /> );
+		await userEvent.click(
+			screen.getByTestId( 'dispute-defender-toggle' )
+		);
+		expect( update ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/client/settings/advanced-settings/__tests__/index.test.js
+++ b/client/settings/advanced-settings/__tests__/index.test.js
@@ -11,6 +11,7 @@ import { render, screen } from '@testing-library/react';
 import AdvancedSettings from '..';
 import {
 	useMultiCurrency,
+	useDisputeDefender,
 	useWCPaySubscriptions,
 	useDevMode,
 	useDebugLog,
@@ -19,6 +20,7 @@ import {
 jest.mock( '../../../data', () => ( {
 	useSettings: jest.fn(),
 	useMultiCurrency: jest.fn(),
+	useDisputeDefender: jest.fn(),
 	useWCPaySubscriptions: jest.fn(),
 	useDevMode: jest.fn(),
 	useDebugLog: jest.fn(),
@@ -27,6 +29,7 @@ jest.mock( '../../../data', () => ( {
 describe( 'AdvancedSettings', () => {
 	beforeEach( () => {
 		useMultiCurrency.mockReturnValue( [ false, jest.fn() ] );
+		useDisputeDefender.mockReturnValue( [ false, jest.fn() ] );
 		useWCPaySubscriptions.mockReturnValue( [ false, jest.fn() ] );
 		useDevMode.mockReturnValue( false );
 		useDebugLog.mockReturnValue( [ false, jest.fn() ] );

--- a/client/settings/advanced-settings/dispute-defender-toggle.js
+++ b/client/settings/advanced-settings/dispute-defender-toggle.js
@@ -21,7 +21,7 @@ const DisputeDefenderToggle = () => {
 		<CheckboxControl
 			label={ __( 'Enable Dispute Defender AI', 'woocommerce-payments' ) }
 			help={ __(
-				'Draft fraudulent dispute evidence with AI. You always review before submitting.',
+				'Use AI to draft evidence for fraudulent disputes. You always review before submitting.',
 				'woocommerce-payments'
 			) }
 			checked={ isDisputeDefenderEnabled }

--- a/client/settings/advanced-settings/dispute-defender-toggle.js
+++ b/client/settings/advanced-settings/dispute-defender-toggle.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { CheckboxControl } from '@wordpress/components';
+import { useDisputeDefender } from 'wcpay/data';
+
+const DisputeDefenderToggle = () => {
+	const [ isDisputeDefenderEnabled, updateIsDisputeDefenderEnabled ] =
+		useDisputeDefender();
+
+	const handleDisputeDefenderStatusChange = ( value ) => {
+		updateIsDisputeDefenderEnabled( value );
+	};
+
+	return (
+		<CheckboxControl
+			label={ __( 'Enable Dispute Defender AI', 'woocommerce-payments' ) }
+			help={ __(
+				'Draft fraudulent dispute evidence with AI. You always review before submitting.',
+				'woocommerce-payments'
+			) }
+			checked={ isDisputeDefenderEnabled }
+			onChange={ handleDisputeDefenderStatusChange }
+			data-testid="dispute-defender-toggle"
+			__nextHasNoMarginBottom
+		/>
+	);
+};
+
+export default DisputeDefenderToggle;

--- a/client/settings/advanced-settings/index.js
+++ b/client/settings/advanced-settings/index.js
@@ -8,6 +8,7 @@ import { Card } from '@wordpress/components';
  * Internal dependencies
  */
 import DebugMode from './debug-mode';
+import DisputeDefenderToggle from './dispute-defender-toggle';
 import MultiCurrencyToggle from './multi-currency-toggle';
 import WCPaySubscriptionsToggle from './wcpay-subscriptions-toggle';
 import './style.scss';
@@ -20,6 +21,7 @@ const AdvancedSettings = () => {
 			<Card>
 				<CardBody className="wcpay-card-body">
 					<MultiCurrencyToggle />
+					<DisputeDefenderToggle />
 					{ wcpaySettings.isSubscriptionsActive &&
 					wcpaySettings.isStripeBillingEligible ? (
 						<StripeBillingSection />

--- a/includes/admin/class-wc-rest-payments-disputes-controller.php
+++ b/includes/admin/class-wc-rest-payments-disputes-controller.php
@@ -5,7 +5,9 @@
  * @package WooCommerce\Payments\Admin
  */
 
+use WCPay\Core\Server\Request\Generate_Dispute_Defense;
 use WCPay\Core\Server\Request\List_Disputes;
+use WCPay\Disputes\Dispute_Evidence_Collector;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -88,6 +90,15 @@ class WC_REST_Payments_Disputes_Controller extends WC_Payments_REST_Controller {
 				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<dispute_id>\w+)/defense/draft',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'generate_defense_draft' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
 	}
 
 	/**
@@ -158,6 +169,61 @@ class WC_REST_Payments_Disputes_Controller extends WC_Payments_REST_Controller {
 	public function close_dispute( $request ) {
 		$dispute_id = $request->get_param( 'dispute_id' );
 		return $this->forward_request( 'close_dispute', [ $dispute_id ] );
+	}
+
+	/**
+	 * Generate an AI-assisted dispute defense draft for a dispute.
+	 *
+	 * Gated on the `WC_Payments_Features::is_dispute_defender_enabled()` flag and
+	 * restricted to `fraudulent` disputes. Collects an evidence-context DTO via
+	 * Dispute_Evidence_Collector and forwards it to Transact-Platform through the
+	 * Generate_Dispute_Defense request class.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response|WP_Error Unchanged Transact-Platform response on success.
+	 */
+	public function generate_defense_draft( WP_REST_Request $request ) {
+		if ( ! WC_Payments_Features::is_dispute_defender_enabled() ) {
+			return new WP_Error(
+				'wcpay_dispute_defender_disabled',
+				__( 'Dispute defender AI is not enabled.', 'woocommerce-payments' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		$dispute_id = $request->get_param( 'dispute_id' );
+
+		try {
+			// Fetch the dispute to get the reason; enforce fraudulent-only.
+			$dispute = $this->api_client->get_dispute( $dispute_id );
+			if ( is_wp_error( $dispute ) ) {
+				return $dispute;
+			}
+			if ( ( $dispute['reason'] ?? '' ) !== 'fraudulent' ) {
+				return new WP_Error(
+					'wcpay_dispute_defender_unsupported_reason',
+					__( 'Only fraudulent disputes are supported.', 'woocommerce-payments' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			$collector        = new Dispute_Evidence_Collector( $this->api_client );
+			$evidence_context = $collector->collect( $dispute_id );
+
+			$defense = Generate_Dispute_Defense::create();
+			$defense->set_dispute_id( $dispute_id );
+			$defense->set_reason( 'fraudulent' );
+			$defense->set_evidence_context( $evidence_context );
+			$response = $defense->send();
+
+			return rest_ensure_response( $response );
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'wcpay_dispute_defender_failure',
+				$e->getMessage(),
+				[ 'status' => 502 ]
+			);
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -146,6 +146,15 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'is_dispute_defender_enabled'          => [
+						'description'       => sprintf(
+							/* translators: %s: WooPayments */
+							__( '%s Dispute Defender AI feature flag setting.', 'woocommerce-payments' ),
+							'WooPayments'
+						),
+						'type'              => 'boolean',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 					'is_wcpay_subscriptions_enabled'       => [
 						'description'       => sprintf(
 							/* translators: %s: WooPayments */
@@ -536,6 +545,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 				'is_test_mode_onboarding'                => WC_Payments::mode()->is_test_mode_onboarding(),
 				'is_dev_mode_enabled'                    => WC_Payments::mode()->is_dev(),
 				'is_multi_currency_enabled'              => WC_Payments_Features::is_customer_multi_currency_enabled(),
+				'is_dispute_defender_enabled'            => WC_Payments_Features::is_dispute_defender_enabled(),
 				'is_wcpay_subscriptions_enabled'         => WC_Payments_Features::is_wcpay_subscriptions_enabled(),
 				'is_stripe_billing_enabled'              => WC_Payments_Features::is_stripe_billing_enabled(),
 				'is_wcpay_subscriptions_eligible'        => WC_Payments_Features::is_wcpay_subscriptions_eligible(),
@@ -600,6 +610,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$this->update_is_test_mode_enabled( $request );
 		$this->update_is_debug_log_enabled( $request );
 		$this->update_is_multi_currency_enabled( $request );
+		$this->update_is_dispute_defender_enabled( $request );
 		$this->update_is_wcpay_subscriptions_enabled( $request );
 		$this->update_is_payment_request_enabled( $request );
 		$this->update_is_express_checkout_in_payment_methods_enabled( $request );
@@ -869,6 +880,21 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$is_multi_currency_enabled = $request->get_param( 'is_multi_currency_enabled' );
 
 		update_option( '_wcpay_feature_customer_multi_currency', $is_multi_currency_enabled ? '1' : '0' );
+	}
+
+	/**
+	 * Updates the Dispute Defender AI feature flag.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_is_dispute_defender_enabled( WP_REST_Request $request ) {
+		if ( ! $request->has_param( 'is_dispute_defender_enabled' ) ) {
+			return;
+		}
+
+		$is_dispute_defender_enabled = $request->get_param( 'is_dispute_defender_enabled' );
+
+		update_option( WC_Payments_Features::DISPUTE_DEFENDER_AI, $is_dispute_defender_enabled ? '1' : '0' );
 	}
 
 	/**

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -27,6 +27,7 @@ class WC_Payments_Features {
 	const WOOPAY_DIRECT_CHECKOUT_FLAG_NAME                    = '_wcpay_feature_woopay_direct_checkout';
 	const DISPUTE_ISSUER_EVIDENCE                             = '_wcpay_feature_dispute_issuer_evidence';
 	const DISPUTE_ADDITIONAL_EVIDENCE_TYPES                   = '_wcpay_feature_dispute_additional_evidence_types';
+	const DISPUTE_DEFENDER_AI                                 = '_wcpay_feature_dispute_defender_ai';
 	const WOOPAY_GLOBAL_THEME_SUPPORT_FLAG_NAME               = '_wcpay_feature_woopay_global_theme_support';
 	const WCPAY_DYNAMIC_CHECKOUT_PLACE_ORDER_BUTTON_FLAG_NAME = '_wcpay_feature_dynamic_checkout_place_order_button';
 	const AMAZON_PAY_FLAG_NAME                                = '_wcpay_feature_amazon_pay';
@@ -327,6 +328,17 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the Dispute Defender AI feature should be enabled. Disabled by default.
+	 *
+	 * This gates the merchant-facing "Generate with AI" button on the dispute detail page.
+	 *
+	 * @return bool
+	 */
+	public static function is_dispute_defender_enabled(): bool {
+		return '1' === get_option( self::DISPUTE_DEFENDER_AI, '0' );
+	}
+
+	/**
 	 * Checks whether the next deposit notice on the deposits list screen has been dismissed.
 	 *
 	 * @return bool
@@ -399,6 +411,7 @@ class WC_Payments_Features {
 				'woopayExpressCheckout'                    => self::is_woopay_express_checkout_enabled(),
 				'isDisputeIssuerEvidenceEnabled'           => self::is_dispute_issuer_evidence_enabled(),
 				'isDisputeAdditionalEvidenceTypesEnabled'  => self::is_dispute_additional_evidence_types_enabled(),
+				'isDisputeDefenderEnabled'                 => self::is_dispute_defender_enabled(),
 				'isFRTReviewFeatureActive'                 => self::is_frt_review_feature_active(),
 				'isDynamicCheckoutPlaceOrderButtonEnabled' => self::is_dynamic_checkout_place_order_button_enabled(),
 				'amazonPay'                                => self::is_amazon_pay_enabled(),

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -508,6 +508,7 @@ class WC_Payments {
 		include_once __DIR__ . '/fraud-prevention/class-buyer-fingerprinting-service.php';
 		include_once __DIR__ . '/fraud-prevention/class-fraud-risk-tools.php';
 		include_once __DIR__ . '/fraud-prevention/wc-payments-fraud-risk-tools.php';
+		include_once __DIR__ . '/disputes/class-dispute-evidence-collector.php';
 		include_once __DIR__ . '/woopay/class-woopay-store-api-token.php';
 		include_once __DIR__ . '/woopay/class-woopay-utilities.php';
 		include_once __DIR__ . '/woopay/class-woopay-order-status-sync.php';

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -417,6 +417,7 @@ class WC_Payments {
 		include_once __DIR__ . '/core/server/request/class-list-transactions.php';
 		include_once __DIR__ . '/core/server/request/class-list-fraud-outcome-transactions.php';
 		include_once __DIR__ . '/core/server/request/class-list-disputes.php';
+		include_once __DIR__ . '/core/server/request/class-generate-dispute-defense.php';
 		include_once __DIR__ . '/core/server/request/class-list-deposits.php';
 		include_once __DIR__ . '/core/server/request/class-list-documents.php';
 		include_once __DIR__ . '/core/server/request/class-list-authorizations.php';

--- a/includes/core/server/class-request.php
+++ b/includes/core/server/class-request.php
@@ -143,6 +143,7 @@ abstract class Request {
 		WC_Payments_API_Client::DEPOSITS_API               => 'deposits',
 		WC_Payments_API_Client::TRANSACTIONS_API           => 'transactions',
 		WC_Payments_API_Client::DISPUTES_API               => 'disputes',
+		WC_Payments_API_Client::DISPUTE_DEFENSE_API        => 'dispute_defense/draft',
 		WC_Payments_API_Client::FILES_API                  => 'files',
 		WC_Payments_API_Client::ONBOARDING_API             => 'onboarding',
 		WC_Payments_API_Client::TIMELINE_API               => 'timeline',

--- a/includes/core/server/request/class-generate-dispute-defense.php
+++ b/includes/core/server/request/class-generate-dispute-defense.php
@@ -16,6 +16,8 @@ use WC_Payments_API_Client;
  */
 class Generate_Dispute_Defense extends Request {
 
+	const IMMUTABLE_PARAMS = [ 'reason' ];
+
 	const REQUIRED_PARAMS = [ 'dispute_id', 'reason', 'evidence_context' ];
 
 	const SUPPORTED_REASON = 'fraudulent';

--- a/includes/core/server/request/class-generate-dispute-defense.php
+++ b/includes/core/server/request/class-generate-dispute-defense.php
@@ -56,7 +56,7 @@ class Generate_Dispute_Defense extends Request {
 	 * @throws Invalid_Request_Parameter_Exception If the ID does not match the Stripe dispute format.
 	 */
 	public function set_dispute_id( string $dispute_id ) {
-		$this->validate_stripe_id( $dispute_id, 'dp' );
+		$this->validate_stripe_id( $dispute_id, [ 'dp', 'du' ] );
 		$this->set_param( 'dispute_id', $dispute_id );
 	}
 

--- a/includes/core/server/request/class-generate-dispute-defense.php
+++ b/includes/core/server/request/class-generate-dispute-defense.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Class file for WCPay\Core\Server\Request\Generate_Dispute_Defense.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Core\Server\Request;
+
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request;
+use WC_Payments_API_Client;
+
+/**
+ * Request class for generating AI-assisted dispute defense drafts.
+ */
+class Generate_Dispute_Defense extends Request {
+
+	const REQUIRED_PARAMS = [ 'dispute_id', 'reason', 'evidence_context' ];
+
+	const SUPPORTED_REASON = 'fraudulent';
+
+	/**
+	 * Specifies the WordPress hook name that will be triggered upon calling the send() method.
+	 *
+	 * @var string
+	 */
+	protected $hook = 'wcpay_generate_dispute_defense_request';
+
+	/**
+	 * Returns the request's API.
+	 *
+	 * @return string
+	 */
+	public function get_api(): string {
+		return WC_Payments_API_Client::DISPUTE_DEFENSE_API;
+	}
+
+	/**
+	 * Returns the request's HTTP method.
+	 *
+	 * @return string
+	 */
+	public function get_method(): string {
+		return 'POST';
+	}
+
+	/**
+	 * Dispute ID setter.
+	 *
+	 * @param string $dispute_id Stripe dispute ID (must start with `dp_`).
+	 *
+	 * @return void
+	 * @throws Invalid_Request_Parameter_Exception If the ID does not match the Stripe dispute format.
+	 */
+	public function set_dispute_id( string $dispute_id ) {
+		$this->validate_stripe_id( $dispute_id, 'dp' );
+		$this->set_param( 'dispute_id', $dispute_id );
+	}
+
+	/**
+	 * Dispute reason setter.
+	 *
+	 * Only the `fraudulent` reason is supported by the AI draft flow.
+	 *
+	 * @param string $reason Stripe dispute reason.
+	 *
+	 * @return void
+	 * @throws Invalid_Request_Parameter_Exception If the reason is not supported.
+	 */
+	public function set_reason( string $reason ) {
+		if ( self::SUPPORTED_REASON !== $reason ) {
+			throw new Invalid_Request_Parameter_Exception(
+				esc_html__( 'Only fraudulent disputes are supported by the AI dispute defender.', 'woocommerce-payments' ),
+				'wcpay_dispute_defender_unsupported_reason'
+			);
+		}
+		$this->set_param( 'reason', $reason );
+	}
+
+	/**
+	 * Evidence context setter.
+	 *
+	 * @param array $context Structured evidence context collected by Dispute_Evidence_Collector.
+	 *
+	 * @return void
+	 */
+	public function set_evidence_context( array $context ) {
+		$this->set_param( 'evidence_context', $context );
+	}
+}

--- a/includes/disputes/class-dispute-evidence-collector.php
+++ b/includes/disputes/class-dispute-evidence-collector.php
@@ -7,9 +7,9 @@
 
 namespace WCPay\Disputes;
 
+use RuntimeException;
 use WC_Order;
 use WC_Payments_API_Client;
-use WC_Payments_Order_Service;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -18,10 +18,12 @@ defined( 'ABSPATH' ) || exit;
  * payload sent to Transact-Platform in the `evidence_context` parameter when
  * drafting an AI-generated dispute defense.
  *
- * PII minimization is load-bearing: the DTO never includes card PAN, CVC,
- * expiry, fingerprint, or any other card-auth data. Only the fields explicitly
- * shaped by the private `shape_*` helpers are returned — the raw dispute blob
- * from the API client is never passed through.
+ * PII minimization is load-bearing. The DTO is an allowlist produced by the
+ * private `shape_*` helpers — the raw dispute blob from the API client is
+ * never passed through. Fields intentionally included per the design doc:
+ * customer name, email, billing/shipping address, customer IP, card brand +
+ * last4 + funding. Fields intentionally excluded: card PAN, CVC, expiry,
+ * fingerprint, iin, user agent, and any other card-auth data.
  */
 class Dispute_Evidence_Collector {
 
@@ -38,21 +40,12 @@ class Dispute_Evidence_Collector {
 	private $api_client;
 
 	/**
-	 * Order service, held for future order-meta reads.
-	 *
-	 * @var WC_Payments_Order_Service
-	 */
-	private $order_service;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param WC_Payments_API_Client    $api_client    API client used to fetch the enriched dispute.
-	 * @param WC_Payments_Order_Service $order_service Order service (kept for future order-meta reads).
+	 * @param WC_Payments_API_Client $api_client API client used to fetch the enriched dispute.
 	 */
-	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_Order_Service $order_service ) {
-		$this->api_client    = $api_client;
-		$this->order_service = $order_service;
+	public function __construct( WC_Payments_API_Client $api_client ) {
+		$this->api_client = $api_client;
 	}
 
 	/**
@@ -66,9 +59,19 @@ class Dispute_Evidence_Collector {
 	 *     radar: array<string, mixed>,
 	 *     customer_history: array<int, array<string, mixed>>,
 	 * }
+	 * @throws RuntimeException When the upstream dispute fetch fails. Callers must not
+	 *                          swallow this — an empty DTO would silently produce an
+	 *                          unreliable AI draft.
 	 */
 	public function collect( string $dispute_id ): array {
 		$dispute = $this->api_client->get_dispute( $dispute_id );
+
+		if ( is_wp_error( $dispute ) ) {
+			throw new RuntimeException(
+				sprintf( 'Failed to fetch dispute %s: %s', $dispute_id, $dispute->get_error_message() )
+			);
+		}
+
 		if ( ! is_array( $dispute ) ) {
 			$dispute = [];
 		}
@@ -188,16 +191,15 @@ class Dispute_Evidence_Collector {
 		$created = $order->get_date_created();
 
 		return [
-			'id'                  => $order->get_id(),
-			'order_number'        => $order->get_order_number(),
-			'status'              => $order->get_status(),
-			'total'               => (float) $order->get_total(),
-			'currency'            => $order->get_currency(),
-			'created'             => $created ? $created->format( 'c' ) : null,
-			'customer_email'      => $order->get_billing_email(),
-			'customer_ip'         => $order->get_customer_ip_address(),
-			'customer_user_agent' => $order->get_customer_user_agent(),
-			'items'               => $items,
+			'id'             => $order->get_id(),
+			'order_number'   => $order->get_order_number(),
+			'status'         => $order->get_status(),
+			'total'          => (float) $order->get_total(),
+			'currency'       => $order->get_currency(),
+			'created'        => $created ? $created->format( 'c' ) : null,
+			'customer_email' => $order->get_billing_email(),
+			'customer_ip'    => $order->get_customer_ip_address(),
+			'items'          => $items,
 		];
 	}
 
@@ -243,7 +245,6 @@ class Dispute_Evidence_Collector {
 				'limit'         => self::PRIOR_ORDERS_LIMIT,
 				'exclude'       => [ $order->get_id() ],
 				'status'        => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-				'return'        => 'objects',
 			]
 		);
 

--- a/includes/disputes/class-dispute-evidence-collector.php
+++ b/includes/disputes/class-dispute-evidence-collector.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Class WCPay\Disputes\Dispute_Evidence_Collector.
+ *
+ * @package WooCommerce Payments
+ */
+
+namespace WCPay\Disputes;
+
+use WC_Order;
+use WC_Payments_API_Client;
+use WC_Payments_Order_Service;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Collects a normalized evidence-context DTO for a dispute, intended as the
+ * payload sent to Transact-Platform in the `evidence_context` parameter when
+ * drafting an AI-generated dispute defense.
+ *
+ * PII minimization is load-bearing: the DTO never includes card PAN, CVC,
+ * expiry, fingerprint, or any other card-auth data. Only the fields explicitly
+ * shaped by the private `shape_*` helpers are returned — the raw dispute blob
+ * from the API client is never passed through.
+ */
+class Dispute_Evidence_Collector {
+
+	/**
+	 * Max prior orders returned in customer_history, to keep the prompt bounded.
+	 */
+	private const PRIOR_ORDERS_LIMIT = 10;
+
+	/**
+	 * API client used to fetch the enriched dispute payload.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $api_client;
+
+	/**
+	 * Order service, held for future order-meta reads.
+	 *
+	 * @var WC_Payments_Order_Service
+	 */
+	private $order_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Payments_API_Client    $api_client    API client used to fetch the enriched dispute.
+	 * @param WC_Payments_Order_Service $order_service Order service (kept for future order-meta reads).
+	 */
+	public function __construct( WC_Payments_API_Client $api_client, WC_Payments_Order_Service $order_service ) {
+		$this->api_client    = $api_client;
+		$this->order_service = $order_service;
+	}
+
+	/**
+	 * Builds the evidence-context DTO for a dispute.
+	 *
+	 * @param string $dispute_id Stripe dispute ID.
+	 * @return array{
+	 *     dispute: array<string, mixed>,
+	 *     charge: array<string, mixed>,
+	 *     order: array<string, mixed>|null,
+	 *     radar: array<string, mixed>,
+	 *     customer_history: array<int, array<string, mixed>>,
+	 * }
+	 */
+	public function collect( string $dispute_id ): array {
+		$dispute = $this->api_client->get_dispute( $dispute_id );
+		if ( ! is_array( $dispute ) ) {
+			$dispute = [];
+		}
+
+		$charge = is_array( $dispute['charge'] ?? null ) ? $dispute['charge'] : [];
+		$order  = $this->load_order_from_dispute( $dispute );
+
+		return [
+			'dispute'          => $this->shape_dispute( $dispute ),
+			'charge'           => $this->shape_charge( $charge ),
+			'order'            => $order ? $this->shape_order( $order ) : null,
+			'radar'            => $this->shape_radar( $charge ),
+			'customer_history' => $order ? $this->prior_orders_for( $order ) : [],
+		];
+	}
+
+	/**
+	 * Shapes the dispute-level fields.
+	 *
+	 * @param array $dispute Raw dispute payload.
+	 * @return array<string, mixed>
+	 */
+	private function shape_dispute( array $dispute ): array {
+		return [
+			'id'       => $dispute['id'] ?? '',
+			'reason'   => $dispute['reason'] ?? '',
+			'amount'   => $dispute['amount'] ?? 0,
+			'currency' => $dispute['currency'] ?? '',
+			'due_by'   => $dispute['evidence_details']['due_by'] ?? null,
+			'status'   => $dispute['status'] ?? '',
+		];
+	}
+
+	/**
+	 * Shapes the charge-level fields.
+	 *
+	 * Card fields are intentionally limited to `brand`, `last4`, and `funding`;
+	 * PAN, CVC, expiry, fingerprint, and any other card-auth data are never
+	 * extracted from the raw payload.
+	 *
+	 * @param array $charge Raw charge payload.
+	 * @return array<string, mixed>
+	 */
+	private function shape_charge( array $charge ): array {
+		$card = $charge['payment_method_details']['card'] ?? [];
+
+		return [
+			'id'              => $charge['id'] ?? '',
+			'amount'          => $charge['amount'] ?? 0,
+			'currency'        => $charge['currency'] ?? '',
+			'created'         => $charge['created'] ?? null,
+			'billing_details' => $this->shape_address( is_array( $charge['billing_details'] ?? null ) ? $charge['billing_details'] : [] ),
+			'shipping'        => $this->shape_address( is_array( $charge['shipping'] ?? null ) ? $charge['shipping'] : [] ),
+			'card'            => [
+				'brand'   => $card['brand'] ?? '',
+				'last4'   => $card['last4'] ?? '',
+				'funding' => $card['funding'] ?? '',
+			],
+		];
+	}
+
+	/**
+	 * Shapes the Radar/risk-outcome fields.
+	 *
+	 * @param array $charge Raw charge payload.
+	 * @return array<string, mixed>
+	 */
+	private function shape_radar( array $charge ): array {
+		$outcome = is_array( $charge['outcome'] ?? null ) ? $charge['outcome'] : [];
+
+		return [
+			'risk_level'     => $outcome['risk_level'] ?? '',
+			'risk_score'     => $outcome['risk_score'] ?? null,
+			'rule_triggered' => $outcome['rule']['id'] ?? null,
+			'network_status' => $outcome['network_status'] ?? '',
+			'seller_message' => $outcome['seller_message'] ?? '',
+		];
+	}
+
+	/**
+	 * Shapes an address-like block (billing_details or shipping).
+	 *
+	 * @param array $details Raw address block from Stripe.
+	 * @return array<string, mixed>
+	 */
+	private function shape_address( array $details ): array {
+		$address = is_array( $details['address'] ?? null ) ? $details['address'] : [];
+
+		return [
+			'name'        => $details['name'] ?? '',
+			'email'       => $details['email'] ?? '',
+			'line1'       => $address['line1'] ?? '',
+			'line2'       => $address['line2'] ?? '',
+			'city'        => $address['city'] ?? '',
+			'state'       => $address['state'] ?? '',
+			'postal_code' => $address['postal_code'] ?? '',
+			'country'     => $address['country'] ?? '',
+		];
+	}
+
+	/**
+	 * Shapes a WooCommerce order into a DTO fragment.
+	 *
+	 * @param WC_Order $order The order.
+	 * @return array<string, mixed>
+	 */
+	private function shape_order( WC_Order $order ): array {
+		$items = [];
+		foreach ( $order->get_items() as $item ) {
+			$items[] = [
+				'name'     => $item->get_name(),
+				'quantity' => $item->get_quantity(),
+				'total'    => (float) $item->get_total(),
+			];
+		}
+
+		$created = $order->get_date_created();
+
+		return [
+			'id'                  => $order->get_id(),
+			'order_number'        => $order->get_order_number(),
+			'status'              => $order->get_status(),
+			'total'               => (float) $order->get_total(),
+			'currency'            => $order->get_currency(),
+			'created'             => $created ? $created->format( 'c' ) : null,
+			'customer_email'      => $order->get_billing_email(),
+			'customer_ip'         => $order->get_customer_ip_address(),
+			'customer_user_agent' => $order->get_customer_user_agent(),
+			'items'               => $items,
+		];
+	}
+
+	/**
+	 * Finds the WooCommerce order linked to the dispute, if any.
+	 *
+	 * WC_Payments_API_Client::get_dispute() enriches the dispute with a top-level
+	 * `order` key via add_order_info_to_charge_object() / build_order_info(), so
+	 * the WC order ID lives at $dispute['order']['id'] (not inside the charge).
+	 *
+	 * @param array $dispute Enriched dispute payload.
+	 * @return WC_Order|null
+	 */
+	private function load_order_from_dispute( array $dispute ): ?WC_Order {
+		$order_info = is_array( $dispute['order'] ?? null ) ? $dispute['order'] : [];
+
+		$order_id = $order_info['id'] ?? null;
+		if ( empty( $order_id ) ) {
+			return null;
+		}
+
+		$order = wc_get_order( $order_id );
+
+		return $order instanceof WC_Order ? $order : null;
+	}
+
+	/**
+	 * Returns a lightweight summary of prior orders for the same customer,
+	 * excluding the current one.
+	 *
+	 * @param WC_Order $order The order linked to the dispute.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function prior_orders_for( WC_Order $order ): array {
+		$email = $order->get_billing_email();
+		if ( empty( $email ) ) {
+			return [];
+		}
+
+		$orders = wc_get_orders(
+			[
+				'billing_email' => $email,
+				'limit'         => self::PRIOR_ORDERS_LIMIT,
+				'exclude'       => [ $order->get_id() ],
+				'status'        => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+				'return'        => 'objects',
+			]
+		);
+
+		$summary = [];
+		foreach ( $orders as $prior ) {
+			if ( ! $prior instanceof WC_Order ) {
+				continue;
+			}
+
+			$created = $prior->get_date_created();
+
+			$summary[] = [
+				'id'       => $prior->get_id(),
+				'status'   => $prior->get_status(),
+				'total'    => (float) $prior->get_total(),
+				'currency' => $prior->get_currency(),
+				'created'  => $created ? $created->format( 'c' ) : null,
+			];
+		}
+
+		return $summary;
+	}
+}

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -56,6 +56,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	const DEPOSITS_API                 = 'deposits';
 	const TRANSACTIONS_API             = 'transactions';
 	const DISPUTES_API                 = 'disputes';
+	const DISPUTE_DEFENSE_API          = 'dispute_defense/draft';
 	const FILES_API                    = 'files';
 	const ONBOARDING_API               = 'onboarding';
 	const TIMELINE_API                 = 'timeline';

--- a/tests/unit/admin/test-class-wc-rest-payments-disputes-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-disputes-controller.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class WC_REST_Payments_Disputes_Controller_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * WC_REST_Payments_Disputes_Controller unit tests.
+ */
+class WC_REST_Payments_Disputes_Controller_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var WC_REST_Payments_Disputes_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Mock API client.
+	 *
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$this->controller      = new WC_REST_Payments_Disputes_Controller( $this->mock_api_client );
+	}
+
+	public function tear_down() {
+		delete_option( WC_Payments_Features::DISPUTE_DEFENDER_AI );
+		parent::tear_down();
+	}
+
+	public function test_generate_defense_draft_returns_403_when_flag_off() {
+		delete_option( WC_Payments_Features::DISPUTE_DEFENDER_AI );
+
+		// API client must not be touched when the flag is off.
+		$this->mock_api_client->expects( $this->never() )->method( 'get_dispute' );
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'dispute_id', 'dp_test_123' );
+
+		$response = $this->controller->generate_defense_draft( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_dispute_defender_disabled', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data()['status'] );
+	}
+
+	public function test_generate_defense_draft_rejects_non_fraudulent() {
+		update_option( WC_Payments_Features::DISPUTE_DEFENDER_AI, '1' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_dispute' )
+			->with( 'dp_test_456' )
+			->willReturn(
+				[
+					'id'     => 'dp_test_456',
+					'reason' => 'duplicate',
+				]
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'dispute_id', 'dp_test_456' );
+
+		$response = $this->controller->generate_defense_draft( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_dispute_defender_unsupported_reason', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+	}
+}

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -807,6 +807,22 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( $status_before_request, get_option( WC_Payments_Features::WCPAY_SUBSCRIPTIONS_FLAG_NAME ) );
 	}
 
+	public function test_update_settings_persists_dispute_defender_flag() {
+		$request = new WP_REST_Request( 'POST', self::$settings_route );
+		$request->set_body_params( [ 'is_dispute_defender_enabled' => true ] );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( '1', get_option( WC_Payments_Features::DISPUTE_DEFENDER_AI ) );
+	}
+
+	public function test_get_settings_exposes_dispute_defender_flag() {
+		update_option( WC_Payments_Features::DISPUTE_DEFENDER_AI, '1' );
+		$request  = new WP_REST_Request( 'GET', self::$settings_route );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+		$this->assertTrue( $data['is_dispute_defender_enabled'] );
+	}
+
 	public function deposit_schedules_data_provider() {
 		return [
 			[

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -99,6 +99,7 @@ function _manually_load_plugin() {
 	require_once $_plugin_dir . 'includes/class-woopay-tracker.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-customer-controller.php';
 	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-refunds-controller.php';
+	require_once $_plugin_dir . 'includes/admin/class-wc-rest-payments-disputes-controller.php';
 
 	// Load currency helper class early to ensure its implementation is used over the one resolved during further test initialization.
 	require_once __DIR__ . '/helpers/class-wc-helper-site-currency.php';

--- a/tests/unit/core/server/request/test-generate-dispute-defense.php
+++ b/tests/unit/core/server/request/test-generate-dispute-defense.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Class Generate_Dispute_Defense_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\Core\Exceptions\Server\Request\Invalid_Request_Parameter_Exception;
+use WCPay\Core\Server\Request\Generate_Dispute_Defense;
+
+/**
+ * WCPay\Core\Server\Request\Generate_Dispute_Defense unit tests.
+ */
+class Generate_Dispute_Defense_Test extends WCPAY_UnitTestCase {
+
+	public function test_get_method_and_api() {
+		$request = Generate_Dispute_Defense::create();
+		$this->assertSame( 'POST', $request->get_method() );
+		$this->assertSame( WC_Payments_API_Client::DISPUTE_DEFENSE_API, $request->get_api() );
+		$this->assertSame( 'dispute_defense/draft', $request->get_api() );
+	}
+
+	public function test_set_dispute_id_rejects_invalid_prefix() {
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request = Generate_Dispute_Defense::create();
+		$request->set_dispute_id( 'ch_not_a_dispute' );
+	}
+
+	public function test_set_reason_rejects_non_fraudulent() {
+		$request = Generate_Dispute_Defense::create();
+		try {
+			$request->set_reason( 'duplicate' );
+			$this->fail( 'Expected Invalid_Request_Parameter_Exception' );
+		} catch ( Invalid_Request_Parameter_Exception $e ) {
+			$this->assertSame( 'wcpay_dispute_defender_unsupported_reason', $e->get_error_code() );
+		}
+	}
+
+	public function test_happy_path_accepts_valid_input() {
+		$request = Generate_Dispute_Defense::create();
+		$request->set_dispute_id( 'dp_test_123' );
+		$request->set_reason( 'fraudulent' );
+		$request->set_evidence_context( [ 'order_id' => 42 ] );
+
+		$params = $request->get_params();
+		$this->assertSame( 'dp_test_123', $params['dispute_id'] );
+		$this->assertSame( 'fraudulent', $params['reason'] );
+		$this->assertSame( [ 'order_id' => 42 ], $params['evidence_context'] );
+	}
+}

--- a/tests/unit/core/server/request/test-generate-dispute-defense.php
+++ b/tests/unit/core/server/request/test-generate-dispute-defense.php
@@ -26,6 +26,22 @@ class Generate_Dispute_Defense_Test extends WCPAY_UnitTestCase {
 		$request->set_dispute_id( 'ch_not_a_dispute' );
 	}
 
+	public function test_set_dispute_id_accepts_du_prefix() {
+		$request = Generate_Dispute_Defense::create();
+		$request->set_dispute_id( 'du_1TN0D8FyLcjBhX8JLKgFTHiC' );
+		$request->set_reason( 'fraudulent' );
+		$request->set_evidence_context( [] );
+		$this->assertSame( 'du_1TN0D8FyLcjBhX8JLKgFTHiC', $request->get_params()['dispute_id'] );
+	}
+
+	public function test_set_dispute_id_accepts_dp_prefix() {
+		$request = Generate_Dispute_Defense::create();
+		$request->set_dispute_id( 'dp_test_123' );
+		$request->set_reason( 'fraudulent' );
+		$request->set_evidence_context( [] );
+		$this->assertSame( 'dp_test_123', $request->get_params()['dispute_id'] );
+	}
+
 	public function test_set_dispute_id_rejects_empty_string() {
 		$this->expectException( Invalid_Request_Parameter_Exception::class );
 		$request = Generate_Dispute_Defense::create();

--- a/tests/unit/core/server/request/test-generate-dispute-defense.php
+++ b/tests/unit/core/server/request/test-generate-dispute-defense.php
@@ -26,6 +26,18 @@ class Generate_Dispute_Defense_Test extends WCPAY_UnitTestCase {
 		$request->set_dispute_id( 'ch_not_a_dispute' );
 	}
 
+	public function test_set_dispute_id_rejects_empty_string() {
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request = Generate_Dispute_Defense::create();
+		$request->set_dispute_id( '' );
+	}
+
+	public function test_set_reason_rejects_uppercase_fraudulent() {
+		$this->expectException( Invalid_Request_Parameter_Exception::class );
+		$request = Generate_Dispute_Defense::create();
+		$request->set_reason( 'FRAUDULENT' );
+	}
+
 	public function test_set_reason_rejects_non_fraudulent() {
 		$request = Generate_Dispute_Defense::create();
 		try {

--- a/tests/unit/disputes/test-class-dispute-evidence-collector.php
+++ b/tests/unit/disputes/test-class-dispute-evidence-collector.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Class Dispute_Evidence_Collector_Test.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use WCPay\Disputes\Dispute_Evidence_Collector;
+
+/**
+ * Dispute_Evidence_Collector unit tests.
+ */
+class Dispute_Evidence_Collector_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * @var WC_Payments_API_Client&MockObject
+	 */
+	private $mock_api_client;
+
+	/**
+	 * @var WC_Payments_Order_Service&MockObject
+	 */
+	private $mock_order_service;
+
+	/**
+	 * @var Dispute_Evidence_Collector
+	 */
+	private $collector;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->mock_api_client    = $this->createMock( WC_Payments_API_Client::class );
+		$this->mock_order_service = $this->createMock( WC_Payments_Order_Service::class );
+
+		$this->collector = new Dispute_Evidence_Collector(
+			$this->mock_api_client,
+			$this->mock_order_service
+		);
+	}
+
+	public function test_collect_returns_expected_shape() {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_dispute' )
+			->with( 'dp_test_123' )
+			->willReturn( $this->make_dispute_fixture() );
+
+		$dto = $this->collector->collect( 'dp_test_123' );
+
+		$this->assertArrayHasKey( 'dispute', $dto );
+		$this->assertArrayHasKey( 'charge', $dto );
+		$this->assertArrayHasKey( 'order', $dto );
+		$this->assertArrayHasKey( 'radar', $dto );
+		$this->assertArrayHasKey( 'customer_history', $dto );
+
+		$this->assertSame( 'dp_test_123', $dto['dispute']['id'] );
+		$this->assertSame( 'fraudulent', $dto['dispute']['reason'] );
+		$this->assertSame( 14200, $dto['dispute']['amount'] );
+		$this->assertSame( 'usd', $dto['dispute']['currency'] );
+		$this->assertSame( 'needs_response', $dto['dispute']['status'] );
+		$this->assertSame( 1715030400, $dto['dispute']['due_by'] );
+
+		$this->assertSame( 'ch_test_123', $dto['charge']['id'] );
+		$this->assertSame( 'visa', $dto['charge']['card']['brand'] );
+		$this->assertSame( '4242', $dto['charge']['card']['last4'] );
+		$this->assertSame( 'credit', $dto['charge']['card']['funding'] );
+	}
+
+	public function test_dto_never_contains_pan_or_cvc() {
+		$dispute = $this->make_dispute_fixture();
+
+		// Sabotage: try to sneak PII in as if the upstream payload had it.
+		$dispute['charge']['payment_method_details']['card']['number']      = '4242424242424242';
+		$dispute['charge']['payment_method_details']['card']['cvc']         = '123';
+		$dispute['charge']['payment_method_details']['card']['exp_month']   = 4;
+		$dispute['charge']['payment_method_details']['card']['exp_year']    = 2030;
+		$dispute['charge']['payment_method_details']['card']['fingerprint'] = 'fp_secret';
+		$dispute['charge']['payment_method_details']['card']['iin']         = '424242';
+
+		$this->mock_api_client->method( 'get_dispute' )->willReturn( $dispute );
+
+		$dto  = $this->collector->collect( 'dp_test_123' );
+		$flat = wp_json_encode( $dto );
+
+		$this->assertIsString( $flat );
+		$this->assertStringNotContainsString( '4242424242424242', $flat );
+		$this->assertStringNotContainsString( '"cvc"', $flat );
+		$this->assertStringNotContainsString( '"number"', $flat );
+		$this->assertStringNotContainsString( '"exp_month"', $flat );
+		$this->assertStringNotContainsString( '"exp_year"', $flat );
+		$this->assertStringNotContainsString( '"fingerprint"', $flat );
+		$this->assertStringNotContainsString( 'fp_secret', $flat );
+	}
+
+	public function test_collect_returns_null_order_when_dispute_has_no_order() {
+		$dispute          = $this->make_dispute_fixture();
+		$dispute['order'] = []; // No WC order attached (this is what get_dispute() yields when the charge isn't tied to a WC order).
+		$this->mock_api_client->method( 'get_dispute' )->willReturn( $dispute );
+
+		$dto = $this->collector->collect( 'dp_test_123' );
+
+		$this->assertNull( $dto['order'] );
+		$this->assertSame( [], $dto['customer_history'] );
+	}
+
+	public function test_radar_fields_extracted() {
+		$this->mock_api_client->method( 'get_dispute' )->willReturn( $this->make_dispute_fixture() );
+
+		$dto = $this->collector->collect( 'dp_test_123' );
+
+		$this->assertSame( 'elevated', $dto['radar']['risk_level'] );
+		$this->assertSame( 75, $dto['radar']['risk_score'] );
+		$this->assertSame( 'approved_by_network', $dto['radar']['network_status'] );
+		$this->assertSame( 'Payment complete.', $dto['radar']['seller_message'] );
+	}
+
+	/**
+	 * Builds a representative enriched dispute fixture matching the shape produced by
+	 * WC_Payments_API_Client::get_dispute() — i.e. the raw Stripe dispute plus a top-level
+	 * 'order' key populated by add_order_info_to_charge_object().
+	 *
+	 * @return array
+	 */
+	private function make_dispute_fixture(): array {
+		return [
+			'id'               => 'dp_test_123',
+			'reason'           => 'fraudulent',
+			'amount'           => 14200,
+			'currency'         => 'usd',
+			'status'           => 'needs_response',
+			'evidence_details' => [
+				'due_by' => 1715030400,
+			],
+			'charge'           => [
+				'id'                     => 'ch_test_123',
+				'amount'                 => 14200,
+				'currency'               => 'usd',
+				'created'                => 1712880000,
+				'billing_details'        => [
+					'name'    => 'Jane Doe',
+					'email'   => 'jane@example.com',
+					'address' => [
+						'line1'       => '123 Main St',
+						'line2'       => '',
+						'city'        => 'Brooklyn',
+						'state'       => 'NY',
+						'postal_code' => '10001',
+						'country'     => 'US',
+					],
+				],
+				'shipping'               => [
+					'name'    => 'Jane Doe',
+					'address' => [
+						'line1'       => '123 Main St',
+						'city'        => 'Brooklyn',
+						'state'       => 'NY',
+						'postal_code' => '10001',
+						'country'     => 'US',
+					],
+				],
+				'payment_method_details' => [
+					'card' => [
+						'brand'   => 'visa',
+						'last4'   => '4242',
+						'funding' => 'credit',
+					],
+				],
+				'outcome'                => [
+					'risk_level'     => 'elevated',
+					'risk_score'     => 75,
+					'network_status' => 'approved_by_network',
+					'seller_message' => 'Payment complete.',
+					'rule'           => [
+						'id' => 'rule_abc',
+					],
+				],
+			],
+			// get_dispute() adds top-level 'order' via add_order_info_to_charge_object();
+			// this empty array mirrors the "no linked WC order" case.
+			'order'            => [],
+		];
+	}
+}

--- a/tests/unit/disputes/test-class-dispute-evidence-collector.php
+++ b/tests/unit/disputes/test-class-dispute-evidence-collector.php
@@ -19,11 +19,6 @@ class Dispute_Evidence_Collector_Test extends WCPAY_UnitTestCase {
 	private $mock_api_client;
 
 	/**
-	 * @var WC_Payments_Order_Service&MockObject
-	 */
-	private $mock_order_service;
-
-	/**
 	 * @var Dispute_Evidence_Collector
 	 */
 	private $collector;
@@ -31,13 +26,8 @@ class Dispute_Evidence_Collector_Test extends WCPAY_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->mock_api_client    = $this->createMock( WC_Payments_API_Client::class );
-		$this->mock_order_service = $this->createMock( WC_Payments_Order_Service::class );
-
-		$this->collector = new Dispute_Evidence_Collector(
-			$this->mock_api_client,
-			$this->mock_order_service
-		);
+		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$this->collector       = new Dispute_Evidence_Collector( $this->mock_api_client );
 	}
 
 	public function test_collect_returns_expected_shape() {
@@ -92,6 +82,17 @@ class Dispute_Evidence_Collector_Test extends WCPAY_UnitTestCase {
 		$this->assertStringNotContainsString( '"exp_year"', $flat );
 		$this->assertStringNotContainsString( '"fingerprint"', $flat );
 		$this->assertStringNotContainsString( 'fp_secret', $flat );
+		$this->assertStringNotContainsString( '"customer_user_agent"', $flat );
+	}
+
+	public function test_collect_throws_on_upstream_wp_error() {
+		$this->mock_api_client
+			->method( 'get_dispute' )
+			->willReturn( new WP_Error( 'api_down', 'Upstream unavailable' ) );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessageMatches( '/dp_test_123/' );
+		$this->collector->collect( 'dp_test_123' );
 	}
 
 	public function test_collect_returns_null_order_when_dispute_has_no_order() {

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -425,4 +425,14 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 
 		$this->assertTrue( $result );
 	}
+
+	public function test_is_dispute_defender_enabled_returns_false_by_default() {
+		delete_option( '_wcpay_feature_dispute_defender_ai' );
+		$this->assertFalse( WC_Payments_Features::is_dispute_defender_enabled() );
+	}
+
+	public function test_is_dispute_defender_enabled_reads_option() {
+		update_option( '_wcpay_feature_dispute_defender_ai', '1' );
+		$this->assertTrue( WC_Payments_Features::is_dispute_defender_enabled() );
+	}
 }

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -427,12 +427,17 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_is_dispute_defender_enabled_returns_false_by_default() {
-		delete_option( '_wcpay_feature_dispute_defender_ai' );
+		delete_option( WC_Payments_Features::DISPUTE_DEFENDER_AI );
 		$this->assertFalse( WC_Payments_Features::is_dispute_defender_enabled() );
 	}
 
 	public function test_is_dispute_defender_enabled_reads_option() {
-		update_option( '_wcpay_feature_dispute_defender_ai', '1' );
+		update_option( WC_Payments_Features::DISPUTE_DEFENDER_AI, '1' );
 		$this->assertTrue( WC_Payments_Features::is_dispute_defender_enabled() );
+	}
+
+	public function test_is_dispute_defender_enabled_requires_strict_one() {
+		update_option( WC_Payments_Features::DISPUTE_DEFENDER_AI, 'yes' );
+		$this->assertFalse( WC_Payments_Features::is_dispute_defender_enabled() );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds an opt-in "Generate with AI" button on the WooPayments dispute detail page for fraudulent disputes. The panel gathers evidence context (order, charge, Radar outcome, prior customer orders), sends it to a new Transact-Platform endpoint (backed by Claude Sonnet 4.5), and renders the returned narrative + evidence-gap list in an editable panel.

Ships as part of Radical Speed Month — design doc: `Gamma/2026-04-14 Dispute Defender AI - Design.md`.

**What's in this PR (WooPayments side):**

- Feature flag `_wcpay_feature_dispute_defender_ai` + Advanced-tab toggle (default OFF)
- `Generate_Dispute_Defense` Request class + REST route `POST /wc/v3/payments/disputes/{id}/defense/draft`
- `Dispute_Evidence_Collector` service with PII-minimized DTO (no PAN, CVC, expiry, fingerprint, user agent)
- `DisputeDefenderPanel` React component: gated on flag + fraudulent reason, editable narrative, per-gap toggle with in-place sentence swap + orphan fallback, "Use this draft" (clipboard or `onUseDraft` prop), friendly error messages with Retry, 4 Tracks events
- 10 commits. 20 Jest tests + 18 PHPUnit tests for the new code (all green); no other suites broken.

**Companion Transact-Platform PR (separate, on the sandbox mirror):**

- `POST /wcpay/dispute_defense/draft` endpoint with `Anthropic_Client` + `Prompt_Builder` + `Response_Validator` + single retry on malformed JSON
- Rate limit 10/min per blog via existing `Rate_Limit_Factory`
- PII-free logging locked in with a regression test
- Requires `WCPAY_ANTHROPIC_API_KEY` in sandbox/prod config

**Scope (MVP):**

- Fraudulent disputes only; other reasons silently hide the button
- Opt-in via Advanced toggle; merchant always reviews before submitting — no auto-submit
- "Use this draft" copies to clipboard in this PR; wiring into the existing evidence form is a follow-up

#### Testing instructions

The Transact endpoint must be synced and deployed to a sandbox with `WCPAY_ANTHROPIC_API_KEY` defined for end-to-end testing. WooPayments-only testing of gating and error paths works without it.

1. Check out this branch and start the dev env: `npm run up && npm run watch`.
2. In **wp-admin → WooPayments → Settings → Advanced**, enable **Dispute Defender AI**. Confirm the option persists on reload.
3. Create/seed a **fraudulent** test dispute (`dp_*` with `reason = fraudulent`). Visit the dispute detail page.
4. Confirm the "Generate with AI" panel appears above the Issuer Evidence list. With the flag OFF or on a non-fraudulent dispute, the panel is hidden.
5. Click **Generate with AI** — without Transact wired, this returns a friendly 502 with a Retry button. Expected without the sandbox endpoint.
6. Once Transact is wired (sandbox with API key), clicking Generate returns a draft. Edit the narrative, toggle a gap between Provide / Can't provide and watch the sentence swap in place. Click **Use this draft** to copy to clipboard.

**Unit tests:**

```bash
npm run test:js -- --testPathPattern='dispute-defender'
# Expect: 20 tests pass across the panel suite

docker compose exec -u www-data wordpress bash -c \
  "cd /var/www/html/wp-content/plugins/woocommerce-payments && \
   vendor/bin/phpunit --filter \
   'DisputeDefender|Generate_Dispute_Defense|Dispute_Evidence|is_dispute_defender_enabled|dispute_defender|defense_draft'"
# Expect: 18 tests, 57 assertions, all green
```

**Tracks events to verify in network tab:**

- `wcpay_dispute_defender_button_viewed` on panel mount
- `wcpay_dispute_defender_generate_clicked` on Generate click
- `wcpay_dispute_defender_gap_resolved` on gap toggle (with `gap_id`, `resolution`)
- `wcpay_dispute_defender_draft_submitted` on Use this draft (with `dispute_id`, `narrative_length`, `edit_distance_percent`)

**Pre-launch open items (not blocking this PR):**

- [ ] Anthropic DPA confirmation for payments-data PII (legal)
- [ ] Real-merchant smoke test with the sandbox Anthropic key
- [ ] Playwright E2E happy-path spec (follow-up PR)
- [ ] Link from release-testing doc

*

-------------------

- [x] Run \`npm run changelog\` to add a changelog file — two entries already present: \`changelog/feat-dispute-evidence-collector\`, \`changelog/feat-dispute-defender-panel\`
- [x] Covered with tests
- [ ] Tested on mobile — dev-only opt-in feature; mobile parity is out of scope for the RSM prototype

**Post merge**

- [ ] Link to testing instructions from release testing doc: *QA Testing Not Applicable — behind opt-in flag, dev-only until Transact endpoint deployed*
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable
- [ ] Add what's changed to the release announcement post, if applicable

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)