### PR TITLE
Register WooPayments abilities for Abilities Everywhere sprint

### DIFF
--- a/changelog/feat-abilities-woopayments
+++ b/changelog/feat-abilities-woopayments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Register WooPayments with the WordPress Abilities API so agents can query accounts, transactions, disputes, payouts, and submit dispute evidence.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -790,6 +790,8 @@ class WC_Payments {
 		self::$duplicate_payment_prevention_service->init( self::$card_gateway, self::$order_service );
 
 		wcpay_get_container()->get( \WCPay\Internal\PluginManagement\TranslationsLoader::class )->init_hooks();
+
+		\WCPay\Internal\Abilities\Abilities_Registrar::init();
 	}
 
 	/**

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -85,6 +85,7 @@ class Abilities_Registrar {
 		self::register_get_account_status_ability();
 		self::register_get_transactions_ability();
 		self::register_get_disputes_ability();
+		self::register_get_dispute_detail_ability();
 	}
 
 	/**
@@ -181,6 +182,35 @@ class Abilities_Registrar {
 			'get_disputes',
 			'/wc/v3/payments/disputes',
 			is_array( $input ) ? $input : null
+		);
+	}
+
+	/**
+	 * Execute callback for woopayments/get-dispute-detail.
+	 *
+	 * Delegates to WC_REST_Payments_Disputes_Controller::get_dispute() which
+	 * fetches a single dispute by ID via the WooPayments server. The natural
+	 * prerequisite for submit-dispute-evidence so an agent can read the
+	 * dispute reason, due-by date, and current status before responding.
+	 *
+	 * @param mixed $input Ability input; must include `dispute_id`.
+	 * @return array|\WP_Error Dispute payload from the server, or WP_Error when
+	 *                         WooPayments is not initialized, the dispute_id
+	 *                         is missing, or the remote request fails.
+	 */
+	public static function execute_get_dispute_detail( $input = null ) {
+		if ( ! is_array( $input ) || empty( $input['dispute_id'] ) ) {
+			return new \WP_Error(
+				'woopayments_missing_dispute_id',
+				__( 'A dispute_id is required to fetch dispute detail.', 'woocommerce-payments' )
+			);
+		}
+
+		return self::delegate_to_rest_controller(
+			'WC_REST_Payments_Disputes_Controller',
+			'get_dispute',
+			'/wc/v3/payments/disputes/' . rawurlencode( (string) $input['dispute_id'] ),
+			$input
 		);
 	}
 
@@ -399,6 +429,48 @@ class Abilities_Registrar {
 				'execute_callback'    => [ __CLASS__, 'execute_get_disputes' ],
 				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
 				// output_schema deliberately omitted — the disputes payload shape comes straight from the WooPayments server and we don't want to couple to a specific structure here.
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Register the woopayments/get-dispute-detail ability.
+	 *
+	 * Fetches a single WooPayments dispute by ID. The natural prerequisite for
+	 * submit-dispute-evidence (Phase 5) — an agent reads the dispute reason,
+	 * due-by date, and current status here before deciding how to respond.
+	 *
+	 * @return void
+	 */
+	private static function register_get_dispute_detail_ability(): void {
+		wp_register_ability(
+			'woopayments/get-dispute-detail',
+			[
+				'label'               => __( 'Get WooPayments dispute detail', 'woocommerce-payments' ),
+				'description'         => __( 'Fetches a single WooPayments dispute by ID. Returns the full dispute payload (status, reason, due-by date, evidence due, amount, etc.). Natural prerequisite for submit-dispute-evidence.', 'woocommerce-payments' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => [
+					'type'                 => 'object',
+					'required'             => [ 'dispute_id' ],
+					'properties'           => [
+						'dispute_id' => [
+							'type'        => 'string',
+							'description' => __( 'The WooPayments dispute ID (e.g. "dp_1ABCxyz...").', 'woocommerce-payments' ),
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'execute_callback'    => [ __CLASS__, 'execute_get_dispute_detail' ],
+				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
+				// output_schema deliberately omitted — the dispute payload shape comes straight from the WooPayments server and we don't want to couple to a specific structure here.
 				'meta'                => [
 					'annotations'  => [
 						'readonly'    => true,

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -82,7 +82,7 @@ class Abilities_Registrar {
 			return;
 		}
 
-		// Concrete abilities registered in subsequent phases.
+		self::register_get_account_status_ability();
 	}
 
 	/**
@@ -95,5 +95,72 @@ class Abilities_Registrar {
 	 */
 	public static function can_manage_payments(): bool {
 		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Execute callback for woopayments/get-account-status.
+	 *
+	 * Delegates to WC_Payments::get_account_service()->get_cached_account_data()
+	 * so we reuse the exact same cached-account data the REST controller serves,
+	 * with no network calls of our own.
+	 *
+	 * @return array|\WP_Error Array of account data, or WP_Error when WooPayments
+	 *                         has not finished initializing.
+	 */
+	public static function execute_get_account_status() {
+		if ( ! class_exists( '\WC_Payments' ) ) {
+			return new \WP_Error(
+				'woopayments_not_initialized',
+				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
+			);
+		}
+
+		$account = \WC_Payments::get_account_service();
+		if ( ! $account ) {
+			return new \WP_Error(
+				'woopayments_not_initialized',
+				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
+			);
+		}
+
+		$data = $account->get_cached_account_data();
+		return is_array( $data ) ? $data : [];
+	}
+
+	/**
+	 * Register the woopayments/get-account-status ability.
+	 *
+	 * Reference implementation for the Abilities Everywhere initiative: a
+	 * read-only ability an agent should call before any write so it understands
+	 * what the merchant's WooPayments account can currently do (KYC state,
+	 * enabled capabilities, deposit schedule, required actions).
+	 *
+	 * @return void
+	 */
+	private static function register_get_account_status_ability(): void {
+		wp_register_ability(
+			'woopayments/get-account-status',
+			[
+				'label'               => __( 'Get WooPayments account status', 'woocommerce-payments' ),
+				'description'         => __( "Returns the merchant's WooPayments account status, including KYC state, enabled capabilities, deposit schedule, and any required actions. Agents should call this before any write ability to understand what the merchant can currently do.", 'woocommerce-payments' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => [
+					'type'                 => 'object',
+					'default'              => [],
+					'properties'           => [],
+					'additionalProperties' => false,
+				],
+				'execute_callback'    => [ __CLASS__, 'execute_get_account_status' ],
+				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
 	}
 }

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -86,6 +86,7 @@ class Abilities_Registrar {
 		self::register_get_transactions_ability();
 		self::register_get_disputes_ability();
 		self::register_get_dispute_detail_ability();
+		self::register_get_payouts_ability();
 	}
 
 	/**
@@ -211,6 +212,28 @@ class Abilities_Registrar {
 			'get_dispute',
 			'/wc/v3/payments/disputes/' . rawurlencode( (string) $input['dispute_id'] ),
 			$input
+		);
+	}
+
+	/**
+	 * Execute callback for woopayments/get-payouts.
+	 *
+	 * Delegates to WC_REST_Payments_Deposits_Controller::get_deposits(). The
+	 * REST endpoint is `deposits`; the user-facing term everywhere else in
+	 * WooPayments is `payouts`, which is why the ability keeps the payouts
+	 * name while wrapping the deposits controller.
+	 *
+	 * @param mixed $input Optional; ability input matching the input_schema.
+	 * @return array|\WP_Error Payouts list payload from the server, or WP_Error
+	 *                         when WooPayments is not initialized or the remote
+	 *                         request fails.
+	 */
+	public static function execute_get_payouts( $input = null ) {
+		return self::delegate_to_rest_controller(
+			'WC_REST_Payments_Deposits_Controller',
+			'get_deposits',
+			'/wc/v3/payments/deposits',
+			is_array( $input ) ? $input : null
 		);
 	}
 
@@ -471,6 +494,92 @@ class Abilities_Registrar {
 				'execute_callback'    => [ __CLASS__, 'execute_get_dispute_detail' ],
 				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
 				// output_schema deliberately omitted — the dispute payload shape comes straight from the WooPayments server and we don't want to couple to a specific structure here.
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Register the woopayments/get-payouts ability.
+	 *
+	 * Lists WooPayments payouts. The backing REST endpoint is `deposits`, but
+	 * user-facing naming is `payouts` — agents and merchants both speak
+	 * "payouts", so this ability uses that term.
+	 *
+	 * @return void
+	 */
+	private static function register_get_payouts_ability(): void {
+		$payout_statuses = [
+			'paid',
+			'pending',
+			'in_transit',
+			'canceled',
+			'failed',
+		];
+
+		wp_register_ability(
+			'woopayments/get-payouts',
+			[
+				'label'               => __( 'List WooPayments payouts', 'woocommerce-payments' ),
+				'description'         => __( 'Lists WooPayments payouts (funds transfers from the WooPayments balance to the merchant\'s bank account). Supports filtering by status, store currency, and date range.', 'woocommerce-payments' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => [
+					'type'                 => 'object',
+					'default'              => [],
+					'properties'           => [
+						'page'              => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Page number.', 'woocommerce-payments' ),
+						],
+						'per_page'          => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 100,
+							'description' => __( 'Number of payouts per page.', 'woocommerce-payments' ),
+						],
+						'match'             => [
+							'type'        => 'string',
+							'enum'        => [ 'and', 'or' ],
+							'description' => __( 'Logical operator applied when combining filters.', 'woocommerce-payments' ),
+						],
+						'store_currency_is' => [
+							'type'        => 'string',
+							'description' => __( 'Filter by store currency code (e.g. "usd").', 'woocommerce-payments' ),
+						],
+						'date_before'       => [
+							'type'        => 'string',
+							'format'      => 'date-time',
+							'description' => __( 'Filter payouts before this date.', 'woocommerce-payments' ),
+						],
+						'date_after'        => [
+							'type'        => 'string',
+							'format'      => 'date-time',
+							'description' => __( 'Filter payouts after this date.', 'woocommerce-payments' ),
+						],
+						'status_is'         => [
+							'type'        => 'string',
+							'enum'        => $payout_statuses,
+							'description' => __( 'Filter to payouts whose status equals this value.', 'woocommerce-payments' ),
+						],
+						'status_is_not'     => [
+							'type'        => 'string',
+							'enum'        => $payout_statuses,
+							'description' => __( 'Filter to payouts whose status does not equal this value.', 'woocommerce-payments' ),
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'execute_callback'    => [ __CLASS__, 'execute_get_payouts' ],
+				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
+				// output_schema deliberately omitted — the payouts payload shape comes straight from the WooPayments server and we don't want to couple to a specific structure here.
 				'meta'                => [
 					'annotations'  => [
 						'readonly'    => true,

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -234,10 +234,14 @@ class Abilities_Registrar {
 	 *
 	 * Delegates to WC_REST_Payments_Disputes_Controller::update_dispute(),
 	 * which accepts `dispute_id`, `evidence`, `submit`, and `metadata` and
-	 * forwards them to the WooPayments server. Defaults `submit` to false on
-	 * the input schema so evidence can be staged as a draft; agents should
-	 * only pass `submit: true` after explicit merchant confirmation because
-	 * once submitted, evidence cannot be retracted.
+	 * forwards them to the WooPayments server. Agents should only pass
+	 * `submit: true` after explicit merchant confirmation because once
+	 * submitted, evidence cannot be retracted.
+	 *
+	 * Normalizes the optional `submit`, `evidence`, and `metadata` input keys
+	 * to their execute-time defaults before delegating — the Abilities API's
+	 * validate path does not inject schema defaults into execute callback
+	 * input.
 	 *
 	 * Not idempotent — calling this twice with `submit: true` produces two
 	 * submission attempts against Stripe. Agent retry logic must guard
@@ -258,6 +262,21 @@ class Abilities_Registrar {
 				'woopayments_missing_dispute_id',
 				__( 'A dispute_id is required to submit dispute evidence.', 'woocommerce-payments' )
 			);
+		}
+
+		// The Abilities API validates input against the schema but does NOT apply
+		// property-level defaults. Apply them here so the backing controller sees
+		// the same shape whether the caller passed them or not.
+		if ( ! array_key_exists( 'submit', $input ) || null === $input['submit'] ) {
+			$input['submit'] = false;
+		}
+		$input['submit'] = (bool) $input['submit'];
+
+		if ( ! array_key_exists( 'evidence', $input ) || null === $input['evidence'] ) {
+			$input['evidence'] = [];
+		}
+		if ( ! array_key_exists( 'metadata', $input ) || null === $input['metadata'] ) {
+			$input['metadata'] = [];
 		}
 
 		return self::delegate_to_rest_controller(

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -157,6 +157,11 @@ class Abilities_Registrar {
 	 *                         request fails.
 	 */
 	public static function execute_get_transactions( $input = null ) {
+		$date_error = self::validate_iso8601_dates( $input, [ 'date_before', 'date_after' ] );
+		if ( null !== $date_error ) {
+			return $date_error;
+		}
+
 		return self::delegate_to_rest_controller(
 			'WC_REST_Payments_Reports_Transactions_Controller',
 			'get_transactions',
@@ -179,11 +184,18 @@ class Abilities_Registrar {
 	 *                         request fails.
 	 */
 	public static function execute_get_disputes( $input = null ) {
+		$date_error = self::validate_iso8601_dates( $input, [ 'date_before', 'date_after' ] );
+		if ( null !== $date_error ) {
+			return $date_error;
+		}
+
+		$input = self::translate_pagination_keys( is_array( $input ) ? $input : null );
+
 		return self::delegate_to_rest_controller(
 			'WC_REST_Payments_Disputes_Controller',
 			'get_disputes',
 			'/wc/v3/payments/disputes',
-			is_array( $input ) ? $input : null
+			$input
 		);
 	}
 
@@ -201,7 +213,7 @@ class Abilities_Registrar {
 	 *                         is missing, or the remote request fails.
 	 */
 	public static function execute_get_dispute_detail( $input = null ) {
-		if ( ! is_array( $input ) || empty( $input['dispute_id'] ) ) {
+		if ( ! is_array( $input ) || ! isset( $input['dispute_id'] ) || ! is_string( $input['dispute_id'] ) || '' === $input['dispute_id'] ) {
 			return new \WP_Error(
 				'woopayments_missing_dispute_id',
 				__( 'A dispute_id is required to fetch dispute detail.', 'woocommerce-payments' )
@@ -230,11 +242,18 @@ class Abilities_Registrar {
 	 *                         request fails.
 	 */
 	public static function execute_get_payouts( $input = null ) {
+		$date_error = self::validate_iso8601_dates( $input, [ 'date_before', 'date_after' ] );
+		if ( null !== $date_error ) {
+			return $date_error;
+		}
+
+		$input = self::translate_pagination_keys( is_array( $input ) ? $input : null );
+
 		return self::delegate_to_rest_controller(
 			'WC_REST_Payments_Deposits_Controller',
 			'get_deposits',
 			'/wc/v3/payments/deposits',
-			is_array( $input ) ? $input : null
+			$input
 		);
 	}
 
@@ -286,13 +305,15 @@ class Abilities_Registrar {
 	 * @param string     $method           Controller method to invoke on the built request.
 	 * @param string     $route            REST route string used when constructing WP_REST_Request.
 	 * @param array|null $input            Ability input; each key/value becomes a request param.
+	 * @param string     $http_method      HTTP method for the WP_REST_Request. Defaults to 'GET'; Phase 5's write ability will pass 'POST'.
 	 * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
 	 */
 	private static function delegate_to_rest_controller(
 		string $controller_class,
 		string $method,
 		string $route,
-		?array $input
+		?array $input,
+		string $http_method = 'GET'
 	) {
 		$fqcn = '\\' . $controller_class;
 		if ( ! class_exists( $fqcn ) ) {
@@ -302,7 +323,7 @@ class Abilities_Registrar {
 			);
 		}
 
-		$request = new \WP_REST_Request( 'GET', $route );
+		$request = new \WP_REST_Request( $http_method, $route );
 		if ( null !== $input ) {
 			foreach ( $input as $param => $value ) {
 				$request->set_param( $param, $value );
@@ -325,6 +346,69 @@ class Abilities_Registrar {
 	}
 
 	/**
+	 * Translate pagination keys for abilities that back Paginated::from_rest_request —
+	 * the shared WooPayments paginated request class reads `pagesize`, not `per_page`.
+	 * Abilities expose `per_page` for consistency; this helper bridges the two.
+	 *
+	 * @param array|null $input Ability input (or null).
+	 * @return array|null       Input with `per_page` rewritten to `pagesize` when present.
+	 */
+	private static function translate_pagination_keys( $input ) {
+		if ( ! is_array( $input ) ) {
+			return $input;
+		}
+		if ( isset( $input['per_page'] ) ) {
+			$input['pagesize'] = $input['per_page'];
+			unset( $input['per_page'] );
+		}
+		return $input;
+	}
+
+	/**
+	 * Validate optional ISO 8601 date-time strings in ability input.
+	 *
+	 * Returns a WP_Error on malformed input, or null if all dates are valid / absent.
+	 *
+	 * @param mixed    $input Ability input; non-array input is treated as having no dates to validate.
+	 * @param string[] $keys  Input keys to check for ISO 8601 date-time values.
+	 * @return \WP_Error|null WP_Error when any listed key holds a malformed value, null otherwise.
+	 */
+	private static function validate_iso8601_dates( $input, array $keys ) {
+		if ( ! is_array( $input ) ) {
+			return null;
+		}
+		foreach ( $keys as $key ) {
+			if ( ! isset( $input[ $key ] ) || '' === $input[ $key ] ) {
+				continue;
+			}
+			$value = $input[ $key ];
+			if ( ! is_string( $value ) ) {
+				return new \WP_Error(
+					'woopayments_invalid_date',
+					sprintf(
+						/* translators: %s: input parameter name. */
+						__( 'The "%s" parameter must be an ISO 8601 date-time string.', 'woocommerce-payments' ),
+						$key
+					)
+				);
+			}
+			// Accept either a full date-time or a bare date — both are common agent inputs
+			// and the backing endpoints will accept either. Reject anything else.
+			if ( ! preg_match( '/^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2}))?$/', $value ) ) {
+				return new \WP_Error(
+					'woopayments_invalid_date',
+					sprintf(
+						/* translators: %s: input parameter name. */
+						__( 'The "%s" parameter must be an ISO 8601 date-time string.', 'woocommerce-payments' ),
+						$key
+					)
+				);
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Register the woopayments/get-transactions ability.
 	 *
 	 * Lists WooPayments transactions using the report-shaped schema so agents
@@ -339,51 +423,72 @@ class Abilities_Registrar {
 			'woopayments/get-transactions',
 			[
 				'label'               => __( 'List WooPayments transactions', 'woocommerce-payments' ),
-				'description'         => __( 'Lists WooPayments transactions using the stable, report-shaped schema (transaction_id, date, payment_id, channel, payment_method, type, currency, amount, fees, customer, deposit status). Supports date, pagination, and basic filter parameters.', 'woocommerce-payments' ),
+				'description'         => __( 'Lists WooPayments transactions using the stable, report-shaped schema (transaction_id, date, payment_id, channel, payment_method, type, currency, amount, fees, customer, deposit status). Supports date, pagination, and basic filter parameters. Returns a single page (default 25, max 100). Iterate by incrementing `page`, or narrow with `date_after`/`date_before` for large result sets.', 'woocommerce-payments' ),
 				'category'            => self::CATEGORY_SLUG,
 				'input_schema'        => [
 					'type'                 => 'object',
 					'default'              => [],
 					'properties'           => [
-						'page'        => [
+						'page'                => [
 							'type'        => 'integer',
 							'minimum'     => 1,
 							'default'     => 1,
 							'description' => __( 'Page number.', 'woocommerce-payments' ),
 						],
-						'per_page'    => [
+						'per_page'            => [
 							'type'        => 'integer',
 							'minimum'     => 1,
 							'maximum'     => 100,
 							'default'     => 25,
 							'description' => __( 'Number of transactions per page.', 'woocommerce-payments' ),
 						],
-						'date_before' => [
+						'date_before'         => [
 							'type'        => 'string',
 							'format'      => 'date-time',
 							'description' => __( 'Filter transactions before this date.', 'woocommerce-payments' ),
 						],
-						'date_after'  => [
+						'date_after'          => [
 							'type'        => 'string',
 							'format'      => 'date-time',
 							'description' => __( 'Filter transactions after this date.', 'woocommerce-payments' ),
 						],
-						'match'       => [
+						'match'               => [
 							'type'        => 'string',
 							'enum'        => [ 'and', 'or' ],
 							'default'     => 'and',
 							'description' => __( 'Logical operator applied when combining filters.', 'woocommerce-payments' ),
 						],
-						'sort'        => [
+						'sort'                => [
 							'type'        => 'string',
 							'default'     => 'date',
 							'description' => __( 'Field on which to sort.', 'woocommerce-payments' ),
 						],
-						'direction'   => [
+						'direction'           => [
 							'type'        => 'string',
 							'enum'        => [ 'asc', 'desc' ],
 							'default'     => 'desc',
 							'description' => __( 'Sort direction.', 'woocommerce-payments' ),
+						],
+						// Canonical agent lookups — the broader List_Transactions filter surface
+						// (type_is_in, source_device_is, channel_is, store_currency_is, deposit_id, etc.)
+						// is deliberately out of scope for the initial shipment and can be added in a follow-up.
+						'type'                => [
+							'type'        => 'string',
+							'description' => __( 'Filter to transactions of a specific type (e.g. "charge", "refund", "payment"). Validation is delegated to the backing controller.', 'woocommerce-payments' ),
+						],
+						'order_id'            => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Filter to transactions linked to a specific WooCommerce order ID.', 'woocommerce-payments' ),
+						],
+						'customer_email'      => [
+							'type'        => 'string',
+							'format'      => 'email',
+							'description' => __( 'Filter to transactions for a specific customer email address.', 'woocommerce-payments' ),
+						],
+						'payment_method_type' => [
+							'type'        => 'string',
+							'description' => __( 'Filter to transactions paid with a specific payment method type (e.g. "card", "link").', 'woocommerce-payments' ),
 						],
 					],
 					'additionalProperties' => false,
@@ -428,7 +533,7 @@ class Abilities_Registrar {
 			'woopayments/get-disputes',
 			[
 				'label'               => __( 'List WooPayments disputes', 'woocommerce-payments' ),
-				'description'         => __( 'Lists WooPayments disputes. Supports filtering by status (e.g. status_is=needs_response to answer "which disputes need a response?"), date range, store currency, and free-text search.', 'woocommerce-payments' ),
+				'description'         => __( 'Lists WooPayments disputes. Supports filtering by status (e.g. status_is=needs_response to answer "which disputes need a response?"), date range, store currency, and free-text search. Returns a single page (default 25, max 100). Iterate by incrementing `page`, or narrow with `date_after`/`date_before` for large result sets.', 'woocommerce-payments' ),
 				'category'            => self::CATEGORY_SLUG,
 				'input_schema'        => [
 					'type'                 => 'object',
@@ -560,7 +665,7 @@ class Abilities_Registrar {
 			'woopayments/get-payouts',
 			[
 				'label'               => __( 'List WooPayments payouts', 'woocommerce-payments' ),
-				'description'         => __( 'Lists WooPayments payouts (funds transfers from the WooPayments balance to the merchant\'s bank account). Supports filtering by status, store currency, and date range.', 'woocommerce-payments' ),
+				'description'         => __( 'Lists WooPayments payouts (funds transfers from the WooPayments balance to the merchant\'s bank account). Supports filtering by status, store currency, and date range. Returns a single page (default 25, max 100). Iterate by incrementing `page`, or narrow with `date_after`/`date_before` for large result sets.', 'woocommerce-payments' ),
 				'category'            => self::CATEGORY_SLUG,
 				'input_schema'        => [
 					'type'                 => 'object',

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -84,6 +84,7 @@ class Abilities_Registrar {
 
 		self::register_get_account_status_ability();
 		self::register_get_transactions_ability();
+		self::register_get_disputes_ability();
 	}
 
 	/**
@@ -178,6 +179,44 @@ class Abilities_Registrar {
 	}
 
 	/**
+	 * Execute callback for woopayments/get-disputes.
+	 *
+	 * Delegates to WC_REST_Payments_Disputes_Controller::get_disputes() which
+	 * returns the raw server response array from the WooPayments API. Critical
+	 * for the canonical "which disputes need a response?" agent query via
+	 * the status_is filter.
+	 *
+	 * @param mixed $input Optional; ability input matching the input_schema.
+	 * @return array|\WP_Error Disputes list payload from the server, or WP_Error
+	 *                         when WooPayments is not initialized or the remote
+	 *                         request fails.
+	 */
+	public static function execute_get_disputes( $input = null ) {
+		if ( ! class_exists( '\WC_REST_Payments_Disputes_Controller' ) ) {
+			return new \WP_Error(
+				'woopayments_not_initialized',
+				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
+			);
+		}
+
+		$request = new \WP_REST_Request( 'GET', '/wc/v3/payments/disputes' );
+		if ( is_array( $input ) ) {
+			foreach ( $input as $param => $value ) {
+				$request->set_param( $param, $value );
+			}
+		}
+
+		$controller = new \WC_REST_Payments_Disputes_Controller();
+		$response   = $controller->get_disputes( $request );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return is_array( $response ) ? $response : [];
+	}
+
+	/**
 	 * Register the woopayments/get-transactions ability.
 	 *
 	 * Lists WooPayments transactions using the report-shaped schema so agents
@@ -244,6 +283,99 @@ class Abilities_Registrar {
 				'execute_callback'    => [ __CLASS__, 'execute_get_transactions' ],
 				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
 				// output_schema deliberately omitted — the transactions report schema is documented on the backing REST controller and duplicating it here would couple this registrar to any future upstream change.
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Register the woopayments/get-disputes ability.
+	 *
+	 * Lists WooPayments disputes. Supports filtering by status — essential for
+	 * the canonical "which disputes need a response?" agent query
+	 * (status_is=needs_response or warning_needs_response).
+	 *
+	 * @return void
+	 */
+	private static function register_get_disputes_ability(): void {
+		$dispute_statuses = [
+			'warning_needs_response',
+			'warning_under_review',
+			'warning_closed',
+			'needs_response',
+			'under_review',
+			'charge_refunded',
+			'won',
+			'lost',
+		];
+
+		wp_register_ability(
+			'woopayments/get-disputes',
+			[
+				'label'               => __( 'List WooPayments disputes', 'woocommerce-payments' ),
+				'description'         => __( 'Lists WooPayments disputes. Supports filtering by status (e.g. status_is=needs_response to answer "which disputes need a response?"), date range, store currency, and free-text search.', 'woocommerce-payments' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => [
+					'type'                 => 'object',
+					'default'              => [],
+					'properties'           => [
+						'page'              => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Page number.', 'woocommerce-payments' ),
+						],
+						'per_page'          => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 100,
+							'description' => __( 'Number of disputes per page.', 'woocommerce-payments' ),
+						],
+						'match'             => [
+							'type'        => 'string',
+							'enum'        => [ 'and', 'or' ],
+							'description' => __( 'Logical operator applied when combining filters.', 'woocommerce-payments' ),
+						],
+						'store_currency_is' => [
+							'type'        => 'string',
+							'description' => __( 'Filter by store currency code (e.g. "usd").', 'woocommerce-payments' ),
+						],
+						'date_before'       => [
+							'type'        => 'string',
+							'format'      => 'date-time',
+							'description' => __( 'Filter disputes created before this date.', 'woocommerce-payments' ),
+						],
+						'date_after'        => [
+							'type'        => 'string',
+							'format'      => 'date-time',
+							'description' => __( 'Filter disputes created after this date.', 'woocommerce-payments' ),
+						],
+						'search'            => [
+							'type'        => 'string',
+							'description' => __( 'Free-text search term.', 'woocommerce-payments' ),
+						],
+						'status_is'         => [
+							'type'        => 'string',
+							'enum'        => $dispute_statuses,
+							'description' => __( 'Filter to disputes whose status equals this value.', 'woocommerce-payments' ),
+						],
+						'status_is_not'     => [
+							'type'        => 'string',
+							'enum'        => $dispute_statuses,
+							'description' => __( 'Filter to disputes whose status does not equal this value.', 'woocommerce-payments' ),
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'execute_callback'    => [ __CLASS__, 'execute_get_disputes' ],
+				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
+				// output_schema deliberately omitted — the disputes payload shape comes straight from the WooPayments server and we don't want to couple to a specific structure here.
 				'meta'                => [
 					'annotations'  => [
 						'readonly'    => true,

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -87,6 +87,7 @@ class Abilities_Registrar {
 		self::register_get_disputes_ability();
 		self::register_get_dispute_detail_ability();
 		self::register_get_payouts_ability();
+		self::register_get_payout_overview_ability();
 	}
 
 	/**
@@ -235,6 +236,37 @@ class Abilities_Registrar {
 			'/wc/v3/payments/deposits',
 			is_array( $input ) ? $input : null
 		);
+	}
+
+	/**
+	 * Execute callback for woopayments/get-payout-overview.
+	 *
+	 * Delegates to WC_REST_Payments_Deposits_Controller::get_all_deposits_overviews().
+	 * Answers the canonical "when do I get paid?" agent question by returning
+	 * the next scheduled payout across all enabled currencies. Zero-input — we
+	 * accept $input for API-signature compatibility but ignore it.
+	 *
+	 * @param mixed $input Optional; unused for this ability (empty input_schema).
+	 * @return array|\WP_Error Overview payload from the server, or WP_Error when
+	 *                         WooPayments is not initialized or the remote
+	 *                         request fails.
+	 */
+	public static function execute_get_payout_overview( $input = null ) {
+		if ( ! class_exists( '\WC_REST_Payments_Deposits_Controller' ) ) {
+			return new \WP_Error(
+				'woopayments_not_initialized',
+				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
+			);
+		}
+
+		$controller = new \WC_REST_Payments_Deposits_Controller();
+		$response   = $controller->get_all_deposits_overviews();
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return is_array( $response ) ? $response : [];
 	}
 
 	/**
@@ -580,6 +612,43 @@ class Abilities_Registrar {
 				'execute_callback'    => [ __CLASS__, 'execute_get_payouts' ],
 				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
 				// output_schema deliberately omitted — the payouts payload shape comes straight from the WooPayments server and we don't want to couple to a specific structure here.
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Register the woopayments/get-payout-overview ability.
+	 *
+	 * Zero-input ability that answers the canonical "when do I get paid?"
+	 * agent question by returning the next scheduled payout across every
+	 * enabled store currency, plus the corresponding balances.
+	 *
+	 * @return void
+	 */
+	private static function register_get_payout_overview_ability(): void {
+		wp_register_ability(
+			'woopayments/get-payout-overview',
+			[
+				'label'               => __( 'Get WooPayments payout overview', 'woocommerce-payments' ),
+				'description'         => __( 'Returns the next scheduled WooPayments payout across every enabled store currency, along with the corresponding pending and available balances. Answers "when do I get paid?" in a single call.', 'woocommerce-payments' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => [
+					'type'                 => 'object',
+					'default'              => [],
+					'properties'           => [],
+					'additionalProperties' => false,
+				],
+				'execute_callback'    => [ __CLASS__, 'execute_get_payout_overview' ],
+				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
+				// output_schema deliberately omitted — the overview payload shape comes straight from the WooPayments server and we don't want to couple to a specific structure here.
 				'meta'                => [
 					'annotations'  => [
 						'readonly'    => true,

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -154,28 +154,12 @@ class Abilities_Registrar {
 	 *                         request fails.
 	 */
 	public static function execute_get_transactions( $input = null ) {
-		if ( ! class_exists( '\WC_REST_Payments_Reports_Transactions_Controller' ) ) {
-			return new \WP_Error(
-				'woopayments_not_initialized',
-				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
-			);
-		}
-
-		$request = new \WP_REST_Request( 'GET', '/wc/v3/payments/reports/transactions' );
-		if ( is_array( $input ) ) {
-			foreach ( $input as $param => $value ) {
-				$request->set_param( $param, $value );
-			}
-		}
-
-		$controller = new \WC_REST_Payments_Reports_Transactions_Controller();
-		$response   = $controller->get_transactions( $request );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		return $response->get_data();
+		return self::delegate_to_rest_controller(
+			'WC_REST_Payments_Reports_Transactions_Controller',
+			'get_transactions',
+			'/wc/v3/payments/reports/transactions',
+			is_array( $input ) ? $input : null
+		);
 	}
 
 	/**
@@ -192,25 +176,64 @@ class Abilities_Registrar {
 	 *                         request fails.
 	 */
 	public static function execute_get_disputes( $input = null ) {
-		if ( ! class_exists( '\WC_REST_Payments_Disputes_Controller' ) ) {
+		return self::delegate_to_rest_controller(
+			'WC_REST_Payments_Disputes_Controller',
+			'get_disputes',
+			'/wc/v3/payments/disputes',
+			is_array( $input ) ? $input : null
+		);
+	}
+
+	/**
+	 * Delegate an ability's execute callback to a WooPayments REST controller.
+	 *
+	 * Builds a WP_REST_Request from the ability's input, instantiates the
+	 * backing controller, invokes the named method, and normalizes the return
+	 * so the caller always sees an array|\WP_Error. Controllers in this plugin
+	 * return either a WP_REST_Response (e.g. the reports endpoints) or a raw
+	 * array from the server's transport layer (e.g. List_Disputes), so the
+	 * helper unwraps both shapes.
+	 *
+	 * Not used by zero-arg abilities — those call their controller directly so
+	 * we don't invent a synthetic WP_REST_Request just to discard it.
+	 *
+	 * @param string     $controller_class Fully-qualified controller class name (no leading backslash).
+	 * @param string     $method           Controller method to invoke on the built request.
+	 * @param string     $route            REST route string used when constructing WP_REST_Request.
+	 * @param array|null $input            Ability input; each key/value becomes a request param.
+	 * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
+	 */
+	private static function delegate_to_rest_controller(
+		string $controller_class,
+		string $method,
+		string $route,
+		?array $input
+	) {
+		$fqcn = '\\' . $controller_class;
+		if ( ! class_exists( $fqcn ) ) {
 			return new \WP_Error(
 				'woopayments_not_initialized',
 				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
 			);
 		}
 
-		$request = new \WP_REST_Request( 'GET', '/wc/v3/payments/disputes' );
-		if ( is_array( $input ) ) {
+		$request = new \WP_REST_Request( 'GET', $route );
+		if ( null !== $input ) {
 			foreach ( $input as $param => $value ) {
 				$request->set_param( $param, $value );
 			}
 		}
 
-		$controller = new \WC_REST_Payments_Disputes_Controller();
-		$response   = $controller->get_disputes( $request );
+		$controller = new $fqcn();
+		$response   = $controller->{$method}( $request );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
+		}
+
+		if ( $response instanceof \WP_REST_Response ) {
+			$data = $response->get_data();
+			return is_array( $data ) ? $data : [];
 		}
 
 		return is_array( $response ) ? $response : [];

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -100,14 +100,17 @@ class Abilities_Registrar {
 	/**
 	 * Execute callback for woopayments/get-account-status.
 	 *
-	 * Delegates to WC_Payments::get_account_service()->get_cached_account_data()
-	 * so we reuse the exact same cached-account data the REST controller serves,
-	 * with no network calls of our own.
+	 * Delegates to WC_Payments_Account::get_cached_account_data(). Usually
+	 * served from cache; on cache miss this may issue a remote request to
+	 * the WooPayments server, so agents should not assume this ability is
+	 * free to call repeatedly.
 	 *
+	 * @param mixed $input Optional; ability input. Unused for this ability (empty input_schema) but accepted to match the Abilities API execute_callback signature.
 	 * @return array|\WP_Error Array of account data, or WP_Error when WooPayments
-	 *                         has not finished initializing.
+	 *                         has not finished initializing or the cached data
+	 *                         is unavailable due to a remote error.
 	 */
-	public static function execute_get_account_status() {
+	public static function execute_get_account_status( $input = null ) {
 		if ( ! class_exists( '\WC_Payments' ) ) {
 			return new \WP_Error(
 				'woopayments_not_initialized',
@@ -124,6 +127,14 @@ class Abilities_Registrar {
 		}
 
 		$data = $account->get_cached_account_data();
+
+		if ( false === $data ) {
+			return new \WP_Error(
+				'woopayments_account_data_unavailable',
+				__( 'Unable to retrieve WooPayments account data. The cache may be stale or the remote service returned an error.', 'woocommerce-payments' )
+			);
+		}
+
 		return is_array( $data ) ? $data : [];
 	}
 
@@ -152,6 +163,7 @@ class Abilities_Registrar {
 				],
 				'execute_callback'    => [ __CLASS__, 'execute_get_account_status' ],
 				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
+				// output_schema deliberately omitted — the account payload shape drifts with Stripe's API and we don't want to couple to a specific structure here.
 				'meta'                => [
 					'annotations'  => [
 						'readonly'    => true,

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -83,6 +83,7 @@ class Abilities_Registrar {
 		}
 
 		self::register_get_account_status_ability();
+		self::register_get_transactions_ability();
 	}
 
 	/**
@@ -136,6 +137,123 @@ class Abilities_Registrar {
 		}
 
 		return is_array( $data ) ? $data : [];
+	}
+
+	/**
+	 * Execute callback for woopayments/get-transactions.
+	 *
+	 * Delegates to WC_REST_Payments_Reports_Transactions_Controller::get_transactions()
+	 * which produces the normalized, report-shaped transaction schema
+	 * (transaction_id, date, payment_id, channel, payment_method, type,
+	 * currency, amount, fees, customer, deposit status, etc.).
+	 *
+	 * @param mixed $input Optional; ability input matching the input_schema.
+	 * @return array|\WP_Error Array of prepared transactions, or WP_Error when
+	 *                         WooPayments is not initialized or the remote
+	 *                         request fails.
+	 */
+	public static function execute_get_transactions( $input = null ) {
+		if ( ! class_exists( '\WC_REST_Payments_Reports_Transactions_Controller' ) ) {
+			return new \WP_Error(
+				'woopayments_not_initialized',
+				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
+			);
+		}
+
+		$request = new \WP_REST_Request( 'GET', '/wc/v3/payments/reports/transactions' );
+		if ( is_array( $input ) ) {
+			foreach ( $input as $param => $value ) {
+				$request->set_param( $param, $value );
+			}
+		}
+
+		$controller = new \WC_REST_Payments_Reports_Transactions_Controller();
+		$response   = $controller->get_transactions( $request );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		return $response->get_data();
+	}
+
+	/**
+	 * Register the woopayments/get-transactions ability.
+	 *
+	 * Lists WooPayments transactions using the report-shaped schema so agents
+	 * receive a stable, documented payload (transaction_id, date, payment_id,
+	 * channel, payment_method, type, amount, fees, customer, deposit status)
+	 * rather than the raw Stripe balance transaction structure.
+	 *
+	 * @return void
+	 */
+	private static function register_get_transactions_ability(): void {
+		wp_register_ability(
+			'woopayments/get-transactions',
+			[
+				'label'               => __( 'List WooPayments transactions', 'woocommerce-payments' ),
+				'description'         => __( 'Lists WooPayments transactions using the stable, report-shaped schema (transaction_id, date, payment_id, channel, payment_method, type, currency, amount, fees, customer, deposit status). Supports date, pagination, and basic filter parameters.', 'woocommerce-payments' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => [
+					'type'                 => 'object',
+					'default'              => [],
+					'properties'           => [
+						'page'        => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'default'     => 1,
+							'description' => __( 'Page number.', 'woocommerce-payments' ),
+						],
+						'per_page'    => [
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => 100,
+							'default'     => 25,
+							'description' => __( 'Number of transactions per page.', 'woocommerce-payments' ),
+						],
+						'date_before' => [
+							'type'        => 'string',
+							'format'      => 'date-time',
+							'description' => __( 'Filter transactions before this date.', 'woocommerce-payments' ),
+						],
+						'date_after'  => [
+							'type'        => 'string',
+							'format'      => 'date-time',
+							'description' => __( 'Filter transactions after this date.', 'woocommerce-payments' ),
+						],
+						'match'       => [
+							'type'        => 'string',
+							'enum'        => [ 'and', 'or' ],
+							'default'     => 'and',
+							'description' => __( 'Logical operator applied when combining filters.', 'woocommerce-payments' ),
+						],
+						'sort'        => [
+							'type'        => 'string',
+							'default'     => 'date',
+							'description' => __( 'Field on which to sort.', 'woocommerce-payments' ),
+						],
+						'direction'   => [
+							'type'        => 'string',
+							'enum'        => [ 'asc', 'desc' ],
+							'default'     => 'desc',
+							'description' => __( 'Sort direction.', 'woocommerce-payments' ),
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'execute_callback'    => [ __CLASS__, 'execute_get_transactions' ],
+				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
+				// output_schema deliberately omitted — the transactions report schema is documented on the backing REST controller and duplicating it here would couple this registrar to any future upstream change.
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
 	}
 
 	/**

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Class Abilities_Registrar
+ *
+ * @package WooCommerce\Payments
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9, but then we need a suppression for the WP 6.8 compat run. @todo Remove this line when we drop WP <6.9.
+
+namespace WCPay\Internal\Abilities;
+
+/**
+ * Registers WooPayments abilities with the WordPress Abilities API.
+ *
+ * Concrete abilities are registered in follow-up phases; this scaffold only
+ * wires the registration hooks and declares the `woopayments` category so
+ * Phase 2 can ship independently.
+ */
+class Abilities_Registrar {
+
+	/**
+	 * The category slug used for every WooPayments ability.
+	 *
+	 * @var string
+	 */
+	const CATEGORY_SLUG = 'woopayments';
+
+	/**
+	 * Initialize the abilities registration.
+	 *
+	 * Mirrors the pattern used by Jetpack Forms: if the relevant Abilities API
+	 * action has already fired we call the registrar directly, otherwise we
+	 * hook it for when the API boots.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		// Register category.
+		if ( did_action( 'wp_abilities_api_categories_init' ) ) {
+			self::register_category();
+		} else {
+			add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+		}
+
+		// Register abilities.
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			self::register_abilities();
+		} else {
+			add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+		}
+	}
+
+	/**
+	 * Register the WooPayments ability category.
+	 *
+	 * @return void
+	 */
+	public static function register_category(): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			self::CATEGORY_SLUG,
+			[
+				// "WooPayments" is a product name and should not be translated.
+				'label'       => 'WooPayments',
+				'description' => __( 'Abilities for managing WooPayments transactions, disputes, payouts, and account status.', 'woocommerce-payments' ),
+			]
+		);
+	}
+
+	/**
+	 * Register all WooPayments abilities.
+	 *
+	 * Concrete abilities are registered in subsequent phases.
+	 *
+	 * @return void
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		// Concrete abilities registered in subsequent phases.
+	}
+
+	/**
+	 * Permission callback mirroring WC_Payments_REST_Controller::check_permission().
+	 *
+	 * Used as the `permission_callback` for every WooPayments ability so the
+	 * authorization surface matches the existing admin REST API.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_payments(): bool {
+		return current_user_can( 'manage_woocommerce' );
+	}
+}

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -338,7 +338,18 @@ class Abilities_Registrar {
 			);
 		}
 
-		$controller = new \WC_REST_Payments_Deposits_Controller();
+		$api_client = null;
+		if ( class_exists( '\WC_Payments' ) && method_exists( '\WC_Payments', 'get_payments_api_client' ) ) {
+			$api_client = \WC_Payments::get_payments_api_client();
+		}
+		if ( null === $api_client ) {
+			return new \WP_Error(
+				'woopayments_not_initialized',
+				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
+			);
+		}
+
+		$controller = new \WC_REST_Payments_Deposits_Controller( $api_client );
 		$response   = $controller->get_all_deposits_overviews();
 
 		if ( is_wp_error( $response ) ) {
@@ -383,6 +394,17 @@ class Abilities_Registrar {
 			);
 		}
 
+		$api_client = null;
+		if ( class_exists( '\WC_Payments' ) && method_exists( '\WC_Payments', 'get_payments_api_client' ) ) {
+			$api_client = \WC_Payments::get_payments_api_client();
+		}
+		if ( null === $api_client ) {
+			return new \WP_Error(
+				'woopayments_not_initialized',
+				__( 'WooPayments is not initialized.', 'woocommerce-payments' )
+			);
+		}
+
 		$request = new \WP_REST_Request( $http_method, $route );
 		if ( null !== $input ) {
 			foreach ( $input as $param => $value ) {
@@ -390,7 +412,7 @@ class Abilities_Registrar {
 			}
 		}
 
-		$controller = new $fqcn();
+		$controller = new $fqcn( $api_client );
 		$response   = $controller->{$method}( $request );
 
 		if ( is_wp_error( $response ) ) {

--- a/src/Internal/Abilities/Abilities_Registrar.php
+++ b/src/Internal/Abilities/Abilities_Registrar.php
@@ -88,6 +88,7 @@ class Abilities_Registrar {
 		self::register_get_dispute_detail_ability();
 		self::register_get_payouts_ability();
 		self::register_get_payout_overview_ability();
+		self::register_submit_dispute_evidence_ability();
 	}
 
 	/**
@@ -225,6 +226,46 @@ class Abilities_Registrar {
 			'get_dispute',
 			'/wc/v3/payments/disputes/' . rawurlencode( (string) $input['dispute_id'] ),
 			$input
+		);
+	}
+
+	/**
+	 * Execute callback for woopayments/submit-dispute-evidence.
+	 *
+	 * Delegates to WC_REST_Payments_Disputes_Controller::update_dispute(),
+	 * which accepts `dispute_id`, `evidence`, `submit`, and `metadata` and
+	 * forwards them to the WooPayments server. Defaults `submit` to false on
+	 * the input schema so evidence can be staged as a draft; agents should
+	 * only pass `submit: true` after explicit merchant confirmation because
+	 * once submitted, evidence cannot be retracted.
+	 *
+	 * Not idempotent — calling this twice with `submit: true` produces two
+	 * submission attempts against Stripe. Agent retry logic must guard
+	 * against double-calls.
+	 *
+	 * @param mixed $input Ability input; must include `dispute_id`.
+	 * @return array|\WP_Error Dispute payload from the server, or WP_Error when
+	 *                         WooPayments is not initialized, the dispute_id
+	 *                         is missing, or the remote request fails.
+	 */
+	public static function execute_submit_dispute_evidence( $input = null ) {
+		if ( ! is_array( $input ) ) {
+			$input = [];
+		}
+
+		if ( ! isset( $input['dispute_id'] ) || ! is_string( $input['dispute_id'] ) || '' === $input['dispute_id'] ) {
+			return new \WP_Error(
+				'woopayments_missing_dispute_id',
+				__( 'A dispute_id is required to submit dispute evidence.', 'woocommerce-payments' )
+			);
+		}
+
+		return self::delegate_to_rest_controller(
+			'WC_REST_Payments_Disputes_Controller',
+			'update_dispute',
+			'/wc/v3/payments/disputes/' . rawurlencode( $input['dispute_id'] ),
+			$input,
+			'POST'
 		);
 	}
 
@@ -636,6 +677,68 @@ class Abilities_Registrar {
 						'readonly'    => true,
 						'destructive' => false,
 						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Register the woopayments/submit-dispute-evidence ability.
+	 *
+	 * First write ability in the WooPayments abilities surface. Attaches or
+	 * finalizes evidence for an open dispute. Chosen over create-refund and
+	 * accept-dispute for MVP because submitting evidence doesn't move money —
+	 * it's additive, not destructive.
+	 *
+	 * Annotations: readonly:false, destructive:false, idempotent:false. The
+	 * non-idempotent flag is load-bearing — duplicate submits to Stripe
+	 * produce duplicate attempts; agent retry logic must guard double-calls.
+	 *
+	 * @return void
+	 */
+	private static function register_submit_dispute_evidence_ability(): void {
+		wp_register_ability(
+			'woopayments/submit-dispute-evidence',
+			[
+				'label'               => __( 'Submit WooPayments dispute evidence', 'woocommerce-payments' ),
+				'description'         => __( 'Attach or update evidence for an open WooPayments dispute. Pass submit:true only after explicit merchant confirmation — once submitted, evidence cannot be retracted. Not idempotent: calling twice with submit:true produces duplicate submission attempts, so agent retry logic must guard against double-calls.', 'woocommerce-payments' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => [
+					'type'                 => 'object',
+					'required'             => [ 'dispute_id' ],
+					'properties'           => [
+						'dispute_id' => [
+							'type'        => 'string',
+							'description' => __( 'The WooPayments dispute identifier to submit evidence for. Starts with "dp_".', 'woocommerce-payments' ),
+						],
+						'evidence'   => [
+							'type'                 => 'object',
+							'description'          => __( 'The evidence payload. Accepts fields documented by Stripe\'s dispute evidence object (e.g. product_description, customer_communication, receipt, shipping_documentation). Unknown fields are forwarded to Stripe.', 'woocommerce-payments' ),
+							'additionalProperties' => true,
+						],
+						'submit'     => [
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'If true, finalize and submit the evidence to Stripe. If false (default), save as draft without submitting. Agents should default to false and only submit after explicit merchant confirmation.', 'woocommerce-payments' ),
+						],
+						'metadata'   => [
+							'type'                 => 'object',
+							'description'          => __( 'Optional metadata key/value pairs to attach to the dispute.', 'woocommerce-payments' ),
+							'additionalProperties' => [ 'type' => 'string' ],
+						],
+					],
+					'additionalProperties' => false,
+				],
+				'execute_callback'    => [ __CLASS__, 'execute_submit_dispute_evidence' ],
+				'permission_callback' => [ __CLASS__, 'can_manage_payments' ],
+				// output_schema deliberately omitted — the dispute payload shape comes straight from the WooPayments server and we don't want to couple to a specific structure here.
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
 					],
 					'show_in_rest' => true,
 				],

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -147,6 +147,26 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Ensures the woopayments/get-disputes ability is registered with
+	 * the shape the Abilities Everywhere initiative expects: correct
+	 * category and the full readonly/destructive/idempotent annotation set.
+	 */
+	public function test_get_disputes_ability_is_registered_with_expected_shape(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
+		}
+
+		$ability = wp_get_ability( 'woopayments/get-disputes' );
+		$this->assertNotNull( $ability, 'get-disputes should be registered.' );
+		$this->assertSame( Abilities_Registrar::CATEGORY_SLUG, $ability->get_category() );
+
+		$annotations = $ability->get_meta()['annotations'];
+		$this->assertTrue( $annotations['readonly'], 'get-disputes should be readonly.' );
+		$this->assertFalse( $annotations['destructive'], 'get-disputes should not be destructive.' );
+		$this->assertTrue( $annotations['idempotent'], 'get-disputes should be idempotent.' );
+	}
+
+	/**
 	 * Ensures the ability's permission callback — shared across every
 	 * WooPayments ability — denies non-admins and allows admins. This is the
 	 * executable-on-current-user surface that matters for real agents.

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -253,4 +253,15 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 			'Administrators must be able to execute get-account-status.'
 		);
 	}
+
+	/**
+	 * Executes the dispute-detail ability with no dispute_id and asserts it returns
+	 * a WP_Error with code woopayments_missing_dispute_id. Establishes the
+	 * execute-path assertion pattern that Phase 5's write ability will extend.
+	 */
+	public function test_get_dispute_detail_returns_wp_error_when_dispute_id_missing(): void {
+		$result = Abilities_Registrar::execute_get_dispute_detail( [] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'woopayments_missing_dispute_id', $result->get_error_code() );
+	}
 }

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -207,6 +207,26 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Ensures the woopayments/get-payout-overview ability is registered with
+	 * the shape the Abilities Everywhere initiative expects: correct
+	 * category and the full readonly/destructive/idempotent annotation set.
+	 */
+	public function test_get_payout_overview_ability_is_registered_with_expected_shape(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
+		}
+
+		$ability = wp_get_ability( 'woopayments/get-payout-overview' );
+		$this->assertNotNull( $ability, 'get-payout-overview should be registered.' );
+		$this->assertSame( Abilities_Registrar::CATEGORY_SLUG, $ability->get_category() );
+
+		$annotations = $ability->get_meta()['annotations'];
+		$this->assertTrue( $annotations['readonly'], 'get-payout-overview should be readonly.' );
+		$this->assertFalse( $annotations['destructive'], 'get-payout-overview should not be destructive.' );
+		$this->assertTrue( $annotations['idempotent'], 'get-payout-overview should be idempotent.' );
+	}
+
+	/**
 	 * Ensures the ability's permission callback — shared across every
 	 * WooPayments ability — denies non-admins and allows admins. This is the
 	 * executable-on-current-user surface that matters for real agents.

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -187,6 +187,26 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Ensures the woopayments/get-payouts ability is registered with
+	 * the shape the Abilities Everywhere initiative expects: correct
+	 * category and the full readonly/destructive/idempotent annotation set.
+	 */
+	public function test_get_payouts_ability_is_registered_with_expected_shape(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
+		}
+
+		$ability = wp_get_ability( 'woopayments/get-payouts' );
+		$this->assertNotNull( $ability, 'get-payouts should be registered.' );
+		$this->assertSame( Abilities_Registrar::CATEGORY_SLUG, $ability->get_category() );
+
+		$annotations = $ability->get_meta()['annotations'];
+		$this->assertTrue( $annotations['readonly'], 'get-payouts should be readonly.' );
+		$this->assertFalse( $annotations['destructive'], 'get-payouts should not be destructive.' );
+		$this->assertTrue( $annotations['idempotent'], 'get-payouts should be idempotent.' );
+	}
+
+	/**
 	 * Ensures the ability's permission callback — shared across every
 	 * WooPayments ability — denies non-admins and allows admins. This is the
 	 * executable-on-current-user surface that matters for real agents.

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -127,6 +127,26 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Ensures the woopayments/get-transactions ability is registered with
+	 * the shape the Abilities Everywhere initiative expects: correct
+	 * category and the full readonly/destructive/idempotent annotation set.
+	 */
+	public function test_get_transactions_ability_is_registered_with_expected_shape(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
+		}
+
+		$ability = wp_get_ability( 'woopayments/get-transactions' );
+		$this->assertNotNull( $ability, 'get-transactions should be registered.' );
+		$this->assertSame( Abilities_Registrar::CATEGORY_SLUG, $ability->get_category() );
+
+		$annotations = $ability->get_meta()['annotations'];
+		$this->assertTrue( $annotations['readonly'], 'get-transactions should be readonly.' );
+		$this->assertFalse( $annotations['destructive'], 'get-transactions should not be destructive.' );
+		$this->assertTrue( $annotations['idempotent'], 'get-transactions should be idempotent.' );
+	}
+
+	/**
 	 * Ensures the ability's permission callback — shared across every
 	 * WooPayments ability — denies non-admins and allows admins. This is the
 	 * executable-on-current-user surface that matters for real agents.

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -86,4 +86,87 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 			'Administrators must pass the manage_woocommerce capability check.'
 		);
 	}
+
+	/**
+	 * Ensure the woopayments category and abilities are registered so the
+	 * assertions below can query them. The plugin bootstrap wires
+	 * Abilities_Registrar::init() at plugin load; when the Abilities API init
+	 * hooks have already fired by that point, init() registers inline, so in
+	 * nearly all test runs this is a no-op. If the hooks haven't fired yet
+	 * (e.g. early-boot test scenarios), we invoke the registrar's callbacks
+	 * directly instead of using do_action() — do_action() would re-run every
+	 * listener on the hook, including unrelated ones from other plugins
+	 * registered before us, and trip _doing_it_wrong() on already-registered
+	 * categories/abilities.
+	 */
+	private function fire_abilities_api_hooks(): void {
+		Abilities_Registrar::init();
+	}
+
+	/**
+	 * Ensures the woopayments/get-account-status ability is registered with
+	 * the shape the Abilities Everywhere initiative expects: correct category,
+	 * readonly annotation, and show_in_rest exposed.
+	 */
+	public function test_get_account_status_ability_is_registered_with_expected_shape() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
+		}
+
+		$this->fire_abilities_api_hooks();
+
+		$ability = wp_get_ability( 'woopayments/get-account-status' );
+		$this->assertNotNull(
+			$ability,
+			'wp_get_ability( "woopayments/get-account-status" ) returned null — ability not registered.'
+		);
+
+		$this->assertSame(
+			Abilities_Registrar::CATEGORY_SLUG,
+			$ability->get_category(),
+			'Ability category must be the woopayments category slug.'
+		);
+
+		$meta = $ability->get_meta();
+		$this->assertIsArray( $meta, 'Ability meta must be an array.' );
+		$this->assertArrayHasKey( 'annotations', $meta );
+		$this->assertTrue(
+			$meta['annotations']['readonly'] ?? false,
+			'get-account-status must advertise itself as readonly.'
+		);
+		$this->assertTrue(
+			$meta['show_in_rest'] ?? false,
+			'get-account-status must be exposed via show_in_rest for the REST bridge.'
+		);
+	}
+
+	/**
+	 * Ensures the ability's permission callback — shared across every
+	 * WooPayments ability — denies non-admins and allows admins. This is the
+	 * executable-on-current-user surface that matters for real agents.
+	 */
+	public function test_get_account_status_permission_requires_manage_woocommerce() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
+		}
+
+		$this->fire_abilities_api_hooks();
+
+		$ability = wp_get_ability( 'woopayments/get-account-status' );
+		$this->assertNotNull( $ability, 'Ability must be registered before checking permissions.' );
+
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		$this->assertFalse(
+			Abilities_Registrar::can_manage_payments(),
+			'Subscribers must not be able to execute get-account-status.'
+		);
+
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		$this->assertTrue(
+			Abilities_Registrar::can_manage_payments(),
+			'Administrators must be able to execute get-account-status.'
+		);
+	}
 }

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -167,6 +167,26 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Ensures the woopayments/get-dispute-detail ability is registered with
+	 * the shape the Abilities Everywhere initiative expects: correct
+	 * category and the full readonly/destructive/idempotent annotation set.
+	 */
+	public function test_get_dispute_detail_ability_is_registered_with_expected_shape(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
+		}
+
+		$ability = wp_get_ability( 'woopayments/get-dispute-detail' );
+		$this->assertNotNull( $ability, 'get-dispute-detail should be registered.' );
+		$this->assertSame( Abilities_Registrar::CATEGORY_SLUG, $ability->get_category() );
+
+		$annotations = $ability->get_meta()['annotations'];
+		$this->assertTrue( $annotations['readonly'], 'get-dispute-detail should be readonly.' );
+		$this->assertFalse( $annotations['destructive'], 'get-dispute-detail should not be destructive.' );
+		$this->assertTrue( $annotations['idempotent'], 'get-dispute-detail should be idempotent.' );
+	}
+
+	/**
 	 * Ensures the ability's permission callback — shared across every
 	 * WooPayments ability — denies non-admins and allows admins. This is the
 	 * executable-on-current-user surface that matters for real agents.

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Class Abilities_Registrar_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Abilities;
+
+use WCPAY_UnitTestCase;
+use WCPay\Internal\Abilities\Abilities_Registrar;
+
+/**
+ * Tests for the Abilities_Registrar scaffold.
+ */
+class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * Abilities API category init hook name.
+	 *
+	 * @var string
+	 */
+	const CATEGORIES_HOOK = 'wp_abilities_api_categories_init';
+
+	/**
+	 * Abilities API init hook name.
+	 *
+	 * @var string
+	 */
+	const ABILITIES_HOOK = 'wp_abilities_api_init';
+
+	/**
+	 * Ensures ::init() registers the category-registration callback on the
+	 * Abilities API category init hook.
+	 */
+	public function test_init_hooks_category_registration() {
+		remove_all_actions( self::CATEGORIES_HOOK );
+		remove_all_actions( self::ABILITIES_HOOK );
+
+		Abilities_Registrar::init();
+
+		$this->assertNotFalse(
+			has_action(
+				self::CATEGORIES_HOOK,
+				[ Abilities_Registrar::class, 'register_category' ]
+			),
+			'Expected Abilities_Registrar::init() to hook register_category on ' . self::CATEGORIES_HOOK
+		);
+	}
+
+	/**
+	 * Ensures ::init() registers the ability-registration callback on the
+	 * Abilities API init hook.
+	 */
+	public function test_init_hooks_abilities_registration() {
+		remove_all_actions( self::CATEGORIES_HOOK );
+		remove_all_actions( self::ABILITIES_HOOK );
+
+		Abilities_Registrar::init();
+
+		$this->assertNotFalse(
+			has_action(
+				self::ABILITIES_HOOK,
+				[ Abilities_Registrar::class, 'register_abilities' ]
+			),
+			'Expected Abilities_Registrar::init() to hook register_abilities on ' . self::ABILITIES_HOOK
+		);
+	}
+
+	/**
+	 * Ensures the permission helper mirrors the base REST controller's
+	 * manage_woocommerce capability check: subscribers are denied, admins allowed.
+	 */
+	public function test_can_manage_payments_matches_manage_woocommerce_capability() {
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		$this->assertFalse(
+			Abilities_Registrar::can_manage_payments(),
+			'Subscribers must not pass the manage_woocommerce capability check.'
+		);
+
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		$this->assertTrue(
+			Abilities_Registrar::can_manage_payments(),
+			'Administrators must pass the manage_woocommerce capability check.'
+		);
+	}
+}

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -264,4 +264,51 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'woopayments_missing_dispute_id', $result->get_error_code() );
 	}
+
+	/**
+	 * Ensures the woopayments/submit-dispute-evidence ability — the first write
+	 * ability — is registered with the correct category and the full
+	 * readonly/destructive/idempotent annotation set. Explicit negative
+	 * assertions on every annotation to catch copy-paste bugs where a read
+	 * ability's `readonly: true` leaks into this write ability.
+	 */
+	public function test_submit_dispute_evidence_ability_is_registered_with_expected_shape(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
+		}
+
+		$ability = wp_get_ability( 'woopayments/submit-dispute-evidence' );
+		$this->assertNotNull( $ability, 'submit-dispute-evidence should be registered.' );
+		$this->assertSame( Abilities_Registrar::CATEGORY_SLUG, $ability->get_category() );
+
+		$annotations = $ability->get_meta()['annotations'];
+		$this->assertFalse( $annotations['readonly'], 'submit-dispute-evidence must NOT be readonly.' );
+		$this->assertFalse( $annotations['destructive'], 'submit-dispute-evidence is additive (does not forfeit money).' );
+		$this->assertFalse( $annotations['idempotent'], 'submit-dispute-evidence is NOT idempotent — duplicate calls produce duplicate attempts.' );
+	}
+
+	/**
+	 * Executes the submit-dispute-evidence ability with no dispute_id and
+	 * asserts it returns a WP_Error with code woopayments_missing_dispute_id.
+	 * Consistent error code across read and write dispute abilities lets agent
+	 * retry logic handle "missing dispute_id" the same way for both.
+	 */
+	public function test_submit_dispute_evidence_returns_wp_error_when_dispute_id_missing(): void {
+		$result = Abilities_Registrar::execute_submit_dispute_evidence( [] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'woopayments_missing_dispute_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Executes the submit-dispute-evidence ability with a non-string
+	 * dispute_id (integer 123) and asserts it returns a WP_Error with code
+	 * woopayments_missing_dispute_id. Guards the explicit is_string() check —
+	 * a lax `empty()` or `isset()` guard would pass an integer through and
+	 * fail later at the backing controller's URL construction.
+	 */
+	public function test_submit_dispute_evidence_returns_wp_error_when_dispute_id_not_a_string(): void {
+		$result = Abilities_Registrar::execute_submit_dispute_evidence( [ 'dispute_id' => 123 ] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'woopayments_missing_dispute_id', $result->get_error_code() );
+	}
 }

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -88,32 +88,18 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Ensure the woopayments category and abilities are registered so the
-	 * assertions below can query them. The plugin bootstrap wires
-	 * Abilities_Registrar::init() at plugin load; when the Abilities API init
-	 * hooks have already fired by that point, init() registers inline, so in
-	 * nearly all test runs this is a no-op. If the hooks haven't fired yet
-	 * (e.g. early-boot test scenarios), we invoke the registrar's callbacks
-	 * directly instead of using do_action() — do_action() would re-run every
-	 * listener on the hook, including unrelated ones from other plugins
-	 * registered before us, and trip _doing_it_wrong() on already-registered
-	 * categories/abilities.
-	 */
-	private function fire_abilities_api_hooks(): void {
-		Abilities_Registrar::init();
-	}
-
-	/**
 	 * Ensures the woopayments/get-account-status ability is registered with
 	 * the shape the Abilities Everywhere initiative expects: correct category,
 	 * readonly annotation, and show_in_rest exposed.
+	 *
+	 * End-to-end check: relies on plugin bootstrap (WC_Payments::init() →
+	 * Abilities_Registrar::init()) having registered the ability by the time
+	 * tests run. Not an isolated unit test of register_abilities().
 	 */
 	public function test_get_account_status_ability_is_registered_with_expected_shape() {
 		if ( ! function_exists( 'wp_get_ability' ) ) {
 			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
 		}
-
-		$this->fire_abilities_api_hooks();
 
 		$ability = wp_get_ability( 'woopayments/get-account-status' );
 		$this->assertNotNull(
@@ -149,8 +135,6 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 		if ( ! function_exists( 'wp_get_ability' ) ) {
 			$this->markTestSkipped( 'Abilities API query functions not available in this WP version.' );
 		}
-
-		$this->fire_abilities_api_hooks();
 
 		$ability = wp_get_ability( 'woopayments/get-account-status' );
 		$this->assertNotNull( $ability, 'Ability must be registered before checking permissions.' );

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -311,4 +311,17 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'woopayments_missing_dispute_id', $result->get_error_code() );
 	}
+
+	/**
+	 * Regression test: executing any read ability must not fatal. If a required
+	 * controller constructor argument is missing, the Phase 6 harness catches it,
+	 * but this unit test shortens the feedback loop.
+	 */
+	public function test_execute_get_payout_overview_does_not_fatal(): void {
+		$result = Abilities_Registrar::execute_get_payout_overview( [] );
+		// On a bootstrapped test env the call either returns data (array) or a
+		// deliberate WP_Error. A PHP fatal would abort the test process, so the
+		// mere fact that we reach this assertion is the regression check.
+		$this->assertTrue( is_array( $result ) || $result instanceof \WP_Error );
+	}
 }

--- a/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
+++ b/tests/unit/src/Internal/Abilities/Abilities_Registrar_Test.php
@@ -116,10 +116,10 @@ class Abilities_Registrar_Test extends WCPAY_UnitTestCase {
 		$meta = $ability->get_meta();
 		$this->assertIsArray( $meta, 'Ability meta must be an array.' );
 		$this->assertArrayHasKey( 'annotations', $meta );
-		$this->assertTrue(
-			$meta['annotations']['readonly'] ?? false,
-			'get-account-status must advertise itself as readonly.'
-		);
+		$annotations = $meta['annotations'];
+		$this->assertTrue( $annotations['readonly'], 'get-account-status should be readonly.' );
+		$this->assertFalse( $annotations['destructive'], 'get-account-status should not be destructive.' );
+		$this->assertTrue( $annotations['idempotent'], 'get-account-status should be idempotent.' );
 		$this->assertTrue(
 			$meta['show_in_rest'] ?? false,
 			'get-account-status must be exposed via show_in_rest for the REST bridge.'


### PR DESCRIPTION
Registers WooPayments with the WordPress 6.9 Abilities API so AI agents can interact with the plugin through typed, gated capabilities instead of inferring REST endpoints. A merchant's agent can now answer "which disputes need a response?", "when is my next payout?", or "here's the evidence for dispute dp_…" with one call each, instead of constructing and chaining REST requests.

#### Changes proposed in this Pull Request

7 abilities ship in this PR.

**Read abilities (readonly, idempotent):**

- `woopayments/get-account-status` — merchant's KYC state, capabilities, payout schedule, required actions.
- `woopayments/get-transactions` — list transactions via the normalized reports controller; filter by `order_id`, `customer_email`, `payment_method_type`, `type`, date range.
- `woopayments/get-disputes` — list disputes; filter by status (`needs_response`, `warning_needs_response`, etc.), date, currency.
- `woopayments/get-dispute-detail` — full dispute by ID. Natural prerequisite for `submit-dispute-evidence`.
- `woopayments/get-payouts` — list payouts/deposits; filter by status, date, currency.
- `woopayments/get-payout-overview` — zero-arg; next scheduled payout across all currencies. Answers "when do I get paid?" in one call.

**Write ability:**

- `woopayments/submit-dispute-evidence` — attach or finalize evidence. `submit: false` by default (draft); `submit: true` finalizes to Stripe. Non-idempotent — duplicate calls with `submit: true` produce duplicate submission attempts.

**Architecture:**

- New code under `src/Internal/Abilities/` (PSR-4, follows the plugin's modern convention).
- Shared `Abilities_Registrar::delegate_to_rest_controller()` helper wraps the 4 list abilities; the two zero-arg abilities stay on a direct-call path.
- All abilities gate on `manage_woocommerce` via `can_manage_payments()` — matches `WC_Payments_REST_Controller::check_permission()`.
- No new REST endpoints. Abilities are a thin agent-facing reshape of the existing REST surface via `WP_REST_Request`.
- Follows the Jetpack Forms abilities pattern — semantic-intent grouping (one ability per merchant question) over the one-per-HTTP-method atomization.

**Deliberately deferred** (tracked for follow-up):

- `create-refund` — real-money write, needs idempotency-key design review.
- `accept-dispute` — forfeits money irreversibly, needs guardrail design.
- `update-account` — PII/tax concerns, needs compliance sign-off.
- `get-refunds` as a list — no `GET /refunds` route exists today; would need a new controller.

#### Testing instructions

**Unit tests:**

```
npm run test:php -- --filter Abilities_Registrar_Test
```

Expected: `OK (15 tests, 52 assertions)`.

**Integration harness (wp-env, requires a bootstrapped WooPayments account for rich output — otherwise most list abilities return `WP_Error(wcpay_bad_request)`, which is also fine):**

```bash
npm run wp-env start

# 1. Enumerate abilities
npx wp-env run cli wp --user=admin eval '
$names = array_filter( array_keys( (array) wp_get_abilities() ), fn( $n ) => str_starts_with( $n, "woopayments/" ) );
echo implode( PHP_EOL, $names );
'
# Expected: 7 abilities listed.

# 2. Verify annotations
npx wp-env run cli wp --user=admin eval '
foreach ( array(
  "woopayments/get-account-status",
  "woopayments/get-transactions",
  "woopayments/get-disputes",
  "woopayments/get-dispute-detail",
  "woopayments/get-payouts",
  "woopayments/get-payout-overview",
  "woopayments/submit-dispute-evidence",
) as $name ) {
  $m = wp_get_ability( $name )->get_meta();
  echo $name . " readonly=" . var_export( $m["annotations"]["readonly"], true ) . " destructive=" . var_export( $m["annotations"]["destructive"], true ) . " idempotent=" . var_export( $m["annotations"]["idempotent"], true ) . PHP_EOL;
}'
# Expected: all read abilities readonly=true destructive=false idempotent=true;
# submit-dispute-evidence: readonly=false destructive=false idempotent=false.

# 3. Execute read abilities
npx wp-env run cli wp --user=admin eval '
foreach ( array(
  "woopayments/get-account-status",
  "woopayments/get-payout-overview",
  "woopayments/get-transactions",
  "woopayments/get-disputes",
  "woopayments/get-payouts",
) as $name ) {
  $r = wp_get_ability( $name )->execute( array() );
  echo $name . ": " . ( is_wp_error( $r ) ? "WP_Error(" . $r->get_error_code() . ")" : "OK" ) . PHP_EOL;
}'

# 4. Exercise input validation on the write ability
npx wp-env run cli wp --user=admin eval '
$a = wp_get_ability( "woopayments/submit-dispute-evidence" );
$r1 = $a->execute( array() );
echo "missing: " . ( is_wp_error( $r1 ) ? "WP_Error(" . $r1->get_error_code() . ")" : "UNEXPECTED_OK" ) . PHP_EOL;
$r2 = $a->execute( array( "dispute_id" => 123 ) );
echo "non-string: " . ( is_wp_error( $r2 ) ? "WP_Error(" . $r2->get_error_code() . ")" : "UNEXPECTED_OK" ) . PHP_EOL;
'
# Expected: both return WP_Error(ability_invalid_input) — schema validation catches them before our callback runs.
```

Pass criteria: no PHP fatals, no unexpected OKs on the write-ability validation cases, all abilities enumerable.

#### Notes for reviewers

- **`submit-dispute-evidence` error code:** the Abilities API's schema validation catches missing/non-string `dispute_id` before our callback fires, so REST-path invocations get `WP_Error(ability_invalid_input)` rather than our custom `woopayments_missing_dispute_id`. Our code path still runs when the callback is invoked directly (covered by unit tests). Belt-and-suspenders — both paths reject bad input deterministically.
- **`get-dispute-detail`:** returns Stripe's raw `resource_missing` error code for bad IDs rather than re-wrapping. Left as-is for transparency; happy to re-wrap if that's preferred.
- **Benign pre-existing PHP warning** in `WC_REST_Payments_Reports_Transactions_Controller::get_transactions` (`Undefined array key "payment_intent_id"`) — not introduced by this PR.
- **Capability gate is uniform:** every ability uses `manage_woocommerce`, matching the existing `WC_Payments_REST_Controller::check_permission()`. No new permission surface.

-------------------

- [x] Run `npm run changelog` to add a changelog file.
- [x] Covered with tests (15 unit tests / 52 assertions + integration harness).
- [x] Tested on mobile (N/A — backend-only change, no UI).

**Post merge**

- [ ] Link to testing instructions from release testing doc: _QA Testing Not Applicable — backend ability surface, not user-facing UI._
- [ ] Add or update critical flows, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
