### PR TITLE
fix: Express Checkout nonce error on shortcode checkout (WOOPMNT-6135)

### DIFF
--- a/changelog/fix-WOOPMNT-6135-express-checkout-shortcode-nonce
+++ b/changelog/fix-WOOPMNT-6135-express-checkout-shortcode-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Express Checkout 403 nonce error on shortcode checkout when Apple Pay/Google Pay sheet selects an address

--- a/client/express-checkout/__tests__/cart-api.test.js
+++ b/client/express-checkout/__tests__/cart-api.test.js
@@ -166,7 +166,6 @@ describe( 'ExpressCheckoutCartApi', () => {
 				method: 'GET',
 				path: expect.stringContaining( '/wc/store/v1/cart' ),
 				headers: expect.objectContaining( {
-					'X-WooPayments-Tokenized-Cart-Session-Nonce': undefined,
 					'X-WooPayments-Tokenized-Cart-Nonce':
 						'global_tokenized_cart_nonce',
 				} ),
@@ -184,7 +183,6 @@ describe( 'ExpressCheckoutCartApi', () => {
 				),
 				// in this case, no additional headers should have been submitted.
 				headers: expect.objectContaining( {
-					'X-WooPayments-Tokenized-Cart-Session-Nonce': undefined,
 					'X-WooPayments-Tokenized-Cart': true,
 					'X-WooPayments-Tokenized-Cart-Nonce':
 						'global_tokenized_cart_nonce',
@@ -192,5 +190,64 @@ describe( 'ExpressCheckoutCartApi', () => {
 				} ),
 			} )
 		);
+	} );
+
+	// Regression test for WOOPMNT-6135.
+	it( 'should keep sending the page-localized store_api_nonce when responses lack a rotating Nonce header', async () => {
+		// On shortcode checkout the custom session handler does not engage,
+		// and responses may not carry a rotating Nonce header. Reading
+		// `response.headers.get( 'Nonce' )` returns `null` in that case, and
+		// we must not let that overwrite the working store_api_nonce default
+		// on the next request — otherwise it serializes to the literal string
+		// "null" and the Store API rejects with `woocommerce_rest_missing_nonce`.
+		global.wcpayExpressCheckoutParams.button_context = 'cart';
+		apiFetch.mockResolvedValue( {
+			headers: new Headers(),
+			json: () => Promise.resolve( {} ),
+		} );
+		const api = new ExpressCheckoutCartApi();
+
+		await api.getCart();
+		await api.updateCustomer( {
+			billing_address: { last_name: 'Last' },
+		} );
+
+		const updateCustomerCall = apiFetch.mock.calls[ 1 ][ 0 ];
+		expect( updateCustomerCall.headers.Nonce ).toBe(
+			'global_store_api_nonce'
+		);
+	} );
+
+	// Regression test for WOOPMNT-6135.
+	it( 'should omit the session-nonce header on non-product contexts so it never serializes as "undefined"', async () => {
+		global.wcpayExpressCheckoutParams.button_context = 'cart';
+		apiFetch.mockResolvedValue( {
+			headers: new Headers(),
+			json: () => Promise.resolve( {} ),
+		} );
+		const api = new ExpressCheckoutCartApi();
+
+		await api.getCart();
+
+		const callArgs = apiFetch.mock.calls[ 0 ][ 0 ];
+		expect( callArgs.headers ).not.toHaveProperty(
+			'X-WooPayments-Tokenized-Cart-Session-Nonce'
+		);
+	} );
+
+	it( 'should send the session-nonce header on product contexts', async () => {
+		global.wcpayExpressCheckoutParams.button_context = 'product';
+		apiFetch.mockResolvedValue( {
+			headers: new Headers(),
+			json: () => Promise.resolve( {} ),
+		} );
+		const api = new ExpressCheckoutCartApi();
+
+		await api.getCart();
+
+		const callArgs = apiFetch.mock.calls[ 0 ][ 0 ];
+		expect(
+			callArgs.headers[ 'X-WooPayments-Tokenized-Cart-Session-Nonce' ]
+		).toBe( 'global_tokenized_cart_session_nonce' );
 	} );
 } );

--- a/client/express-checkout/cart-api.js
+++ b/client/express-checkout/cart-api.js
@@ -4,6 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { applyFilters } from '@wordpress/hooks';
 import { addQueryArgs } from '@wordpress/url';
+import { isNil, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,34 +29,9 @@ export default class ExpressCheckoutCartApi {
 	 * @return {Promise} Result from `apiFetch`.
 	 */
 	async _request( options ) {
-		// Build defaults explicitly so we only include header keys when we
-		// actually have a value. apiFetch / Fetch serialize `undefined` and
-		// `null` to the literal strings "undefined" and "null" on the wire,
-		// which breaks server-side nonce verification.
-		const headerDefaults = {
-			Nonce: getExpressCheckoutData( 'nonce' ).store_api_nonce,
-		};
-
-		const tokenizedCartNonce =
-			getExpressCheckoutData( 'nonce' ).tokenized_cart_nonce;
-		if ( tokenizedCartNonce ) {
-			headerDefaults[ 'X-WooPayments-Tokenized-Cart-Nonce' ] =
-				tokenizedCartNonce;
-		}
-
-		// The session nonce is only meaningful on PDP, where the custom
-		// session handler is intended to engage and create an isolated
-		// tokenized cart. Sending it on shortcode cart/checkout would replace
-		// the customer's existing cart with an empty one.
-		if ( getExpressCheckoutData( 'button_context' ) === 'product' ) {
-			const sessionNonce =
-				getExpressCheckoutData( 'nonce' ).tokenized_cart_session_nonce;
-			if ( sessionNonce ) {
-				headerDefaults[ 'X-WooPayments-Tokenized-Cart-Session-Nonce' ] =
-					sessionNonce;
-			}
-		}
-
+		// Drop nullish values so we never serialize `undefined` / `null` to
+		// the literal strings "undefined" / "null" on the wire (which breaks
+		// server-side nonce verification).
 		const response = await apiFetch( {
 			...options,
 			parse: false,
@@ -67,32 +43,45 @@ export default class ExpressCheckoutCartApi {
 						'checkout'
 					).currency_code.toUpperCase(),
 			} ),
-			headers: {
-				...headerDefaults,
-				...this.cartRequestHeaders,
-				...options.headers,
-			},
+			headers: omitBy(
+				{
+					// the Store API nonce, which could later be overwritten in subsequent requests.
+					Nonce: getExpressCheckoutData( 'nonce' ).store_api_nonce,
+					// needed for validation of address data, etc.
+					'X-WooPayments-Tokenized-Cart-Nonce':
+						getExpressCheckoutData( 'nonce' ).tokenized_cart_nonce,
+					// The session nonce is only meaningful on PDP, where the
+					// custom session handler is intended to engage and create
+					// an isolated tokenized cart. Sending it on shortcode
+					// cart/checkout would replace the customer's existing cart
+					// with an empty one.
+					'X-WooPayments-Tokenized-Cart-Session-Nonce':
+						getExpressCheckoutData( 'button_context' ) === 'product'
+							? getExpressCheckoutData( 'nonce' )
+									.tokenized_cart_session_nonce
+							: undefined,
+					...this.cartRequestHeaders,
+					...options.headers,
+				},
+				isNil
+			),
 		} );
 
 		// Only carry forward response headers we actually received. Reading
 		// an absent header returns `null`, and assigning that null over the
 		// `Nonce` default on the next request would serialize as "null" and
 		// trigger `woocommerce_rest_missing_nonce`.
-		const newCartRequestHeaders = {};
-		const rotatedNonce = response.headers.get( 'Nonce' );
-		if ( rotatedNonce ) {
-			// used as a reference on shortcode cart/checkout pages, where the Nonce might not be automatically added to the request.
-			newCartRequestHeaders.Nonce = rotatedNonce;
-		}
-		const cartSession = response.headers.get(
-			'X-WooPayments-Tokenized-Cart-Session'
+		this.cartRequestHeaders = omitBy(
+			{
+				// used as a reference on shortcode cart/checkout pages, where the Nonce might not be automatically added to the request.
+				Nonce: response.headers.get( 'Nonce' ),
+				// saving the received value as a cart reference for future usage. This value could be updated multiple times.
+				'X-WooPayments-Tokenized-Cart-Session': response.headers.get(
+					'X-WooPayments-Tokenized-Cart-Session'
+				),
+			},
+			isNil
 		);
-		if ( cartSession !== null ) {
-			// saving the received value as a cart reference for future usage. This value could be updated multiple times.
-			newCartRequestHeaders[ 'X-WooPayments-Tokenized-Cart-Session' ] =
-				cartSession;
-		}
-		this.cartRequestHeaders = newCartRequestHeaders;
 
 		return response.json();
 	}

--- a/client/express-checkout/cart-api.js
+++ b/client/express-checkout/cart-api.js
@@ -28,6 +28,34 @@ export default class ExpressCheckoutCartApi {
 	 * @return {Promise} Result from `apiFetch`.
 	 */
 	async _request( options ) {
+		// Build defaults explicitly so we only include header keys when we
+		// actually have a value. apiFetch / Fetch serialize `undefined` and
+		// `null` to the literal strings "undefined" and "null" on the wire,
+		// which breaks server-side nonce verification.
+		const headerDefaults = {
+			Nonce: getExpressCheckoutData( 'nonce' ).store_api_nonce,
+		};
+
+		const tokenizedCartNonce =
+			getExpressCheckoutData( 'nonce' ).tokenized_cart_nonce;
+		if ( tokenizedCartNonce ) {
+			headerDefaults[ 'X-WooPayments-Tokenized-Cart-Nonce' ] =
+				tokenizedCartNonce;
+		}
+
+		// The session nonce is only meaningful on PDP, where the custom
+		// session handler is intended to engage and create an isolated
+		// tokenized cart. Sending it on shortcode cart/checkout would replace
+		// the customer's existing cart with an empty one.
+		if ( getExpressCheckoutData( 'button_context' ) === 'product' ) {
+			const sessionNonce =
+				getExpressCheckoutData( 'nonce' ).tokenized_cart_session_nonce;
+			if ( sessionNonce ) {
+				headerDefaults[ 'X-WooPayments-Tokenized-Cart-Session-Nonce' ] =
+					sessionNonce;
+			}
+		}
+
 		const response = await apiFetch( {
 			...options,
 			parse: false,
@@ -40,31 +68,31 @@ export default class ExpressCheckoutCartApi {
 					).currency_code.toUpperCase(),
 			} ),
 			headers: {
-				// the Store API nonce, which could later be overwritten in subsequent requests.
-				Nonce: getExpressCheckoutData( 'nonce' ).store_api_nonce,
-				// needed for validation of address data, etc.
-				'X-WooPayments-Tokenized-Cart-Nonce':
-					getExpressCheckoutData( 'nonce' ).tokenized_cart_nonce ||
-					undefined,
-				// necessary to validate any request made to the backend from the PDP.
-				'X-WooPayments-Tokenized-Cart-Session-Nonce':
-					getExpressCheckoutData( 'button_context' ) === 'product'
-						? getExpressCheckoutData( 'nonce' )
-								.tokenized_cart_session_nonce
-						: undefined,
+				...headerDefaults,
 				...this.cartRequestHeaders,
 				...options.headers,
 			},
 		} );
 
-		this.cartRequestHeaders = {
+		// Only carry forward response headers we actually received. Reading
+		// an absent header returns `null`, and assigning that null over the
+		// `Nonce` default on the next request would serialize as "null" and
+		// trigger `woocommerce_rest_missing_nonce`.
+		const newCartRequestHeaders = {};
+		const rotatedNonce = response.headers.get( 'Nonce' );
+		if ( rotatedNonce ) {
 			// used as a reference on shortcode cart/checkout pages, where the Nonce might not be automatically added to the request.
-			Nonce: response.headers.get( 'Nonce' ),
+			newCartRequestHeaders.Nonce = rotatedNonce;
+		}
+		const cartSession = response.headers.get(
+			'X-WooPayments-Tokenized-Cart-Session'
+		);
+		if ( cartSession !== null ) {
 			// saving the received value as a cart reference for future usage. This value could be updated multiple times.
-			'X-WooPayments-Tokenized-Cart-Session': response.headers.get(
-				'X-WooPayments-Tokenized-Cart-Session'
-			),
-		};
+			newCartRequestHeaders[ 'X-WooPayments-Tokenized-Cart-Session' ] =
+				cartSession;
+		}
+		this.cartRequestHeaders = newCartRequestHeaders;
 
 		return response.json();
 	}

--- a/client/express-checkout/shortcode-buttons-express/__tests__/tokenized-express-checkout--order-pay-page.test.js
+++ b/client/express-checkout/shortcode-buttons-express/__tests__/tokenized-express-checkout--order-pay-page.test.js
@@ -15,6 +15,7 @@ jest.mock( 'tracks', () => ( {
 	recordUserEvent: jest.fn(),
 } ) );
 jest.mock( 'lodash', () => ( {
+	...jest.requireActual( 'lodash' ),
 	debounce: jest.fn( ( callback ) => callback ),
 } ) );
 

--- a/client/express-checkout/shortcode-buttons-express/__tests__/tokenized-express-checkout--product-page.test.js
+++ b/client/express-checkout/shortcode-buttons-express/__tests__/tokenized-express-checkout--product-page.test.js
@@ -10,6 +10,7 @@ jest.mock( 'tracks', () => ( {
 	recordUserEvent: jest.fn(),
 } ) );
 jest.mock( 'lodash', () => ( {
+	...jest.requireActual( 'lodash' ),
 	debounce: jest.fn( ( callback ) => callback ),
 } ) );
 

--- a/client/express-checkout/shortcode-buttons-express/__tests__/tokenized-express-checkout--shortcode-checkout-page.test.js
+++ b/client/express-checkout/shortcode-buttons-express/__tests__/tokenized-express-checkout--shortcode-checkout-page.test.js
@@ -14,6 +14,7 @@ jest.mock( 'tracks', () => ( {
 	recordUserEvent: jest.fn(),
 } ) );
 jest.mock( 'lodash', () => ( {
+	...jest.requireActual( 'lodash' ),
 	debounce: jest.fn( ( callback ) => callback ),
 } ) );
 jest.mock( '@wordpress/api-fetch', () => ( {


### PR DESCRIPTION
Closes WOOPMNT-6135.

#### Changes proposed in this Pull Request

Defensive hardening of `client/express-checkout/cart-api.js#_request` for Apple Pay / Google Pay on **shortcode (classic) checkout**. None of the three observed issues reproduce as a `401`/`403` on a clean `develop` (verified by @frosso). The merchant's specific `401`/`403` trigger remains unidentified — most plausible candidate: something on their stack stripping the rotating `Nonce` *response* header in transit. Credentials requested on the ZD ticket; will follow up if pinned down.

Three observable issues, only one of which can plausibly cause an HTTP error:

- **Session-nonce serialized as `"undefined"` on non-PDP contexts** — wire-cosmetic only. Server just skips `add_payment_request_store_api_session_handler`, which is the intended behavior on shortcode.
- **`X-WooPayments-Tokenized-Cart-Session: "null"` from call 2 onward** — also benign. `JsonWebToken::validate("null", ...)` rejects cleanly.
- **`Nonce: null` overwriting the `store_api_nonce` default** — real bug, environment-conditional. WC core's `AbstractCartRoute::add_response_headers` rotates `Nonce` on every cart response, so on a clean setup `response.headers.get('Nonce')` returns the rotated value. If something strips that header, `get('Nonce')` returns `null`, overwrites the working default, and Store API rejects with `woocommerce_rest_missing_nonce` (`401`).

**Fix:** `omitBy(headers, isNil)` for both the request headers and the carried-forward `cartRequestHeaders`, so absent values are omitted instead of serialized as `"undefined"` / `"null"`. The PDP-only gate on the session nonce is preserved — removing it would engage the custom session handler on shortcode and replace the customer's existing cart with an empty one.

#### Testing instructions

```bash
npm run test:js -- client/express-checkout/__tests__/cart-api.test.js
```

Three new tests cover the regression cases plus the PDP happy path; the first mocks the missing-`Nonce`-response-header precondition.

**No-regression smoke check on a clean dev env** (the bug doesn't reproduce here — this verifies the fix doesn't break the working path):

1. Shortcode (classic) checkout with Google Pay / Apple Pay enabled.
2. Open the page with a non-empty cart, click the express button, select a shipping address.
3. **Expected:** `update-customer` returns `200`, sheet stays open, shipping rates populate.

**To force-reproduce the real bug locally:** add a `rest_post_dispatch` filter that strips the `Nonce` response header, then repeat the steps above. Without the fix: `401 woocommerce_rest_missing_nonce`. With the fix: `200`.

**PDP regression check:** add to cart from a PDP, click the express button — the tokenized session handler should still engage (response carries `X-WooPayments-Tokenized-Cart-Session`).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — Chrome iOS is the affected merchant's primary platform; needs verification on a device or via emulation as part of QA.

**Post merge**

- [ ] Link to testing instructions from the release testing doc: _Add link here_
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
