### PR TITLE
chore(deps): bump lodash from 4.17.21 to 4.18.1

### DIFF
--- a/changelog/fix-bump-lodash-4.18.1
+++ b/changelog/fix-bump-lodash-4.18.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Bump lodash from 4.17.21 to 4.18.1 (security: prototype pollution in _.unset/_.omit, code injection in _.template) and @types/lodash to 4.17.24

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"canvas-confetti": "1.9.2",
 				"decimal.js-light": "2.5.1",
 				"intl-tel-input": "17.0.15",
-				"lodash": "4.17.21"
+				"lodash": "4.18.1"
 			},
 			"devDependencies": {
 				"@automattic/color-studio": "4.0.0",
@@ -40,7 +40,7 @@
 				"@types/canvas-confetti": "1.6.4",
 				"@types/intl-tel-input": "17.0.4",
 				"@types/jest": "29.5.12",
-				"@types/lodash": "4.14.170",
+				"@types/lodash": "4.17.24",
 				"@types/node": "20.9.0",
 				"@types/react": "18.3.17",
 				"@types/react-dom": "19.1.7",
@@ -7861,9 +7861,9 @@
 			"dev": true
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.14.170",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
-			"integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==",
+			"version": "4.17.24",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+			"integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
 			"dev": true
 		},
 		"node_modules/@types/mdast": {
@@ -30489,9 +30489,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
 		},
 		"node_modules/lodash-es": {
 			"version": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"canvas-confetti": "1.9.2",
 		"decimal.js-light": "2.5.1",
 		"intl-tel-input": "17.0.15",
-		"lodash": "4.17.21"
+		"lodash": "4.18.1"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "4.0.0",
@@ -125,7 +125,7 @@
 		"@types/canvas-confetti": "1.6.4",
 		"@types/intl-tel-input": "17.0.4",
 		"@types/jest": "29.5.12",
-		"@types/lodash": "4.14.170",
+		"@types/lodash": "4.17.24",
 		"@types/node": "20.9.0",
 		"@types/react": "18.3.17",
 		"@types/react-dom": "19.1.7",


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Bumps `lodash` from `4.17.21` to `4.18.1` and `@types/lodash` from `4.14.170` to `4.17.24`.

`4.18.0` contains two security fixes:

- **[GHSA-f23m-r3pf-42rh](https://github.com/lodash/lodash/security/advisories/GHSA-f23m-r3pf-42rh)** — prototype pollution in `_.unset` / `_.omit`. Array-wrapped path segments and primitive roots could bypass the existing `constructor` / `prototype` guards, allowing deletion of properties from built-in prototypes. Now blocked unconditionally.
- **[GHSA-r5fr-rjxr-66jc](https://github.com/lodash/lodash/security/advisories/GHSA-r5fr-rjxr-66jc) / CVE-2026-4800** — code injection in `_.template` via `imports` keys. This is an incomplete-patch follow-up for CVE-2021-23337: the `variable` option was already guarded, but `importsKeys` was not, allowing the same `Function()` sink to be reached.

`4.18.1` is a build-artifact-only fix for a `ReferenceError` regression in `4.18.0`'s modular distributions; no behavior changes.

`@types/lodash` is bumped in the same PR to keep it in rough lockstep with the runtime package.

##### How can this code break?

The behavior changes in `4.18.0` affect three APIs: `_.unset`, `_.omit`, and `_.template`. A repo-wide scan of `client/` confirms none of them are imported from `lodash` in this codebase — the only functions we use are `capitalize`, `debounce`, `find`, `flatMap`, `get`, `isEmpty`, `isMatchWith`, `isNil`, `keyBy`, `map`, `mapValues`, `memoize`, `noop`, `omitBy`, `parseInt`, `partial`, `set`, `snakeCase`, `sumBy`, `throttle`, `toPairs`, `uniq`, `uniqueId`. `omitBy` is a separate function and is unaffected.

##### What are we doing to make sure this code doesn't break?

- `tsc --noEmit` passes cleanly with the new `@types/lodash` (a four-year jump in type definitions).
- Verified lockfile diff touches only `lodash` and `@types/lodash`; integrity hash matches npm dist metadata (`sha512-dMInicTPVE8d1e5ot…`).
- Verified release provenance: GitHub tags exist on `lodash/lodash`, releases authored by current maintainer, npm signatures present.
- CI (Jest / Playwright) will cover runtime usage of the other lodash helpers.

#### Testing instructions

* Pull the branch and run `npm install` — confirm `node_modules/lodash/package.json` reports `4.18.1`.
* Run `npm run lint:js` — should pass.
* Run `npm run test:js` — should pass.
* Smoke-test any flow that exercises lodash-heavy components (transactions list, disputes, deposits list, onboarding form). No visible behavior change expected.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (existing Jest suite exercises affected code paths; no new lodash behavior introduced by this PR)
- [x] Tested on mobile (does not apply — dependency-only change)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)