### PR TITLE
Fix WC beta unit test order fixtures

### DIFF
--- a/changelog/fix-wc-beta-payment-complete-checkout-evidence
+++ b/changelog/fix-wc-beta-payment-complete-checkout-evidence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add checkout evidence to unit test order fixtures for WooCommerce beta compatibility.

--- a/tests/unit/helpers/class-wc-helper-order.php
+++ b/tests/unit/helpers/class-wc-helper-order.php
@@ -69,6 +69,8 @@ class WC_Helper_Order {
 			'status'        => Order_Status::PENDING,
 			'customer_id'   => $customer_id,
 			'customer_note' => '',
+			'created_via'   => 'checkout',
+			'cart_hash'     => 'test_cart_hash',
 			'total'         => '',
 		];
 


### PR DESCRIPTION
Refs #11599 follow-up CI investigation.

#### Changes proposed in this Pull Request

WooCommerce beta adds a checkout-evidence guard to `WC_Order::payment_complete()`.

For WooPayments' unit-test failures, the issue is that `WC_Helper_Order::create_order()` builds orders with `wc_create_order()` directly, so the orders do not get the checkout metadata that real WooCommerce checkout-created orders have.

This PR keeps the WooPayments fix limited to test fixtures by adding checkout evidence to the helper orders:

- `created_via=checkout`
- a non-empty `cart_hash`

It intentionally does not add any WooPayments production bypass/wrapper for `payment_complete()`.

Subscription renewal orders using `created_via=subscription` are a separate upstream compatibility concern and are not handled in this PR.

#### Testing instructions

Automated/local checks run:

- `php -l tests/unit/helpers/class-wc-helper-order.php`

Not run locally:

- PHPUnit/PHPCS: local worktree does not have installed test/composer dependencies (`vendor/bin/phpunit` and `vendor/bin/phpcs` unavailable). CI should verify the WC beta compatibility matrix that exposed the failure.

-------------------

- [x] Run `npm run changelog` to add a changelog file
- [x] Updated unit-test order fixtures for WooCommerce beta compatibility
- [x] Tested on mobile (does not apply)

**Post merge**

- [ ] QA Testing Not Applicable
- [ ] Critical flows: test fixture-only change
- [ ] Release announcement: N/A
