### PR TITLE
feat: show funding card last 4 on Amazon Pay order received page

### DIFF
--- a/changelog/feat-amazon-pay-order-success-last-four
+++ b/changelog/feat-amazon-pay-order-success-last-four
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Show the funding card last four digits on the order received page for Amazon Pay transactions, matching Apple Pay and Google Pay.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2000,6 +2000,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				}
 				$order->save_meta_data();
 			}
+			if ( 'amazon_pay' === $payment_method_type
+				&& isset( $payment_method_details['amazon_pay']['funding']['card']['last4'] ) ) {
+				$funding_card = $payment_method_details['amazon_pay']['funding']['card'];
+				$order->add_meta_data( 'last4', $funding_card['last4'], true );
+				if ( isset( $funding_card['brand'] ) ) {
+					$order->add_meta_data( '_card_brand', strtolower( $funding_card['brand'] ), true );
+				}
+				$order->save_meta_data();
+			}
 		} else {
 			$payment_method_details = false;
 			$token                  = $payment_information->is_using_saved_payment_method() ? $payment_information->get_payment_token() : null;
@@ -2416,6 +2425,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// then fall back to Stripe's wallet info (authoritative for Apple Pay, Google Pay, Link).
 		$express_checkout_type = $order->get_meta( '_wcpay_express_checkout_payment_method' );
 		$wallet_type           = is_array( $payment_method_details ) ? $payment_method_details['card']['wallet']['type'] ?? null : null;
+		// Amazon Pay reports its type at the top level rather than under card.wallet.
+		if ( ! $wallet_type && is_array( $payment_method_details )
+			&& 'amazon_pay' === ( $payment_method_details['type'] ?? null ) ) {
+			$wallet_type = 'amazon_pay';
+		}
 		if ( ! $express_checkout_type && $wallet_type ) {
 			$express_checkout_type = sanitize_text_field( $wallet_type );
 			$order->update_meta_data( '_wcpay_express_checkout_payment_method', $express_checkout_type );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -735,6 +735,31 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Test that Amazon Pay is detected as an express checkout wallet from the top-level
+	 * payment_method_details.type when no meta is pre-set on the order. Amazon Pay does
+	 * not nest its wallet info under card.wallet, so we need a separate detection path.
+	 */
+	public function test_amazon_pay_detection_sets_express_checkout_meta() {
+		$order           = WC_Helper_Order::create_order();
+		$payment_details = [
+			'type'       => 'amazon_pay',
+			'amazon_pay' => [
+				'funding' => [
+					'card' => [
+						'brand' => 'Visa',
+						'last4' => '4242',
+					],
+					'type' => 'card',
+				],
+			],
+		];
+
+		$this->card_gateway->set_payment_method_title_for_order( $order, 'amazon_pay', $payment_details );
+
+		$this->assertEquals( 'amazon_pay', $order->get_meta( '_wcpay_express_checkout_payment_method' ), 'amazon_pay meta should be persisted' );
+	}
+
+	/**
 	 * Test that the express checkout title suffix can be customized via filter.
 	 */
 	public function test_express_checkout_title_suffix_filter() {

--- a/tests/unit/test-class-wc-payments-order-success-page.php
+++ b/tests/unit/test-class-wc-payments-order-success-page.php
@@ -267,4 +267,49 @@ class WC_Payments_Order_Success_Page_Test extends WCPAY_UnitTestCase {
 
 		$this->assertEquals( $original_text, $result );
 	}
+
+	public function test_show_express_checkout_payment_method_name_amazon_pay_with_last4() {
+		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( 'last4', '4242' );
+		$order->set_payment_method( 'woocommerce_payments_amazon_pay' );
+		$order->save();
+
+		$payment_method = $this->createMock( \WCPay\Payment_Methods\UPE_Payment_Method::class );
+		$payment_method->method( 'get_title' )->willReturn( 'Amazon Pay' );
+		$payment_method->method( 'get_icon' )->willReturn( 'amazon-pay.svg' );
+		$payment_method->method( 'get_dark_icon' )->willReturn( 'amazon-pay.svg' );
+
+		$original_map = $this->get_payment_method_map();
+		$this->set_payment_method_map( array_merge( $original_map, [ 'amazon_pay' => $payment_method ] ) );
+
+		$result = $this->payments_order_success_page->show_express_checkout_payment_method_name( $order, 'amazon_pay' );
+
+		$this->set_payment_method_map( $original_map );
+
+		$this->assertStringContainsString( 'wc-payment-gateway-method-logo-wrapper', $result );
+		$this->assertStringContainsString( 'amazon', strtolower( $result ) );
+		$this->assertStringContainsString( '•••', $result );
+		$this->assertStringContainsString( '4242', $result );
+	}
+
+	public function test_show_express_checkout_payment_method_name_amazon_pay_without_last4() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments_amazon_pay' );
+		$order->save();
+
+		$payment_method = $this->createMock( \WCPay\Payment_Methods\UPE_Payment_Method::class );
+		$payment_method->method( 'get_title' )->willReturn( 'Amazon Pay' );
+		$payment_method->method( 'get_icon' )->willReturn( 'amazon-pay.svg' );
+		$payment_method->method( 'get_dark_icon' )->willReturn( 'amazon-pay.svg' );
+
+		$original_map = $this->get_payment_method_map();
+		$this->set_payment_method_map( array_merge( $original_map, [ 'amazon_pay' => $payment_method ] ) );
+
+		$result = $this->payments_order_success_page->show_express_checkout_payment_method_name( $order, 'amazon_pay' );
+
+		$this->set_payment_method_map( $original_map );
+
+		$this->assertStringContainsString( 'wc-payment-gateway-method-logo-wrapper', $result );
+		$this->assertStringNotContainsString( '•••', $result );
+	}
 }


### PR DESCRIPTION
Fixes WOOPMNT-6114

#### Changes proposed in this Pull Request

Showing the card's last 4 digits on the order received page, next to the Amazon Pay logo (similar to Apple Pay and Google Pay).
Fallback to the Amazon Pay logo alone when Stripe does not share the funding card.

<!-- Images or gifs: Include before and after screenshots or gifs/videos when it makes sense. -->

#### Testing instructions

- Ensure Amazon Pay is enabled in Payments > Settings
- Place an order with the `1111` card within the amazon pay wallet
<img width="511" height="107" alt="Screenshot 2026-04-17 at 10 45 59 PM" src="https://github.com/user-attachments/assets/a09781dd-d8de-49a4-836f-bc02764b0f00" />

- The "last 4" should not display on the "order success" page (`1111` is not mapped to a "card" instrument in Stripe)
<img width="229" height="148" alt="Screenshot 2026-04-17 at 10 46 12 PM" src="https://github.com/user-attachments/assets/b115934d-6243-410e-b771-003a561798cc" />

- Place an order with the Discover card within the amazon pay wallet
<img width="551" height="114" alt="Screenshot 2026-04-17 at 7 37 55 PM" src="https://github.com/user-attachments/assets/4dde1807-9a69-4abd-b1d9-f2d283b9c86f" />

- The "last 4" should display on the "order success" page
<img width="273" height="137" alt="Screenshot 2026-04-17 at 7 38 18 PM" src="https://github.com/user-attachments/assets/94dc8297-6f12-488d-bca9-31f850147066" />

> [!IMPORTANT]
> Stripe's test mapping translates the Discover card to last4 `4242`, which may not match what the Amazon Pay wallet UI itself shows: that's a Stripe-side mapping, not a bug in this PR.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
