### PR TITLE
[codex] Add WooPayments modern settings POC

### DIFF
--- a/changelog/poc-modern-settings-sdk
+++ b/changelog/poc-modern-settings-sdk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add proof-of-concept WooPayments modern settings adapter with custom components

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -12,6 +12,7 @@ import SettingsManager from './settings-manager';
 import ExpressCheckoutSettings from './express-checkout-settings';
 import WCPaySettingsContext from './wcpay-settings-context';
 import ErrorBoundary from '../components/error-boundary';
+import './modern-settings';
 
 window.addEventListener( 'load', () => {
 	enqueueFraudScripts( wcpaySettings.fraudServices );

--- a/client/settings/modern-settings/index.js
+++ b/client/settings/modern-settings/index.js
@@ -1,0 +1,262 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { CheckboxControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import PaymentMethodItem from 'wcpay/components/payment-method-item';
+import './style.scss';
+
+const PAYMENT_METHODS_FIELD_ID =
+	'woocommerce_woocommerce_payments_upe_enabled_payment_method_ids';
+const CARD_PAYMENT_METHOD_ID = 'card';
+
+const parseOptions = ( options ) => {
+	if ( Array.isArray( options ) ) {
+		return options.map( ( option ) => ( {
+			label: String( option.label || option.value || '' ),
+			value: String( option.value || '' ),
+		} ) );
+	}
+
+	return Object.keys( options || {} ).map( ( value ) => ( {
+		label: String( options[ value ] || '' ),
+		value: String( value ),
+	} ) );
+};
+
+const getPaymentMethodDefinition = ( id ) =>
+	window.wooPaymentsPaymentMethodDefinitions?.[ id ] || {};
+
+const getSelectedValues = ( props, fieldId ) => {
+	const rawValue = props.data?.[ fieldId ];
+
+	if ( Array.isArray( rawValue ) ) {
+		return rawValue.map( String );
+	}
+
+	return rawValue ? [ String( rawValue ) ] : [];
+};
+
+const updateSelectedValues = (
+	props,
+	fieldId,
+	selectedValues,
+	value,
+	checked
+) => {
+	const nextValues = checked
+		? [ ...selectedValues, value ]
+		: selectedValues.filter( ( selectedValue ) => selectedValue !== value );
+
+	props.onChange( {
+		[ fieldId ]: nextValues,
+	} );
+};
+
+const WCPayCheckboxList = ( { baseField, options, props } ) => {
+	const fieldId = props.field?.id || baseField.id;
+	const selectedValues = getSelectedValues( props, fieldId );
+
+	return (
+		<fieldset className="wcpay-modern-settings-multiselect">
+			<legend
+				className={
+					props.hideLabelFromVision
+						? 'screen-reader-text'
+						: 'components-base-control__label'
+				}
+			>
+				{ baseField.label }
+			</legend>
+			<div className="wcpay-modern-settings-multiselect__checkboxes">
+				{ options.map( ( option ) => (
+					<CheckboxControl
+						key={ option.value }
+						label={ option.label }
+						checked={ selectedValues.includes( option.value ) }
+						onChange={ ( checked ) =>
+							updateSelectedValues(
+								props,
+								fieldId,
+								selectedValues,
+								option.value,
+								checked
+							)
+						}
+						__nextHasNoMarginBottom
+					/>
+				) ) }
+			</div>
+			{ baseField.description && (
+				<p className="components-base-control__help">
+					{ baseField.description }
+				</p>
+			) }
+		</fieldset>
+	);
+};
+
+const WCPayPaymentMethodsList = ( { baseField, options, props } ) => {
+	const fieldId = props.field?.id || baseField.id;
+	const selectedValues = getSelectedValues( props, fieldId );
+
+	return (
+		<div className="wcpay-modern-settings-multiselect wcpay-modern-settings-payment-methods">
+			<div
+				className={
+					props.hideLabelFromVision
+						? 'screen-reader-text'
+						: 'components-base-control__label'
+				}
+			>
+				{ baseField.label }
+			</div>
+			<ul className="payment-methods-list payment-methods__available-methods">
+				{ options.map( ( option ) => {
+					const definition = getPaymentMethodDefinition(
+						option.value
+					);
+					const label = definition.label || option.label;
+					const description = definition.description || '';
+					const isCard = option.value === CARD_PAYMENT_METHOD_ID;
+					const Icon = definition.settings_icon_url
+						? () => (
+								<img
+									src={ definition.settings_icon_url }
+									alt={ label }
+									className="payment-method__icon"
+								/>
+						  )
+						: null;
+
+					return (
+						<PaymentMethodItem
+							key={ option.value }
+							className="payment-method__list-item"
+						>
+							<PaymentMethodItem.Checkbox
+								label={ label }
+								checked={ selectedValues.includes(
+									option.value
+								) }
+								disabled={
+									isCard &&
+									selectedValues.includes( option.value )
+								}
+								onChange={ ( checked ) =>
+									updateSelectedValues(
+										props,
+										fieldId,
+										selectedValues,
+										option.value,
+										checked
+									)
+								}
+							/>
+							<PaymentMethodItem.Body>
+								<PaymentMethodItem.Subgroup
+									Icon={ Icon }
+									label={
+										<>
+											{ label }
+											{ isCard && (
+												<span className="payment-method__required-label">
+													{ ` (${ __(
+														'Required',
+														'woocommerce-payments'
+													) })` }
+												</span>
+											) }
+										</>
+									}
+								>
+									{ description }
+								</PaymentMethodItem.Subgroup>
+							</PaymentMethodItem.Body>
+						</PaymentMethodItem>
+					);
+				} ) }
+			</ul>
+			{ baseField.description && (
+				<p className="components-base-control__help">
+					{ baseField.description }
+				</p>
+			) }
+		</div>
+	);
+};
+
+const registerMultiselectTransformer = ( registerFieldTypeTransformer ) => {
+	if (
+		typeof registerFieldTypeTransformer !== 'function' ||
+		registerFieldTypeTransformer.__wcpayMultiselectRegistered
+	) {
+		return;
+	}
+
+	registerFieldTypeTransformer.__wcpayMultiselectRegistered = true;
+	registerFieldTypeTransformer( 'multiselect', ( setting, baseField ) => {
+		const options = parseOptions( setting.options );
+		const optionValues = options.map( ( option ) => option.value );
+		const Edit =
+			setting.id === PAYMENT_METHODS_FIELD_ID
+				? ( props ) => (
+						<WCPayPaymentMethodsList
+							baseField={ baseField }
+							options={ options }
+							props={ props }
+						/>
+				  )
+				: ( props ) => (
+						<WCPayCheckboxList
+							baseField={ baseField }
+							options={ options }
+							props={ props }
+						/>
+				  );
+
+		return {
+			...baseField,
+			type: 'array',
+			elements: options,
+			Edit,
+			isValid: ( value ) =>
+				Array.isArray( value ) &&
+				value.every( ( item ) => optionValues.includes( item ) ),
+		};
+	} );
+};
+
+window.wcReactSettings = window.wcReactSettings || {};
+
+if (
+	typeof window.wcReactSettings.registerFieldTypeTransformer === 'function'
+) {
+	registerMultiselectTransformer(
+		window.wcReactSettings.registerFieldTypeTransformer
+	);
+} else {
+	let currentRegisterFieldTypeTransformer;
+	Object.defineProperty(
+		window.wcReactSettings,
+		'registerFieldTypeTransformer',
+		{
+			configurable: true,
+			get() {
+				return currentRegisterFieldTypeTransformer;
+			},
+			set( nextRegisterFieldTypeTransformer ) {
+				currentRegisterFieldTypeTransformer =
+					nextRegisterFieldTypeTransformer;
+				registerMultiselectTransformer(
+					nextRegisterFieldTypeTransformer
+				);
+			},
+		}
+	);
+}

--- a/client/settings/modern-settings/style.scss
+++ b/client/settings/modern-settings/style.scss
@@ -1,0 +1,46 @@
+.wcpay-modern-settings-multiselect {
+	.components-base-control__label {
+		display: block;
+		margin-bottom: 8px;
+		font-weight: 500;
+	}
+
+	.components-base-control__help {
+		margin-top: 8px;
+	}
+}
+
+.wcpay-modern-settings-multiselect__checkboxes {
+	display: grid;
+	grid-template-columns: repeat( auto-fit, minmax( 180px, 1fr ) );
+	gap: 10px 16px;
+	padding: 12px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.wcpay-modern-settings-payment-methods {
+	.payment-methods-list {
+		margin: 0;
+		padding: 0;
+		border: 1px solid #dcdcde;
+		border-radius: 4px;
+		background: #fff;
+	}
+
+	.payment-method-item {
+		padding: 16px;
+	}
+
+	.payment-method-item__icon img {
+		max-width: 64px;
+		max-height: 40px;
+	}
+
+	.payment-method__required-label {
+		margin-left: 4px;
+		color: #646970;
+		font-weight: 400;
+	}
+}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -53,6 +53,7 @@ use WCPay\WooPay\WooPay_Order_Status_Sync;
 use WCPay\WooPay\WooPay_Utilities;
 use WCPay\Session_Rate_Limiter;
 use WCPay\Tracker;
+use WCPay\Internal\Admin\Settings\WooPaymentsModernSettingsPage;
 use WCPay\Internal\Service\Level3Service;
 use WCPay\Internal\Service\OrderService;
 use WCPay\Payment_Methods\UPE_Payment_Method;
@@ -1060,6 +1061,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	public function admin_options() {
 		// Add notices to the WooPayments settings page.
 		do_action( 'woocommerce_woocommerce_payments_admin_notices' );
+
+		if (
+			empty( $_GET['method'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			&& interface_exists( '\Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsPageInterface' )
+			&& class_exists( '\Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema' )
+		) {
+			$modern_settings_page = new WooPaymentsModernSettingsPage( $this );
+			if ( $modern_settings_page->output() ) {
+				return;
+			}
+		}
 
 		$this->output_payments_settings_screen();
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -554,6 +554,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	public function init_hooks() {
 		add_action( 'init', [ $this, 'maybe_update_properties_with_country' ] );
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 
 		// Only add certain actions/filter if this is the main gateway (i.e. not split UPE).
 		if ( self::GATEWAY_ID === $this->id ) {

--- a/src/Internal/Admin/Settings/WooPaymentsModernSettingsPage.php
+++ b/src/Internal/Admin/Settings/WooPaymentsModernSettingsPage.php
@@ -93,7 +93,10 @@ final class WooPaymentsModernSettingsPage implements ReactSettingsPageInterface 
 	 * @return array<int, array{label: string, value: string}>|null
 	 */
 	public function get_field_options( string $field_id, array $field, string $section ): ?array {
-		if ( 'upe_enabled_payment_method_ids' !== $field_id ) {
+		if (
+			'upe_enabled_payment_method_ids' !== $field_id
+			&& $this->gateway->get_field_key( 'upe_enabled_payment_method_ids' ) !== $field_id
+		) {
 			return null;
 		}
 
@@ -135,7 +138,10 @@ final class WooPaymentsModernSettingsPage implements ReactSettingsPageInterface 
 		$GLOBALS['hide_save_button'] = true;
 		wp_dequeue_script( 'woocommerce_settings' );
 
-		$this->output_preloaded_settings_data( $render_plan['payload_path'], $render_plan['response'] );
+		$response = $this->include_ungrouped_fields_in_response( $render_plan['response'], $settings_definitions );
+
+		$this->enqueue_modern_settings_assets();
+		$this->enqueue_preloaded_settings_data( $render_plan['payload_path'], $response );
 		$this->output_checkbox_save_compatibility_script( $render_plan['mount_id'] );
 
 		echo '<div id="' . esc_attr( $render_plan['mount_id'] ) . '" data-wc-modern-settings="1" data-wc-settings-tab="' . esc_attr( self::TAB_ID ) . '" data-wc-settings-section="' . esc_attr( self::SECTION_ID ) . '"> </div>';
@@ -187,8 +193,9 @@ final class WooPaymentsModernSettingsPage implements ReactSettingsPageInterface 
 	 * @return array<string, mixed>
 	 */
 	private function normalize_gateway_field( string $field_id, array $field ): array {
-		$field['id']         = $field_id;
-		$field['field_name'] = $this->gateway->get_field_key( $field_id );
+		$field['id']         = $this->gateway->get_field_key( $field_id );
+		$field['field_name'] = $field['id'];
+		$field['name']       = $field['field_name'];
 		$field['value']      = $this->gateway->get_option( $field_id );
 
 		if ( empty( $field['type'] ) ) {
@@ -225,13 +232,13 @@ final class WooPaymentsModernSettingsPage implements ReactSettingsPageInterface 
 	}
 
 	/**
-	 * Preload the settings payload for WooCommerce's settings embed registry.
+	 * Enqueue the settings payload for WooCommerce's settings embed registry.
 	 *
 	 * @param array<int, string>   $payload_path Payload path.
 	 * @param array<string, mixed> $response     React settings response.
 	 * @return void
 	 */
-	private function output_preloaded_settings_data( array $payload_path, array $response ): void {
+	private function enqueue_preloaded_settings_data( array $payload_path, array $response ): void {
 		$script = sprintf(
 			'( function() {
 				window.wcSettings = window.wcSettings || {};
@@ -248,12 +255,157 @@ final class WooPaymentsModernSettingsPage implements ReactSettingsPageInterface 
 			wp_json_encode( $response )
 		);
 
-		wp_print_inline_script_tag(
+		wp_add_inline_script(
+			'wc-admin-settings-embed',
 			$script,
-			[
-				'id' => 'wcpay-modern-settings-data',
-			]
+			'before'
 		);
+	}
+
+	/**
+	 * Enqueue WCPay settings assets before WooCommerce mounts the modern settings app.
+	 *
+	 * @return void
+	 */
+	private function enqueue_modern_settings_assets(): void {
+		if ( ! wp_script_is( 'WCPAY_ADMIN_SETTINGS', 'registered' ) ) {
+			return;
+		}
+
+		wp_enqueue_script( 'WCPAY_ADMIN_SETTINGS' );
+		wp_enqueue_style( 'WCPAY_ADMIN_SETTINGS' );
+
+		$wp_scripts = wp_scripts();
+		if (
+			isset( $wp_scripts->registered['wc-admin-settings-embed'] )
+			&& ! in_array( 'WCPAY_ADMIN_SETTINGS', $wp_scripts->registered['wc-admin-settings-embed']->deps, true )
+		) {
+			$wp_scripts->registered['wc-admin-settings-embed']->deps[] = 'WCPAY_ADMIN_SETTINGS';
+		}
+	}
+
+	/**
+	 * Include fields that WooCommerce's current response builder drops before the first title marker.
+	 *
+	 * @param array<string, mixed>            $response    React settings response.
+	 * @param array<int, array<string,mixed>> $definitions Settings definitions.
+	 * @return array<string, mixed>
+	 */
+	private function include_ungrouped_fields_in_response( array $response, array $definitions ): array {
+		$fields = [];
+		$values = [];
+
+		foreach ( $definitions as $definition ) {
+			$type = isset( $definition['type'] ) && is_string( $definition['type'] ) ? $definition['type'] : 'text';
+
+			if ( 'title' === $type ) {
+				break;
+			}
+
+			if ( 'sectionend' === $type || empty( $definition['id'] ) ) {
+				continue;
+			}
+
+			$field = $this->transform_definition_to_field( $definition );
+			if ( empty( $field['id'] ) || ! is_string( $field['id'] ) ) {
+				continue;
+			}
+
+			$fields[]               = $field;
+			$values[ $field['id'] ] = $this->normalize_field_value( $definition['value'] ?? ( $definition['default'] ?? '' ), $field['type'] );
+		}
+
+		if ( empty( $fields ) ) {
+			return $response;
+		}
+
+		$groups = isset( $response['groups'] ) && is_array( $response['groups'] ) ? $response['groups'] : [];
+
+		$response['groups'] = array_merge(
+			[
+				'woocommerce_payments_general' => [
+					'title'       => __( 'General', 'woocommerce-payments' ),
+					'description' => '',
+					'order'       => -1,
+					'fields'      => $fields,
+				],
+			],
+			$groups
+		);
+		$response['values'] = array_merge(
+			$values,
+			isset( $response['values'] ) && is_array( $response['values'] ) ? $response['values'] : []
+		);
+
+		return $response;
+	}
+
+	/**
+	 * Transform a normalized gateway definition to a React settings field.
+	 *
+	 * @param array<string, mixed> $definition Gateway definition.
+	 * @return array<string, mixed>
+	 */
+	private function transform_definition_to_field( array $definition ): array {
+		$type      = isset( $definition['type'] ) && is_string( $definition['type'] ) ? $definition['type'] : 'text';
+		$type_map  = $this->get_extra_type_map( self::SECTION_ID );
+		$type      = isset( $type_map[ $type ] ) ? $type_map[ $type ] : $type;
+		$field     = [
+			'id'    => $definition['id'],
+			'label' => $definition['title'] ?? $definition['name'] ?? $definition['id'],
+			'type'  => $type,
+			'desc'  => $definition['desc'] ?? '',
+		];
+		$pass_keys = [
+			'class',
+			'css',
+			'custom_attributes',
+			'disabled',
+			'field_name',
+			'name',
+			'placeholder',
+			'row_class',
+			'suffix',
+		];
+
+		foreach ( $pass_keys as $key ) {
+			if ( array_key_exists( $key, $definition ) ) {
+				$field[ $key ] = $definition[ $key ];
+			}
+		}
+
+		if ( isset( $definition['options'] ) && is_array( $definition['options'] ) ) {
+			$field['options'] = $definition['options'];
+		}
+
+		return $field;
+	}
+
+	/**
+	 * Normalize field values to the shape expected by the modern settings SDK.
+	 *
+	 * @param mixed  $value Field value.
+	 * @param string $type  Field type.
+	 * @return mixed
+	 */
+	private function normalize_field_value( $value, string $type ) {
+		if ( 'checkbox' === $type || 'toggle' === $type ) {
+			return wc_string_to_bool( $value );
+		}
+
+		if ( 'multiselect' === $type ) {
+			return is_array( $value ) ? array_values( $value ) : [];
+		}
+
+		if ( 'number' === $type ) {
+			if ( '' === $value || null === $value ) {
+				return '';
+			}
+
+			return is_numeric( $value ) ? (float) $value : 0;
+		}
+
+		return is_string( $value ) ? $value : (string) $value;
 	}
 
 	/**

--- a/src/Internal/Admin/Settings/WooPaymentsModernSettingsPage.php
+++ b/src/Internal/Admin/Settings/WooPaymentsModernSettingsPage.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * WooPayments modern settings page adapter.
+ *
+ * @package WCPay\Internal\Admin\Settings
+ */
+
+declare( strict_types=1 );
+
+namespace WCPay\Internal\Admin\Settings;
+
+use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsPageInterface;
+use Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsSchema;
+use WC_Payment_Gateway_WCPay;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PoC adapter that lets the WooPayments gateway settings render through WooCommerce's modern settings SDK.
+ *
+ * WooPayments currently owns a payment-gateway section (`checkout/woocommerce_payments`) rather than a
+ * `WC_Settings_Page` subclass. This small adapter supplies the same contract shape that
+ * `ReactSettingsSchema` expects while keeping the implementation scoped to WooPayments.
+ */
+final class WooPaymentsModernSettingsPage implements ReactSettingsPageInterface {
+
+	private const TAB_ID = 'checkout';
+
+	private const SECTION_ID = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+
+	/**
+	 * WooPayments gateway.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private WC_Payment_Gateway_WCPay $gateway;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Payment_Gateway_WCPay $gateway WooPayments gateway.
+	 */
+	public function __construct( WC_Payment_Gateway_WCPay $gateway ) {
+		$this->gateway = $gateway;
+	}
+
+	/**
+	 * Label used by ReactSettingsSchema.
+	 *
+	 * @return string
+	 */
+	public function get_label(): string {
+		return 'WooPayments';
+	}
+
+	/**
+	 * Expose the React settings page contract to ReactSettingsSchema.
+	 *
+	 * @return ReactSettingsPageInterface|null
+	 */
+	public function get_react_settings_page(): ?ReactSettingsPageInterface {
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $section Section id.
+	 * @return array<string, string>
+	 */
+	public function get_extra_type_map( string $section ): array {
+		return [
+			'account_statement_descriptor' => 'text',
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $section Section id.
+	 * @return array<int, string>
+	 */
+	public function get_extra_supported_types( string $section ): array {
+		return [];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string $field_id Field id.
+	 * @param array  $field    Raw settings definition.
+	 * @param string $section  Section id.
+	 * @return array<int, array{label: string, value: string}>|null
+	 */
+	public function get_field_options( string $field_id, array $field, string $section ): ?array {
+		if ( 'upe_enabled_payment_method_ids' !== $field_id ) {
+			return null;
+		}
+
+		$options = [];
+		foreach ( $this->gateway->get_payment_methods() as $payment_method_id => $payment_method ) {
+			$options[] = [
+				'label' => method_exists( $payment_method, 'get_title' )
+					? (string) $payment_method->get_title( $this->gateway->get_account_country() )
+					: (string) $payment_method_id,
+				'value' => (string) $payment_method_id,
+			];
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Output the modern settings mount when WooCommerce's modern-settings feature is enabled.
+	 *
+	 * @return bool Whether the modern mount was output.
+	 */
+	public function output(): bool {
+		if ( ! class_exists( ReactSettingsSchema::class ) || ! ReactSettingsSchema::is_feature_enabled() ) {
+			return false;
+		}
+
+		$settings_definitions = $this->get_settings_definitions();
+		$render_plan          = ReactSettingsSchema::get_screen_render_context(
+			self::TAB_ID,
+			self::SECTION_ID,
+			$settings_definitions,
+			$this
+		);
+
+		if ( ! $render_plan['should_render'] || empty( $render_plan['response'] ) ) {
+			return false;
+		}
+
+		$GLOBALS['hide_save_button'] = true;
+		wp_dequeue_script( 'woocommerce_settings' );
+
+		$this->output_preloaded_settings_data( $render_plan['payload_path'], $render_plan['response'] );
+		$this->output_checkbox_save_compatibility_script( $render_plan['mount_id'] );
+
+		echo '<div id="' . esc_attr( $render_plan['mount_id'] ) . '" data-wc-modern-settings="1" data-wc-settings-tab="' . esc_attr( self::TAB_ID ) . '" data-wc-settings-section="' . esc_attr( self::SECTION_ID ) . '"> </div>';
+
+		return true;
+	}
+
+	/**
+	 * Get modern-ready definitions from the legacy WooPayments gateway fields.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function get_settings_definitions(): array {
+		$definitions = [];
+
+		foreach ( $this->gateway->get_form_fields() as $field_id => $field ) {
+			if ( ! is_array( $field ) ) {
+				continue;
+			}
+
+			$definitions[] = $this->normalize_gateway_field( (string) $field_id, $field );
+		}
+
+		return $definitions;
+	}
+
+	/**
+	 * Get the gateway POST field names for checkbox settings.
+	 *
+	 * @return array<int, string>
+	 */
+	public function get_checkbox_field_names(): array {
+		$field_names = [];
+
+		foreach ( $this->gateway->get_form_fields() as $field_id => $field ) {
+			if ( is_array( $field ) && 'checkbox' === ( $field['type'] ?? '' ) ) {
+				$field_names[] = $this->gateway->get_field_key( (string) $field_id );
+			}
+		}
+
+		return $field_names;
+	}
+
+	/**
+	 * Normalize a WC_Settings_API gateway field for ReactSettingsSchema.
+	 *
+	 * @param string $field_id Field id.
+	 * @param array  $field    Gateway field.
+	 * @return array<string, mixed>
+	 */
+	private function normalize_gateway_field( string $field_id, array $field ): array {
+		$field['id']         = $field_id;
+		$field['field_name'] = $this->gateway->get_field_key( $field_id );
+		$field['value']      = $this->gateway->get_option( $field_id );
+
+		if ( empty( $field['type'] ) ) {
+			$field['type'] = 'text';
+		}
+
+		if ( 'checkbox' === $field['type'] && ! empty( $field['label'] ) ) {
+			$field['title'] = $field['label'];
+		}
+
+		if ( ! isset( $field['title'] ) ) {
+			$field['title'] = $this->get_fallback_field_title( $field_id );
+		}
+
+		if ( ! isset( $field['desc'] ) && isset( $field['description'] ) ) {
+			$field['desc'] = $field['description'];
+		}
+
+		return $field;
+	}
+
+	/**
+	 * Get a readable title for legacy settings that were not originally rendered as form rows.
+	 *
+	 * @param string $field_id Field id.
+	 * @return string
+	 */
+	private function get_fallback_field_title( string $field_id ): string {
+		if ( 'platform_checkout_custom_message' === $field_id ) {
+			return __( 'WooPay custom message', 'woocommerce-payments' );
+		}
+
+		return ucwords( str_replace( '_', ' ', $field_id ) );
+	}
+
+	/**
+	 * Preload the settings payload for WooCommerce's settings embed registry.
+	 *
+	 * @param array<int, string>   $payload_path Payload path.
+	 * @param array<string, mixed> $response     React settings response.
+	 * @return void
+	 */
+	private function output_preloaded_settings_data( array $payload_path, array $response ): void {
+		$script = sprintf(
+			'( function() {
+				window.wcSettings = window.wcSettings || {};
+				window.wcSettings.admin = window.wcSettings.admin || {};
+				var target = window.wcSettings.admin;
+				var path = %1$s;
+				for ( var i = 0; i < path.length - 1; i++ ) {
+					target[ path[ i ] ] = target[ path[ i ] ] || {};
+					target = target[ path[ i ] ];
+				}
+				target[ path[ path.length - 1 ] ] = %2$s;
+			} )();',
+			wp_json_encode( $payload_path ),
+			wp_json_encode( $response )
+		);
+
+		wp_print_inline_script_tag(
+			$script,
+			[
+				'id' => 'wcpay-modern-settings-data',
+			]
+		);
+	}
+
+	/**
+	 * Preserve WC_Settings_API checkbox save semantics.
+	 *
+	 * WC_Settings_API treats an absent checkbox POST field as "no" and any present value as "yes".
+	 * The modern SDK submits hidden `no` values, so this PoC removes those inputs just before submit.
+	 *
+	 * @param string $mount_id React mount id.
+	 * @return void
+	 */
+	private function output_checkbox_save_compatibility_script( string $mount_id ): void {
+		$script = sprintf(
+			'( function() {
+				var mountId = %1$s;
+				var checkboxNames = %2$s;
+				document.addEventListener( "submit", function( event ) {
+					var form = event.target;
+					if ( ! form || ! form.querySelector || ! form.querySelector( "#" + mountId ) ) {
+						return;
+					}
+
+					checkboxNames.forEach( function( name ) {
+						Array.prototype.slice.call( form.getElementsByTagName( "input" ) ).forEach( function( input ) {
+							if ( "hidden" === input.type && name === input.name && "no" === input.value && input.parentNode ) {
+								input.parentNode.removeChild( input );
+							}
+						} );
+					} );
+				} );
+			} )();',
+			wp_json_encode( $mount_id ),
+			wp_json_encode( $this->get_checkbox_field_names() )
+		);
+
+		wp_print_inline_script_tag(
+			$script,
+			[
+				'id' => 'wcpay-modern-settings-checkbox-compat',
+			]
+		);
+	}
+}

--- a/tests/unit/src/Internal/Admin/Settings/WooPaymentsModernSettingsPageTest.php
+++ b/tests/unit/src/Internal/Admin/Settings/WooPaymentsModernSettingsPageTest.php
@@ -79,13 +79,14 @@ class WooPaymentsModernSettingsPageTest extends WCPAY_UnitTestCase {
 
 		$definitions = $this->page->get_settings_definitions();
 
-		$this->assertSame( 'manual_capture', $definitions[0]['id'] );
+		$this->assertSame( 'woocommerce_woocommerce_payments_manual_capture', $definitions[0]['id'] );
 		$this->assertSame( 'woocommerce_woocommerce_payments_manual_capture', $definitions[0]['field_name'] );
+		$this->assertSame( 'woocommerce_woocommerce_payments_manual_capture', $definitions[0]['name'] );
 		$this->assertSame( 'Capture later', $definitions[0]['title'] );
 		$this->assertSame( 'Authorize at checkout.', $definitions[0]['desc'] );
 		$this->assertSame( 'no', $definitions[0]['value'] );
 
-		$this->assertSame( 'platform_checkout_custom_message', $definitions[1]['id'] );
+		$this->assertSame( 'woocommerce_woocommerce_payments_platform_checkout_custom_message', $definitions[1]['id'] );
 		$this->assertSame( 'text', $definitions[1]['type'] );
 		$this->assertSame( 'WooPay custom message', $definitions[1]['title'] );
 		$this->assertSame( 'Default WooPay message', $definitions[1]['value'] );

--- a/tests/unit/src/Internal/Admin/Settings/WooPaymentsModernSettingsPageTest.php
+++ b/tests/unit/src/Internal/Admin/Settings/WooPaymentsModernSettingsPageTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * WooPayments modern settings page adapter tests.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Admin\Settings;
+
+use WC_Payment_Gateway_WCPay;
+use WCPay\Internal\Admin\Settings\WooPaymentsModernSettingsPage;
+use WCPAY_UnitTestCase;
+
+/**
+ * WooPaymentsModernSettingsPage unit tests.
+ */
+class WooPaymentsModernSettingsPageTest extends WCPAY_UnitTestCase {
+
+	/**
+	 * Gateway mock.
+	 *
+	 * @var WC_Payment_Gateway_WCPay
+	 */
+	private $gateway;
+
+	/**
+	 * Adapter under test.
+	 *
+	 * @var WooPaymentsModernSettingsPage
+	 */
+	private $page;
+
+	/**
+	 * Set up.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! interface_exists( '\Automattic\WooCommerce\Internal\Admin\Settings\ReactSettingsPageInterface' ) ) {
+			$this->markTestSkipped( 'WooCommerce modern settings SDK is not available.' );
+		}
+
+		$this->gateway     = $this->getMockBuilder( WC_Payment_Gateway_WCPay::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_form_fields', 'get_option', 'get_payment_methods', 'get_account_country' ] )
+			->getMock();
+		$this->gateway->id = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+
+		$this->page = new WooPaymentsModernSettingsPage( $this->gateway );
+	}
+
+	public function test_maps_woopayments_custom_statement_descriptor_type_to_text(): void {
+		$this->assertSame(
+			[ 'account_statement_descriptor' => 'text' ],
+			$this->page->get_extra_type_map( WC_Payment_Gateway_WCPay::GATEWAY_ID )
+		);
+	}
+
+	public function test_normalizes_gateway_form_fields_for_react_settings_schema(): void {
+		$this->gateway->method( 'get_form_fields' )->willReturn(
+			[
+				'manual_capture'                   => [
+					'title'       => 'Manual capture',
+					'label'       => 'Capture later',
+					'type'        => 'checkbox',
+					'description' => 'Authorize at checkout.',
+				],
+				'platform_checkout_custom_message' => [
+					'default' => 'Default WooPay message',
+				],
+			]
+		);
+		$this->gateway->method( 'get_option' )->willReturnMap(
+			[
+				[ 'manual_capture', null, 'no' ],
+				[ 'platform_checkout_custom_message', null, 'Default WooPay message' ],
+			]
+		);
+
+		$definitions = $this->page->get_settings_definitions();
+
+		$this->assertSame( 'manual_capture', $definitions[0]['id'] );
+		$this->assertSame( 'woocommerce_woocommerce_payments_manual_capture', $definitions[0]['field_name'] );
+		$this->assertSame( 'Capture later', $definitions[0]['title'] );
+		$this->assertSame( 'Authorize at checkout.', $definitions[0]['desc'] );
+		$this->assertSame( 'no', $definitions[0]['value'] );
+
+		$this->assertSame( 'platform_checkout_custom_message', $definitions[1]['id'] );
+		$this->assertSame( 'text', $definitions[1]['type'] );
+		$this->assertSame( 'WooPay custom message', $definitions[1]['title'] );
+		$this->assertSame( 'Default WooPay message', $definitions[1]['value'] );
+	}
+
+	public function test_synthesizes_options_for_payment_method_multiselect(): void {
+		$card = new class() {
+			public function get_title( string $country ): string {
+				return 'US' === $country ? 'Card' : 'Card fallback';
+			}
+		};
+
+		$this->gateway->method( 'get_payment_methods' )->willReturn(
+			[
+				'card' => $card,
+			]
+		);
+		$this->gateway->method( 'get_account_country' )->willReturn( 'US' );
+
+		$this->assertSame(
+			[
+				[
+					'label' => 'Card',
+					'value' => 'card',
+				],
+			],
+			$this->page->get_field_options( 'upe_enabled_payment_method_ids', [], WC_Payment_Gateway_WCPay::GATEWAY_ID )
+		);
+	}
+
+	public function test_lists_legacy_checkbox_post_field_names(): void {
+		$this->gateway->method( 'get_form_fields' )->willReturn(
+			[
+				'manual_capture' => [ 'type' => 'checkbox' ],
+				'button_type'    => [ 'type' => 'select' ],
+			]
+		);
+
+		$this->assertSame(
+			[ 'woocommerce_woocommerce_payments_manual_capture' ],
+			$this->page->get_checkbox_field_names()
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a WooPayments modern settings adapter that renders the gateway section through WooCommerce modern settings when available.
- Adds a WCPay-owned modern-settings multiselect transformer from the settings bundle.
- Renders payment methods with WCPay-style rows, icons, descriptions, and required-card handling; renders other multiselects as checkbox groups.
- Keeps gateway field names and save hooks compatible with WC_Settings_API.

## Why

This is a proof of concept for the modern settings SDK workflow: a settings page can still provide custom components where generic schema fields are not enough, without abandoning the shared modern settings renderer.

## Testing

- Chrome MCP: verified localhost:8082 WooPayments settings renders General and Payment request groups.
- Chrome MCP: verified custom payment method component renders 20 payment method rows with icons/descriptions.
- Chrome MCP: toggled Affirm, saved through the page button, and verified `upe_enabled_payment_method_ids` persisted via WP-CLI.
- `npm run build:client`
- `npx eslint client/settings/index.js client/settings/modern-settings/index.js`
- `npx prettier --check client/settings/index.js client/settings/modern-settings/index.js client/settings/modern-settings/style.scss`
- `vendor/bin/phpcs --standard=phpcs.xml.dist src/Internal/Admin/Settings/WooPaymentsModernSettingsPage.php includes/class-wc-payment-gateway-wcpay.php tests/unit/src/Internal/Admin/Settings/WooPaymentsModernSettingsPageTest.php`
- `docker compose exec -u www-data wordpress bash -c "cd /var/www/html/wp-content/plugins/woocommerce-payments && vendor/bin/phpunit --configuration phpunit.xml.dist --filter WooPaymentsModernSettingsPageTest"` skipped because this local PHPUnit env does not provide `ReactSettingsPageInterface`.
- 
<img width="997" height="811" alt="Screenshot 2026-04-24 at 07 36 05" src="https://github.com/user-attachments/assets/0feb8807-e915-4677-b975-d2966bfd77c5" />

