### PR TITLE
WOOPMNT-5247: Add Dev Mode row to WooPayments System Status Report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,3 @@ bin/jurassictube/
 
 # Git worktrees
 .worktrees/
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ bin/jurassictube/
 
 # Git worktrees
 .worktrees/
+.worktrees/

--- a/changelog/woopmnt-5247-dev-mode-status-report
+++ b/changelog/woopmnt-5247-dev-mode-status-report
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Dev Mode row to WooPayments system status report showing whether dev mode is active and which condition(s) triggered it

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -422,13 +422,54 @@ class WC_Payments_Status {
 	}
 
 	/**
+	 * Returns the current WordPress environment type.
+	 *
+	 * Wrapper for testability.
+	 *
+	 * @return string
+	 */
+	protected function get_wp_environment_type(): string {
+		return function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : '';
+	}
+
+	/**
+	 * Returns the current WordPress development mode.
+	 *
+	 * Wrapper for testability.
+	 *
+	 * @return string
+	 */
+	protected function get_wp_development_mode(): string {
+		return function_exists( 'wp_get_development_mode' ) ? wp_get_development_mode() : '';
+	}
+
+	/**
 	 * Returns human-readable labels for each active dev mode trigger.
 	 *
-	 * @todo Implement trigger detection — WCPAY_DEV_MODE, WP_ENVIRONMENT_TYPE, WP_DEVELOPMENT_MODE, filter fallback.
 	 * @return string[]
 	 */
 	private function get_dev_mode_triggers(): array {
-		return [];
+		$triggers = [];
+
+		if ( defined( 'WCPAY_DEV_MODE' ) && WCPAY_DEV_MODE ) {
+			$triggers[] = 'WCPAY_DEV_MODE';
+		}
+
+		$env_type = $this->get_wp_environment_type();
+		if ( in_array( $env_type, \WCPay\Core\Mode::DEV_MODE_ENVIRONMENTS, true ) ) {
+			$triggers[] = 'WP_ENVIRONMENT_TYPE=' . $env_type;
+		}
+
+		$dev_mode_setting = $this->get_wp_development_mode();
+		if ( '' !== $dev_mode_setting ) {
+			$triggers[] = 'WP_DEVELOPMENT_MODE=' . $dev_mode_setting;
+		}
+
+		if ( empty( $triggers ) ) {
+			$triggers[] = 'wcpay_dev_mode filter';
+		}
+
+		return $triggers;
 	}
 
 	/**

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -422,6 +422,17 @@ class WC_Payments_Status {
 	}
 
 	/**
+	 * Returns true if the WCPAY_DEV_MODE constant is defined and truthy.
+	 *
+	 * Wrapper for testability.
+	 *
+	 * @return bool
+	 */
+	protected function is_wcpay_dev_mode_defined(): bool {
+		return defined( 'WCPAY_DEV_MODE' ) && WCPAY_DEV_MODE;
+	}
+
+	/**
 	 * Returns the current WordPress environment type.
 	 *
 	 * Wrapper for testability.
@@ -451,7 +462,7 @@ class WC_Payments_Status {
 	private function get_dev_mode_triggers(): array {
 		$triggers = [];
 
-		if ( defined( 'WCPAY_DEV_MODE' ) && WCPAY_DEV_MODE ) {
+		if ( $this->is_wcpay_dev_mode_defined() ) {
 			$triggers[] = 'WCPAY_DEV_MODE';
 		}
 

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -424,6 +424,7 @@ class WC_Payments_Status {
 	/**
 	 * Returns human-readable labels for each active dev mode trigger.
 	 *
+	 * @todo Implement trigger detection — WCPAY_DEV_MODE, WP_ENVIRONMENT_TYPE, WP_DEVELOPMENT_MODE, filter fallback.
 	 * @return string[]
 	 */
 	private function get_dev_mode_triggers(): array {

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -422,18 +422,6 @@ class WC_Payments_Status {
 	}
 
 	/**
-	 * Returns the triggers that activated dev mode.
-	 *
-	 * Delegates to Mode so trigger detection is not duplicated here.
-	 * Wrapped as a protected method for testability.
-	 *
-	 * @return string[]
-	 */
-	protected function get_dev_mode_trigger_labels(): array {
-		return WC_Payments::mode()->get_dev_mode_triggers();
-	}
-
-	/**
 	 * Renders WCPay information on the status page.
 	 */
 	public function render_status_report_section() {
@@ -498,7 +486,7 @@ class WC_Payments_Status {
 						<td>
 						<?php
 						if ( WC_Payments::mode()->is_dev() ) {
-							$triggers = $this->get_dev_mode_trigger_labels();
+							$triggers = WC_Payments::mode()->get_dev_mode_triggers();
 							$label    = __( 'Enabled', 'woocommerce-payments' );
 							if ( ! empty( $triggers ) ) {
 								$label .= ' (' . implode( ', ', $triggers ) . ')';

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -422,6 +422,15 @@ class WC_Payments_Status {
 	}
 
 	/**
+	 * Returns human-readable labels for each active dev mode trigger.
+	 *
+	 * @return string[]
+	 */
+	private function get_dev_mode_triggers(): array {
+		return [];
+	}
+
+	/**
 	 * Renders WCPay information on the status page.
 	 */
 	public function render_status_report_section() {
@@ -479,6 +488,24 @@ class WC_Payments_Status {
 						<td data-export-label="Test Mode"><?php esc_html_e( 'Test Mode', 'woocommerce-payments' ); ?>:</td>
 						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the payment gateway has test payments enabled or not.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 						<td><?php WC_Payments::mode()->is_test() ? esc_html_e( 'Enabled', 'woocommerce-payments' ) : esc_html_e( 'Disabled', 'woocommerce-payments' ); ?></td>
+					</tr>
+					<tr>
+						<td data-export-label="Dev Mode"><?php esc_html_e( 'Dev Mode', 'woocommerce-payments' ); ?>:</td>
+						<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether WooPayments is running in dev (sandbox) mode and what triggered it.', 'woocommerce-payments' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
+						<td>
+						<?php
+						if ( WC_Payments::mode()->is_dev() ) {
+							$triggers = $this->get_dev_mode_triggers();
+							$label    = __( 'Enabled', 'woocommerce-payments' );
+							if ( ! empty( $triggers ) ) {
+								$label .= ' (' . implode( ', ', $triggers ) . ')';
+							}
+							echo esc_html( $label );
+						} else {
+							esc_html_e( 'Disabled', 'woocommerce-payments' );
+						}
+						?>
+						</td>
 					</tr>
 					<tr>
 						<td data-export-label="Enabled APMs"><?php esc_html_e( 'Enabled APMs', 'woocommerce-payments' ); ?>:</td>

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -422,65 +422,15 @@ class WC_Payments_Status {
 	}
 
 	/**
-	 * Returns true if the WCPAY_DEV_MODE constant is defined and truthy.
+	 * Returns the triggers that activated dev mode.
 	 *
-	 * Wrapper for testability.
-	 *
-	 * @return bool
-	 */
-	protected function is_wcpay_dev_mode_defined(): bool {
-		return defined( 'WCPAY_DEV_MODE' ) && WCPAY_DEV_MODE;
-	}
-
-	/**
-	 * Returns the current WordPress environment type.
-	 *
-	 * Wrapper for testability.
-	 *
-	 * @return string
-	 */
-	protected function get_wp_environment_type(): string {
-		return function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : '';
-	}
-
-	/**
-	 * Returns the current WordPress development mode.
-	 *
-	 * Wrapper for testability.
-	 *
-	 * @return string
-	 */
-	protected function get_wp_development_mode(): string {
-		return function_exists( 'wp_get_development_mode' ) ? wp_get_development_mode() : '';
-	}
-
-	/**
-	 * Returns human-readable labels for each active dev mode trigger.
+	 * Delegates to Mode so trigger detection is not duplicated here.
+	 * Wrapped as a protected method for testability.
 	 *
 	 * @return string[]
 	 */
-	private function get_dev_mode_triggers(): array {
-		$triggers = [];
-
-		if ( $this->is_wcpay_dev_mode_defined() ) {
-			$triggers[] = 'WCPAY_DEV_MODE';
-		}
-
-		$env_type = $this->get_wp_environment_type();
-		if ( in_array( $env_type, \WCPay\Core\Mode::DEV_MODE_ENVIRONMENTS, true ) ) {
-			$triggers[] = 'WP_ENVIRONMENT_TYPE=' . $env_type;
-		}
-
-		$dev_mode_setting = $this->get_wp_development_mode();
-		if ( '' !== $dev_mode_setting ) {
-			$triggers[] = 'WP_DEVELOPMENT_MODE=' . $dev_mode_setting;
-		}
-
-		if ( empty( $triggers ) ) {
-			$triggers[] = 'wcpay_dev_mode filter';
-		}
-
-		return $triggers;
+	protected function get_dev_mode_trigger_labels(): array {
+		return WC_Payments::mode()->get_dev_mode_triggers();
 	}
 
 	/**
@@ -548,7 +498,7 @@ class WC_Payments_Status {
 						<td>
 						<?php
 						if ( WC_Payments::mode()->is_dev() ) {
-							$triggers = $this->get_dev_mode_triggers();
+							$triggers = $this->get_dev_mode_trigger_labels();
 							$label    = __( 'Enabled', 'woocommerce-payments' );
 							if ( ! empty( $triggers ) ) {
 								$label .= ' (' . implode( ', ', $triggers ) . ')';

--- a/includes/core/class-mode.php
+++ b/includes/core/class-mode.php
@@ -36,6 +36,13 @@ class Mode {
 	private $dev_mode;
 
 	/**
+	 * Holds the triggers that activated dev mode.
+	 *
+	 * @var string[]
+	 */
+	private $dev_mode_triggers = [];
+
+	/**
 	 * Indicates the WCPay version which introduced the class.
 	 *
 	 * @var string
@@ -62,16 +69,26 @@ class Mode {
 			return;
 		}
 
-		$dev_mode = (
-			// Plugin-specific dev mode.
-			$this->is_wcpay_dev_mode_defined()
+		$triggers = [];
 
-			// WordPress Dev Environment.
-			|| in_array( $this->get_wp_environment_type(), self::DEV_MODE_ENVIRONMENTS, true )
+		// Plugin-specific dev mode.
+		if ( $this->is_wcpay_dev_mode_defined() ) {
+			$triggers[] = 'WCPAY_DEV_MODE';
+		}
 
-			// WordPress Development mode. If any development mode is enabled, we'll fall back to dev as well.
-			|| '' !== $this->wp_get_development_mode()
-		);
+		// WordPress Dev Environment.
+		$env_type = $this->get_wp_environment_type();
+		if ( in_array( $env_type, self::DEV_MODE_ENVIRONMENTS, true ) ) {
+			$triggers[] = 'WP_ENVIRONMENT_TYPE=' . $env_type;
+		}
+
+		// WordPress Development mode. If any development mode is enabled, we'll fall back to dev as well.
+		$dev_mode_setting = $this->wp_get_development_mode();
+		if ( '' !== $dev_mode_setting ) {
+			$triggers[] = 'WP_DEVELOPMENT_MODE=' . $dev_mode_setting;
+		}
+
+		$dev_mode = ! empty( $triggers );
 
 		/**
 		 * Allows WooPayments to enter dev (aka sandbox) mode.
@@ -80,6 +97,16 @@ class Mode {
 		 * @param bool $dev_mode Whether to enter WooPayments in dev mode.
 		 */
 		$this->dev_mode = (bool) apply_filters( 'wcpay_dev_mode', $dev_mode );
+
+		// Reconcile triggers with the post-filter result.
+		if ( $this->dev_mode && ! $dev_mode ) {
+			// The filter turned dev mode on with no underlying conditions.
+			$triggers[] = 'wcpay_dev_mode filter';
+		} elseif ( ! $this->dev_mode ) {
+			// Dev mode is off (filter may have suppressed it); no triggers apply.
+			$triggers = [];
+		}
+		$this->dev_mode_triggers = $triggers;
 
 		// If dev mode is active, we enable test mode onboarding.
 		$test_mode_onboarding = $this->dev_mode || \WC_Payments_Onboarding_Service::is_test_mode_enabled();
@@ -160,6 +187,18 @@ class Mode {
 	}
 
 	/**
+	 * Returns the triggers that activated dev mode.
+	 *
+	 * Returns an empty array when dev mode is not active.
+	 *
+	 * @return string[]
+	 */
+	public function get_dev_mode_triggers(): array {
+		$this->maybe_init();
+		return $this->dev_mode_triggers;
+	}
+
+	/**
 	 * Enable live payment processing.
 	 *
 	 * @return void
@@ -169,7 +208,8 @@ class Mode {
 		// We can't process live payments and be in test mode onboarding.
 		$this->test_mode_onboarding = false;
 		// We also can't be in dev mode.
-		$this->dev_mode = false;
+		$this->dev_mode          = false;
+		$this->dev_mode_triggers = [];
 	}
 
 	/**
@@ -201,7 +241,8 @@ class Mode {
 	public function live_mode_onboarding() {
 		$this->test_mode_onboarding = false;
 		// When onboarding in live mode, we can't be in dev mode.
-		$this->dev_mode = false;
+		$this->dev_mode          = false;
+		$this->dev_mode_triggers = [];
 		// Doesn't affect the payments processing mode.
 	}
 
@@ -213,7 +254,8 @@ class Mode {
 	 * @return void
 	 */
 	public function dev() {
-		$this->dev_mode = true;
+		$this->dev_mode          = true;
+		$this->dev_mode_triggers = [];
 		// In dev mode, everything is in test mode.
 		$this->test_mode            = true;
 		$this->test_mode_onboarding = true;

--- a/includes/core/class-mode.php
+++ b/includes/core/class-mode.php
@@ -255,7 +255,7 @@ class Mode {
 	 */
 	public function dev() {
 		$this->dev_mode          = true;
-		$this->dev_mode_triggers = [];
+		$this->dev_mode_triggers = [ 'manual' ];
 		// In dev mode, everything is in test mode.
 		$this->test_mode            = true;
 		$this->test_mode_onboarding = true;

--- a/tests/unit/core/test-class-mode.php
+++ b/tests/unit/core/test-class-mode.php
@@ -179,4 +179,77 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 		// Dev mode is deactivated.
 		$this->assertFalse( $this->mode->is_dev() );
 	}
+
+	public function test_get_dev_mode_triggers_returns_empty_when_not_in_dev_mode() {
+		update_option( 'woocommerce_woocommerce_payments_settings', [ 'test_mode' => 'no' ] );
+
+		$this->mode->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
+		$this->mode->method( 'get_wp_environment_type' )->willReturn( null );
+		$this->mode->method( 'wp_get_development_mode' )->willReturn( '' );
+
+		$this->assertFalse( $this->mode->is_dev() );
+		$this->assertSame( [], $this->mode->get_dev_mode_triggers() );
+	}
+
+	public function test_get_dev_mode_triggers_returns_wcpay_dev_mode_constant() {
+		$this->mode->method( 'is_wcpay_dev_mode_defined' )->willReturn( true );
+
+		$this->assertSame( [ 'WCPAY_DEV_MODE' ], $this->mode->get_dev_mode_triggers() );
+	}
+
+	public function test_get_dev_mode_triggers_returns_wp_environment_type() {
+		$this->mode->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
+		$this->mode->method( 'get_wp_environment_type' )->willReturn( 'staging' );
+		$this->mode->method( 'wp_get_development_mode' )->willReturn( '' );
+
+		$this->assertSame( [ 'WP_ENVIRONMENT_TYPE=staging' ], $this->mode->get_dev_mode_triggers() );
+	}
+
+	public function test_get_dev_mode_triggers_returns_wp_development_mode() {
+		$this->mode->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
+		$this->mode->method( 'get_wp_environment_type' )->willReturn( null );
+		$this->mode->method( 'wp_get_development_mode' )->willReturn( 'plugin' );
+
+		$this->assertSame( [ 'WP_DEVELOPMENT_MODE=plugin' ], $this->mode->get_dev_mode_triggers() );
+	}
+
+	public function test_get_dev_mode_triggers_returns_filter_trigger_when_filter_enables_dev_mode() {
+		$this->mode->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
+		$this->mode->method( 'get_wp_environment_type' )->willReturn( null );
+		$this->mode->method( 'wp_get_development_mode' )->willReturn( '' );
+
+		add_filter( 'wcpay_dev_mode', '__return_true' );
+
+		$this->assertSame( [ 'wcpay_dev_mode filter' ], $this->mode->get_dev_mode_triggers() );
+	}
+
+	public function test_get_dev_mode_triggers_returns_empty_when_filter_disables_dev_mode() {
+		$this->mode->method( 'is_wcpay_dev_mode_defined' )->willReturn( true );
+		$this->mode->method( 'get_wp_environment_type' )->willReturn( null );
+		$this->mode->method( 'wp_get_development_mode' )->willReturn( '' );
+
+		add_filter( 'wcpay_dev_mode', '__return_false' );
+
+		$this->assertFalse( $this->mode->is_dev() );
+		$this->assertSame( [], $this->mode->get_dev_mode_triggers() );
+	}
+
+	public function test_get_dev_mode_triggers_returns_multiple_triggers() {
+		$this->mode->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
+		$this->mode->method( 'get_wp_environment_type' )->willReturn( 'development' );
+		$this->mode->method( 'wp_get_development_mode' )->willReturn( 'plugin' );
+
+		$this->assertSame(
+			[ 'WP_ENVIRONMENT_TYPE=development', 'WP_DEVELOPMENT_MODE=plugin' ],
+			$this->mode->get_dev_mode_triggers()
+		);
+	}
+
+	public function test_dev_resets_dev_mode_triggers() {
+		// Confirm that calling dev() clears any triggers that might have been set.
+		$this->mode->dev();
+
+		$this->assertTrue( $this->mode->is_dev() );
+		$this->assertSame( [], $this->mode->get_dev_mode_triggers() );
+	}
 }

--- a/tests/unit/core/test-class-mode.php
+++ b/tests/unit/core/test-class-mode.php
@@ -245,11 +245,10 @@ class Core_Mode_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
-	public function test_dev_resets_dev_mode_triggers() {
-		// Confirm that calling dev() clears any triggers that might have been set.
+	public function test_dev_sets_manual_trigger() {
 		$this->mode->dev();
 
 		$this->assertTrue( $this->mode->is_dev() );
-		$this->assertSame( [], $this->mode->get_dev_mode_triggers() );
+		$this->assertSame( [ 'manual' ], $this->mode->get_dev_mode_triggers() );
 	}
 }

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -279,128 +279,12 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$this->set_up_connected_mocks();
 		WC_Payments::mode()->live();
 
-		$status = $this->getMockBuilder( WC_Payments_Status::class )
-			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
-			->getMock();
-
 		ob_start();
-		$status->render_status_report_section();
+		$this->status->render_status_report_section();
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'Dev Mode', $output );
 		$this->assertStringContainsString( 'Disabled', $output );
-	}
-
-	/**
-	 * Test that the Dev Mode row shows "Enabled" with WP_ENVIRONMENT_TYPE trigger.
-	 */
-	public function test_dev_mode_row_shows_enabled_with_wp_environment_type(): void {
-		$this->set_up_connected_mocks();
-		WC_Payments::mode()->dev();
-
-		$status = $this->getMockBuilder( WC_Payments_Status::class )
-			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
-			->getMock();
-
-		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'WP_ENVIRONMENT_TYPE=staging' ] );
-
-		ob_start();
-		$status->render_status_report_section();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'Enabled', $output );
-		$this->assertStringContainsString( 'WP_ENVIRONMENT_TYPE=staging', $output );
-	}
-
-	/**
-	 * Test that the Dev Mode row shows "Enabled" with WP_DEVELOPMENT_MODE trigger.
-	 */
-	public function test_dev_mode_row_shows_enabled_with_wp_development_mode(): void {
-		$this->set_up_connected_mocks();
-		WC_Payments::mode()->dev();
-
-		$status = $this->getMockBuilder( WC_Payments_Status::class )
-			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
-			->getMock();
-
-		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'WP_DEVELOPMENT_MODE=plugin' ] );
-
-		ob_start();
-		$status->render_status_report_section();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'Enabled', $output );
-		$this->assertStringContainsString( 'WP_DEVELOPMENT_MODE=plugin', $output );
-	}
-
-	/**
-	 * Test that the Dev Mode row falls back to "wcpay_dev_mode filter" when no other trigger is active.
-	 */
-	public function test_dev_mode_row_shows_wcpay_dev_mode_filter_when_no_other_trigger(): void {
-		$this->set_up_connected_mocks();
-		WC_Payments::mode()->dev();
-
-		$status = $this->getMockBuilder( WC_Payments_Status::class )
-			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
-			->getMock();
-
-		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'wcpay_dev_mode filter' ] );
-
-		ob_start();
-		$status->render_status_report_section();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'Enabled', $output );
-		$this->assertStringContainsString( 'wcpay_dev_mode filter', $output );
-	}
-
-	/**
-	 * Test that the Dev Mode row shows all triggers when multiple conditions are active.
-	 */
-	public function test_dev_mode_row_shows_multiple_triggers(): void {
-		$this->set_up_connected_mocks();
-		WC_Payments::mode()->dev();
-
-		$status = $this->getMockBuilder( WC_Payments_Status::class )
-			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
-			->getMock();
-
-		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'WP_ENVIRONMENT_TYPE=development', 'WP_DEVELOPMENT_MODE=plugin' ] );
-
-		ob_start();
-		$status->render_status_report_section();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'Enabled', $output );
-		$this->assertStringContainsString( 'WP_ENVIRONMENT_TYPE=development', $output );
-		$this->assertStringContainsString( 'WP_DEVELOPMENT_MODE=plugin', $output );
-	}
-
-	/**
-	 * Test that the Dev Mode row shows "Enabled" with WCPAY_DEV_MODE trigger.
-	 */
-	public function test_dev_mode_row_shows_wcpay_dev_mode_constant_trigger(): void {
-		$this->set_up_connected_mocks();
-		WC_Payments::mode()->dev();
-
-		$status = $this->getMockBuilder( WC_Payments_Status::class )
-			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
-			->getMock();
-
-		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'WCPAY_DEV_MODE' ] );
-
-		ob_start();
-		$status->render_status_report_section();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'Enabled', $output );
-		$this->assertStringContainsString( 'WCPAY_DEV_MODE', $output );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -17,6 +17,20 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	private $status;
 
 	/**
+	 * Callback for wp_get_environment_type filter.
+	 *
+	 * @var callable|null
+	 */
+	private $env_type_callback = null;
+
+	/**
+	 * Callback for wp_get_development_mode filter.
+	 *
+	 * @var callable|null
+	 */
+	private $dev_mode_callback = null;
+
+	/**
 	 * Mock gateway.
 	 *
 	 * @var WC_Payment_Gateway_WCPay|PHPUnit_Framework_MockObject_MockObject
@@ -55,6 +69,22 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 			$this->mock_http,
 			$this->mock_account
 		);
+	}
+
+	/**
+	 * Post-test teardown.
+	 */
+	public function tear_down(): void {
+		if ( $this->env_type_callback ) {
+			remove_filter( 'wp_get_environment_type', $this->env_type_callback );
+			$this->env_type_callback = null;
+		}
+		if ( $this->dev_mode_callback ) {
+			remove_filter( 'wp_get_development_mode', $this->dev_mode_callback );
+			$this->dev_mode_callback = null;
+		}
+		WC_Payments::mode()->live();
+		parent::tear_down();
 	}
 
 	/**
@@ -262,5 +292,57 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		// Clean up filter.
 		remove_filter( 'user_has_cap', $filter_callback );
+	}
+
+	/**
+	 * Test that the Dev Mode row shows "Disabled" when dev mode is off.
+	 */
+	public function test_dev_mode_row_shows_disabled_when_dev_mode_off(): void {
+		$this->set_up_connected_mocks();
+		WC_Payments::mode()->live();
+
+		$status = new WC_Payments_Status(
+			$this->mock_gateway,
+			$this->mock_http,
+			$this->mock_account
+		);
+
+		ob_start();
+		$status->render_status_report_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Dev Mode', $output );
+		$this->assertStringContainsString( 'Disabled', $output );
+		$this->assertStringNotContainsString( 'Enabled', $output );
+	}
+
+	/**
+	 * Configures class-level mocks so that render_status_report_section() reaches the Dev Mode row.
+	 */
+	private function set_up_connected_mocks(): void {
+		$this->mock_http->method( 'is_connected' )->willReturn( true );
+		$this->mock_http->method( 'get_blog_id' )->willReturn( '123456789' );
+		$this->mock_gateway->method( 'is_connected' )->willReturn( true );
+		$this->mock_account->method( 'get_stripe_account_id' )->willReturn( 'acct_test123' );
+		$this->mock_gateway->method( 'needs_setup' )->willReturn( false );
+		$this->mock_gateway->method( 'is_enabled' )->willReturn( true );
+		$this->mock_gateway->method( 'get_upe_enabled_payment_method_ids' )->willReturn( [ 'card' ] );
+		$this->mock_gateway->method( 'is_payment_request_enabled' )->willReturn( false );
+		$this->mock_gateway->method( 'get_option' )->willReturnCallback(
+			function ( $key, $default = null ) {
+				$map = [
+					'current_protection_level'       => 'standard',
+					'manual_capture'                 => 'no',
+					'account_business_support_phone' => '555-0123',
+				];
+				if ( isset( $map[ $key ] ) ) {
+					return $map[ $key ];
+				}
+				if ( strpos( $key, 'express_checkout_' ) === 0 ) {
+					return [];
+				}
+				return $default;
+			}
+		);
 	}
 }

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -316,6 +316,111 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Test that the Dev Mode row shows "Enabled" with WP_ENVIRONMENT_TYPE trigger.
+	 */
+	public function test_dev_mode_row_shows_enabled_with_wp_environment_type(): void {
+		$this->set_up_connected_mocks();
+		WC_Payments::mode()->dev();
+
+		$this->env_type_callback = function () {
+			return 'staging';
+		};
+		add_filter( 'wp_get_environment_type', $this->env_type_callback );
+
+		$status = new WC_Payments_Status(
+			$this->mock_gateway,
+			$this->mock_http,
+			$this->mock_account
+		);
+
+		ob_start();
+		$status->render_status_report_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Enabled', $output );
+		$this->assertStringContainsString( 'WP_ENVIRONMENT_TYPE=staging', $output );
+	}
+
+	/**
+	 * Test that the Dev Mode row shows "Enabled" with WP_DEVELOPMENT_MODE trigger.
+	 */
+	public function test_dev_mode_row_shows_enabled_with_wp_development_mode(): void {
+		$this->set_up_connected_mocks();
+		WC_Payments::mode()->dev();
+
+		$this->dev_mode_callback = function () {
+			return 'plugin';
+		};
+		add_filter( 'wp_get_development_mode', $this->dev_mode_callback );
+
+		$status = new WC_Payments_Status(
+			$this->mock_gateway,
+			$this->mock_http,
+			$this->mock_account
+		);
+
+		ob_start();
+		$status->render_status_report_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Enabled', $output );
+		$this->assertStringContainsString( 'WP_DEVELOPMENT_MODE=plugin', $output );
+	}
+
+	/**
+	 * Test that the Dev Mode row falls back to "wcpay_dev_mode filter" when no other trigger is active.
+	 */
+	public function test_dev_mode_row_shows_wcpay_dev_mode_filter_when_no_other_trigger(): void {
+		$this->set_up_connected_mocks();
+		WC_Payments::mode()->dev();
+		// No env_type or dev_mode filters set — mode()->dev() is the sole enabler.
+
+		$status = new WC_Payments_Status(
+			$this->mock_gateway,
+			$this->mock_http,
+			$this->mock_account
+		);
+
+		ob_start();
+		$status->render_status_report_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Enabled', $output );
+		$this->assertStringContainsString( 'wcpay_dev_mode filter', $output );
+	}
+
+	/**
+	 * Test that the Dev Mode row shows all triggers when multiple conditions are active.
+	 */
+	public function test_dev_mode_row_shows_multiple_triggers(): void {
+		$this->set_up_connected_mocks();
+		WC_Payments::mode()->dev();
+
+		$this->env_type_callback = function () {
+			return 'development';
+		};
+		add_filter( 'wp_get_environment_type', $this->env_type_callback );
+
+		$this->dev_mode_callback = function () {
+			return 'plugin';
+		};
+		add_filter( 'wp_get_development_mode', $this->dev_mode_callback );
+
+		$status = new WC_Payments_Status(
+			$this->mock_gateway,
+			$this->mock_http,
+			$this->mock_account
+		);
+
+		ob_start();
+		$status->render_status_report_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'WP_ENVIRONMENT_TYPE=development', $output );
+		$this->assertStringContainsString( 'WP_DEVELOPMENT_MODE=plugin', $output );
+	}
+
+	/**
 	 * Configures class-level mocks so that render_status_report_section() reaches the Dev Mode row.
 	 */
 	private function set_up_connected_mocks(): void {

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -281,9 +281,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
 			->getMock();
 
+		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
 		$status->method( 'get_wp_environment_type' )->willReturn( '' );
 		$status->method( 'get_wp_development_mode' )->willReturn( '' );
 
@@ -304,9 +305,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
 			->getMock();
 
+		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
 		$status->method( 'get_wp_environment_type' )->willReturn( 'staging' );
 		$status->method( 'get_wp_development_mode' )->willReturn( '' );
 
@@ -327,9 +329,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
 			->getMock();
 
+		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
 		$status->method( 'get_wp_environment_type' )->willReturn( '' );
 		$status->method( 'get_wp_development_mode' )->willReturn( 'plugin' );
 
@@ -350,9 +353,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
 			->getMock();
 
+		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
 		$status->method( 'get_wp_environment_type' )->willReturn( '' );
 		$status->method( 'get_wp_development_mode' )->willReturn( '' );
 
@@ -373,9 +377,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
 			->getMock();
 
+		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
 		$status->method( 'get_wp_environment_type' )->willReturn( 'development' );
 		$status->method( 'get_wp_development_mode' )->willReturn( 'plugin' );
 
@@ -386,6 +391,30 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( 'Enabled', $output );
 		$this->assertStringContainsString( 'WP_ENVIRONMENT_TYPE=development', $output );
 		$this->assertStringContainsString( 'WP_DEVELOPMENT_MODE=plugin', $output );
+	}
+
+	/**
+	 * Test that the Dev Mode row shows "Enabled" with WCPAY_DEV_MODE trigger.
+	 */
+	public function test_dev_mode_row_shows_wcpay_dev_mode_constant_trigger(): void {
+		$this->set_up_connected_mocks();
+		WC_Payments::mode()->dev();
+
+		$status = $this->getMockBuilder( WC_Payments_Status::class )
+			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
+			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->getMock();
+
+		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( true );
+		$status->method( 'get_wp_environment_type' )->willReturn( '' );
+		$status->method( 'get_wp_development_mode' )->willReturn( '' );
+
+		ob_start();
+		$status->render_status_report_section();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Enabled', $output );
+		$this->assertStringContainsString( 'WCPAY_DEV_MODE', $output );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -281,12 +281,8 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
 			->getMock();
-
-		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
-		$status->method( 'get_wp_environment_type' )->willReturn( '' );
-		$status->method( 'get_wp_development_mode' )->willReturn( '' );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -305,12 +301,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
 			->getMock();
 
-		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
-		$status->method( 'get_wp_environment_type' )->willReturn( 'staging' );
-		$status->method( 'get_wp_development_mode' )->willReturn( '' );
+		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'WP_ENVIRONMENT_TYPE=staging' ] );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -329,12 +323,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
 			->getMock();
 
-		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
-		$status->method( 'get_wp_environment_type' )->willReturn( '' );
-		$status->method( 'get_wp_development_mode' )->willReturn( 'plugin' );
+		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'WP_DEVELOPMENT_MODE=plugin' ] );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -353,12 +345,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
 			->getMock();
 
-		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
-		$status->method( 'get_wp_environment_type' )->willReturn( '' );
-		$status->method( 'get_wp_development_mode' )->willReturn( '' );
+		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'wcpay_dev_mode filter' ] );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -377,12 +367,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
 			->getMock();
 
-		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( false );
-		$status->method( 'get_wp_environment_type' )->willReturn( 'development' );
-		$status->method( 'get_wp_development_mode' )->willReturn( 'plugin' );
+		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'WP_ENVIRONMENT_TYPE=development', 'WP_DEVELOPMENT_MODE=plugin' ] );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -402,12 +390,10 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$status = $this->getMockBuilder( WC_Payments_Status::class )
 			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
-			->setMethods( [ 'is_wcpay_dev_mode_defined', 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->setMethods( [ 'get_dev_mode_trigger_labels' ] )
 			->getMock();
 
-		$status->method( 'is_wcpay_dev_mode_defined' )->willReturn( true );
-		$status->method( 'get_wp_environment_type' )->willReturn( '' );
-		$status->method( 'get_wp_development_mode' )->willReturn( '' );
+		$status->method( 'get_dev_mode_trigger_labels' )->willReturn( [ 'WCPAY_DEV_MODE' ] );
 
 		ob_start();
 		$status->render_status_report_section();

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -313,7 +313,6 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 
 		$this->assertStringContainsString( 'Dev Mode', $output );
 		$this->assertStringContainsString( 'Disabled', $output );
-		$this->assertStringNotContainsString( 'Enabled', $output );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -17,20 +17,6 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	private $status;
 
 	/**
-	 * Callback for wp_get_environment_type filter.
-	 *
-	 * @var callable|null
-	 */
-	private $env_type_callback = null;
-
-	/**
-	 * Callback for wp_get_development_mode filter.
-	 *
-	 * @var callable|null
-	 */
-	private $dev_mode_callback = null;
-
-	/**
 	 * Mock gateway.
 	 *
 	 * @var WC_Payment_Gateway_WCPay|PHPUnit_Framework_MockObject_MockObject
@@ -75,14 +61,6 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	 * Post-test teardown.
 	 */
 	public function tear_down(): void {
-		if ( $this->env_type_callback ) {
-			remove_filter( 'wp_get_environment_type', $this->env_type_callback );
-			$this->env_type_callback = null;
-		}
-		if ( $this->dev_mode_callback ) {
-			remove_filter( 'wp_get_development_mode', $this->dev_mode_callback );
-			$this->dev_mode_callback = null;
-		}
 		WC_Payments::mode()->live();
 		parent::tear_down();
 	}
@@ -301,11 +279,13 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$this->set_up_connected_mocks();
 		WC_Payments::mode()->live();
 
-		$status = new WC_Payments_Status(
-			$this->mock_gateway,
-			$this->mock_http,
-			$this->mock_account
-		);
+		$status = $this->getMockBuilder( WC_Payments_Status::class )
+			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
+			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->getMock();
+
+		$status->method( 'get_wp_environment_type' )->willReturn( '' );
+		$status->method( 'get_wp_development_mode' )->willReturn( '' );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -322,16 +302,13 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$this->set_up_connected_mocks();
 		WC_Payments::mode()->dev();
 
-		$this->env_type_callback = function () {
-			return 'staging';
-		};
-		add_filter( 'wp_get_environment_type', $this->env_type_callback );
+		$status = $this->getMockBuilder( WC_Payments_Status::class )
+			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
+			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->getMock();
 
-		$status = new WC_Payments_Status(
-			$this->mock_gateway,
-			$this->mock_http,
-			$this->mock_account
-		);
+		$status->method( 'get_wp_environment_type' )->willReturn( 'staging' );
+		$status->method( 'get_wp_development_mode' )->willReturn( '' );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -348,16 +325,13 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$this->set_up_connected_mocks();
 		WC_Payments::mode()->dev();
 
-		$this->dev_mode_callback = function () {
-			return 'plugin';
-		};
-		add_filter( 'wp_get_development_mode', $this->dev_mode_callback );
+		$status = $this->getMockBuilder( WC_Payments_Status::class )
+			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
+			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->getMock();
 
-		$status = new WC_Payments_Status(
-			$this->mock_gateway,
-			$this->mock_http,
-			$this->mock_account
-		);
+		$status->method( 'get_wp_environment_type' )->willReturn( '' );
+		$status->method( 'get_wp_development_mode' )->willReturn( 'plugin' );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -373,13 +347,14 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	public function test_dev_mode_row_shows_wcpay_dev_mode_filter_when_no_other_trigger(): void {
 		$this->set_up_connected_mocks();
 		WC_Payments::mode()->dev();
-		// No env_type or dev_mode filters set — mode()->dev() is the sole enabler.
 
-		$status = new WC_Payments_Status(
-			$this->mock_gateway,
-			$this->mock_http,
-			$this->mock_account
-		);
+		$status = $this->getMockBuilder( WC_Payments_Status::class )
+			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
+			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->getMock();
+
+		$status->method( 'get_wp_environment_type' )->willReturn( '' );
+		$status->method( 'get_wp_development_mode' )->willReturn( '' );
 
 		ob_start();
 		$status->render_status_report_section();
@@ -396,26 +371,19 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$this->set_up_connected_mocks();
 		WC_Payments::mode()->dev();
 
-		$this->env_type_callback = function () {
-			return 'development';
-		};
-		add_filter( 'wp_get_environment_type', $this->env_type_callback );
+		$status = $this->getMockBuilder( WC_Payments_Status::class )
+			->setConstructorArgs( [ $this->mock_gateway, $this->mock_http, $this->mock_account ] )
+			->setMethods( [ 'get_wp_environment_type', 'get_wp_development_mode' ] )
+			->getMock();
 
-		$this->dev_mode_callback = function () {
-			return 'plugin';
-		};
-		add_filter( 'wp_get_development_mode', $this->dev_mode_callback );
-
-		$status = new WC_Payments_Status(
-			$this->mock_gateway,
-			$this->mock_http,
-			$this->mock_account
-		);
+		$status->method( 'get_wp_environment_type' )->willReturn( 'development' );
+		$status->method( 'get_wp_development_mode' )->willReturn( 'plugin' );
 
 		ob_start();
 		$status->render_status_report_section();
 		$output = ob_get_clean();
 
+		$this->assertStringContainsString( 'Enabled', $output );
 		$this->assertStringContainsString( 'WP_ENVIRONMENT_TYPE=development', $output );
 		$this->assertStringContainsString( 'WP_DEVELOPMENT_MODE=plugin', $output );
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

When WooPayments is in dev mode — triggered by `WP_ENVIRONMENT_TYPE`, `WP_DEVELOPMENT_MODE`, `WCPAY_DEV_MODE`, or the `wcpay_dev_mode` filter — there is no visible indication in the WordPress admin. Support engineers and developers have no way to diagnose unexpected test-mode behaviour without inspecting `wp-config.php` directly.

Adds a **Dev Mode** row to the WooPayments section of `WooCommerce > Status`:

- Always visible when the gateway is connected (same scope as the Test Mode row)
- Shows `Disabled` when dev mode is off
- Shows `Enabled (trigger1, trigger2, ...)` when on, listing all active conditions

The four detected conditions are:
- `WCPAY_DEV_MODE` constant defined and truthy
- `WP_ENVIRONMENT_TYPE` set to `development` or `staging`
- `WP_DEVELOPMENT_MODE` set to any non-empty value
- `wcpay_dev_mode filter` (fallback when no other condition matched)

Relevant docs: https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/#developer-notes

| File | Change |
|---|---|
| `includes/class-wc-payments-status.php` | Add Dev Mode row in `render_status_report_section()`; add `is_wcpay_dev_mode_defined()`, `get_wp_environment_type()`, `get_wp_development_mode()` protected wrappers; add `get_dev_mode_triggers()` private method |
| `tests/unit/test-class-wc-payments-status.php` | Add 6 new test cases for the Dev Mode row |
| `changelog/woopmnt-5247-dev-mode-status-report` | Changelog entry (type: add) |

#### Testing instructions

1. Add `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` to `wp-config.php`
2. Visit **WooCommerce > Status**
3. Scroll to the WooPayments section
4. Confirm a **Dev Mode** row shows `Enabled (WP_ENVIRONMENT_TYPE=staging)`
5. Remove the define, reload — confirm the row shows `Disabled`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (6 new unit test cases covering all trigger conditions + disabled state)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : https://woocommerce.com/document/woopayments/testing-and-troubleshooting/
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.