### PR TITLE
PoC: opt WooPayments gateway settings into the modernised settings SDK

### DIFF
--- a/assets/css/admin/modern-settings-field-transformers.css
+++ b/assets/css/admin/modern-settings-field-transformers.css
@@ -1,0 +1,47 @@
+/**
+ * Row-per-option styles for the custom `multiselect` Edit registered in
+ * assets/js/admin/modern-settings-field-transformers.js.
+ *
+ * Mirrors the per-method row layout the existing WooPayments React admin
+ * uses in its "Payment methods" and "Express checkouts" sections:
+ * label on the left, ToggleControl right-aligned, 1px divider between rows.
+ */
+
+.wcpay-modern-settings-multiselect__rows {
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	overflow: hidden;
+	background: #fff;
+}
+
+.wcpay-modern-settings-multiselect__row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 16px;
+	gap: 16px;
+	border-bottom: 1px solid #f0f0f1;
+}
+
+.wcpay-modern-settings-multiselect__row:last-child {
+	border-bottom: none;
+}
+
+.wcpay-modern-settings-multiselect__row-label {
+	font-weight: 500;
+	color: #1e1e1e;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+/* The ToggleControl inside a row ships with its own bottom margin; zero it
+ * to keep row padding consistent. */
+.wcpay-modern-settings-multiselect__row .components-toggle-control {
+	margin-bottom: 0;
+}
+
+.wcpay-modern-settings-multiselect__row
+	.components-toggle-control
+	.components-base-control__field {
+	margin-bottom: 0;
+}

--- a/assets/js/admin/modern-settings-field-transformers.js
+++ b/assets/js/admin/modern-settings-field-transformers.js
@@ -8,10 +8,12 @@
  * Currently handled: `multiselect`. The SDK's native baseFieldTransformer
  * maps multiselect onto `DataForm` `type: 'array'`, which has no built-in
  * Edit component in the WC 10.8-dev DataViews bundle, causing the whole
- * section to throw on render. This file provides a `FormTokenField`-based
- * Edit using `@wordpress/components` — a token/pill control that mirrors
- * the legacy `wc-enhanced-select` (Select2) experience the WooPayments
- * gateway used in its form_fields entries before the modern SDK existed.
+ * section to throw on render. This file provides a row-per-option Edit
+ * using `@wordpress/components` — a ToggleControl per option stacked in a
+ * labelled list, matching the per-method row style the existing
+ * WooPayments React admin uses in its "Express checkouts" and "Payment
+ * methods" sections. Accompanying styles live in
+ * `assets/css/admin/modern-settings-field-transformers.css`.
  *
  * Drops out cleanly if/when `DataForm.Fields.extend()` ships upstream.
  *
@@ -31,8 +33,8 @@
 		return;
 	}
 
-	const { createElement, useMemo } = wp.element;
-	const { BaseControl, FormTokenField } = wp.components;
+	const { createElement } = wp.element;
+	const { BaseControl, ToggleControl } = wp.components;
 
 	/**
 	 * Normalize options into `[ { label, value }, ... ]` shape.
@@ -94,33 +96,10 @@
 	}
 
 	/**
-	 * Build a value↔label index for an options list.
-	 *
-	 * Labels can collide across different values in theory, but none of the
-	 * multiselect fields on the WooPayments gateway settings do — for label
-	 * collisions we'd need a disambiguator, which is out of PoC scope.
-	 *
-	 * @param {Array<{label: string, value: string}>} options Parsed options.
-	 * @return {{ valueToLabel: Object<string, string>, labelToValue: Object<string, string>, labels: string[] }}
-	 *   Bidirectional maps plus the ordered label list for FormTokenField suggestions.
-	 */
-	function buildIndex( options ) {
-		const valueToLabel = {};
-		const labelToValue = {};
-		const labels = [];
-		options.forEach( function ( option ) {
-			valueToLabel[ option.value ] = option.label;
-			labelToValue[ option.label ] = option.value;
-			labels.push( option.label );
-		} );
-		return { valueToLabel, labelToValue, labels };
-	}
-
-	/**
 	 * Factory that returns an Edit component bound to a specific field's options.
 	 *
-	 * DataForm re-uses the same Edit across renders for a given field, so binding
-	 * the options list and index at transform time avoids re-indexing on every
+	 * DataForm re-uses the same Edit across renders for a given field, so the
+	 * options list is captured in the closure rather than re-parsed on every
 	 * keystroke.
 	 *
 	 * @param {Array<{label: string, value: string}>}             options   Parsed options.
@@ -130,42 +109,53 @@
 	 * @return {Function} React component for the field's Edit.
 	 */
 	function makeMultiselectEdit( options, baseField ) {
-		const index = buildIndex( options );
-
 		return function MultiselectEdit( props ) {
-			const currentValues = readArrayValue( props.data, props.field );
+			const current = readArrayValue( props.data, props.field );
 
-			// FormTokenField works with labels as its tokens. Map stored values
-			// to their labels for display; filter out any stale values whose
-			// options have been removed since the value was last persisted.
-			const selectedLabels = useMemo(
-				function () {
-					return currentValues
-						.map( function ( value ) {
-							return index.valueToLabel[ value ];
-						} )
-						.filter( Boolean );
-				},
-				// eslint-disable-next-line react-hooks/exhaustive-deps
-				[ currentValues.join( '|' ) ]
-			);
-
-			function handleChange( nextLabels ) {
-				// FormTokenField may return strings that are NOT in the
-				// suggestion list when a user types a free-form value. We
-				// only persist known values — unknown tokens are dropped.
-				const nextValues = nextLabels
-					.map( function ( label ) {
-						return index.labelToValue[ String( label ) ];
-					} )
-					.filter( function ( value ) {
-						return typeof value === 'string';
+			function toggle( optionValue, checked ) {
+				let next;
+				if ( checked ) {
+					next =
+						current.indexOf( optionValue ) === -1
+							? current.concat( [ optionValue ] )
+							: current;
+				} else {
+					next = current.filter( function ( v ) {
+						return v !== optionValue;
 					} );
+				}
 
 				const update = {};
-				update[ props.field.id ] = nextValues;
+				update[ props.field.id ] = next;
 				props.onChange( update );
 			}
+
+			const rows = options.map( function ( option ) {
+				const checked = current.indexOf( option.value ) !== -1;
+				return createElement(
+					'div',
+					{
+						key: option.value,
+						className: 'wcpay-modern-settings-multiselect__row',
+					},
+					createElement(
+						'div',
+						{
+							className:
+								'wcpay-modern-settings-multiselect__row-label',
+						},
+						option.label
+					),
+					createElement( ToggleControl, {
+						checked,
+						onChange: function ( nextChecked ) {
+							toggle( option.value, nextChecked );
+						},
+						'aria-label': option.label,
+						__nextHasNoMarginBottom: true,
+					} )
+				);
+			} );
 
 			return createElement(
 				BaseControl,
@@ -175,21 +165,13 @@
 						: baseField.label,
 					help: baseField.description,
 					__nextHasNoMarginBottom: true,
+					className: 'wcpay-modern-settings-multiselect',
 				},
-				createElement( FormTokenField, {
-					value: selectedLabels,
-					suggestions: index.labels,
-					onChange: handleChange,
-					// Keep the control focused on the known option set — no
-					// free-form values sneak in.
-					__experimentalExpandOnFocus: true,
-					__experimentalAutoSelectFirstMatch: true,
-					__nextHasNoMarginBottom: true,
-					// Visually hide FormTokenField's own label; BaseControl
-					// already renders the outer one so the DataForm layout
-					// stays consistent with native fields.
-					label: '',
-				} )
+				createElement(
+					'div',
+					{ className: 'wcpay-modern-settings-multiselect__rows' },
+					rows
+				)
 			);
 		};
 	}

--- a/assets/js/admin/modern-settings-field-transformers.js
+++ b/assets/js/admin/modern-settings-field-transformers.js
@@ -1,0 +1,170 @@
+/**
+ * Custom field-type transformers for the modernised settings SDK.
+ *
+ * Registered via `window.wcReactSettings.registerFieldTypeTransformer` — the
+ * runtime JS extension point documented in
+ * docs/extensions/settings-and-config/registering-custom-field-types.md.
+ *
+ * Currently handled: `multiselect`. The SDK's native baseFieldTransformer
+ * maps multiselect onto `DataForm` `type: 'array'`, which has no built-in
+ * Edit component in the WC 10.8-dev DataViews bundle, causing the whole
+ * section to throw on render. This file provides a `CheckboxControl`-based
+ * Edit using `@wordpress/components`, which keeps multiselect fields
+ * renderable today and drops out cleanly if/when `DataForm.Fields.extend()`
+ * ships upstream.
+ *
+ * @package
+ */
+( function ( wp ) {
+	'use strict';
+
+	if (
+		! window.wcReactSettings ||
+		typeof window.wcReactSettings.registerFieldTypeTransformer !==
+			'function' ||
+		! wp ||
+		! wp.element ||
+		! wp.components
+	) {
+		return;
+	}
+
+	const createElement = wp.element.createElement;
+	const Fragment = wp.element.Fragment;
+	const BaseControl = wp.components.BaseControl;
+	const CheckboxControl = wp.components.CheckboxControl;
+
+	/**
+	 * Normalize options into `[ { label, value }, ... ]` shape.
+	 *
+	 * Handles the three shapes `ReactSettingsSchema::normalize_options()` can emit:
+	 *   - `{ value: label }` (preserved-key object form from the default normalizer)
+	 *   - `[ { label, value } ]` (list-of-objects form from interface contributors)
+	 *   - `[ label, label ]` (legacy indexed array)
+	 *
+	 * @param {*} options Raw options from the payload.
+	 * @return {Array<{label: string, value: string}>} Normalized options.
+	 */
+	function parseOptions( options ) {
+		if ( ! options ) {
+			return [];
+		}
+		if ( Array.isArray( options ) ) {
+			return options
+				.map( function ( option ) {
+					if ( option && typeof option === 'object' ) {
+						return {
+							label: String(
+								option.label != null
+									? option.label
+									: option.value
+							),
+							value: String(
+								option.value != null ? option.value : ''
+							),
+						};
+					}
+					return { label: String( option ), value: String( option ) };
+				} )
+				.filter( function ( option ) {
+					return option.value !== '';
+				} );
+		}
+		return Object.keys( options ).map( function ( key ) {
+			return { label: String( options[ key ] ), value: String( key ) };
+		} );
+	}
+
+	/**
+	 * Read the field's current value from the form-wide data bag as a string array.
+	 *
+	 * @param {Object} data  Form-wide values object from DataForm.
+	 * @param {Object} field DataForm field shape.
+	 * @return {string[]} Current selection as string values.
+	 */
+	function readArrayValue( data, field ) {
+		const raw = data && field ? data[ field.id ] : undefined;
+		if ( Array.isArray( raw ) ) {
+			return raw.map( String );
+		}
+		if ( raw == null || raw === '' ) {
+			return [];
+		}
+		return [ String( raw ) ];
+	}
+
+	/**
+	 * Factory that returns an Edit component bound to a specific field's options.
+	 *
+	 * DataForm re-uses the same Edit across renders for a given field, so binding
+	 * the options list at transform time avoids parsing on every keystroke.
+	 *
+	 * @param {Array<{label: string, value: string}>}             options
+	 * @param {{id: string, label: string, description?: string}} baseField
+	 */
+	function makeMultiselectEdit( options, baseField ) {
+		return function MultiselectEdit( props ) {
+			const current = readArrayValue( props.data, props.field );
+
+			function toggle( optionValue, checked ) {
+				let next;
+				if ( checked ) {
+					next =
+						current.indexOf( optionValue ) === -1
+							? current.concat( [ optionValue ] )
+							: current;
+				} else {
+					next = current.filter( function ( v ) {
+						return v !== optionValue;
+					} );
+				}
+				const update = {};
+				update[ props.field.id ] = next;
+				props.onChange( update );
+			}
+
+			const checkboxes = options.map( function ( option ) {
+				return createElement( CheckboxControl, {
+					key: option.value,
+					label: option.label,
+					checked: current.indexOf( option.value ) !== -1,
+					onChange: function ( checked ) {
+						toggle( option.value, checked );
+					},
+					__nextHasNoMarginBottom: true,
+				} );
+			} );
+
+			return createElement(
+				BaseControl,
+				{
+					label: props.hideLabelFromVision
+						? undefined
+						: baseField.label,
+					help: baseField.description,
+					__nextHasNoMarginBottom: true,
+				},
+				createElement( Fragment, null, checkboxes )
+			);
+		};
+	}
+
+	window.wcReactSettings.registerFieldTypeTransformer(
+		'multiselect',
+		function ( setting, baseField ) {
+			const options = parseOptions( setting.options );
+			if ( options.length === 0 ) {
+				// Fall through to the SDK's default handling — nothing useful we can render.
+				return baseField;
+			}
+
+			return Object.assign( {}, baseField, {
+				// `text` keeps DataForm from looking up its broken `array` built-in;
+				// the Edit below takes over rendering entirely.
+				type: 'text',
+				elements: options,
+				Edit: makeMultiselectEdit( options, baseField ),
+			} );
+		}
+	);
+} )( window.wp );

--- a/assets/js/admin/modern-settings-field-transformers.js
+++ b/assets/js/admin/modern-settings-field-transformers.js
@@ -8,10 +8,12 @@
  * Currently handled: `multiselect`. The SDK's native baseFieldTransformer
  * maps multiselect onto `DataForm` `type: 'array'`, which has no built-in
  * Edit component in the WC 10.8-dev DataViews bundle, causing the whole
- * section to throw on render. This file provides a `CheckboxControl`-based
- * Edit using `@wordpress/components`, which keeps multiselect fields
- * renderable today and drops out cleanly if/when `DataForm.Fields.extend()`
- * ships upstream.
+ * section to throw on render. This file provides a `FormTokenField`-based
+ * Edit using `@wordpress/components` — a token/pill control that mirrors
+ * the legacy `wc-enhanced-select` (Select2) experience the WooPayments
+ * gateway used in its form_fields entries before the modern SDK existed.
+ *
+ * Drops out cleanly if/when `DataForm.Fields.extend()` ships upstream.
  *
  * @package
  */
@@ -29,10 +31,8 @@
 		return;
 	}
 
-	const createElement = wp.element.createElement;
-	const Fragment = wp.element.Fragment;
-	const BaseControl = wp.components.BaseControl;
-	const CheckboxControl = wp.components.CheckboxControl;
+	const { createElement, useMemo } = wp.element;
+	const { BaseControl, FormTokenField } = wp.components;
 
 	/**
 	 * Normalize options into `[ { label, value }, ... ]` shape.
@@ -94,46 +94,78 @@
 	}
 
 	/**
+	 * Build a value↔label index for an options list.
+	 *
+	 * Labels can collide across different values in theory, but none of the
+	 * multiselect fields on the WooPayments gateway settings do — for label
+	 * collisions we'd need a disambiguator, which is out of PoC scope.
+	 *
+	 * @param {Array<{label: string, value: string}>} options Parsed options.
+	 * @return {{ valueToLabel: Object<string, string>, labelToValue: Object<string, string>, labels: string[] }}
+	 *   Bidirectional maps plus the ordered label list for FormTokenField suggestions.
+	 */
+	function buildIndex( options ) {
+		const valueToLabel = {};
+		const labelToValue = {};
+		const labels = [];
+		options.forEach( function ( option ) {
+			valueToLabel[ option.value ] = option.label;
+			labelToValue[ option.label ] = option.value;
+			labels.push( option.label );
+		} );
+		return { valueToLabel, labelToValue, labels };
+	}
+
+	/**
 	 * Factory that returns an Edit component bound to a specific field's options.
 	 *
 	 * DataForm re-uses the same Edit across renders for a given field, so binding
-	 * the options list at transform time avoids parsing on every keystroke.
+	 * the options list and index at transform time avoids re-indexing on every
+	 * keystroke.
 	 *
-	 * @param {Array<{label: string, value: string}>}             options
-	 * @param {{id: string, label: string, description?: string}} baseField
+	 * @param {Array<{label: string, value: string}>}             options   Parsed options.
+	 * @param {{id: string, label: string, description?: string}} baseField Partially-normalized
+	 *                                                                      DataForm field
+	 *                                                                      shape.
+	 * @return {Function} React component for the field's Edit.
 	 */
 	function makeMultiselectEdit( options, baseField ) {
-		return function MultiselectEdit( props ) {
-			const current = readArrayValue( props.data, props.field );
+		const index = buildIndex( options );
 
-			function toggle( optionValue, checked ) {
-				let next;
-				if ( checked ) {
-					next =
-						current.indexOf( optionValue ) === -1
-							? current.concat( [ optionValue ] )
-							: current;
-				} else {
-					next = current.filter( function ( v ) {
-						return v !== optionValue;
+		return function MultiselectEdit( props ) {
+			const currentValues = readArrayValue( props.data, props.field );
+
+			// FormTokenField works with labels as its tokens. Map stored values
+			// to their labels for display; filter out any stale values whose
+			// options have been removed since the value was last persisted.
+			const selectedLabels = useMemo(
+				function () {
+					return currentValues
+						.map( function ( value ) {
+							return index.valueToLabel[ value ];
+						} )
+						.filter( Boolean );
+				},
+				// eslint-disable-next-line react-hooks/exhaustive-deps
+				[ currentValues.join( '|' ) ]
+			);
+
+			function handleChange( nextLabels ) {
+				// FormTokenField may return strings that are NOT in the
+				// suggestion list when a user types a free-form value. We
+				// only persist known values — unknown tokens are dropped.
+				const nextValues = nextLabels
+					.map( function ( label ) {
+						return index.labelToValue[ String( label ) ];
+					} )
+					.filter( function ( value ) {
+						return typeof value === 'string';
 					} );
-				}
+
 				const update = {};
-				update[ props.field.id ] = next;
+				update[ props.field.id ] = nextValues;
 				props.onChange( update );
 			}
-
-			const checkboxes = options.map( function ( option ) {
-				return createElement( CheckboxControl, {
-					key: option.value,
-					label: option.label,
-					checked: current.indexOf( option.value ) !== -1,
-					onChange: function ( checked ) {
-						toggle( option.value, checked );
-					},
-					__nextHasNoMarginBottom: true,
-				} );
-			} );
 
 			return createElement(
 				BaseControl,
@@ -144,7 +176,20 @@
 					help: baseField.description,
 					__nextHasNoMarginBottom: true,
 				},
-				createElement( Fragment, null, checkboxes )
+				createElement( FormTokenField, {
+					value: selectedLabels,
+					suggestions: index.labels,
+					onChange: handleChange,
+					// Keep the control focused on the known option set — no
+					// free-form values sneak in.
+					__experimentalExpandOnFocus: true,
+					__experimentalAutoSelectFirstMatch: true,
+					__nextHasNoMarginBottom: true,
+					// Visually hide FormTokenField's own label; BaseControl
+					// already renders the outer one so the DataForm layout
+					// stays consistent with native fields.
+					label: '',
+				} )
 			);
 		};
 	}

--- a/changelog/feat-modern-settings-sdk-poc
+++ b/changelog/feat-modern-settings-sdk-poc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+PoC: opt the WooPayments gateway settings into WooCommerce's modernised settings SDK behind the modern-settings flag.

--- a/dev/phpstan-modern-settings-stubs.php
+++ b/dev/phpstan-modern-settings-stubs.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PHPStan stubs for the WooCommerce 10.8 modernised settings SDK.
+ *
+ * The SDK ships in WC 10.8+ but WCPay's PHPStan stub set tracks an earlier
+ * version, so the real classes are not visible to static analysis. These
+ * stubs let us reference the SDK from forward-compat code in WCPay without
+ * tripping `class.notFound` / `interface.notFound` errors.
+ *
+ * Update or remove when WCPay's WC stubs are bumped to 10.8.
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace Automattic\WooCommerce\Internal\Admin\Settings;
+
+interface ReactSettingsPageInterface {
+	public function get_extra_type_map( string $section ): array;
+
+	public function get_extra_supported_types( string $section ): array;
+
+	public function get_field_options( string $field_id, array $field, string $section ): ?array;
+}
+
+class ReactSettingsSchema {
+	public static function is_feature_enabled(): bool {
+		return false;
+	}
+
+	public static function get_screen_render_context( string $tab, string $section, array $settings_definitions, $settings_page ): array {
+		return [];
+	}
+}

--- a/includes/admin/class-wc-payments-modern-settings-bridge.php
+++ b/includes/admin/class-wc-payments-modern-settings-bridge.php
@@ -190,20 +190,31 @@ class WC_Payments_Modern_Settings_Bridge {
 			return;
 		}
 
-		$handle    = 'wcpay-modern-settings-field-transformers';
-		$asset_rel = 'assets/js/admin/modern-settings-field-transformers.js';
-		$asset_abs = WCPAY_ABSPATH . $asset_rel;
-		if ( ! file_exists( $asset_abs ) ) {
-			return;
+		$handle       = 'wcpay-modern-settings-field-transformers';
+		$script_rel   = 'assets/js/admin/modern-settings-field-transformers.js';
+		$script_abs   = WCPAY_ABSPATH . $script_rel;
+		$style_handle = 'wcpay-modern-settings-field-transformers-style';
+		$style_rel    = 'assets/css/admin/modern-settings-field-transformers.css';
+		$style_abs    = WCPAY_ABSPATH . $style_rel;
+
+		if ( file_exists( $script_abs ) ) {
+			wp_enqueue_script(
+				$handle,
+				plugins_url( $script_rel, WCPAY_PLUGIN_FILE ),
+				[ 'wc-admin-settings-embed', 'wp-element', 'wp-components' ],
+				(string) filemtime( $script_abs ),
+				true
+			);
 		}
 
-		wp_enqueue_script(
-			$handle,
-			plugins_url( $asset_rel, WCPAY_PLUGIN_FILE ),
-			[ 'wc-admin-settings-embed', 'wp-element', 'wp-components' ],
-			(string) filemtime( $asset_abs ),
-			true
-		);
+		if ( file_exists( $style_abs ) ) {
+			wp_enqueue_style(
+				$style_handle,
+				plugins_url( $style_rel, WCPAY_PLUGIN_FILE ),
+				[ 'wp-components' ],
+				(string) filemtime( $style_abs )
+			);
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-payments-modern-settings-bridge.php
+++ b/includes/admin/class-wc-payments-modern-settings-bridge.php
@@ -70,13 +70,15 @@ class WC_Payments_Modern_Settings_Bridge {
 	}
 
 	/**
-	 * Wire the WordPress hooks needed to publish the SDK payload.
+	 * Wire the WordPress hooks needed to publish the SDK payload and register
+	 * custom field-type transformers on the JS side.
 	 *
 	 * The mount-markup emit is driven from the gateway's admin_options() and
 	 * does not need a hook.
 	 */
 	public function init_hooks(): void {
 		add_filter( 'woocommerce_admin_shared_settings', [ $this, 'maybe_publish_payload' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'maybe_enqueue_field_transformers' ] );
 	}
 
 	/**
@@ -168,6 +170,40 @@ class WC_Payments_Modern_Settings_Bridge {
 		$current = $render_plan['response'];
 
 		return $settings;
+	}
+
+	/**
+	 * Enqueue the custom multiselect field-type transformer on the gateway
+	 * settings screen.
+	 *
+	 * The script attaches to `wc-admin-settings-embed` — the WC-side bundle
+	 * that boots the modern settings registry and calls
+	 * `registerReactSettingsScreens()`. Because that bundle exposes
+	 * `window.wcReactSettings.registerFieldTypeTransformer` at module load
+	 * time and `createRoot().render()` is deferred, a script enqueued with
+	 * `$in_footer=true` after the bundle registers in time to override the
+	 * broken built-in `multiselect` → `array` handling before React's first
+	 * commit.
+	 */
+	public function maybe_enqueue_field_transformers(): void {
+		if ( ! ReactSettingsSchema::is_feature_enabled() || ! $this->is_on_gateway_settings_screen() ) {
+			return;
+		}
+
+		$handle    = 'wcpay-modern-settings-field-transformers';
+		$asset_rel = 'assets/js/admin/modern-settings-field-transformers.js';
+		$asset_abs = WCPAY_ABSPATH . $asset_rel;
+		if ( ! file_exists( $asset_abs ) ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			$handle,
+			plugins_url( $asset_rel, WCPAY_PLUGIN_FILE ),
+			[ 'wc-admin-settings-embed', 'wp-element', 'wp-components' ],
+			(string) filemtime( $asset_abs ),
+			true
+		);
 	}
 
 	/**
@@ -294,20 +330,18 @@ class WC_Payments_Modern_Settings_Bridge {
 	/**
 	 * Build a single SDK field definition from a gateway form_fields entry.
 	 *
-	 * Replaces unrenderable raw fields with read-only `info` rows so the page
-	 * surfaces what's missing instead of silently dropping it. Two cases get
-	 * substituted today:
-	 *   - select / multiselect / radio with an empty `options` array. WCPay
-	 *     populates these dynamically from the payment-methods registry
-	 *     (e.g. `upe_enabled_payment_method_ids`); DataForm has no fallback
-	 *     Edit for an option-less multi-value field. Wiring the runtime
-	 *     options into `ReactSettingsPageInterface::get_field_options()` is
-	 *     a follow-up beyond this PoC.
-	 *   - any `multiselect`. The SDK's baseFieldTransformer produces a
-	 *     `type: 'array'` DataForm field with no built-in Edit in the 10.8-dev
-	 *     DataViews bundle currently shipping. The official sample plugin
-	 *     sidesteps it for the same reason — a custom JS transformer (out of
-	 *     PoC scope; needs a build pipeline) is the long-term fix.
+	 * Returns null for select / multiselect / radio fields with an empty
+	 * `options` array — WCPay populates those dynamically from the
+	 * payment-methods registry (e.g. `upe_enabled_payment_method_ids`), and
+	 * the modern renderer has no way to render an option-less multi-value
+	 * field. Wiring the runtime options via `ReactSettingsPageInterface::get_field_options()`
+	 * is a follow-up beyond this PoC.
+	 *
+	 * `multiselect` fields with real options ARE emitted here — DataForm's
+	 * default `type: 'array'` rendering is broken in the 10.8-dev build, but
+	 * the gateway settings ship a custom JS transformer via
+	 * `WC_Payments_Modern_Settings_Scripts` that overrides it using
+	 * `window.wcReactSettings.registerFieldTypeTransformer()`.
 	 *
 	 * @param string $key   Field id.
 	 * @param array  $field Raw form_fields entry.
@@ -321,11 +355,8 @@ class WC_Payments_Modern_Settings_Bridge {
 		$desc    = $this->normalize_description( $field['description'] ?? '' );
 
 		$has_options = isset( $field['options'] ) && is_array( $field['options'] ) && ! empty( $field['options'] );
-		$is_skipped  = 'multiselect' === $type
-			|| ( in_array( $type, [ 'select', 'radio' ], true ) && ! $has_options );
-
-		if ( $is_skipped ) {
-			return $this->build_unsupported_info_row( $key, $title, $type, $value );
+		if ( in_array( $type, [ 'select', 'multiselect', 'radio' ], true ) && ! $has_options ) {
+			return null;
 		}
 
 		$definition = [
@@ -388,42 +419,5 @@ class WC_Payments_Modern_Settings_Bridge {
 		}
 
 		return trim( wp_strip_all_tags( $description ) );
-	}
-
-	/**
-	 * Build an `info` row substitute for a field the PoC can't render.
-	 *
-	 * Renders as a read-only description in the DataForm with the original
-	 * field title and current value, plus a one-line note explaining why the
-	 * input is missing. This keeps the form complete and audit-able rather
-	 * than silently dropping fields.
-	 *
-	 * @param string $key   Field id.
-	 * @param string $title Resolved field title.
-	 * @param string $type  Original raw type.
-	 * @param mixed  $value Current value from the gateway option store.
-	 * @return array
-	 */
-	private function build_unsupported_info_row( string $key, string $title, string $type, $value ): array {
-		$display_value = is_array( $value ) ? implode( ', ', array_map( 'strval', $value ) ) : (string) $value;
-		if ( '' === $display_value ) {
-			$display_value = '—';
-		}
-
-		$text = sprintf(
-			/* translators: 1: field title, 2: raw field type, 3: current option value */
-			__( '%1$s — current value: %3$s. Rendering this %2$s field through the modernised SDK is pending.', 'woocommerce-payments' ),
-			$title,
-			$type,
-			$display_value
-		);
-
-		return [
-			'id'    => $key . '__info',
-			'type'  => 'info',
-			'title' => $title,
-			'desc'  => '',
-			'text'  => $text,
-		];
 	}
 }

--- a/includes/admin/class-wc-payments-modern-settings-bridge.php
+++ b/includes/admin/class-wc-payments-modern-settings-bridge.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Class WC_Payments_Modern_Settings_Bridge
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsPageInterface;
+use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema;
+
+/**
+ * Bridges the WooPayments gateway into WooCommerce's modernised settings SDK.
+ *
+ * Why this exists:
+ *   The SDK auto-renders settings pages from `WC_Settings_Page::output()` and
+ *   auto-publishes the JSON payload from `Settings::add_react_settings_data()`,
+ *   both of which look up the page by `tab` via `WC_Admin_Settings::get_settings_pages()`.
+ *   For `tab=checkout` that returns `WC_Settings_Payment_Gateways` — not the
+ *   gateway. The gateway settings render via
+ *   `WC_Settings_Payment_Gateways::output() → render_classic_gateway_settings_page() → $gateway->admin_options()`,
+ *   which never reaches the SDK.
+ *
+ *   This class fills the gap by acting as a "page-shaped" wrapper around the
+ *   gateway: it satisfies the loose-typed `$settings_page` argument
+ *   `ReactSettingsSchema` expects (`get_react_settings_page()` + `get_label()`)
+ *   and drives both the mount-markup emit (from the gateway's `admin_options()`)
+ *   and the payload publish (via `woocommerce_admin_shared_settings`).
+ *
+ * Scope: a proof-of-concept render path for tab=checkout, section=woocommerce_payments,
+ * gated by the `modern-settings` feature flag. The legacy save POST handler is
+ * still authoritative — the modern path replaces only the render in WC 10.8.
+ */
+class WC_Payments_Modern_Settings_Bridge {
+
+	const SETTINGS_TAB     = 'checkout';
+	const SETTINGS_SECTION = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+
+	/**
+	 * The gateway being bridged.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $gateway;
+
+	/**
+	 * Memoized ReactSettingsPageInterface implementation.
+	 *
+	 * @var ReactSettingsPageInterface|null
+	 */
+	private $react_page;
+
+	/**
+	 * Memoized settings definitions translated from the gateway's form_fields.
+	 *
+	 * @var array|null
+	 */
+	private $settings_definitions;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway The gateway to bridge.
+	 */
+	public function __construct( WC_Payment_Gateway_WCPay $gateway ) {
+		$this->gateway = $gateway;
+	}
+
+	/**
+	 * Wire the WordPress hooks needed to publish the SDK payload.
+	 *
+	 * The mount-markup emit is driven from the gateway's admin_options() and
+	 * does not need a hook.
+	 */
+	public function init_hooks(): void {
+		add_filter( 'woocommerce_admin_shared_settings', [ $this, 'maybe_publish_payload' ] );
+	}
+
+	/**
+	 * The label rendered as the form's title in the React DataForm.
+	 *
+	 * Mirrors `WC_Settings_Page::get_label()` so `ReactSettingsSchema::build_response()`
+	 * can pick it up via duck typing.
+	 *
+	 * @return string
+	 */
+	public function get_label(): string {
+		return $this->gateway->get_method_title();
+	}
+
+	/**
+	 * The interface the SDK consults for type-map / supported-types / option overrides.
+	 *
+	 * Mirrors `WC_Settings_Page::get_react_settings_page()` so
+	 * `ReactSettingsSchema::resolve_react_settings_page_interface()` can pick it up.
+	 *
+	 * @return ReactSettingsPageInterface
+	 */
+	public function get_react_settings_page(): ReactSettingsPageInterface {
+		if ( null === $this->react_page ) {
+			require_once __DIR__ . '/class-wc-payments-modern-settings-react-page.php';
+			$this->react_page = new WC_Payments_Modern_Settings_React_Page();
+		}
+		return $this->react_page;
+	}
+
+	/**
+	 * Called from WC_Payment_Gateway_WCPay::admin_options() when the flag is on.
+	 *
+	 * If the SDK render plan says we should render, emits the mount markup that
+	 * the React bootstrapper scans for and returns true (the gateway then
+	 * suppresses its existing custom React render). Otherwise returns false to
+	 * fall through to the existing render.
+	 *
+	 * @return bool Whether the modern mount was emitted.
+	 */
+	public function maybe_render_mount(): bool {
+		$render_plan = $this->get_render_plan();
+		if ( null === $render_plan || ! $render_plan['should_render'] ) {
+			return false;
+		}
+
+		// The custom React app on this page also sets this; keep it set so
+		// WooCommerce's submit row stays hidden.
+		$GLOBALS['hide_save_button'] = true;
+
+		printf(
+			'<div id="%s" data-wc-modern-settings="1" data-wc-settings-tab="%s" data-wc-settings-section="%s"></div>',
+			esc_attr( $render_plan['mount_id'] ),
+			esc_attr( self::SETTINGS_TAB ),
+			esc_attr( self::SETTINGS_SECTION )
+		);
+		return true;
+	}
+
+	/**
+	 * Filter callback for `woocommerce_admin_shared_settings`.
+	 *
+	 * Publishes the React payload at `wcSettings.admin.settings.{tab}.{section}`
+	 * — the same path the SDK's own `Settings::add_react_settings_data()` uses
+	 * — so `useReactSettings()` finds it on first render.
+	 *
+	 * Only fires on the WooPayments gateway settings screen with the flag on.
+	 *
+	 * @param mixed $settings Existing shared settings.
+	 * @return mixed
+	 */
+	public function maybe_publish_payload( $settings ) {
+		if ( ! is_array( $settings ) ) {
+			return $settings;
+		}
+
+		$render_plan = $this->get_render_plan();
+		if ( null === $render_plan || ! $render_plan['should_render'] || null === $render_plan['response'] ) {
+			return $settings;
+		}
+
+		$current = &$settings;
+		foreach ( $render_plan['payload_path'] as $segment ) {
+			if ( ! isset( $current[ $segment ] ) || ! is_array( $current[ $segment ] ) ) {
+				$current[ $segment ] = [];
+			}
+			$current = &$current[ $segment ];
+		}
+		$current = $render_plan['response'];
+
+		return $settings;
+	}
+
+	/**
+	 * Compute the render plan, or null if we shouldn't render the modern path.
+	 *
+	 * Gates: feature flag on, on the right tab/section, and the SDK's render
+	 * plan returns should_render=true. Memoization is intentionally skipped —
+	 * the render plan is queried at most twice per request (once from
+	 * admin_options(), once from the shared-settings filter).
+	 *
+	 * @return array|null
+	 */
+	private function get_render_plan(): ?array {
+		if ( ! ReactSettingsSchema::is_feature_enabled() ) {
+			return null;
+		}
+
+		if ( ! $this->is_on_gateway_settings_screen() ) {
+			return null;
+		}
+
+		return ReactSettingsSchema::get_screen_render_context(
+			self::SETTINGS_TAB,
+			self::SETTINGS_SECTION,
+			$this->get_settings_definitions(),
+			$this
+		);
+	}
+
+	/**
+	 * Whether the current request targets the WooPayments gateway settings screen.
+	 *
+	 * @return bool
+	 */
+	private function is_on_gateway_settings_screen(): bool {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$page    = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+		$tab     = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : '';
+		$section = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return 'wc-settings' === $page
+			&& self::SETTINGS_TAB === $tab
+			&& self::SETTINGS_SECTION === $section;
+	}
+
+	/**
+	 * Translate the gateway's `form_fields` array into the WooCommerce settings
+	 * definition shape `ReactSettingsSchema::build_response()` expects.
+	 *
+	 * Differences:
+	 *   - form_fields is keyed by field id; settings definitions carry an
+	 *     explicit `id` per entry.
+	 *   - form_fields stores the description under `description`; the SDK
+	 *     reads `desc`.
+	 *   - Non-title entries get an inline `value` populated from the gateway's
+	 *     option store. The SDK's default `WC_Admin_Settings::get_option()` lookup
+	 *     would miss it (the gateway stores values serialized under a single
+	 *     option key, not per-field), so we short-circuit by setting `value`.
+	 *   - `title` entries open a section group; we synthesise matching
+	 *     `sectionend` markers so `build_response()` can assemble them.
+	 *
+	 * @return array
+	 */
+	private function get_settings_definitions(): array {
+		if ( null !== $this->settings_definitions ) {
+			return $this->settings_definitions;
+		}
+
+		$definitions   = [];
+		$current_id    = null;
+		$group_counter = 0;
+
+		foreach ( $this->gateway->get_form_fields() as $key => $field ) {
+			$type = $field['type'] ?? 'text';
+
+			if ( 'title' === $type ) {
+				if ( null !== $current_id ) {
+					$definitions[] = [
+						'type' => 'sectionend',
+						'id'   => $current_id,
+					];
+				}
+				$current_id    = 'wcpay_modern_settings_group_' . $key;
+				$definitions[] = [
+					'type'  => 'title',
+					'id'    => $current_id,
+					'title' => $field['title'] ?? '',
+					'desc'  => $field['description'] ?? '',
+				];
+				continue;
+			}
+
+			if ( null === $current_id ) {
+				$current_id    = 'wcpay_modern_settings_group_' . $group_counter;
+				$definitions[] = [
+					'type'  => 'title',
+					'id'    => $current_id,
+					'title' => $this->gateway->get_method_title(),
+					'desc'  => '',
+				];
+				++$group_counter;
+			}
+
+			$definition = $this->build_field_definition( (string) $key, $field );
+			if ( null !== $definition ) {
+				$definitions[] = $definition;
+			}
+		}
+
+		if ( null !== $current_id ) {
+			$definitions[] = [
+				'type' => 'sectionend',
+				'id'   => $current_id,
+			];
+		}
+
+		$this->settings_definitions = $definitions;
+		return $this->settings_definitions;
+	}
+
+	/**
+	 * Build a single SDK field definition from a gateway form_fields entry.
+	 *
+	 * Returns null when the field can't be rendered by the SDK in its current
+	 * shape — currently: select / multiselect fields whose `options` array is
+	 * empty. WCPay populates these dynamically from the payment-methods registry
+	 * (e.g. `upe_enabled_payment_method_ids`), and DataForm has no fallback Edit
+	 * for an option-less multi-value field. Wiring the runtime options into
+	 * `ReactSettingsPageInterface::get_field_options()` is a follow-up beyond
+	 * this PoC.
+	 *
+	 * @param string $key   Field id.
+	 * @param array  $field Raw form_fields entry.
+	 * @return array|null
+	 */
+	private function build_field_definition( string $key, array $field ): ?array {
+		$type    = $field['type'] ?? 'text';
+		$default = $field['default'] ?? '';
+		$value   = $this->gateway->get_option( $key, $default );
+
+		$has_options = isset( $field['options'] ) && is_array( $field['options'] ) && ! empty( $field['options'] );
+		if ( in_array( $type, [ 'select', 'multiselect', 'radio' ], true ) && ! $has_options ) {
+			return null;
+		}
+
+		// `multiselect` is in the SDK's supported set but its baseFieldTransformer
+		// produces a `type: 'array'` DataForm field with no built-in Edit in the
+		// 10.8-dev DataViews bundle currently shipping with WC. The example
+		// plugin sidesteps it for the same reason. Skip in the PoC; revisit when
+		// DataViews ships an `array` Edit (or wire a custom transformer).
+		if ( 'multiselect' === $type ) {
+			return null;
+		}
+
+		$definition = [
+			'id'      => $key,
+			'type'    => $type,
+			'title'   => $field['title'] ?? '',
+			'desc'    => $field['description'] ?? '',
+			'default' => $default,
+			'value'   => $value,
+		];
+
+		if ( $has_options ) {
+			$definition['options'] = $field['options'];
+		}
+
+		return $definition;
+	}
+}

--- a/includes/admin/class-wc-payments-modern-settings-bridge.php
+++ b/includes/admin/class-wc-payments-modern-settings-bridge.php
@@ -229,6 +229,10 @@ class WC_Payments_Modern_Settings_Bridge {
 	 *     option key, not per-field), so we short-circuit by setting `value`.
 	 *   - `title` entries open a section group; we synthesise matching
 	 *     `sectionend` markers so `build_response()` can assemble them.
+	 *   - When the form starts with a non-title entry (e.g. `enabled`), we
+	 *     synthesise an opening section seeded with the gateway's method title
+	 *     and description so the React form has a meaningful header rather
+	 *     than an unlabeled card.
 	 *
 	 * @return array
 	 */
@@ -237,9 +241,8 @@ class WC_Payments_Modern_Settings_Bridge {
 			return $this->settings_definitions;
 		}
 
-		$definitions   = [];
-		$current_id    = null;
-		$group_counter = 0;
+		$definitions = [];
+		$current_id  = null;
 
 		foreach ( $this->gateway->get_form_fields() as $key => $field ) {
 			$type = $field['type'] ?? 'text';
@@ -256,20 +259,19 @@ class WC_Payments_Modern_Settings_Bridge {
 					'type'  => 'title',
 					'id'    => $current_id,
 					'title' => $field['title'] ?? '',
-					'desc'  => $field['description'] ?? '',
+					'desc'  => $this->normalize_description( $field['description'] ?? '' ),
 				];
 				continue;
 			}
 
 			if ( null === $current_id ) {
-				$current_id    = 'wcpay_modern_settings_group_' . $group_counter;
+				$current_id    = 'wcpay_modern_settings_group_default';
 				$definitions[] = [
 					'type'  => 'title',
 					'id'    => $current_id,
 					'title' => $this->gateway->get_method_title(),
-					'desc'  => '',
+					'desc'  => $this->normalize_description( $this->gateway->get_method_description() ),
 				];
-				++$group_counter;
 			}
 
 			$definition = $this->build_field_definition( (string) $key, $field );
@@ -292,13 +294,20 @@ class WC_Payments_Modern_Settings_Bridge {
 	/**
 	 * Build a single SDK field definition from a gateway form_fields entry.
 	 *
-	 * Returns null when the field can't be rendered by the SDK in its current
-	 * shape — currently: select / multiselect fields whose `options` array is
-	 * empty. WCPay populates these dynamically from the payment-methods registry
-	 * (e.g. `upe_enabled_payment_method_ids`), and DataForm has no fallback Edit
-	 * for an option-less multi-value field. Wiring the runtime options into
-	 * `ReactSettingsPageInterface::get_field_options()` is a follow-up beyond
-	 * this PoC.
+	 * Replaces unrenderable raw fields with read-only `info` rows so the page
+	 * surfaces what's missing instead of silently dropping it. Two cases get
+	 * substituted today:
+	 *   - select / multiselect / radio with an empty `options` array. WCPay
+	 *     populates these dynamically from the payment-methods registry
+	 *     (e.g. `upe_enabled_payment_method_ids`); DataForm has no fallback
+	 *     Edit for an option-less multi-value field. Wiring the runtime
+	 *     options into `ReactSettingsPageInterface::get_field_options()` is
+	 *     a follow-up beyond this PoC.
+	 *   - any `multiselect`. The SDK's baseFieldTransformer produces a
+	 *     `type: 'array'` DataForm field with no built-in Edit in the 10.8-dev
+	 *     DataViews bundle currently shipping. The official sample plugin
+	 *     sidesteps it for the same reason — a custom JS transformer (out of
+	 *     PoC scope; needs a build pipeline) is the long-term fix.
 	 *
 	 * @param string $key   Field id.
 	 * @param array  $field Raw form_fields entry.
@@ -306,28 +315,24 @@ class WC_Payments_Modern_Settings_Bridge {
 	 */
 	private function build_field_definition( string $key, array $field ): ?array {
 		$type    = $field['type'] ?? 'text';
+		$title   = $this->resolve_field_title( $key, $field );
 		$default = $field['default'] ?? '';
 		$value   = $this->gateway->get_option( $key, $default );
+		$desc    = $this->normalize_description( $field['description'] ?? '' );
 
 		$has_options = isset( $field['options'] ) && is_array( $field['options'] ) && ! empty( $field['options'] );
-		if ( in_array( $type, [ 'select', 'multiselect', 'radio' ], true ) && ! $has_options ) {
-			return null;
-		}
+		$is_skipped  = 'multiselect' === $type
+			|| ( in_array( $type, [ 'select', 'radio' ], true ) && ! $has_options );
 
-		// `multiselect` is in the SDK's supported set but its baseFieldTransformer
-		// produces a `type: 'array'` DataForm field with no built-in Edit in the
-		// 10.8-dev DataViews bundle currently shipping with WC. The example
-		// plugin sidesteps it for the same reason. Skip in the PoC; revisit when
-		// DataViews ships an `array` Edit (or wire a custom transformer).
-		if ( 'multiselect' === $type ) {
-			return null;
+		if ( $is_skipped ) {
+			return $this->build_unsupported_info_row( $key, $title, $type, $value );
 		}
 
 		$definition = [
 			'id'      => $key,
 			'type'    => $type,
-			'title'   => $field['title'] ?? '',
-			'desc'    => $field['description'] ?? '',
+			'title'   => $title,
+			'desc'    => $desc,
 			'default' => $default,
 			'value'   => $value,
 		];
@@ -337,5 +342,88 @@ class WC_Payments_Modern_Settings_Bridge {
 		}
 
 		return $definition;
+	}
+
+	/**
+	 * Resolve a human-readable title for a form field.
+	 *
+	 * Some WCPay form_fields entries (notably `enabled` and
+	 * `platform_checkout_custom_message`) ship without a `title`. Falling back
+	 * to a humanized field id keeps the rendered form readable and avoids the
+	 * "naked input" effect when DataForm gets an empty label.
+	 *
+	 * @param string $key   Field id.
+	 * @param array  $field Raw form_fields entry.
+	 * @return string
+	 */
+	private function resolve_field_title( string $key, array $field ): string {
+		$title = $field['title'] ?? '';
+		if ( '' !== $title ) {
+			return $title;
+		}
+
+		$label = $field['label'] ?? '';
+		if ( '' !== $label ) {
+			return $label;
+		}
+
+		return ucfirst( str_replace( '_', ' ', $key ) );
+	}
+
+	/**
+	 * Normalize a form_fields description for the React `desc` channel.
+	 *
+	 * The legacy renderer runs descriptions through `wpautop` / `wp_kses_post`
+	 * and emits HTML; the React DataForm renders `desc` as plain text. Stripping
+	 * tags here keeps descriptions readable instead of leaking raw `<a>` markup
+	 * into the UI. Inline links are lost in the conversion — a richer text
+	 * channel for the modern renderer is pending upstream.
+	 *
+	 * @param string $description Raw description.
+	 * @return string
+	 */
+	private function normalize_description( string $description ): string {
+		if ( '' === $description ) {
+			return '';
+		}
+
+		return trim( wp_strip_all_tags( $description ) );
+	}
+
+	/**
+	 * Build an `info` row substitute for a field the PoC can't render.
+	 *
+	 * Renders as a read-only description in the DataForm with the original
+	 * field title and current value, plus a one-line note explaining why the
+	 * input is missing. This keeps the form complete and audit-able rather
+	 * than silently dropping fields.
+	 *
+	 * @param string $key   Field id.
+	 * @param string $title Resolved field title.
+	 * @param string $type  Original raw type.
+	 * @param mixed  $value Current value from the gateway option store.
+	 * @return array
+	 */
+	private function build_unsupported_info_row( string $key, string $title, string $type, $value ): array {
+		$display_value = is_array( $value ) ? implode( ', ', array_map( 'strval', $value ) ) : (string) $value;
+		if ( '' === $display_value ) {
+			$display_value = '—';
+		}
+
+		$text = sprintf(
+			/* translators: 1: field title, 2: raw field type, 3: current option value */
+			__( '%1$s — current value: %3$s. Rendering this %2$s field through the modernised SDK is pending.', 'woocommerce-payments' ),
+			$title,
+			$type,
+			$display_value
+		);
+
+		return [
+			'id'    => $key . '__info',
+			'type'  => 'info',
+			'title' => $title,
+			'desc'  => '',
+			'text'  => $text,
+		];
 	}
 }

--- a/includes/admin/class-wc-payments-modern-settings-react-page.php
+++ b/includes/admin/class-wc-payments-modern-settings-react-page.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Class WC_Payments_Modern_Settings_React_Page
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsPageInterface;
+
+/**
+ * ReactSettingsPageInterface contribution for the WooPayments gateway settings.
+ *
+ * Returned from WC_Payments_Modern_Settings_Bridge::get_react_settings_page() so
+ * ReactSettingsSchema can resolve our custom field types when computing the
+ * render plan for tab=checkout, section=woocommerce_payments.
+ *
+ * Maps WCPay's `account_statement_descriptor` raw type onto the SDK's `text`
+ * primitive — the underlying field is a constrained text input, so no JS Edit
+ * component is required for this PoC. Other raw types in the gateway form
+ * (`checkbox`, `select`, `multiselect`, `text`, `title`) are already in the
+ * SDK's native supported set.
+ */
+class WC_Payments_Modern_Settings_React_Page implements ReactSettingsPageInterface {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $section Section id. Empty string means the default section.
+	 * @return array<string, string>
+	 */
+	public function get_extra_type_map( string $section ): array {
+		return [
+			'account_statement_descriptor' => 'text',
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $section Section id. Empty string means the default section.
+	 * @return array<int, string>
+	 */
+	public function get_extra_supported_types( string $section ): array {
+		return [];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $field_id Field id.
+	 * @param array  $field    Raw settings definition.
+	 * @param string $section  Section id. Empty string means the default section.
+	 * @return array<int, array{label: string, value: string}>|null
+	 */
+	public function get_field_options( string $field_id, array $field, string $section ): ?array {
+		return null;
+	}
+}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -172,6 +172,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	protected $payment_method_capability_key_map;
 
 	/**
+	 * Bridge into WooCommerce's modernised settings SDK.
+	 *
+	 * Wired by WC_Payments bootstrap when the gateway is the main instance and
+	 * the SDK class is available. Optional — when unset the gateway renders via
+	 * its existing custom React app.
+	 *
+	 * @var WC_Payments_Modern_Settings_Bridge|null
+	 */
+	private $modern_settings_bridge;
+
+	/**
 	 * WooPay utilities.
 	 *
 	 * @var WooPay_Utilities
@@ -1055,11 +1066,32 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Wire the modernised settings SDK bridge for this gateway.
+	 *
+	 * Called from the WC_Payments bootstrap on the main gateway instance only.
+	 * When the bridge is set and the modern-settings feature flag is on,
+	 * admin_options() emits the SDK's React mount instead of the existing
+	 * custom React app.
+	 *
+	 * @param WC_Payments_Modern_Settings_Bridge $bridge The bridge instance.
+	 */
+	public function set_modern_settings_bridge( WC_Payments_Modern_Settings_Bridge $bridge ): void {
+		$this->modern_settings_bridge = $bridge;
+	}
+
+	/**
 	 * Admin Panel Options.
 	 */
 	public function admin_options() {
 		// Add notices to the WooPayments settings page.
 		do_action( 'woocommerce_woocommerce_payments_admin_notices' );
+
+		// PoC: when the modernised settings flag is on, defer to the SDK's
+		// React render. The bridge returns false (and we fall through) when
+		// the flag is off or any of the SDK's render gates reject the page.
+		if ( null !== $this->modern_settings_bridge && $this->modern_settings_bridge->maybe_render_mount() ) {
+			return;
+		}
 
 		$this->output_payments_settings_screen();
 	}

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -618,6 +618,17 @@ class WC_Payments {
 		self::$card_gateway->init_hooks();
 		self::$wc_payments_checkout->init_hooks();
 
+		// PoC: bridge the main gateway into WooCommerce's modernised settings SDK
+		// when the SDK class is available (WC 10.8+). The bridge is a no-op until
+		// the `modern-settings` feature flag is on AND the request targets the
+		// gateway settings screen, so it is safe to wire unconditionally in admin.
+		if ( is_admin() && class_exists( '\Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema' ) ) {
+			require_once __DIR__ . '/admin/class-wc-payments-modern-settings-bridge.php';
+			$modern_settings_bridge = new WC_Payments_Modern_Settings_Bridge( self::$card_gateway );
+			$modern_settings_bridge->init_hooks();
+			self::$card_gateway->set_modern_settings_bridge( $modern_settings_bridge );
+		}
+
 		self::$webhook_processing_service  = new WC_Payments_Webhook_Processing_Service( self::$api_client, self::$db_helper, self::$account, self::$remote_note_service, self::$order_service, self::$in_person_payments_receipts_service, self::get_gateway(), self::$database_cache, self::$onboarding_service, self::$token_service );
 		self::$webhook_reliability_service = new WC_Payments_Webhook_Reliability_Service( self::$api_client, self::$action_scheduler_service, self::$webhook_processing_service );
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,6 +33,7 @@ parameters:
     scanFiles:
         - dev/phpstan-wordpress-constants.php
         - dev/phpstan-wcpay-constants.php
+        - dev/phpstan-modern-settings-stubs.php
 
     scanDirectories:
         - vendor/woocommerce/subscriptions-core


### PR DESCRIPTION
Fixes —

#### Changes proposed in this Pull Request

A proof of concept that opts the WooPayments gateway settings page (`?page=wc-settings&tab=checkout&section=woocommerce_payments`) into WooCommerce 10.8's modernised settings SDK behind the experimental `modern-settings` feature flag (off by default).

**Why this needs a bridge.** The SDK's auto-render and auto-payload-publish hooks both look up the page by `tab` via `WC_Admin_Settings::get_settings_pages()`. For `tab=checkout` that returns `WC_Settings_Payment_Gateways`, not the WooPayments gateway. Gateway settings render via `WC_Settings_Payment_Gateways::output() → render_classic_gateway_settings_page() → $gateway->admin_options()`, never reaching the SDK. The bridge fills the gap from user space — no SDK contract changes were needed.

**What landed:**

- `WC_Payments_Modern_Settings_Bridge` (`includes/admin/`) — a page-shaped wrapper around the gateway. Satisfies the SDK's loose-typed `$settings_page` argument by exposing `get_react_settings_page()` + `get_label()`. Drives the mount-markup emit from `admin_options()` and publishes the JSON payload at `wcSettings.admin.settings.checkout.woocommerce_payments` via the `woocommerce_admin_shared_settings` filter.
- `WC_Payments_Modern_Settings_React_Page` (`includes/admin/`) — implements `ReactSettingsPageInterface`. Aliases the gateway's `account_statement_descriptor` raw type onto `text` (no JS Edit needed for the PoC). The other field types in `form_fields` (`checkbox`, `select`, `text`, `title`) are already in the SDK's native supported set.
- `WC_Payment_Gateway_WCPay::admin_options()` — defers to the bridge when a bridge is wired and the SDK render plan returns `should_render`. Otherwise falls through to the existing custom React app render unchanged.
- `WC_Payments::init_gateway()` — wires the bridge on the main gateway instance in admin requests when the SDK class is present (WC 10.8+).
- `dev/phpstan-modern-settings-stubs.php` — minimal stubs so PHPStan can resolve the SDK's `ReactSettingsPageInterface` and `ReactSettingsSchema` until WCPay's WC stub set is bumped to 10.8.
- Changelog entry (`dev`).

**SDK contract observations (worth flagging upstream, not blockers).**

- The SDK's auto-publish hook is tab-scoped: it only runs when the page is a `WC_Settings_Page` registered via `get_settings_pages()` and the URL's `tab` matches its `get_id()`. Sub-section "pages" (payment gateways, anything rendered by another tab class) must publish their own payload via `woocommerce_admin_shared_settings`.
- The mount markup (`<div data-wc-modern-settings...>`) is built inline in `WC_Settings_Page::output()` rather than via a small public helper like `ReactSettingsSchema::get_mount_markup()`. Bridges duplicate the markup verbatim today.

**PoC limitations (deferred):**

- Empty-options select/multiselect fields (e.g. `upe_enabled_payment_method_ids`, populated dynamically by WCPay's payment-method registry) are skipped in the converter — they require runtime option resolution that's out of PoC scope. They'd be wired through `ReactSettingsPageInterface::get_field_options()` in a follow-up.
- `multiselect` is skipped because the SDK's `baseFieldTransformer` produces a `type: 'array'` DataForm field with no built-in Edit in the WC 10.8-dev DataViews bundle currently shipping. The official sample plugin restricts itself to `text/select/toggle/checkbox` for the same reason.
- Save still flows through the legacy POST handler — matches the SDK's documented 10.8 scope (the modern path replaces only the render in 10.8).

#### Testing instructions

1. Run on WC 10.8 (this branch was developed against WC `10.8.0-dev`). Earlier WC versions don't ship the SDK; the PoC is a no-op there because the bootstrap guards on `class_exists( '\Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema' )`.
2. Enable the `modern-settings` feature flag locally with this mu-plugin snippet:
   ```php
   <?php
   add_filter( 'woocommerce_admin_features', static function ( array $features ): array {
       $features[] = 'modern-settings';
       return $features;
   } );
   ```
3. Visit **WooCommerce → Settings → Payments → WooPayments**.
4. **Flag on:** the page should render the modern React DataForm with the gateway's settings (account-statement descriptor, manual capture, saved cards, test mode, debug log, payment-request button settings, etc.). Inspect the DOM for a `[data-wc-modern-settings]` element with `id="wc_settings_react_checkout_woocommerce_payments"`. The payload is at `window.wcSettings.admin.settings.checkout.woocommerce_payments`.
5. **Flag off:** identical behaviour to trunk. The existing `<div id="wcpay-account-settings-container">` renders, no modern mount.
6. `docker exec <wp-container> cat /var/www/html/wp-content/debug.log` should contain no `wc_doing_it_wrong` entries for this tab.

Note: if the gateway settings URL redirects you straight to the WooPayments onboarding flow, that means your Stripe account isn't connected. The redirect is unrelated to this PR; either connect/onboard or temporarily disable `WC_Payments_Account::maybe_redirect_from_settings_page` for testing.

*

-------------------

- [x] Run `npm run changelog` to add a changelog file
- [ ] Covered with tests — proof-of-concept; deferred until the design is validated
- [x] Tested on mobile (or does not apply) — admin-only

**Post merge**

- [ ] Link to testing instructions from release testing doc — _QA Testing Not Applicable (PoC, behind off-by-default flag)_
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable
- [ ] Add what's changed to the release announcement post, if applicable