### PR TITLE
fix: tooltip viewport bounds

### DIFF
--- a/changelog/fix-tooltip-bounds-fix
+++ b/changelog/fix-tooltip-bounds-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: prevent tooltip from rendering outside the viewport horizontally on narrow breakpoints

--- a/client/components/tooltip/tooltip-base.tsx
+++ b/client/components/tooltip/tooltip-base.tsx
@@ -209,7 +209,16 @@ const TooltipBase: React.FC< React.PropsWithChildren< TooltipBaseProps > > = ( {
 				return;
 			}
 
+			const viewportPadding = 8;
+
 			tooltipElement.style.maxWidth = maxWidth;
+
+			// Cap maxWidth to the viewport so the tooltip can never be wider
+			// than the available space on narrow screens.
+			const viewportMaxWidth = window.innerWidth - 2 * viewportPadding;
+			if ( tooltipElement.offsetWidth > viewportMaxWidth ) {
+				tooltipElement.style.maxWidth = `${ viewportMaxWidth }px`;
+			}
 
 			const wrappedElementRect = wrappedElement.getBoundingClientRect();
 			const tooltipElementRect = tooltipElement.getBoundingClientRect();
@@ -221,18 +230,15 @@ const TooltipBase: React.FC< React.PropsWithChildren< TooltipBaseProps > > = ( {
 			const elementMiddle =
 				wrappedElement.offsetWidth / 2 + wrappedElementRect.left;
 			const tooltipWidth = tooltipElement.offsetWidth;
-			let tooltipLeft = elementMiddle - tooltipWidth / 2;
-			const tooltipRight =
-				window.innerWidth -
-				( wrappedElementRect.left + tooltipElement.offsetWidth );
 
-			if ( tooltipLeft < 0 ) {
-				// create a gap with the left edge if the element is out of view port
-				tooltipLeft = 45;
-			} else if ( tooltipRight < 0 ) {
-				// create a gap with the right edge if the element is out of view port
-				tooltipLeft = tooltipLeft - 85;
-			}
+			// Center on the trigger, then clamp inside the viewport so the
+			// tooltip stays visible at any breakpoint or scroll position.
+			const minLeft = viewportPadding;
+			const maxLeft = window.innerWidth - tooltipWidth - viewportPadding;
+			const tooltipLeft = Math.max(
+				minLeft,
+				Math.min( elementMiddle - tooltipWidth / 2, maxLeft )
+			);
 
 			tooltipElement.style.left = `${ tooltipLeft }px`;
 


### PR DESCRIPTION
Fixes WOOPMNT-6150


#### Changes proposed in this Pull Request

@dmvrtx  [pointed out](https://github.com/Automattic/woocommerce-payments/pull/11685#pullrequestreview-4241951227) that the payout-status tooltip on the Overview page renders outside the viewport on narrow widths.

The positioning logic in `tooltip-base.tsx` was applying an arbitrary `-85px` shift when it detected right-edge overflow, and the overflow check itself was using the trigger's left position rather than the tooltip's actual placement. On mobile widths, that "fix" pushed the tooltip off the *left* edge.

Replacing that logic with a proper viewport clamp on `left` (`Math.max(minLeft, Math.min(centered, maxLeft))`), and capping `maxWidth` to the viewport so the tooltip can never be wider than the screen.

I considered adding a Jest test for the clamp, but mocking `innerWidth` / `offsetWidth` / `getBoundingClientRect` per case felt heavier than the fix itself: happy to add one if this ever regresses.

Before:
<img width="367" height="642" alt="Screenshot 2026-05-07 at 10 16 00 AM" src="https://github.com/user-attachments/assets/5efc2b27-465d-4e78-92b7-1c336330e079" />

After:
<img width="376" height="167" alt="Screenshot 2026-05-07 at 11 33 09 AM" src="https://github.com/user-attachments/assets/f27e664e-19e0-4a21-b3d5-d9fe6998412d" />
<img width="355" height="186" alt="Screenshot 2026-05-07 at 11 32 51 AM" src="https://github.com/user-attachments/assets/e0ebc5c2-3271-4505-8584-21c70a6f2929" />


#### Testing instructions

* Visit Payments > Overview on a narrow viewport (or use DevTools device emulation at ~375px)
* In the **Account details** card → **Payouts** row, click the help icon (`?`) next to the "Available in X days" chip
* Without this PR: the tooltip clips off the left edge of the viewport (same screen as [Valerie's screenshot](https://github.com/Automattic/woocommerce-payments/pull/11685#pullrequestreview-4241951227))
* With this PR: the tooltip stays fully inside the viewport with a small gap from each edge
* Repeat at a few widths (e.g. 320, 375, 768) and confirm it stays in bounds

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [ ] Covered with tests (the clamp is pure math; verifying it would need mocking `innerWidth` / `offsetWidth` / `getBoundingClientRect` per case — skipping unless it regresses)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
