### PR TITLE
fix: preserve order on downstream post-payment errors

### DIFF
--- a/changelog/woopmnt-6145-preserve-order-on-downstream-error
+++ b/changelog/woopmnt-6145-preserve-order-on-downstream-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Don't mark an order as Failed when a third-party plugin throws after the payment intent has already succeeded

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1231,6 +1231,36 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// Log the exception.
 			Logger::exception( 'Error occurred during the payment process.', $e );
 
+			// Defense in depth: when the payment intent already succeeded, a
+			// downstream exception (e.g. third-party plugin throwing from
+			// woocommerce_reduce_order_stock, woocommerce_payment_complete, or
+			// woocommerce_order_status_processing) must not flip the order to
+			// Failed or surface a failure to the customer who has already been
+			// charged. Preserve the post-payment order status, record a
+			// diagnostic note, and complete the checkout normally.
+			if ( Intent_Status::SUCCEEDED === $this->order_service->get_intention_status_for_order( $order ) ) {
+				$order->add_order_note(
+					sprintf(
+						/* translators: %s: error message from the downstream exception */
+						__( 'Payment succeeded, but a downstream error occurred during post-payment processing: %s. Order status preserved.', 'woocommerce-payments' ),
+						esc_html( $e->getMessage() )
+					)
+				);
+
+				Logger::warning(
+					sprintf(
+						'Payment intent already succeeded; downstream %s on order #%d suppressed to preserve order status.',
+						get_class( $e ),
+						$order->get_id()
+					)
+				);
+
+				return [
+					'result'   => 'success',
+					'redirect' => $this->get_return_url( $order ),
+				];
+			}
+
 			// We set this variable to be used in following checks.
 			$blocked_by_fraud_rules = $this->is_blocked_by_fraud_rules( $e );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -4084,6 +4084,125 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		delete_transient( 'wcpay_fraud_protection_settings' );
 	}
 
+	/**
+	 * Regression test for WOOPMNT-6145.
+	 *
+	 * When the payment intent has already succeeded but a third-party plugin
+	 * hooked into a post-payment WooCommerce hook (e.g. Square's inventory sync
+	 * on woocommerce_reduce_order_stock) throws an exception that escapes
+	 * process_payment_for_order(), the catch block must NOT flip the order to
+	 * Failed nor return 'fail' to the checkout. Doing so caused merchants to
+	 * see successfully-paid orders marked Failed, customers to retry payments,
+	 * and resulting duplicate charges.
+	 */
+	public function test_process_payment_does_not_mark_failed_when_intent_succeeded_and_downstream_throws() {
+		$order = WC_Helper_Order::create_order();
+
+		$mock_order_service = $this->getMockBuilder( WC_Payments_Order_Service::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mock_order_service
+			->expects( $this->any() )
+			->method( 'get_intention_status_for_order' )
+			->willReturn( Intent_Status::SUCCEEDED );
+
+		$expected_redirect = 'https://example.com/test-redirect';
+
+		$mock_wcpay_gateway = $this->get_partial_mock_for_gateway(
+			[ 'prepare_payment_information', 'process_payment_for_order', 'get_return_url' ],
+			[ WC_Payments_Order_Service::class => $mock_order_service ]
+		);
+
+		$mock_wcpay_gateway
+			->expects( $this->any() )
+			->method( 'get_return_url' )
+			->willReturn( $expected_redirect );
+
+		$mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'prepare_payment_information' );
+
+		$mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'process_payment_for_order' )
+			->willThrowException( new Exception( 'Auth credentials missing' ) );
+
+		$result = $mock_wcpay_gateway->process_payment( $order->get_id() );
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertSame( $expected_redirect, $result['redirect'] );
+
+		// WC_Helper_Order::create_order() produces a 'pending' order; the
+		// guard must leave the status unchanged when the downstream throw is
+		// caught after the intent has succeeded.
+		$persisted_order = wc_get_order( $order->get_id() );
+		$this->assertSame( Order_Status::PENDING, $persisted_order->get_status() );
+
+		$notes               = wc_get_order_notes( [ 'order_id' => $order->get_id() ] );
+		$matching_note_count = count(
+			array_filter(
+				$notes,
+				function ( $note ) {
+					return false !== stripos( $note->content, 'Auth credentials missing' );
+				}
+			)
+		);
+		$this->assertGreaterThan( 0, $matching_note_count, 'Expected an order note containing the downstream error message.' );
+	}
+
+	/**
+	 * Sanity counterpart to the WOOPMNT-6145 regression test above.
+	 *
+	 * When the intent has not succeeded, a thrown exception must still flip
+	 * the order to Failed and return 'fail' to the checkout. Locks in the
+	 * existing behavior so the new guard does not over-broaden.
+	 */
+	public function test_process_payment_still_marks_failed_when_intent_not_succeeded_and_downstream_throws() {
+		$order = WC_Helper_Order::create_order();
+
+		$mock_order_service = $this->getMockBuilder( WC_Payments_Order_Service::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mock_order_service
+			->expects( $this->any() )
+			->method( 'get_intention_status_for_order' )
+			->willReturn( '' );
+
+		$mock_wcpay_gateway = $this->get_partial_mock_for_gateway(
+			[ 'prepare_payment_information', 'process_payment_for_order' ],
+			[ WC_Payments_Order_Service::class => $mock_order_service ]
+		);
+
+		$mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'prepare_payment_information' );
+
+		$mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'process_payment_for_order' )
+			->willThrowException( new Exception( 'Genuine payment failure' ) );
+
+		$result = $mock_wcpay_gateway->process_payment( $order->get_id() );
+
+		$this->assertSame( 'fail', $result['result'] );
+
+		$persisted_order = wc_get_order( $order->get_id() );
+		$this->assertSame( Order_Status::FAILED, $persisted_order->get_status() );
+
+		// Counterpart assertion: the WOOPMNT-6145 guard must NOT fire on the
+		// failure path, so the diagnostic note must be absent.
+		$notes      = wc_get_order_notes( [ 'order_id' => $order->get_id() ] );
+		$guard_note = array_filter(
+			$notes,
+			function ( $note ) {
+				return false !== stripos( $note->content, 'Payment succeeded, but a downstream error occurred' );
+			}
+		);
+		$this->assertEmpty( $guard_note, 'Guard diagnostic note must not appear on the failure path.' );
+	}
+
 	public function test_process_payment_continues_if_valid_fraud_prevention_token() {
 		$order = WC_Helper_Order::create_order();
 


### PR DESCRIPTION
Fixes [WOOPMNT-6145](https://linear.app/a8c/issue/WOOPMNT-6145)

#### Changes proposed in this Pull Request

`process_payment()`'s catch block unconditionally marked orders `Failed` and returned `'fail'` to the checkout when any exception escaped the try block. That includes the case where `mark_payment_completed()` had already set `_intention_status = 'succeeded'` before a third-party plugin threw from a post-payment hook.

Result: successfully-charged customers saw a failure UI, retried, and either double-paid or switched gateways.

This PR adds a defense guard at the top of the catch block: when the intent has already succeeded, log the exception, add a diagnostic order note describing the downstream error, and complete the checkout normally with a redirect to the order-received page. Existing failure paths (genuine payment errors, fraud blocks, rate-limiter, duplicate amount mismatch) are unchanged.

#### Screenshots
| Before | After |
|--------|--------|
|<img width="582" height="135" alt="2026-05-07-woopmnt-6145-08-WITHOUT-FIX-checkout-error" src="https://github.com/user-attachments/assets/b60e76d5-f07b-42dd-8c29-47ce0f8a424e" />|<img width="556" height="168" alt="2026-05-07-woopmnt-6145-07-WITH-FIX-thank-you" src="https://github.com/user-attachments/assets/08fde4af-6aad-4e67-ba2a-69de3d1ffb12" />|
|<img width="284" height="689" alt="Screenshot 2026-05-07 at 11 24 45" src="https://github.com/user-attachments/assets/66147441-21bb-4cbe-9c97-9d559df0aaf9" />|<img width="285" height="607" alt="Screenshot 2026-05-07 at 11 25 04" src="https://github.com/user-attachments/assets/585ce3b2-2a97-463d-9e63-73b4a966ac88" />|

#### Open questions for reviewers

1. Should `do_action('woocommerce_payments_order_failed', ...)` still fire when the intent succeeded? This PR says no: the order did not actually fail, and firing the hook would mislead consumers. 
2. Should the guard also cover `Intent_Status::REQUIRES_CAPTURE` (manual-capture flows)? Could be a follow-up.

#### Testing instructions
1. Add a `mu-plugins/woopmnt-6145-repro.php` snippet that throws on `woocommerce_cart_emptied`.
   ```php
   <?php
   add_action( 'woocommerce_cart_emptied', function () {
       $uri = $_SERVER['REQUEST_URI'] ?? '';
       if ( false !== strpos( $uri, '/order-received/' ) ) {
           return;
       }
       throw new Exception( 'Simulated third-party plugin error after payment succeeded' );
   } );
   ```
2. Place an order via WooPayments (test card `4242 4242 4242 4242`).
3. **Without the fix:** order goes Pending then Processing then Failed. Checkout shows error. Stripe dashboard shows successful intent. Merchant sees confused order notes.
4. **With this fix:** order stays Processing. Checkout redirects to thank-you. Stripe dashboard shows successful intent. Order note records the downstream error message.
5. Sanity check: remove the mu-plugin snippet, place another order. Should complete normally with no diagnostic note.

-------------------

- [x] Run \`npm run changelog\` to add a changelog file. (Added: \`changelog/woopmnt-6145-preserve-order-on-downstream-error\`.)
- [x] Covered with tests
- [x] Tested on mobile (does not apply: backend-only PHP fix)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions): _Add link here_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
