### PR TITLE
fix: clear inherited Stripe identifiers on resubscribe orders

### DIFF
--- a/changelog/fix-subscription-resubscribe-meta-inheritance
+++ b/changelog/fix-subscription-resubscribe-meta-inheritance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clear inherited Stripe identifiers on subscription resubscribe orders so the customer's new checkout runs against fresh state.

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -307,6 +307,9 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			add_filter( 'wc_subscriptions_renewal_order_data', [ $this, 'remove_data_renewal_order' ], 10, 3 );
 		}
 
+		// Clear inherited Stripe identifiers on resubscribe orders so the checkout runs fresh.
+		add_action( 'wcs_resubscribe_order_created', [ $this, 'delete_resubscribe_meta' ], 10, 1 );
+
 		// Allow store managers to manually set Stripe as the payment method on a subscription.
 		add_filter( 'woocommerce_subscription_payment_meta', [ $this, 'add_subscription_payment_meta' ], 10, 2 );
 		add_filter( 'woocommerce_subscription_validate_payment_meta', [ $this, 'validate_subscription_payment_meta' ], 10, 3 );
@@ -1047,6 +1050,41 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	public function remove_data_renewal_order( $order_data ) {
 		unset( $order_data['_new_order_tracking_complete'] );
 		return $order_data;
+	}
+
+	/**
+	 * Don't transfer Stripe identifiers to resubscribe orders.
+	 *
+	 * A resubscribe order is a fresh checkout the customer has to complete, so any
+	 * intent/charge/payment-method/customer meta inherited from the cancelled or expired
+	 * subscription's parent order would point at stale state and may confuse payment
+	 * confirmation (e.g. confirming against a stale intent, or attaching a charge to a
+	 * payment method the customer no longer owns).
+	 *
+	 * @param \WC_Order $resubscribe_order The order created for the customer to resubscribe.
+	 */
+	public function delete_resubscribe_meta( $resubscribe_order ) {
+		$meta_keys = [
+			WC_Payments_Order_Service::INTENT_ID_META_KEY,
+			WC_Payments_Order_Service::CHARGE_ID_META_KEY,
+			WC_Payments_Order_Service::INTENTION_STATUS_META_KEY,
+			WC_Payments_Order_Service::CHARGE_RISK_LEVEL_META_KEY,
+			WC_Payments_Order_Service::CUSTOMER_ID_META_KEY,
+			WC_Payments_Order_Service::WCPAY_INTENT_CURRENCY_META_KEY,
+			WC_Payments_Order_Service::WCPAY_TRANSACTION_FEE_META_KEY,
+			WC_Payments_Order_Service::WCPAY_MODE_META_KEY,
+			WC_Payments_Order_Service::WCPAY_PAYMENT_TRANSACTION_ID_META_KEY,
+			WC_Payments_Order_Service::WCPAY_REFUND_ID_META_KEY,
+			WC_Payments_Order_Service::WCPAY_REFUND_TRANSACTION_ID_META_KEY,
+			WC_Payments_Order_Service::WCPAY_REFUND_STATUS_META_KEY,
+			'_payment_method_id',
+		];
+
+		foreach ( $meta_keys as $key ) {
+			$resubscribe_order->delete_meta_data( $key );
+		}
+
+		$resubscribe_order->save();
 	}
 
 	/**

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -1070,6 +1070,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			WC_Payments_Order_Service::INTENTION_STATUS_META_KEY,
 			WC_Payments_Order_Service::CHARGE_RISK_LEVEL_META_KEY,
 			WC_Payments_Order_Service::CUSTOMER_ID_META_KEY,
+			WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY,
 			WC_Payments_Order_Service::WCPAY_INTENT_CURRENCY_META_KEY,
 			WC_Payments_Order_Service::WCPAY_TRANSACTION_FEE_META_KEY,
 			WC_Payments_Order_Service::WCPAY_MODE_META_KEY,
@@ -1077,14 +1078,16 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			WC_Payments_Order_Service::WCPAY_REFUND_ID_META_KEY,
 			WC_Payments_Order_Service::WCPAY_REFUND_TRANSACTION_ID_META_KEY,
 			WC_Payments_Order_Service::WCPAY_REFUND_STATUS_META_KEY,
-			'_payment_method_id',
 		];
 
 		foreach ( $meta_keys as $key ) {
 			$resubscribe_order->delete_meta_data( $key );
 		}
 
-		$resubscribe_order->save();
+		// Persist the deletions WITHOUT firing `woocommerce_update_order`: `schedule_order_tracking`
+		// hooks that action and backfills `_payment_method_id` / `_stripe_customer_id` from the parent
+		// order when they're empty, which would undo the cleanup we just performed.
+		$resubscribe_order->save_meta_data();
 	}
 
 	/**

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -1078,6 +1078,21 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 			WC_Payments_Order_Service::WCPAY_REFUND_ID_META_KEY,
 			WC_Payments_Order_Service::WCPAY_REFUND_TRANSACTION_ID_META_KEY,
 			WC_Payments_Order_Service::WCPAY_REFUND_STATUS_META_KEY,
+			// Fraud outcome is per-charge — the resubscribe hasn't been evaluated yet.
+			WC_Payments_Order_Service::WCPAY_FRAUD_META_BOX_TYPE_META_KEY,
+			WC_Payments_Order_Service::WCPAY_FRAUD_OUTCOME_STATUS_META_KEY,
+			// Multibanco reference/entity/expiry/URL are per-payment.
+			WC_Payments_Order_Service::WCPAY_MULTIBANCO_ENTITY_META_KEY,
+			WC_Payments_Order_Service::WCPAY_MULTIBANCO_REFERENCE_META_KEY,
+			WC_Payments_Order_Service::WCPAY_MULTIBANCO_EXPIRY_META_KEY,
+			WC_Payments_Order_Service::WCPAY_MULTIBANCO_URL_META_KEY,
+			// Cached details of the parent charge's payment method.
+			WC_Payments_Order_Service::PAYMENT_METHOD_DETAILS_META_KEY,
+			// In-person payment channel — a resubscribe is always online.
+			WC_Payments_Order_Service::IPP_CHANNEL_META_KEY,
+			// WCPay-managed subscription ID belongs to the cancelled subscription; a resubscribe
+			// creates a brand-new WCPay subscription and must not reuse the old one.
+			WC_Payments_Subscription_Service::SUBSCRIPTION_ID_META_KEY,
 		];
 
 		foreach ( $meta_keys as $key ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

Registers a handler for `wcs_resubscribe_order_created` that actively removes WCPay/Stripe identifying meta from the newly created resubscribe order before the customer completes checkout.

Meta cleared:
- `_intent_id`, `_charge_id`, `_intention_status`, `_charge_risk_level`
- `_stripe_customer_id`, `_payment_method_id`
- `_wcpay_intent_currency`, `_wcpay_transaction_fee`, `_wcpay_mode`, `_wcpay_payment_transaction_id`
- `_wcpay_refund_id`, `_wcpay_refund_transaction_id`, `_wcpay_refund_status`

#### Why this is needed

A resubscribe is, semantically, a fresh checkout — the customer is re-purchasing a cancelled/expired subscription and re-entering payment details. Without this handler, the resubscribe order inherits all the above from the original subscription's parent order, which means:

- Payment confirmation logic that reads `_intent_id` may attempt to confirm against a stale (already-captured or expired) PaymentIntent from the original subscription.
- `_payment_method_id` and `_stripe_customer_id` may point at identifiers that are no longer associated with the customer (removed card, deleted customer, etc.), leading to `no_such_payment_method` or `resource_missing` errors.
- Historical refund meta lingers on the new order before any refund has occurred.

The sibling plugin woocommerce-gateway-stripe registers the same handler (`trait-wc-stripe-subscriptions.php::delete_resubscribe_meta`). This brings WooPayments to parity.

### Testing instructions

1. Install and activate WooCommerce Subscriptions on a test store.
2. Purchase a subscription. The parent order should have `_intent_id`, `_charge_id`, `_stripe_customer_id`, `_payment_method_id`, etc. in its meta.
3. Cancel the subscription.
4. As the customer (My Account → Subscriptions), click the resubscribe action.
5. On `develop` (before this PR): the new resubscribe order in the cart already carries the old parent order's `_intent_id` / `_charge_id` / `_payment_method_id` / `_stripe_customer_id` meta. Check via `SELECT meta_key, meta_value FROM wp_postmeta WHERE post_id = <resubscribe_order_id>;` before submitting payment.
6. On this branch: after the resubscribe order is created (before checkout submission), those meta keys should be absent. Complete checkout with a different card than the original subscription used — the payment should succeed fresh, with no interference from stale PaymentIntent/customer references.
7. Repeat with the same card — payment should still succeed.

Quick SQL check:
\`\`\`sql
SELECT meta_key FROM wp_postmeta
WHERE post_id = <resubscribe_order_id>
  AND meta_key IN ('_intent_id','_charge_id','_stripe_customer_id','_payment_method_id','_wcpay_mode','_wcpay_refund_id');
\`\`\`
Should return 0 rows immediately after the resubscribe order is created.

-------------------

- [x] Run \`npm run changelog\` to add a changelog file, choose \`patch\` to leave it empty if the change is not significant.
- [ ] Covered with tests — manual repro above; a unit test for the hook could be added but would largely verify the same thing as inspecting the code. Open to adding one.
- [x] Tested on mobile (or does not apply) — N/A, backend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)