### PR TITLE
fix: qit-test failures

### DIFF
--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -23,9 +23,6 @@ jobs:
         id: build_plugin
         uses: ./.github/actions/build
 
-      - name: Install PHP & Composer
-        run: sudo apt-get update && sudo apt-get install -y php-cli php-zip unzip
-
       - name: Install QIT CLI
         run: composer global require woocommerce/qit-cli:^1.0
 

--- a/changelog/fix-qit-test-failing-php-composer
+++ b/changelog/fix-qit-test-failing-php-composer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: qit-tests failures

--- a/changelog/fix-qit-test-failing-php-composer
+++ b/changelog/fix-qit-test-failing-php-composer
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-fix: qit-tests failures
+fix: failing qit-tests


### PR DESCRIPTION
Fixes WOOPMNT-6146

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Removed the `Install PHP & Composer` step from `.github/workflows/qit.yml`.
It's been failing for the past day or so because `apt-get install php-cli php-zip` resolves through the `ondrej/php` PPA, and `ppa.launchpadcontent.net` has been refusing connections, so the step bails out with exit 100.

The preceding `Set up repository` step already runs `.github/actions/setup-php`, which installs PHP and Composer via `shivammathur/setup-php@v2` (with `tools: composer`). `unzip` is preinstalled on `ubuntu-latest`.
So QIT CLI install has everything it needs without going through apt.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI should pass on this PR: the QIT workflow no longer hits the broken PPA.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
