### PR TITLE
feat: Add AfterShip provider to WooPay tracking adapter (Phase 3)

### DIFF
--- a/changelog/feat-multi-plugin-tracking-adapter#3
+++ b/changelog/feat-multi-plugin-tracking-adapter#3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Added AfterShip provider for WooPay order tracking sync, covering merchants using the AfterShip WooCommerce Tracking plugin.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -515,6 +515,7 @@ class WC_Payments {
 		include_once __DIR__ . '/woopay/tracking-providers/class-woopay-fulfillments-api-provider.php';
 		include_once __DIR__ . '/woopay/tracking-providers/class-woopay-shipment-tracking-provider.php';
 		include_once __DIR__ . '/woopay/tracking-providers/class-woopay-shipstation-provider.php';
+		include_once __DIR__ . '/woopay/tracking-providers/class-woopay-aftership-provider.php';
 		include_once __DIR__ . '/woopay/class-woopay-order-tracking-sync.php';
 		include_once __DIR__ . '/woopay/class-woopay-store-api-session-handler.php';
 		include_once __DIR__ . '/woopay/class-woopay-scheduler.php';

--- a/includes/woopay/class-woopay-order-tracking-sync.php
+++ b/includes/woopay/class-woopay-order-tracking-sync.php
@@ -15,6 +15,7 @@ use WCPay\WooPay\Tracking_Providers\WooPay_Tracking_Provider;
 use WCPay\WooPay\Tracking_Providers\WooPay_Fulfillments_API_Provider;
 use WCPay\WooPay\Tracking_Providers\WooPay_ShipStation_Provider;
 use WCPay\WooPay\Tracking_Providers\WooPay_Shipment_Tracking_Provider;
+use WCPay\WooPay\Tracking_Providers\WooPay_AfterShip_Provider;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -152,6 +153,8 @@ class WooPay_Order_Tracking_Sync {
 			new WooPay_Shipment_Tracking_Provider(),
 			// Priority 3: ShipStation standalone (no WC Shipment Tracking bridge).
 			new WooPay_ShipStation_Provider(),
+			// Priority 4: AfterShip WooCommerce Tracking (1M+ downloads, separate meta key).
+			new WooPay_AfterShip_Provider(),
 		];
 
 		/**

--- a/includes/woopay/tracking-providers/class-woopay-aftership-provider.php
+++ b/includes/woopay/tracking-providers/class-woopay-aftership-provider.php
@@ -92,8 +92,14 @@ class WooPay_AfterShip_Provider implements WooPay_Tracking_Provider {
 				continue;
 			}
 
+			// Defensive: tolerate `additional_fields` being a non-array (e.g. a
+			// string or null) without raising a PHP 8+ "Cannot access offset of
+			// type X" notice. The is_string guard on $raw_date below still
+			// produces a safe empty date_shipped for any non-string value.
+			$additional_fields = is_array( $item['additional_fields'] ?? null ) ? $item['additional_fields'] : [];
+
 			$date_shipped = '';
-			$raw_date     = $item['additional_fields']['ship_date'] ?? '';
+			$raw_date     = $additional_fields['ship_date'] ?? '';
 			if ( is_string( $raw_date ) && '' !== $raw_date ) {
 				$dt = \DateTime::createFromFormat( 'Y-m-d', $raw_date );
 				if ( $dt && $dt->format( 'Y-m-d' ) === $raw_date ) {
@@ -104,6 +110,11 @@ class WooPay_AfterShip_Provider implements WooPay_Tracking_Provider {
 			$shipments[] = [
 				'tracking_number' => $tracking_number,
 				'carrier_name'    => self::sanitize_field( $item['slug'] ?? '' ),
+				// AfterShip generates tracking URLs server-side and doesn't
+				// store them in meta. If a future AfterShip release starts
+				// persisting URLs in `_aftership_tracking_items`, switch this
+				// to `self::sanitize_url( $item['tracking_url'] ?? '' )` and
+				// add a `sanitize_url()` helper mirroring Phase 1's pattern.
 				'tracking_url'    => '',
 				'date_shipped'    => $date_shipped,
 				'status'          => 'fulfilled',
@@ -157,6 +168,10 @@ class WooPay_AfterShip_Provider implements WooPay_Tracking_Provider {
 	/**
 	 * Strip HTML/JS, trim, and bound the length of a string field.
 	 *
+	 * Defense-in-depth: tracking meta is written by 3rd-party plugins, so
+	 * any string forwarded to WooPay should be defanged before transmission
+	 * even though the receiver re-escapes on render.
+	 *
 	 * @param mixed $value Raw value from order meta.
 	 * @return string
 	 */
@@ -169,7 +184,11 @@ class WooPay_AfterShip_Provider implements WooPay_Tracking_Provider {
 	}
 
 	/**
-	 * Truncate a string to a max length, with mbstring fallback.
+	 * Truncate a string to a max length safely on hosts without the
+	 * mbstring extension. Falls back to byte-level substr() when
+	 * mb_substr() is not available; that fallback may slice a multi-byte
+	 * character mid-byte, but the values we forward are tracking numbers
+	 * and short carrier slugs which are overwhelmingly ASCII.
 	 *
 	 * @param string $value Already-sanitized string.
 	 * @param int    $max   Max character length.

--- a/includes/woopay/tracking-providers/class-woopay-aftership-provider.php
+++ b/includes/woopay/tracking-providers/class-woopay-aftership-provider.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * WooPay AfterShip Provider
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\WooPay\Tracking_Providers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reads tracking data written by the AfterShip WooCommerce Tracking plugin
+ * (1M+ downloads).
+ *
+ * AfterShip stores tracking in `_aftership_tracking_items` order meta as an
+ * array of per-shipment entries. It does NOT fire a custom `do_action` for
+ * tracking add/update — verified against the plugin source: every save path
+ * (admin metabox AJAX, REST API, legacy metabox save on
+ * `woocommerce_process_shop_order_meta`) calls
+ * `$order->update_meta_data('_aftership_tracking_items', ...)` and
+ * `$order->save()` directly. We therefore hook the WordPress core
+ * meta-write events filtered to this meta key, the same approach the
+ * Phase 1 WC Shipment Tracking / AST provider uses for its own meta key.
+ *
+ * AfterShip's "fulfillments v2" mode stores some data in a separate
+ * `_aftership_fulfillments` meta key, but every v2 write path also calls
+ * `save_tracking_items()` which writes `_aftership_tracking_items` as a
+ * sync step — so hooking only this key is sufficient regardless of the
+ * AfterShip UI mode.
+ */
+class WooPay_AfterShip_Provider implements WooPay_Tracking_Provider {
+
+	/**
+	 * Meta key AfterShip writes its tracking entries to.
+	 */
+	const META_KEY = '_aftership_tracking_items';
+
+	/**
+	 * Maximum length for forwarded string fields.
+	 */
+	const STRING_FIELD_MAX_LEN = 256;
+
+	/**
+	 * Whether AfterShip is active and the order has tracking entries.
+	 *
+	 * @param \WC_Order $order The WooCommerce order.
+	 * @return bool
+	 */
+	public function is_available( \WC_Order $order ): bool {
+		if ( ! class_exists( 'AfterShip' ) ) {
+			return false;
+		}
+
+		$items = $order->get_meta( self::META_KEY );
+		return ! empty( $items ) && is_array( $items );
+	}
+
+	/**
+	 * Extract and normalize shipments from AfterShip meta.
+	 *
+	 * AfterShip stores `slug` (e.g. `fedex`) — a machine slug, not a display
+	 * name — and a `Y-m-d` `ship_date` inside `additional_fields`. We pass
+	 * the slug through as `carrier_name` (consistent with what AfterShip
+	 * itself stores; WooPay handles display) and validate the date with a
+	 * strict round-trip check to catch malformed values. AfterShip
+	 * generates tracking URLs server-side and does not store them in meta,
+	 * so `tracking_url` is always empty.
+	 *
+	 * @param \WC_Order $order The WooCommerce order.
+	 * @return array[]
+	 */
+	public function get_shipments( \WC_Order $order ): array {
+		$items = $order->get_meta( self::META_KEY );
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			return [];
+		}
+
+		$shipments = [];
+
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			// Sanitize before checking emptiness: a non-empty raw value can
+			// reduce to empty after wp_strip_all_tags() (e.g. tags-only input
+			// like "<script>X</script>"), and we must not emit a shipment
+			// with an empty tracking_number.
+			$tracking_number = self::sanitize_field( $item['tracking_number'] ?? '' );
+			if ( '' === $tracking_number ) {
+				continue;
+			}
+
+			$date_shipped = '';
+			$raw_date     = $item['additional_fields']['ship_date'] ?? '';
+			if ( is_string( $raw_date ) && '' !== $raw_date ) {
+				$dt = \DateTime::createFromFormat( 'Y-m-d', $raw_date );
+				if ( $dt && $dt->format( 'Y-m-d' ) === $raw_date ) {
+					$date_shipped = $raw_date;
+				}
+			}
+
+			$shipments[] = [
+				'tracking_number' => $tracking_number,
+				'carrier_name'    => self::sanitize_field( $item['slug'] ?? '' ),
+				'tracking_url'    => '',
+				'date_shipped'    => $date_shipped,
+				'status'          => 'fulfilled',
+				'items'           => [],
+			];
+		}
+
+		return $shipments;
+	}
+
+	/**
+	 * Return hooks that signal tracking changes.
+	 *
+	 * Verified against AfterShip's source: the plugin fires no custom
+	 * `do_action` for tracking add/update — it only writes
+	 * `_aftership_tracking_items` and saves the order. We therefore hook
+	 * the WordPress core meta-write events instead, filtered to this key.
+	 *
+	 * Registering both `*_post_meta` (legacy CPT order storage) and
+	 * `*_order_meta` (HPOS) covers WooCommerce's two storage backends.
+	 *
+	 * @return array[]
+	 */
+	public function get_hooks(): array {
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- 'meta_key' here is an array key in the hook spec, not a DB query argument.
+		return [
+			[
+				'hook'      => 'added_post_meta',
+				'arg_count' => 4,
+				'meta_key'  => self::META_KEY,
+			],
+			[
+				'hook'      => 'updated_post_meta',
+				'arg_count' => 4,
+				'meta_key'  => self::META_KEY,
+			],
+			[
+				'hook'      => 'added_order_meta',
+				'arg_count' => 4,
+				'meta_key'  => self::META_KEY,
+			],
+			[
+				'hook'      => 'updated_order_meta',
+				'arg_count' => 4,
+				'meta_key'  => self::META_KEY,
+			],
+		];
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+	}
+
+	/**
+	 * Strip HTML/JS, trim, and bound the length of a string field.
+	 *
+	 * @param mixed $value Raw value from order meta.
+	 * @return string
+	 */
+	private static function sanitize_field( $value ): string {
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+		$clean = trim( wp_strip_all_tags( (string) $value ) );
+		return self::truncate( $clean, self::STRING_FIELD_MAX_LEN );
+	}
+
+	/**
+	 * Truncate a string to a max length, with mbstring fallback.
+	 *
+	 * @param string $value Already-sanitized string.
+	 * @param int    $max   Max character length.
+	 * @return string
+	 */
+	private static function truncate( string $value, int $max ): string {
+		if ( function_exists( 'mb_substr' ) ) {
+			return mb_substr( $value, 0, $max );
+		}
+		return substr( $value, 0, $max );
+	}
+}

--- a/tests/unit/woopay/test-class-woopay-order-tracking-sync.php
+++ b/tests/unit/woopay/test-class-woopay-order-tracking-sync.php
@@ -84,7 +84,7 @@ class WooPay_Order_Tracking_Sync_Test extends WCPAY_UnitTestCase {
 		$providers = WooPay_Order_Tracking_Sync::get_providers();
 
 		$this->assertIsArray( $providers );
-		$this->assertCount( 3, $providers );
+		$this->assertCount( 4, $providers );
 		$this->assertInstanceOf(
 			\WCPay\WooPay\Tracking_Providers\WooPay_Fulfillments_API_Provider::class,
 			$providers[0],
@@ -99,6 +99,11 @@ class WooPay_Order_Tracking_Sync_Test extends WCPAY_UnitTestCase {
 			\WCPay\WooPay\Tracking_Providers\WooPay_ShipStation_Provider::class,
 			$providers[2],
 			'ShipStation standalone should be priority 3.'
+		);
+		$this->assertInstanceOf(
+			\WCPay\WooPay\Tracking_Providers\WooPay_AfterShip_Provider::class,
+			$providers[3],
+			'AfterShip should be priority 4.'
 		);
 	}
 
@@ -134,7 +139,7 @@ class WooPay_Order_Tracking_Sync_Test extends WCPAY_UnitTestCase {
 		WooPay_Order_Tracking_Sync::get_providers();
 
 		$this->assertIsArray( $received );
-		$this->assertCount( 3, $received );
+		$this->assertCount( 4, $received );
 	}
 
 	public function test_constructor_calls_register_persistence_hooks_on_providers_that_implement_it() {

--- a/tests/unit/woopay/tracking-providers/stub-aftership.php
+++ b/tests/unit/woopay/tracking-providers/stub-aftership.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Stub for AfterShip class detection in unit tests.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+if ( ! class_exists( 'AfterShip' ) ) {
+	// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound,Squiz.Commenting.ClassComment.Missing
+	class AfterShip {}
+}

--- a/tests/unit/woopay/tracking-providers/test-class-woopay-aftership-provider.php
+++ b/tests/unit/woopay/tracking-providers/test-class-woopay-aftership-provider.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * Class WooPay_AfterShip_Provider_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\WooPay\Tracking_Providers\WooPay_AfterShip_Provider;
+
+require_once __DIR__ . '/../../../../includes/woopay/tracking-providers/interface-woopay-tracking-provider.php';
+require_once __DIR__ . '/../../../../includes/woopay/tracking-providers/class-woopay-aftership-provider.php';
+
+/*
+ * Load the AfterShip detection stub. This simulates the plugin being active
+ * for the rest of the test suite. PHPUnit auto-loads this stub during its
+ * directory scan, so once required it persists for the whole process — the
+ * `class_exists('AfterShip') → return false` branch of `is_available()` is
+ * therefore not directly testable in this file.
+ *
+ * The gap is acceptable because the same `class_exists('AfterShip')` check
+ * is the standard sentinel AfterShip itself uses, and the provider chain
+ * ordering in WooPay_Order_Tracking_Sync ensures higher-priority providers
+ * (Fulfillments API, WC Shipment Tracking / AST, ShipStation) run first
+ * for merchants who don't have AfterShip installed.
+ */
+require_once __DIR__ . '/stub-aftership.php';
+
+/**
+ * WooPay_AfterShip_Provider unit tests.
+ */
+class WooPay_AfterShip_Provider_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * @var WooPay_AfterShip_Provider
+	 */
+	private $provider;
+
+	public function set_up() {
+		parent::set_up();
+		$this->provider = new WooPay_AfterShip_Provider();
+	}
+
+	// -------------------------------------------------------------------------
+	// is_available()
+	// -------------------------------------------------------------------------
+
+	public function test_is_available_returns_true_when_meta_has_entries() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_number' => '398242362749',
+					'slug'            => 'fedex',
+				],
+			]
+		);
+		$order->save();
+
+		$this->assertTrue( $this->provider->is_available( $order ) );
+	}
+
+	public function test_is_available_returns_false_when_meta_absent() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->assertFalse( $this->provider->is_available( $order ) );
+	}
+
+	public function test_is_available_returns_false_when_meta_is_empty_array() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( WooPay_AfterShip_Provider::META_KEY, [] );
+		$order->save();
+
+		$this->assertFalse( $this->provider->is_available( $order ) );
+	}
+
+	public function test_is_available_returns_false_when_meta_is_not_array() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( WooPay_AfterShip_Provider::META_KEY, 'not-an-array' );
+		$order->save();
+
+		$this->assertFalse( $this->provider->is_available( $order ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_shipments()
+	// -------------------------------------------------------------------------
+
+	public function test_get_shipments_returns_empty_when_meta_absent() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->assertEmpty( $this->provider->get_shipments( $order ) );
+	}
+
+	public function test_get_shipments_normalizes_tracking_data() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_id'       => '07d0390057d53be7af161ee22dc00eb4',
+					'tracking_number'   => '398242362749',
+					'slug'              => 'fedex',
+					'additional_fields' => [
+						'ship_date' => '2026-03-28',
+					],
+					'line_items'        => [
+						[
+							'id'       => 3,
+							'quantity' => 1,
+						],
+					],
+					'metrics'           => [
+						'created_at' => '2026-03-28T20:13:15Z',
+						'updated_at' => '2026-03-28T20:13:15Z',
+					],
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 1, $shipments );
+		$this->assertEquals( '398242362749', $shipments[0]['tracking_number'] );
+		$this->assertEquals( 'fedex', $shipments[0]['carrier_name'] );
+		$this->assertEquals( '2026-03-28', $shipments[0]['date_shipped'] );
+		$this->assertEquals( 'fulfilled', $shipments[0]['status'] );
+		$this->assertEquals( '', $shipments[0]['tracking_url'] );
+		$this->assertEmpty( $shipments[0]['items'] );
+	}
+
+	public function test_get_shipments_returns_multiple_shipments() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_number'   => '398242362749',
+					'slug'              => 'fedex',
+					'additional_fields' => [ 'ship_date' => '2026-03-28' ],
+				],
+				[
+					'tracking_number'   => '1Z999AA10123456784',
+					'slug'              => 'ups',
+					'additional_fields' => [ 'ship_date' => '2026-03-29' ],
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 2, $shipments );
+		$this->assertEquals( '398242362749', $shipments[0]['tracking_number'] );
+		$this->assertEquals( 'fedex', $shipments[0]['carrier_name'] );
+		$this->assertEquals( '1Z999AA10123456784', $shipments[1]['tracking_number'] );
+		$this->assertEquals( 'ups', $shipments[1]['carrier_name'] );
+	}
+
+	public function test_get_shipments_returns_empty_date_shipped_when_ship_date_absent() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_number'   => '398242362749',
+					'slug'              => 'fedex',
+					'additional_fields' => [],
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 1, $shipments );
+		$this->assertEquals( '', $shipments[0]['date_shipped'] );
+	}
+
+	public function test_get_shipments_returns_empty_date_shipped_when_additional_fields_absent() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_number' => '398242362749',
+					'slug'            => 'fedex',
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 1, $shipments );
+		$this->assertEquals( '', $shipments[0]['date_shipped'] );
+	}
+
+	public function test_get_shipments_returns_empty_date_shipped_when_ship_date_invalid_format() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_number'   => '398242362749',
+					'slug'              => 'fedex',
+					'additional_fields' => [ 'ship_date' => 'not-a-date' ],
+				],
+				[
+					'tracking_number'   => '1Z999AA10123456784',
+					'slug'              => 'ups',
+					'additional_fields' => [ 'ship_date' => '2026-13-99' ],
+				],
+				[
+					'tracking_number'   => '9400111899223397865584',
+					'slug'              => 'usps',
+					// Unix timestamp passed as integer — strict Y-m-d round-trip rejects it.
+					'additional_fields' => [ 'ship_date' => 1710288000 ],
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 3, $shipments );
+		$this->assertEquals( '', $shipments[0]['date_shipped'] );
+		$this->assertEquals( '', $shipments[1]['date_shipped'] );
+		$this->assertEquals( '', $shipments[2]['date_shipped'] );
+	}
+
+	public function test_get_shipments_skips_entries_without_tracking_number() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'slug' => 'fedex',
+				],
+				[
+					'tracking_number' => '398242362749',
+					'slug'            => 'fedex',
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 1, $shipments );
+		$this->assertEquals( '398242362749', $shipments[0]['tracking_number'] );
+	}
+
+	public function test_get_shipments_skips_entries_when_tracking_number_sanitizes_to_empty() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_number' => '<script></script>',
+					'slug'            => 'fedex',
+				],
+				[
+					'tracking_number' => '398242362749',
+					'slug'            => 'fedex',
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 1, $shipments );
+		$this->assertEquals( '398242362749', $shipments[0]['tracking_number'] );
+	}
+
+	public function test_get_shipments_skips_non_array_entries() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				'not-an-array',
+				[
+					'tracking_number' => '398242362749',
+					'slug'            => 'fedex',
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 1, $shipments );
+		$this->assertEquals( '398242362749', $shipments[0]['tracking_number'] );
+	}
+
+	public function test_get_shipments_strips_html_from_slug_and_tracking_number() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_number' => '<b>1Z999</b>',
+					'slug'            => '<script>alert(1)</script>ups',
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 1, $shipments );
+		$this->assertEquals( '1Z999', $shipments[0]['tracking_number'] );
+		$this->assertEquals( 'ups', $shipments[0]['carrier_name'] );
+	}
+
+	public function test_get_shipments_truncates_pathologically_long_strings() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data(
+			WooPay_AfterShip_Provider::META_KEY,
+			[
+				[
+					'tracking_number' => str_repeat( 'A', 1000 ),
+					'slug'            => str_repeat( 'B', 1000 ),
+				],
+			]
+		);
+		$order->save();
+
+		$shipments = $this->provider->get_shipments( $order );
+
+		$this->assertCount( 1, $shipments );
+		$this->assertSame( 256, mb_strlen( $shipments[0]['tracking_number'] ) );
+		$this->assertSame( 256, mb_strlen( $shipments[0]['carrier_name'] ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_hooks()
+	// -------------------------------------------------------------------------
+
+	public function test_get_hooks_returns_meta_write_hooks_filtered_by_key() {
+		$hooks = $this->provider->get_hooks();
+
+		$this->assertCount( 4, $hooks );
+
+		$expected_hook_names = [
+			'added_post_meta',
+			'updated_post_meta',
+			'added_order_meta',
+			'updated_order_meta',
+		];
+
+		foreach ( $hooks as $i => $hook ) {
+			$this->assertEquals( $expected_hook_names[ $i ], $hook['hook'] );
+			$this->assertEquals( 4, $hook['arg_count'] );
+			$this->assertEquals( '_aftership_tracking_items', $hook['meta_key'] );
+		}
+	}
+}

--- a/tests/unit/woopay/tracking-providers/test-class-woopay-aftership-provider.php
+++ b/tests/unit/woopay/tracking-providers/test-class-woopay-aftership-provider.php
@@ -257,8 +257,19 @@ class WooPay_AfterShip_Provider_Test extends WCPAY_UnitTestCase {
 		$order->update_meta_data(
 			WooPay_AfterShip_Provider::META_KEY,
 			[
+				// Tags-only: wp_strip_all_tags produces an empty string.
 				[
 					'tracking_number' => '<script></script>',
+					'slug'            => 'fedex',
+				],
+				// Whitespace-only: trim() produces an empty string.
+				[
+					'tracking_number' => "   \t  ",
+					'slug'            => 'fedex',
+				],
+				// Mixed tags + whitespace: combined sanitization produces empty.
+				[
+					'tracking_number' => "  <b></b>\n",
 					'slug'            => 'fedex',
 				],
 				[


### PR DESCRIPTION
### * EXPERIMENTAL *

**Linear:** WOOPAY-447 — Shipping tracking dashboard: receiver, UI, and wc-delivered status
**Depends on:** #11517 (Phase 1 + Phase 2). This PR is currently based on the \`feat/multi-plugin-tracking-adapter\` branch and will be retargeted to \`develop\` after #11517 merges.

## Description

Adds the **AfterShip** provider to the WooPay order-tracking adapter chain at priority 4, covering merchants running the AfterShip WooCommerce Tracking plugin (1M+ downloads).

This is a small follow-up to #11517: the sync class \`meta_key\` extension and the \"hook core meta-write events filtered by key\" pattern were both established in that PR (used by the WC Shipment Tracking / AST provider). AfterShip is the same pattern with a different meta key — \`_aftership_tracking_items\` instead of \`_wc_shipment_tracking_items\`.

## Why a separate PR

- **Independent scope.** AfterShip is conceptually independent of Phases 1 and 2. Reviewers can evaluate it without re-reviewing the prior work.
- **Small, focused diff.** One provider class + one stub + one test class + a 1-line registration in two places + a changelog. The infrastructure it depends on already landed in #11517.

## Verified meta format (real install, order #71)

\`\`\`php
[
    [
        'tracking_id'       => '07d0390057d53be7af161ee22dc00eb4',  // md5(slug-tracking_number)
        'tracking_number'   => '398242362749',
        'slug'              => 'fedex',                              // machine slug, NOT display name
        'additional_fields' => [
            'ship_date' => '2026-03-28',                             // Y-m-d string (not unix timestamp)
            // ... other fields we don't read
        ],
        'line_items' => [
            [ 'id' => 3, 'quantity' => 1 ],                          // ignored — provider returns items: []
        ],
        'metrics' => [
            'created_at' => '2026-03-28T20:13:15Z',
            'updated_at' => '2026-03-28T20:13:15Z',
        ],
    ]
]
\`\`\`

Differences from WC Shipment Tracking:
- \`slug\` (e.g. \`fedex\`) is a machine slug, not display name → forwarded as \`carrier_name\` (consistent with what AfterShip stores; WooPay handles display)
- \`ship_date\` is \`Y-m-d\` string in \`additional_fields\`, not unix timestamp at top level → strict round-trip validation
- \`tracking_url\` not stored (AfterShip generates URLs server-side) → always empty string

## Verified: AfterShip fires no custom action

Every save path in the AfterShip plugin (admin metabox AJAX, REST API, legacy metabox save on \`woocommerce_process_shop_order_meta\`) calls \`\$order->update_meta_data('_aftership_tracking_items', ...)\` and \`\$order->save()\` directly — no \`do_action\`. We therefore hook the WordPress core meta-write events (\`added_post_meta\`, \`updated_post_meta\`, \`added_order_meta\`, \`updated_order_meta\`) filtered to the meta key. Covers both legacy CPT storage and HPOS.

## Verified: Fulfillments v2 mode is safe

AfterShip's \"fulfillments v2\" mode stores some data in a separate \`_aftership_fulfillments\` meta key, but every v2 write path also calls \`save_tracking_items()\` which writes \`_aftership_tracking_items\` as a sync step:

- \`save_order_fulfillments_controller()\` (class-aftership-fulfillment.php:119) calls \`AfterShip_Actions::get_instance()->save_tracking_items( \$order_id, \$old_trackings )\`
- \`delete_order_fulfillments_controller()\` (line 230) calls \`delete_tracking_item()\` per tracking → \`save_tracking_items()\`
- \`delete_order_fulfillment_tracking_controller()\` (line 275) calls \`delete_tracking_item()\` → \`save_tracking_items()\`

Hooking only \`_aftership_tracking_items\` is sufficient regardless of the AfterShip UI mode.

## Provider chain (after this PR)

1. WC Core Fulfillments API (WC 10.2+)
2. WC Shipment Tracking / Advanced Shipment Tracking
3. ShipStation standalone
4. **AfterShip** ← this PR

## Changes proposed in this Pull Request

**New files:**
- \`includes/woopay/tracking-providers/class-woopay-aftership-provider.php\` — provider implementation
- \`tests/unit/woopay/tracking-providers/stub-aftership.php\` — \`AfterShip\` class stub for unit tests
- \`tests/unit/woopay/tracking-providers/test-class-woopay-aftership-provider.php\` — 16 unit tests
- \`changelog/feat-multi-plugin-tracking-adapter#3\` — changelog entry

**Modified files:**
- \`includes/woopay/class-woopay-order-tracking-sync.php\` — \`use\` import + priority-4 provider entry
- \`includes/class-wc-payments.php\` — \`include_once\` for the new provider file
- \`tests/unit/woopay/test-class-woopay-order-tracking-sync.php\` — bump provider count assertions 3 → 4 (and add the priority-4 \`assertInstanceOf\`)

## Testing instructions

1. Install the [AfterShip WooCommerce Tracking](https://wordpress.org/plugins/aftership-woocommerce-tracking/) plugin on a WooPay-enabled store
2. Place a WooPay order (order must have \`is_woopay\` meta)
3. Add a tracking number to the order via AfterShip's admin UI (carrier slug + tracking number, optionally a ship date)
4. Verify the corresponding meta-write hook (\`updated_order_meta\` for HPOS or \`updated_post_meta\` for legacy) fires with \`_aftership_tracking_items\` and \`send_webhook()\` is called
5. Verify the webhook payload contains normalized shipment data:
   \`\`\`json
   {
     \"blog_id\": <store_id>,
     \"order_id\": <order_id>,
     \"shipments\": [{
       \"tracking_number\": \"398242362749\",
       \"carrier_name\": \"fedex\",
       \"tracking_url\": \"\",
       \"date_shipped\": \"2026-03-28\",
       \"status\": \"fulfilled\",
       \"items\": []
     }]
   }
   \`\`\`
6. Verify adding multiple tracking entries to the same order produces multiple shipments in the payload
7. Verify a malformed \`ship_date\` (e.g. \`2026-13-99\`) is forwarded as empty string (not a fatal)
8. Verify a merchant who runs both AfterShip and WC Shipment Tracking is covered by Phase 1 (priority 2 wins)

### Run tests

\`\`\`bash
# AfterShip provider tests (16 tests)
vendor/bin/phpunit --filter 'WooPay_AfterShip_Provider_Test'

# Sync class tests (provider chain priority assertions updated)
vendor/bin/phpunit --filter 'WooPay_Order_Tracking_Sync_Test'
\`\`\`

## Pre-review checklist

- [x] Added changelog entry
- [x] Added/updated tests (16 new tests for the provider, all passing; sync class assertions updated)
- [ ] Tested on mobile (N/A — PHP-only)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)