### PR TITLE
refactor: also propagate customer ID and payment method ID to subscriptions

### DIFF
--- a/changelog/refactor-subscription-payment-state-sync
+++ b/changelog/refactor-subscription-payment-state-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Propagate the Stripe customer ID and payment method ID from the parent order to its subscriptions alongside the gateway and title, so subscription renewals run against consistent state.

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -1280,15 +1280,18 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	}
 
 	/**
-	 * Propagate the order's payment method and title to any subscriptions created from it.
+	 * Propagate the order's finalised payment state (gateway, title, Stripe customer/PM IDs)
+	 * to any subscriptions created from it.
 	 *
 	 * When an order flows through Express Checkout (Amazon Pay in particular), the subscription
 	 * is created before Stripe has confirmed the payment method, so the subscription inherits
-	 * the default card gateway/title. Once the real payment method is known (in
-	 * `set_payment_method_title_for_order()`), we sync it to the subscription so the
-	 * "My Subscriptions" view and future renewals use the right one.
+	 * the default card gateway/title and has no `_stripe_customer_id` / `_payment_method_id`
+	 * meta. `set_payment_method_title_for_order()` is the single chokepoint where the real
+	 * payment state is known (inline success, redirect return, webhook, setup-intent) — we
+	 * propagate all of it so the "My Subscriptions" view and future renewals run against
+	 * consistent state.
 	 *
-	 * @param \WC_Order $order The parent order whose payment method has just been finalised.
+	 * @param \WC_Order $order The parent order whose payment state has just been finalised.
 	 */
 	private function sync_payment_method_to_subscriptions( $order ) {
 		if ( ! function_exists( 'wcs_get_subscriptions_for_order' ) ) {
@@ -1302,15 +1305,32 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		$payment_method       = $order->get_payment_method();
 		$payment_method_title = $order->get_payment_method_title();
+		$customer_id          = $order->get_meta( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, true );
+		$payment_method_id    = $order->get_meta( '_payment_method_id', true );
 
 		foreach ( $subscriptions as $subscription ) {
-			if ( $subscription->get_payment_method() === $payment_method
-				&& $subscription->get_payment_method_title() === $payment_method_title ) {
-				continue;
+			$dirty = false;
+
+			if ( $subscription->get_payment_method() !== $payment_method ) {
+				$subscription->set_payment_method( $payment_method );
+				$dirty = true;
 			}
-			$subscription->set_payment_method( $payment_method );
-			$subscription->set_payment_method_title( $payment_method_title );
-			$subscription->save();
+			if ( $subscription->get_payment_method_title() !== $payment_method_title ) {
+				$subscription->set_payment_method_title( $payment_method_title );
+				$dirty = true;
+			}
+			if ( ! empty( $customer_id ) && $subscription->get_meta( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, true ) !== $customer_id ) {
+				$subscription->update_meta_data( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, $customer_id );
+				$dirty = true;
+			}
+			if ( ! empty( $payment_method_id ) && $subscription->get_meta( '_payment_method_id', true ) !== $payment_method_id ) {
+				$subscription->update_meta_data( '_payment_method_id', $payment_method_id );
+				$dirty = true;
+			}
+
+			if ( $dirty ) {
+				$subscription->save();
+			}
 		}
 	}
 

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -1308,6 +1308,10 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		$customer_id          = $order->get_meta( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, true );
 		$payment_method_id    = $order->get_meta( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, true );
 
+		// Gateway/title: `set_payment_method_title_for_order()` always populates these before calling
+		// sync, so we propagate unconditionally. Customer / PM ids: only set on the order on some code
+		// paths — if the order has an empty value we skip, to avoid clearing a valid value already on
+		// the subscription.
 		foreach ( $subscriptions as $subscription ) {
 			$dirty = false;
 

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -1306,7 +1306,7 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		$payment_method       = $order->get_payment_method();
 		$payment_method_title = $order->get_payment_method_title();
 		$customer_id          = $order->get_meta( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, true );
-		$payment_method_id    = $order->get_meta( '_payment_method_id', true );
+		$payment_method_id    = $order->get_meta( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, true );
 
 		foreach ( $subscriptions as $subscription ) {
 			$dirty = false;
@@ -1323,8 +1323,8 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 				$subscription->update_meta_data( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, $customer_id );
 				$dirty = true;
 			}
-			if ( ! empty( $payment_method_id ) && $subscription->get_meta( '_payment_method_id', true ) !== $payment_method_id ) {
-				$subscription->update_meta_data( '_payment_method_id', $payment_method_id );
+			if ( ! empty( $payment_method_id ) && $subscription->get_meta( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, true ) !== $payment_method_id ) {
+				$subscription->update_meta_data( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, $payment_method_id );
 				$dirty = true;
 			}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -868,7 +868,11 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 	 * any subscriptions attached to the order.
 	 */
 	public function test_amazon_pay_propagates_payment_method_and_title_to_subscriptions() {
-		$order        = WC_Helper_Order::create_order();
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, 'cus_amzn_123' );
+		$order->update_meta_data( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, 'pm_amzn_abc' );
+		$order->save();
+
 		$subscription = new WC_Subscription();
 		$subscription->set_parent( $order );
 		$subscription->set_payment_method( 'woocommerce_payments' );
@@ -915,6 +919,66 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			$order->get_payment_method_title(),
 			$subscription->get_payment_method_title(),
 			'Subscription title should match the parent order.'
+		);
+		$this->assertEquals(
+			'cus_amzn_123',
+			$subscription->get_meta( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, true ),
+			'Subscription should inherit the Stripe customer ID from the parent order.'
+		);
+		$this->assertEquals(
+			'pm_amzn_abc',
+			$subscription->get_meta( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, true ),
+			'Subscription should inherit the Stripe payment method ID from the parent order.'
+		);
+	}
+
+	/**
+	 * Asserts the `$dirty` guard in `sync_payment_method_to_subscriptions`: when the parent
+	 * order's payment state already matches what's on the subscription, no save should occur.
+	 */
+	public function test_sync_payment_method_skips_save_when_nothing_changes() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->set_payment_method_title( 'Credit card / debit card' );
+		$order->update_meta_data( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, 'cus_same' );
+		$order->update_meta_data( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, 'pm_same' );
+		$order->save();
+
+		$subscription = new WC_Subscription();
+		$subscription->set_parent( $order );
+		$subscription->set_payment_method( 'woocommerce_payments' );
+		$subscription->set_payment_method_title( 'Credit card / debit card' );
+		$subscription->update_meta_data( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, 'cus_same' );
+		$subscription->update_meta_data( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, 'pm_same' );
+		$subscription->save();
+		$initial_modified = $subscription->get_date_modified() ? $subscription->get_date_modified()->getTimestamp() : null;
+
+		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
+			function () use ( $subscription ) {
+				return [ $subscription->get_id() => $subscription ];
+			}
+		);
+
+		// Sleep 1s so any save() would bump date_modified to a different timestamp.
+		sleep( 1 );
+
+		$this->card_gateway->set_payment_method_title_for_order(
+			$order,
+			'card',
+			[
+				'type' => 'card',
+				'card' => [
+					'brand' => 'visa',
+					'last4' => '4242',
+				],
+			]
+		);
+
+		$after_modified = $subscription->get_date_modified() ? $subscription->get_date_modified()->getTimestamp() : null;
+		$this->assertSame(
+			$initial_modified,
+			$after_modified,
+			'Subscription should not be re-saved when payment state already matches the parent order.'
 		);
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -951,7 +951,6 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$subscription->update_meta_data( WC_Payments_Order_Service::CUSTOMER_ID_META_KEY, 'cus_same' );
 		$subscription->update_meta_data( WC_Payments_Order_Service::PAYMENT_METHOD_ID_META_KEY, 'pm_same' );
 		$subscription->save();
-		$initial_modified = $subscription->get_date_modified() ? $subscription->get_date_modified()->getTimestamp() : null;
 
 		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
 			function () use ( $subscription ) {
@@ -959,25 +958,36 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			}
 		);
 
-		// Sleep 1s so any save() would bump date_modified to a different timestamp.
-		sleep( 1 );
+		// Count `woocommerce_update_order` invocations for this subscription; the sync helper
+		// should short-circuit and fire zero when nothing changes.
+		$subscription_id = $subscription->get_id();
+		$save_count      = 0;
+		$save_count_hook = function ( $order_id ) use ( &$save_count, $subscription_id ) {
+			if ( (int) $order_id === (int) $subscription_id ) {
+				++$save_count;
+			}
+		};
+		add_action( 'woocommerce_update_order', $save_count_hook );
 
-		$this->card_gateway->set_payment_method_title_for_order(
-			$order,
-			'card',
-			[
-				'type' => 'card',
-				'card' => [
-					'brand' => 'visa',
-					'last4' => '4242',
-				],
-			]
-		);
+		try {
+			$this->card_gateway->set_payment_method_title_for_order(
+				$order,
+				'card',
+				[
+					'type' => 'card',
+					'card' => [
+						'brand' => 'visa',
+						'last4' => '4242',
+					],
+				]
+			);
+		} finally {
+			remove_action( 'woocommerce_update_order', $save_count_hook );
+		}
 
-		$after_modified = $subscription->get_date_modified() ? $subscription->get_date_modified()->getTimestamp() : null;
 		$this->assertSame(
-			$initial_modified,
-			$after_modified,
+			0,
+			$save_count,
 			'Subscription should not be re-saved when payment state already matches the parent order.'
 		);
 	}


### PR DESCRIPTION
> **Stacked on top of** #11612 (\`fix/amazon-pay-saved-token-funding-card\`). Merge that first.

### Changes proposed in this Pull Request

Extends `sync_payment_method_to_subscriptions()` (introduced in #11612) to also copy from the parent order to its subscriptions:

- `_stripe_customer_id` (Stripe customer ID)
- `_payment_method_id` (saved Stripe payment method ID)

in addition to the gateway and title it was already propagating.

The helper remains called once from `set_payment_method_title_for_order()` — the single chokepoint where the real payment state is known, hit by every confirmation path (inline success, redirect return, webhook, setup-intent).

#### Why this is needed

Before this change, the subscription's gateway and title were being fixed up by the title-sync helper, but `_stripe_customer_id` and `_payment_method_id` were only being populated via `maybe_add_token_to_subscription_order()` (token-only, on save-payment-method paths). Subscriptions that didn't go through that path (Express Checkout in particular) had empty meta for the customer and PM id, and renewal logic had to derive them from the token on every call.

The sibling plugin woocommerce-gateway-stripe has a single helper (`maybe_update_source_on_subscription_order`) called from every success path that writes `_stripe_customer_id` + `_stripe_source_id`. This PR brings WooPayments' equivalent closer to that shape: one helper, called from one chokepoint, propagates the full set of identifiers.

No new hook registrations, no behaviour change for orders without subscriptions.

### Testing instructions

1. **Amazon Pay Express Checkout regression** (already covered by the test added in the base PR — should continue to pass):
   \`\`\`bash
   docker compose exec -u www-data wordpress bash -c "cd /var/www/html/wp-content/plugins/woocommerce-payments && vendor/bin/phpunit --filter 'test_amazon_pay_propagates_payment_method_and_title_to_subscriptions'"
   \`\`\`
2. **Manual check — subscription meta is populated after a successful ECE checkout:**
   - Buy a subscription via Amazon Pay Express Checkout.
   - On the subscription (Edit Subscription → Custom Fields), confirm `_stripe_customer_id` and `_payment_method_id` are populated and match the parent order's values.
   - Before this PR: these are empty on Amazon Pay subscriptions.
   - After this PR: both are populated.
3. **Regression — manual-checkout subscription unaffected:**
   - Buy a subscription via the normal card checkout.
   - `_stripe_customer_id` and `_payment_method_id` should still be present on the subscription (they were already populated by the token flow; this change doesn't undo that).
4. **Idempotency check:**
   - Re-confirm the same order (e.g. force a webhook replay). The subscription should not be saved if nothing actually changed — the `$dirty` guard skips pointless writes.

-------------------

- [x] Run \`npm run changelog\` to add a changelog file.
- [x] Covered with tests — existing regression test in `test-class-wc-payment-gateway-wcpay.php` exercises the helper end-to-end.
- [x] Tested on mobile (or does not apply) — N/A, backend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)