### PR TITLE
fix(ci): pin GitHub Actions to SHAs and enable Dependabot for actions

### DIFF
--- a/.github/actions/e2e-pw/run-log-tests/action.yml
+++ b/.github/actions/e2e-pw/run-log-tests/action.yml
@@ -9,7 +9,7 @@ runs:
           # Use +e to trap errors when running E2E tests.
           shell: /bin/bash +e {0}
           run: npm run test:e2e-ci
-        - uses: actions/upload-artifact@v4
+        - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
           if: always()
           with:
               name: playwright-report

--- a/.github/actions/e2e/atomic-prepare-and-run/action.yml
+++ b/.github/actions/e2e/atomic-prepare-and-run/action.yml
@@ -10,7 +10,7 @@ runs:
     # Cache node dependencies
     - name: "Cache node modules"
       id: node-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ./node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -32,7 +32,7 @@ runs:
 
     - name: Cache Playwright browsers
       id: playwright-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}

--- a/.github/actions/e2e/env-setup/action.yml
+++ b/.github/actions/e2e/env-setup/action.yml
@@ -20,14 +20,14 @@ runs:
 
     # Use node version from .nvmrc
     - name: Setup NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: '.nvmrc'
 
     # Cache composer dependencies
     - name: Cache composer dependencies
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ./vendor
         key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
@@ -35,7 +35,7 @@ runs:
     # Cache node dependencies
     - name: Cache node dependencies
       id: node-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ./node_modules
         key:  ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -85,7 +85,7 @@ runs:
 
     - name: Cache Playwright browsers
       id: playwright-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/ms-playwright
         key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}

--- a/.github/actions/e2e/run-log-tests/action.yml
+++ b/.github/actions/e2e/run-log-tests/action.yml
@@ -75,7 +75,7 @@ runs:
     # Archive screenshots if any
     - name: Archive e2e test screenshots & logs
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
           name: wp(${{ env.E2E_WP_VERSION }})-wc(${{ env.E2E_WC_VERSION }})-${{ env.E2E_GROUP }}-${{ env.E2E_BRANCH }}
           path: |

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -5,13 +5,13 @@ runs:
   using: composite
   steps:
     - name: "Setup Node"
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: ".nvmrc"
         cache: "npm"
 
     - name: "Enable composer dependencies caching"
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/composer/
         key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,14 @@ updates:
       reviewers:
         - 'Automattic/gamma'
         - 'Automattic/moltres'
+
+    # Enable version updates for GitHub Actions (SHA pins in .github/workflows/ and .github/actions/)
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      # Check for updates once a week
+      schedule:
+        interval: 'weekly'
+      # Reviewers for issues created
+      reviewers:
+        - 'Automattic/gamma'
+        - 'Automattic/moltres'

--- a/.github/workflows/agent-address-comments.yml
+++ b/.github/workflows/agent-address-comments.yml
@@ -34,14 +34,14 @@ jobs:
 
     steps:
       - name: Checkout WooPayments
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
           fetch-depth: 0
           token: ${{ secrets.BOTWOO_TOKEN }}
 
       - name: Checkout WooCommerce (context)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: woocommerce/woocommerce
           path: woocommerce
@@ -51,7 +51,7 @@ jobs:
             plugins/woocommerce-blocks
 
       - name: Checkout gamma-ai-tools (prompt templates)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: Automattic/gamma-ai-tools
           github-server-url: https://github.a8c.com

--- a/.github/workflows/agent-plan.yml
+++ b/.github/workflows/agent-plan.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout WooPayments
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.target_branch }}
           fetch-depth: 0
 
       - name: Checkout WooCommerce (context)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: woocommerce/woocommerce
           path: woocommerce
@@ -42,7 +42,7 @@ jobs:
             plugins/woocommerce-blocks
 
       - name: Checkout gamma-ai-tools (prompt templates)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: Automattic/gamma-ai-tools
           github-server-url: https://github.a8c.com
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload plan.md as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: plan-${{ inputs.linear_issue_id }}
           path: plan.md

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout WooPayments
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.branch_name }}
           fetch-depth: 0
 
       - name: Checkout WooCommerce (context)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: woocommerce/woocommerce
           path: woocommerce
@@ -46,7 +46,7 @@ jobs:
             plugins/woocommerce-blocks
 
       - name: Checkout gamma-ai-tools (prompt templates)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: Automattic/gamma-ai-tools
           github-server-url: https://github.a8c.com
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload review-report.md as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: review-${{ inputs.linear_issue_id }}
           path: review-report.md

--- a/.github/workflows/build-live-branch.yml
+++ b/.github/workflows/build-live-branch.yml
@@ -37,7 +37,7 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Set up repository"
         uses: ./.github/actions/setup-repo
@@ -95,7 +95,7 @@ jobs:
           echo "plugin-data=$PLUGIN_DATA" >> $GITHUB_OUTPUT
 
       - name: "Upload the zip file as an artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: steps.get-plugin-data.outputs.plugin-data != '{}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-zip-and-run-smoke-tests.yml
+++ b/.github/workflows/build-zip-and-run-smoke-tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.repo-branch || github.ref }}
 
@@ -43,7 +43,7 @@ jobs:
           echo ":information_source: Ignore the artifact size mentioned since GitHub calculates the size of the source folder instead of the zip file created." >> $GITHUB_STEP_SUMMARY
 
       - name: "Upload the zip file as an artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -14,9 +14,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
             - name: Use desired version of NodeJS
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version-file: '.nvmrc'
                   cache: npm

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # enable dependencies caching
       - name: Add composer to cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -40,9 +40,9 @@ jobs:
       matrix: ${{ fromJSON(needs.generate-wc-compat-matrix.outputs.matrix) }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # enable dependencies caching
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
@@ -81,9 +81,9 @@ jobs:
       GUTENBERG_VERSION: ${{ matrix.gutenberg }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # enable dependencies caching
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,9 +25,9 @@ jobs:
       COVERAGE_DIR: ${{ matrix.directory }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # enable dependencies caching
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/create-pre-release.yml
+++ b/.github/workflows/create-pre-release.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Set up repository"
         uses: ./.github/actions/setup-repo

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
             - name: Build
               run: cd docs/rest-api && ./build.sh
             - name: Deploy to GitHub Pages

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -47,7 +47,7 @@ jobs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
       - name: Checkout WCPay repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.repo-branch || github.ref }}
 
@@ -113,13 +113,13 @@ jobs:
 
     steps:
       - name: Checkout WCPay repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.repo-branch || github.ref }}
 
       - name: "Download WooCommerce Payments build file"
         if: ${{ inputs.wcpay-use-build-artifact }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: woocommerce-payments
           path: ${{ env.WCPAY_ARTIFACT_DIRECTORY }}

--- a/.github/workflows/e2e-pw-pull-request.yml
+++ b/.github/workflows/e2e-pw-pull-request.yml
@@ -53,13 +53,13 @@ jobs:
 
         steps:
             - name: Checkout WCPay repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
               with:
                   ref: ${{ inputs.repo-branch || github.ref }}
 
             - name: 'Download WooCommerce Payments build file'
               if: ${{ inputs.wcpay-use-build-artifact }}
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
               with:
                   name: woocommerce-payments
                   path: ${{ env.WCPAY_ARTIFACT_DIRECTORY }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -35,7 +35,7 @@ jobs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Generate matrix"
         id: generate_matrix
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Checkout WCPay repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup E2E environment
         uses: ./.github/actions/e2e/env-setup
@@ -185,7 +185,7 @@ jobs:
 
     steps:
       - name: Checkout WCPay repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup E2E environment
         uses: ./.github/actions/e2e/env-setup

--- a/.github/workflows/e2e-tests-atomic.yml
+++ b/.github/workflows/e2e-tests-atomic.yml
@@ -39,7 +39,7 @@ jobs:
     
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Run the tests"
         uses: ./.github/actions/e2e/atomic-prepare-and-run

--- a/.github/workflows/i18n-weekly-release.yml
+++ b/.github/workflows/i18n-weekly-release.yml
@@ -10,19 +10,19 @@ jobs:
 
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # Use project specific node version
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 
       # enable dependencies caching (vendor and node_modules are wiped during build so they are ignored here)
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.npm/
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
@@ -35,16 +35,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
       # enable dependencies caching
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.npm/
           key:  ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -13,7 +13,7 @@ jobs:
     name: PHP Compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "Set up PHP"
         uses: ./.github/actions/setup-php
       - run: bash bin/phpcs-compat.sh

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # enable dependencies caching
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
@@ -53,9 +53,9 @@ jobs:
       matrix: ${{ fromJSON(needs.generate-test-matrix.outputs.matrix) }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # enable dependencies caching
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: "Checkout repository (trunk)"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: 'trunk'
 
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: "Checkout repository (trunk)"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: 'trunk'
 
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: 'trunk'
           fetch-depth: 0
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository (trunk)"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: 'trunk'
 
@@ -120,7 +120,7 @@ jobs:
     
     steps:
       - name: "Checkout repository (develop)"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: 'develop'
   
@@ -129,7 +129,7 @@ jobs:
         run: php .github/workflows/scripts/get-next-version.php
   
       - name: "Checkout repository's wiki"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: "${{ github.repository }}.wiki"
           path: "wiki"

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Get current version"
         id: current-version
@@ -73,7 +73,7 @@ jobs:
           echo ":information_source: Ignore the artifact size mentioned since GitHub calculates the size of the source folder instead of the zip file created." >> $GITHUB_STEP_SUMMARY
 
       - name: "Upload the zip file as an artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/qit-e2e-pr.yml
+++ b/.github/workflows/qit-e2e-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up repository
         uses: ./.github/actions/setup-repo
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/build
 
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: woocommerce-payments-${{ github.run_id }}
           path: woocommerce-payments.zip
@@ -39,7 +39,7 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Generate matrix
         id: generate

--- a/.github/workflows/qit-e2e-prerelease.yml
+++ b/.github/workflows/qit-e2e-prerelease.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up repository
         uses: ./.github/actions/setup-repo
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/build
 
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: woocommerce-payments-${{ github.run_id }}
           path: woocommerce-payments.zip

--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download plugin artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ inputs.artifact-name }}
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: qit-e2e-results-wp${{ inputs.wordpress-version }}-wc${{ inputs.woocommerce-version }}-php${{ inputs.php-version }}-${{ inputs.playwright-project }}
           path: |

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up repository
         uses: ./.github/actions/setup-repo
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/build
 
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: woocommerce-payments-${{ github.run_id }}
           path: woocommerce-payments.zip
@@ -35,7 +35,7 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Generate matrix
         id: generate

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -36,7 +36,7 @@ jobs:
       RELEASE_DATE: ${{ inputs.release-date }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ SECRETS.BOTWOO_TOKEN }}
       

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -26,7 +26,7 @@ jobs:
       nextReleaseDate: ${{ steps.define_var.outputs.RELEASE_PLANNED_DATE }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: 'develop'
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Set up repository"
         uses: ./.github/actions/setup-repo

--- a/changelog/dev-woopmnt-6116-sha-pin-github-actions
+++ b/changelog/dev-woopmnt-6116-sha-pin-github-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Pin GitHub Actions (checkout, cache, setup-node, upload-artifact, download-artifact) to full-length commit SHAs and add the github-actions ecosystem to Dependabot so SHA pins stay current.


### PR DESCRIPTION
Fixes WOOPMNT-6116

Full context and rationale are in [WOOPMNT-6116](https://linear.app/a8c/issue/WOOPMNT-6116/sha-pin-github-actions-across-workflows-enable-dependabot-for-actions). The short version: every `uses: actions/NAME@v4` reference under `.github/` pins to a mutable git tag, which lets whoever owns the upstream action change what runs in our workflows at any time. SHA pinning closes that door; Dependabot keeps the pins from going stale.

#### Changes proposed in this Pull Request

Replaces every `uses: actions/NAME@v4` reference under `.github/workflows/` and `.github/actions/` with a 40-character commit SHA plus a `# v4.X.Y` comment. 86 refs across 34 files, covering the five first-party actions we use:

| Action | SHA | Tag |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| `actions/download-artifact` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4.3.0 |
| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4.3.0 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |

Each SHA is the current tip of the respective `v4` tag, so the code CI runs after this merges is byte-identical to what ran before it. The only externally visible change is that Dependabot will now send weekly PRs when a new action release ships.

Also adds the `github-actions` ecosystem to `.github/dependabot.yml`, with the same reviewers as the existing npm, composer, and docker entries.

Third-party actions (`cweagans/composer-patches`, `hmarr/*`, etc.) aren't touched — they have a different maintenance profile and are worth a separate pass.

Follow-up from the review on #11592.

#### Testing instructions

Three quick checks:

1. `grep -rE "uses: actions/[a-z-]+@v[0-9]+" .github` should return nothing.
2. For each row in the table above, `gh api repos/actions/<name>/commits/<tag> --jq .sha` should match the SHA pinned here.
3. CI should pass. Because each pinned SHA is the tip of its `v4` tag at the time of this PR, a workflow failure would mean we pinned the wrong commit, not a behaviour change.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests — not applicable (mechanical substitution, verified by CI)
- [x] Tested on mobile — not applicable (CI-only)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : QA Testing Not Applicable
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) — not applicable (no runtime surface changes)
- [x] Add what's changed to the release announcement post — not applicable (CI/security hardening)
