### PR TITLE
fix: WooPay orders store server IP instead of customer IP

### DIFF
--- a/changelog/fix-11428-woopay-customer-ip
+++ b/changelog/fix-11428-woopay-customer-ip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed WooPay storing server IP instead of customer IP on orders

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -65,6 +65,9 @@ class WooPay_Session {
 		register_deactivation_hook( WCPAY_PLUGIN_FILE, [ __CLASS__, 'run_and_remove_woopay_restore_order_customer_id_schedules' ] );
 
 		add_filter( 'automatewoo/referrals/referred_order_advocate', [ __CLASS__, 'automatewoo_refer_a_friend_referral_from_parameter' ] );
+
+		// Override REMOTE_ADDR early so WooCommerce records the customer's real IP, not the WooPay server IP.
+		self::maybe_override_customer_ip();
 	}
 
 	/**
@@ -866,6 +869,78 @@ class WooPay_Session {
 		$has_woopay_verified_email_address = isset( $_SERVER['HTTP_X_WOOPAY_VERIFIED_EMAIL_ADDRESS'] );
 
 		return $has_woopay_verified_email_address ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_WOOPAY_VERIFIED_EMAIL_ADDRESS'] ) ) : null;
+	}
+
+	/**
+	 * Override REMOTE_ADDR with the customer's real IP for WooPay requests.
+	 *
+	 * When WooPay proxies a checkout request to the merchant's Store API,
+	 * $_SERVER['REMOTE_ADDR'] contains the WooPay server IP instead of the
+	 * customer's real IP. WooPay forwards the customer's real IP via the
+	 * X-Forwarded-For or X-Real-IP header.
+	 *
+	 * This method overrides REMOTE_ADDR early in the request lifecycle so
+	 * WooCommerce core (and any other IP-dependent code) records the correct
+	 * customer IP on the order.
+	 *
+	 * Security: Only executes when the request is confirmed from WooPay
+	 * (User-Agent check) AND the request carries a valid blog token signature.
+	 *
+	 * @since 9.4.0
+	 * @return void
+	 */
+	public static function maybe_override_customer_ip() {
+		if ( ! self::is_request_from_woopay() ) {
+			return;
+		}
+
+		if ( ! self::has_valid_request_signature() ) {
+			return;
+		}
+
+		$customer_ip = self::get_customer_ip_from_headers();
+
+		if ( null === $customer_ip ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated -- IP is validated above.
+		$_SERVER['REMOTE_ADDR'] = $customer_ip;
+	}
+
+	/**
+	 * Extract the customer's real IP address from proxy headers.
+	 *
+	 * Checks X-Forwarded-For and X-Real-IP headers (in that order).
+	 * For X-Forwarded-For, the leftmost (first) IP is used because it
+	 * represents the originating client before any intermediate proxies.
+	 *
+	 * Only valid IPv4 and IPv6 addresses are returned.
+	 *
+	 * @since 9.4.0
+	 * @return string|null A validated IP address, or null if none found.
+	 */
+	private static function get_customer_ip_from_headers() {
+		// X-Forwarded-For can contain a comma-separated list: "client, proxy1, proxy2".
+		if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$forwarded_ips = explode( ',', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) );
+			$client_ip     = trim( $forwarded_ips[0] );
+
+			if ( false !== filter_var( $client_ip, FILTER_VALIDATE_IP ) ) {
+				return $client_ip;
+			}
+		}
+
+		// Fallback to X-Real-IP (single IP, typically set by Nginx reverse proxies).
+		if ( ! empty( $_SERVER['HTTP_X_REAL_IP'] ) ) {
+			$real_ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_REAL_IP'] ) );
+
+			if ( false !== filter_var( $real_ip, FILTER_VALIDATE_IP ) ) {
+				return $real_ip;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/unit/woopay/test-class-woopay-session.php
+++ b/tests/unit/woopay/test-class-woopay-session.php
@@ -92,6 +92,10 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 
 		remove_filter( 'wcpay_woopay_is_signed_with_blog_token', '__return_true' );
 
+		// Clean up IP-related headers that tests may have set.
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		unset( $_SERVER['HTTP_X_REAL_IP'] );
+
 		parent::tear_down();
 	}
 
@@ -355,6 +359,115 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( WooPay_Session::determine_current_user_for_woopay( $guest_user ), $woopay_user->ID );
 
 		unset( $_REQUEST['rest_route'] );
+	}
+
+	/**
+	 * Tests for maybe_override_customer_ip().
+	 */
+
+	public function test_maybe_override_customer_ip_sets_remote_addr_from_x_forwarded_for() {
+		$original_remote_addr            = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+		$_SERVER['REMOTE_ADDR']          = '192.0.91.172';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.50';
+
+		WooPay_Session::maybe_override_customer_ip();
+
+		$this->assertEquals( '203.0.113.50', $_SERVER['REMOTE_ADDR'] );
+
+		$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
+	}
+
+	public function test_maybe_override_customer_ip_uses_first_ip_from_x_forwarded_for_chain() {
+		$original_remote_addr            = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+		$_SERVER['REMOTE_ADDR']          = '192.0.91.172';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.50, 198.51.100.10, 192.0.89.12';
+
+		WooPay_Session::maybe_override_customer_ip();
+
+		$this->assertEquals( '203.0.113.50', $_SERVER['REMOTE_ADDR'] );
+
+		$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
+	}
+
+	public function test_maybe_override_customer_ip_falls_back_to_x_real_ip() {
+		$original_remote_addr      = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+		$_SERVER['REMOTE_ADDR']    = '192.0.91.172';
+		$_SERVER['HTTP_X_REAL_IP'] = '198.51.100.25';
+
+		WooPay_Session::maybe_override_customer_ip();
+
+		$this->assertEquals( '198.51.100.25', $_SERVER['REMOTE_ADDR'] );
+
+		$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
+	}
+
+	public function test_maybe_override_customer_ip_prefers_x_forwarded_for_over_x_real_ip() {
+		$original_remote_addr            = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+		$_SERVER['REMOTE_ADDR']          = '192.0.91.172';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.50';
+		$_SERVER['HTTP_X_REAL_IP']       = '198.51.100.25';
+
+		WooPay_Session::maybe_override_customer_ip();
+
+		$this->assertEquals( '203.0.113.50', $_SERVER['REMOTE_ADDR'] );
+
+		$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
+	}
+
+	public function test_maybe_override_customer_ip_ignores_non_woopay_requests() {
+		$_SERVER['HTTP_USER_AGENT']      = 'Mozilla/5.0';
+		$original_remote_addr            = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+		$_SERVER['REMOTE_ADDR']          = '192.0.91.172';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.50';
+
+		WooPay_Session::maybe_override_customer_ip();
+
+		// REMOTE_ADDR should NOT be changed.
+		$this->assertEquals( '192.0.91.172', $_SERVER['REMOTE_ADDR'] );
+
+		$_SERVER['REMOTE_ADDR']     = $original_remote_addr;
+		$_SERVER['HTTP_USER_AGENT'] = 'WooPay';
+	}
+
+	public function test_maybe_override_customer_ip_ignores_invalid_ip() {
+		$original_remote_addr            = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+		$_SERVER['REMOTE_ADDR']          = '192.0.91.172';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = 'not-an-ip-address';
+
+		WooPay_Session::maybe_override_customer_ip();
+
+		// REMOTE_ADDR should NOT be changed when the header has an invalid IP.
+		$this->assertEquals( '192.0.91.172', $_SERVER['REMOTE_ADDR'] );
+
+		$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
+	}
+
+	public function test_maybe_override_customer_ip_no_change_when_no_ip_headers() {
+		$original_remote_addr   = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+		$_SERVER['REMOTE_ADDR'] = '192.0.91.172';
+
+		// No X-Forwarded-For or X-Real-IP set.
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		unset( $_SERVER['HTTP_X_REAL_IP'] );
+
+		WooPay_Session::maybe_override_customer_ip();
+
+		// REMOTE_ADDR should remain unchanged.
+		$this->assertEquals( '192.0.91.172', $_SERVER['REMOTE_ADDR'] );
+
+		$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
+	}
+
+	public function test_maybe_override_customer_ip_handles_ipv6() {
+		$original_remote_addr            = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+		$_SERVER['REMOTE_ADDR']          = '192.0.91.172';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '2001:db8::1';
+
+		WooPay_Session::maybe_override_customer_ip();
+
+		$this->assertEquals( '2001:db8::1', $_SERVER['REMOTE_ADDR'] );
+
+		$_SERVER['REMOTE_ADDR'] = $original_remote_addr;
 	}
 
 	private function setup_session( $customer_id, $customer_email = null ) {


### PR DESCRIPTION
## Summary

WooPay checkout orders record the WooPay server IP (e.g., `192.0.91.172`) instead of the customer's real IP address. This happens because WooPay proxies the checkout request to the merchant's Store API, so `$_SERVER['REMOTE_ADDR']` reflects the proxy server, not the customer.

This fix overrides `REMOTE_ADDR` with the customer's real IP from `X-Forwarded-For` / `X-Real-IP` headers — only when the request is verified as a signed WooPay request.

Fixes #11428

## Changes

### [class-woopay-session.php](includes/woopay/class-woopay-session.php)

Added `maybe_override_customer_ip()` — called early in `init()`:

```php
public static function maybe_override_customer_ip() {
    if ( ! self::is_request_from_woopay() ) {
        return;
    }
    if ( ! self::has_valid_request_signature() ) {
        return;
    }
    $customer_ip = self::get_customer_ip_from_headers();
    if ( null === $customer_ip ) {
        return;
    }
    $_SERVER['REMOTE_ADDR'] = $customer_ip;
}
```

Added `get_customer_ip_from_headers()` — reads `X-Forwarded-For` (first IP from chain) or falls back to `X-Real-IP`, validates with `FILTER_VALIDATE_IP`.

**Why:** Overriding `REMOTE_ADDR` at the source ensures all downstream consumers (WooCommerce core order creation, API client, fraud extensions, geolocation) see the correct customer IP. This is the standard approach used by WordPress.com VIP, Cloudflare, and other reverse-proxy environments. The double-gate (User-Agent + blog token signature) prevents untrusted requests from spoofing IPs.

## Testing

**Test 1: WooPay checkout records correct IP**
1. Enable WooPay in WooPayments settings
2. Complete a checkout via WooPay
3. Open the order in WP Admin → WooCommerce → Orders
4. Check the "Customer IP" field

Expected: Shows the customer's real IP, not a WooPay server IP

**Test 2: Regular checkout unaffected**
1. Complete a standard card checkout (not WooPay)
2. Check the order's Customer IP

Expected: Shows your real IP (unchanged behavior)

**Test 3: No headers = no change (safe no-op)**
1. If WooPay doesn't send `X-Forwarded-For` yet, the fix is a no-op
2. No regressions — `REMOTE_ADDR` remains untouched

## Screenshot

<img width="1434" height="469" alt="image" src="https://github.com/user-attachments/assets/de055132-9f01-4cd2-9a52-c3327405178d" />
.
<img width="1425" height="480" alt="image" src="https://github.com/user-attachments/assets/13d9d08b-0ca7-4a5f-985b-f80f06edc736" />
