### PR TITLE
fix(woopay): replace alert() with inline notices for express checkout validation

### DIFF
--- a/changelog/fix-11540-replace-alert-with-inline-notices
+++ b/changelog/fix-11540-replace-alert-with-inline-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace browser alert() dialogs with inline WooCommerce notices for gift card email validation and product option errors in WooPay express checkout.

--- a/client/checkout/woopay/express-button/__tests__/use-express-checkout-product-handler.test.js
+++ b/client/checkout/woopay/express-button/__tests__/use-express-checkout-product-handler.test.js
@@ -1,9 +1,18 @@
-jest.spyOn( window, 'alert' ).mockImplementation( () => {} );
+/**
+ * Internal dependencies
+ */
+import { showErrorMessage } from '../utils';
+
+jest.mock( '../utils', () => ( {
+	showErrorMessage: jest.fn(),
+} ) );
 
 describe( 'validateGiftCardFields', () => {
+	const TEST_CONTEXT = 'product';
+
 	beforeEach( () => {
 		jest.resetModules();
-		window.alert.mockClear();
+		showErrorMessage.mockClear();
 	} );
 
 	const setupDomWithGiftCardForm = ( formFields = {} ) => {
@@ -38,7 +47,7 @@ describe( 'validateGiftCardFields', () => {
 	const getProductDataFromHook = () => {
 		const handler =
 			require( '../use-express-checkout-product-handler' ).default;
-		const { getProductData } = handler( {} );
+		const { getProductData } = handler( {}, TEST_CONTEXT );
 		return getProductData;
 	};
 
@@ -57,13 +66,14 @@ describe( 'validateGiftCardFields', () => {
 		expect( result.product_id ).toBe( '123' );
 	} );
 
-	it( 'returns false when required gift card field is empty', () => {
+	it( 'returns false and shows inline notice when required gift card field is empty', () => {
 		setupDomWithGiftCardForm( { wc_gc_giftcard_to: '' } );
 		const getProductData = getProductDataFromHook();
 		const result = getProductData();
 		expect( result ).toBe( false );
-		expect( window.alert ).toHaveBeenCalledWith(
-			'Please fill out all required fields'
+		expect( showErrorMessage ).toHaveBeenCalledWith(
+			TEST_CONTEXT,
+			'Please fill out all required fields.'
 		);
 	} );
 
@@ -77,7 +87,7 @@ describe( 'validateGiftCardFields', () => {
 		expect( result ).not.toBe( false );
 	} );
 
-	it( 'returns false when single recipient email is invalid', () => {
+	it( 'returns false and shows inline notice when single recipient email is invalid', () => {
 		setupDomWithGiftCardForm( {
 			wc_gc_giftcard_to: 'notanemail',
 			wc_gc_giftcard_from: 'Sender',
@@ -85,8 +95,9 @@ describe( 'validateGiftCardFields', () => {
 		const getProductData = getProductDataFromHook();
 		const result = getProductData();
 		expect( result ).toBe( false );
-		expect( window.alert ).toHaveBeenCalledWith(
-			'Please type only valid emails'
+		expect( showErrorMessage ).toHaveBeenCalledWith(
+			TEST_CONTEXT,
+			'Please enter a valid email address.'
 		);
 	} );
 
@@ -99,15 +110,16 @@ describe( 'validateGiftCardFields', () => {
 		expect( result ).not.toBe( false );
 	} );
 
-	it( 'returns false when one of multiple recipient emails is invalid', () => {
+	it( 'returns false and shows inline notice when one of multiple recipient emails is invalid', () => {
 		setupDomWithGiftCardForm( {
 			wc_gc_giftcard_to_multiple: 'a@example.com,notanemail',
 		} );
 		const getProductData = getProductDataFromHook();
 		const result = getProductData();
 		expect( result ).toBe( false );
-		expect( window.alert ).toHaveBeenCalledWith(
-			'Please type only valid emails'
+		expect( showErrorMessage ).toHaveBeenCalledWith(
+			TEST_CONTEXT,
+			'Please enter valid email addresses.'
 		);
 	} );
 
@@ -120,27 +132,29 @@ describe( 'validateGiftCardFields', () => {
 		expect( result ).not.toBe( false );
 	} );
 
-	it( 'returns false for trailing comma in multiple recipients', () => {
+	it( 'returns false and shows inline notice for trailing comma in multiple recipients', () => {
 		setupDomWithGiftCardForm( {
 			wc_gc_giftcard_to_multiple: 'a@example.com,',
 		} );
 		const getProductData = getProductDataFromHook();
 		const result = getProductData();
 		expect( result ).toBe( false );
-		expect( window.alert ).toHaveBeenCalledWith(
-			'Please type only valid emails'
+		expect( showErrorMessage ).toHaveBeenCalledWith(
+			TEST_CONTEXT,
+			'Please enter valid email addresses.'
 		);
 	} );
 
-	it( 'returns false for empty segment in multiple recipients', () => {
+	it( 'returns false and shows inline notice for empty segment in multiple recipients', () => {
 		setupDomWithGiftCardForm( {
 			wc_gc_giftcard_to_multiple: 'a@example.com,,b@example.com',
 		} );
 		const getProductData = getProductDataFromHook();
 		const result = getProductData();
 		expect( result ).toBe( false );
-		expect( window.alert ).toHaveBeenCalledWith(
-			'Please type only valid emails'
+		expect( showErrorMessage ).toHaveBeenCalledWith(
+			TEST_CONTEXT,
+			'Please enter valid email addresses.'
 		);
 	} );
 } );

--- a/client/checkout/woopay/express-button/__tests__/woopay-express-checkout-button.test.js
+++ b/client/checkout/woopay/express-button/__tests__/woopay-express-checkout-button.test.js
@@ -14,12 +14,13 @@ import WCPayAPI from 'wcpay/checkout/api';
 import request from 'wcpay/checkout/utils/request';
 import { getConfig } from 'utils/checkout';
 import useExpressCheckoutProductHandler from '../use-express-checkout-product-handler';
+import { showErrorMessage } from 'wcpay/checkout/woopay/express-button/utils';
 
 jest.mock( 'wcpay/checkout/utils/request', () =>
 	jest.fn( () => Promise.resolve( {} ) )
 );
 jest.mock( 'wcpay/checkout/woopay/express-button/utils', () => ( {
-	showErrorMessage: () => null,
+	showErrorMessage: jest.fn(),
 } ) );
 jest.mock( 'wcpay/checkout/woopay/connect/woopay-connect-iframe', () => ( {
 	WooPayConnectIframe: () => null,
@@ -79,7 +80,6 @@ jest.mock( '../preferred-card-utils', () => ( {
 	...jest.requireActual( '../preferred-card-utils' ),
 } ) );
 
-jest.spyOn( window, 'alert' ).mockImplementation( () => {} );
 
 global.fetch = jest.fn( () => Promise.resolve( { json: () => ( {} ) } ) );
 
@@ -498,7 +498,7 @@ describe( 'WoopayExpressCheckoutButton', () => {
 			} );
 		} );
 
-		test( 'should show an alert when clicking the button when add to cart button is disabled', async () => {
+		test( 'should show inline notice when clicking the button when add to cart button is disabled', async () => {
 			getConfig.mockImplementation( ( v ) => {
 				return v === 'isWoopayFirstPartyAuthEnabled' ? false : 'foo';
 			} );
@@ -529,7 +529,8 @@ describe( 'WoopayExpressCheckoutButton', () => {
 
 			await userEvent.click( expressButton );
 
-			expect( window.alert ).toHaveBeenCalledWith(
+			expect( showErrorMessage ).toHaveBeenCalledWith(
+				buttonSettings.context,
 				'Please select your product options before proceeding.'
 			);
 

--- a/client/checkout/woopay/express-button/use-express-checkout-product-handler.js
+++ b/client/checkout/woopay/express-button/use-express-checkout-product-handler.js
@@ -11,6 +11,7 @@ import {
 	getQuantity,
 } from 'wcpay/utils/wc-product-page-selectors';
 import { isEmail } from 'wcpay/utils/email-validation';
+import { showErrorMessage } from 'wcpay/checkout/woopay/express-button/utils';
 
 /**
  * Get the product form element.
@@ -27,7 +28,7 @@ export const getProductFormElement = () => {
 	);
 };
 
-const useExpressCheckoutProductHandler = ( api ) => {
+const useExpressCheckoutProductHandler = ( api, context ) => {
 	const getAttributes = () => {
 		const select = document
 			.querySelector( '.variations_form' )
@@ -58,9 +59,10 @@ const useExpressCheckoutProductHandler = ( api ) => {
 				data.hasOwnProperty( requiredField ) &&
 				! data[ requiredField ]
 			) {
-				alert(
+				showErrorMessage(
+					context,
 					__(
-						'Please fill out all required fields',
+						'Please fill out all required fields.',
 						'woocommerce-payments'
 					)
 				);
@@ -74,9 +76,10 @@ const useExpressCheckoutProductHandler = ( api ) => {
 					.split( ',' )
 					.every( ( email ) => isEmail( email.trim() ) )
 			) {
-				alert(
+				showErrorMessage(
+					context,
 					__(
-						'Please type only valid emails',
+						'Please enter valid email addresses.',
 						'woocommerce-payments'
 					)
 				);
@@ -86,9 +89,10 @@ const useExpressCheckoutProductHandler = ( api ) => {
 
 		if ( data.hasOwnProperty( 'wc_gc_giftcard_to' ) ) {
 			if ( ! isEmail( data.wc_gc_giftcard_to ) ) {
-				alert(
+				showErrorMessage(
+					context,
 					__(
-						'Please type only valid emails',
+						'Please enter a valid email address.',
 						'woocommerce-payments'
 					)
 				);

--- a/client/checkout/woopay/express-button/woopay-express-checkout-button.js
+++ b/client/checkout/woopay/express-button/woopay-express-checkout-button.js
@@ -101,7 +101,7 @@ export const WoopayExpressCheckoutButton = ( {
 	const woopayUrl = getConfig( 'woopayHost' ) + '/woopay/';
 
 	const { addToCart, getProductData } =
-		useExpressCheckoutProductHandler( api );
+		useExpressCheckoutProductHandler( api, context );
 	const getProductDataRef = useRef( getProductData );
 	const addToCartRef = useRef( addToCart );
 
@@ -138,7 +138,8 @@ export const WoopayExpressCheckoutButton = ( {
 					'wc-variation-is-unavailable'
 				)
 			) {
-				window.alert(
+				showErrorMessage(
+					context,
 					window?.wc_add_to_cart_variation_params
 						?.i18n_unavailable_text ||
 						__(
@@ -147,7 +148,8 @@ export const WoopayExpressCheckoutButton = ( {
 						)
 				);
 			} else {
-				window.alert(
+				showErrorMessage(
+					context,
 					__(
 						'Please select your product options before proceeding.',
 						'woocommerce-payments'


### PR DESCRIPTION
## Summary

Replaces all `window.alert()` / `alert()` calls in the WooPay express checkout button with `showErrorMessage()` — the inline WooCommerce notice pattern already used for other errors in the same flow. Affects gift card email validation and product option selection errors on product pages.

Fixes #11540

## Changes

### `use-express-checkout-product-handler.js`

**Before:**
```js
alert( __( 'Please fill out all required fields', 'woocommerce-payments' ) );
// ...
alert( __( 'Please type only valid emails', 'woocommerce-payments' ) );
```

**After:**
```js
showErrorMessage( context, __( 'Please fill out all required fields.', 'woocommerce-payments' ) );
// ...
showErrorMessage( context, __( 'Please enter valid email addresses.', 'woocommerce-payments' ) );
showErrorMessage( context, __( 'Please enter a valid email address.', 'woocommerce-payments' ) );
```

**Why:** The hook now accepts `context` as a second parameter (passed from the button component) so it can route notices to the correct WooCommerce target. Single vs. multiple recipient email errors now have distinct messages for clarity.

---

### `woopay-express-checkout-button.js`

**Before:**
```js
const { addToCart, getProductData } = useExpressCheckoutProductHandler( api );
// ...
window.alert( window?.wc_add_to_cart_variation_params?.i18n_unavailable_text || __( 'Sorry, this product is unavailable...', 'woocommerce-payments' ) );
window.alert( __( 'Please select your product options before proceeding.', 'woocommerce-payments' ) );
```

**After:**
```js
const { addToCart, getProductData } = useExpressCheckoutProductHandler( api, context );
// ...
showErrorMessage( context, window?.wc_add_to_cart_variation_params?.i18n_unavailable_text || __( '...', 'woocommerce-payments' ) );
showErrorMessage( context, __( 'Please select your product options before proceeding.', 'woocommerce-payments' ) );
```

**Why:** `context` (`'product'`, `'cart'`, `'checkout'`) is already available in the button component and determines whether notices render via `wp.data` (blocks) or AJAX DOM injection (classic/shortcode). Passing it through gives the hook the same routing logic used by all other error paths in this file.

## Testing

**Test 1: Gift card — invalid recipient email**
1. Add a gift card product to a WooCommerce store
2. Go to the product page, enter an invalid email in the recipient field
3. Click the WooPay express button

Result: Inline WooCommerce error notice appears (no browser alert dialog)

**Test 2: Variable product — options not selected**
1. Go to a variable product page, do not select a variation
2. Click the WooPay express button

Result: Inline notice appears instead of a blocking browser alert

**Test 3: Unavailable variation**
1. Select a variation marked as unavailable
2. Click the WooPay express button

Result: Inline notice with the unavailable text appears (or fallback string)
