### PR TITLE
Fix Express Checkout auto-selecting Local Pickup despite wallet address

### DIFF
--- a/changelog/WOOPMNT-6159
+++ b/changelog/WOOPMNT-6159
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Express Checkout (Apple Pay/Google Pay): switch the auto-selected shipping method to delivery when the wallet provides a shipping address, instead of keeping the previously-chosen Local Pickup.

--- a/changelog/WOOPMNT-6159
+++ b/changelog/WOOPMNT-6159
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Express Checkout (Apple Pay/Google Pay): switch the auto-selected shipping method to delivery when the wallet provides a shipping address, instead of keeping the previously-chosen Local Pickup.
+Express Checkout (Apple Pay/Google Pay): switch the shipping method to delivery when the wallet provides a shipping address and the selected Local Pickup was auto-defaulted rather than chosen by the customer (uses the Store API selected_rate_origin field where available; a deliberately chosen pickup is never overridden).

--- a/client/express-checkout/__tests__/event-handlers.test.js
+++ b/client/express-checkout/__tests__/event-handlers.test.js
@@ -425,7 +425,11 @@ describe( 'Express checkout event handlers', () => {
 		} );
 
 		describe( 'when wallet address triggers Local Pickup → delivery switch', () => {
-			const buildCart = ( shippingRates, totalPrice = 1000 ) => ( {
+			const buildCart = (
+				shippingRates,
+				totalPrice = 1000,
+				selectedRateOrigin
+			) => ( {
 				items: [],
 				shipping_rates: [
 					{
@@ -434,6 +438,9 @@ describe( 'Express checkout event handlers', () => {
 						destination: {},
 						items: [],
 						shipping_rates: shippingRates,
+						...( selectedRateOrigin !== undefined
+							? { selected_rate_origin: selectedRateOrigin }
+							: {} ),
 					},
 				],
 				totals: {
@@ -618,6 +625,100 @@ describe( 'Express checkout event handlers', () => {
 				);
 
 				consoleWarnSpy.mockRestore();
+			} );
+
+			it( 'leaves a manually chosen Local Pickup selected (selected_rate_origin: manual)', async () => {
+				cartApiUpdateCustomerMock.mockResolvedValue(
+					buildCart( [ pickupRate, deliveryRate ], 0, 'manual' )
+				);
+
+				await shippingAddressChangeHandler( event, elements );
+
+				expect( cartApiSelectShippingRateMock ).not.toHaveBeenCalled();
+				expect( event.resolve ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						shippingRates: [
+							expect.objectContaining( {
+								id: 'pickup_location:0',
+							} ),
+							expect.objectContaining( { id: 'flat_rate:14' } ),
+						],
+					} )
+				);
+				// The shopper chose free pickup — the charged amount must stay 0.
+				expect( elements.update ).toHaveBeenCalledWith(
+					expect.objectContaining( { amount: 0 } )
+				);
+			} );
+
+			it( 'reselects delivery when the pickup was auto-defaulted (selected_rate_origin: auto)', async () => {
+				cartApiUpdateCustomerMock.mockResolvedValue(
+					buildCart( [ pickupRate, deliveryRate ], 0, 'auto' )
+				);
+				cartApiSelectShippingRateMock.mockResolvedValue(
+					buildCart(
+						[
+							{ ...pickupRate, selected: false },
+							{ ...deliveryRate, selected: true },
+						],
+						1000,
+						'manual'
+					)
+				);
+
+				await shippingAddressChangeHandler( event, elements );
+
+				expect( cartApiSelectShippingRateMock ).toHaveBeenCalledWith( {
+					package_id: 0,
+					rate_id: 'flat_rate:14',
+				} );
+			} );
+
+			it( 'reselects delivery when the origin field is absent (WC without origin tracking)', async () => {
+				// buildCart without the third argument emits no selected_rate_origin —
+				// the shape every WC release without the core origin-tracking fix sends.
+				cartApiUpdateCustomerMock.mockResolvedValue(
+					buildCart( [ pickupRate, deliveryRate ], 0 )
+				);
+				cartApiSelectShippingRateMock.mockResolvedValue(
+					buildCart(
+						[
+							{ ...pickupRate, selected: false },
+							{ ...deliveryRate, selected: true },
+						],
+						1000
+					)
+				);
+
+				await shippingAddressChangeHandler( event, elements );
+
+				expect( cartApiSelectShippingRateMock ).toHaveBeenCalledWith( {
+					package_id: 0,
+					rate_id: 'flat_rate:14',
+				} );
+			} );
+
+			it( 'reselects delivery when the origin is explicitly null (no prior selection recorded)', async () => {
+				cartApiUpdateCustomerMock.mockResolvedValue(
+					buildCart( [ pickupRate, deliveryRate ], 0, null )
+				);
+				cartApiSelectShippingRateMock.mockResolvedValue(
+					buildCart(
+						[
+							{ ...pickupRate, selected: false },
+							{ ...deliveryRate, selected: true },
+						],
+						1000,
+						'manual'
+					)
+				);
+
+				await shippingAddressChangeHandler( event, elements );
+
+				expect( cartApiSelectShippingRateMock ).toHaveBeenCalledWith( {
+					package_id: 0,
+					rate_id: 'flat_rate:14',
+				} );
 			} );
 
 			it( 'resolves rates and package id through the express-checkout filters (deferred-shipping carts)', async () => {

--- a/client/express-checkout/__tests__/event-handlers.test.js
+++ b/client/express-checkout/__tests__/event-handlers.test.js
@@ -494,6 +494,7 @@ describe( 'Express checkout event handlers', () => {
 				} );
 				expect( elements.update ).toHaveBeenCalledWith( {
 					amount: 1000,
+					setupFutureUsage: null,
 				} );
 				expect( event.resolve ).toHaveBeenCalledWith(
 					expect.objectContaining( {
@@ -545,6 +546,7 @@ describe( 'Express checkout event handlers', () => {
 				expect( event.reject ).not.toHaveBeenCalled();
 				expect( elements.update ).toHaveBeenCalledWith( {
 					amount: 1000,
+					setupFutureUsage: null,
 				} );
 				expect( event.resolve ).toHaveBeenCalledWith(
 					expect.objectContaining( {
@@ -604,7 +606,6 @@ describe( 'Express checkout event handlers', () => {
 			} );
 		} );
 	} );
-
 
 	describe( 'shippingRateChangeHandler', () => {
 		let event;

--- a/client/express-checkout/__tests__/event-handlers.test.js
+++ b/client/express-checkout/__tests__/event-handlers.test.js
@@ -413,7 +413,154 @@ describe( 'Express checkout event handlers', () => {
 			expect( event.reject ).not.toHaveBeenCalled();
 			expect( event.resolve ).toHaveBeenCalled();
 		} );
+
+		describe( 'when wallet address triggers Local Pickup → delivery switch', () => {
+			const buildCart = ( shippingRates, totalPrice = 1000 ) => ( {
+				items: [],
+				shipping_rates: [
+					{
+						package_id: 0,
+						name: 'Shipment 1',
+						destination: {},
+						items: [],
+						shipping_rates: shippingRates,
+					},
+				],
+				totals: {
+					total_price: totalPrice,
+					currency_minor_unit: 2,
+					currency_code: 'USD',
+					currency_symbol: '$',
+					currency_decimal_separator: '.',
+					currency_thousand_separator: ',',
+					currency_prefix: '$',
+					currency_suffix: '',
+				},
+			} );
+
+			const baseRate = {
+				description: '',
+				delivery_time: '',
+				taxes: '0',
+				meta_data: [],
+				currency_code: 'USD',
+				currency_symbol: '$',
+				currency_minor_unit: 2,
+				currency_decimal_separator: '.',
+				currency_thousand_separator: ',',
+				currency_prefix: '$',
+				currency_suffix: '',
+			};
+
+			const pickupRate = {
+				...baseRate,
+				rate_id: 'pickup_location:0',
+				name: 'Local Pickup',
+				price: '0',
+				instance_id: 0,
+				method_id: 'pickup_location',
+				selected: true,
+			};
+
+			const deliveryRate = {
+				...baseRate,
+				rate_id: 'flat_rate:14',
+				name: 'Standard Shipping',
+				price: '1000',
+				instance_id: 14,
+				method_id: 'flat_rate',
+				selected: false,
+			};
+
+			it( 'reselects the first delivery rate when Local Pickup is stuck as selected', async () => {
+				cartApiUpdateCustomerMock.mockResolvedValue(
+					buildCart( [ pickupRate, deliveryRate ], 0 )
+				);
+				cartApiSelectShippingRateMock.mockResolvedValue(
+					buildCart(
+						[
+							{ ...pickupRate, selected: false },
+							{ ...deliveryRate, selected: true },
+						],
+						1000
+					)
+				);
+
+				await shippingAddressChangeHandler( event, elements );
+
+				expect( cartApiSelectShippingRateMock ).toHaveBeenCalledWith( {
+					package_id: 0,
+					rate_id: 'flat_rate:14',
+				} );
+				expect( elements.update ).toHaveBeenCalledWith( {
+					amount: 1000,
+				} );
+				expect( event.resolve ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						shippingRates: [
+							expect.objectContaining( {
+								id: 'flat_rate:14',
+							} ),
+							expect.objectContaining( {
+								id: 'pickup_location:0',
+							} ),
+						],
+					} )
+				);
+			} );
+
+			it( 'leaves the selection alone when only Local Pickup is available', async () => {
+				cartApiUpdateCustomerMock.mockResolvedValue(
+					buildCart( [ pickupRate ], 0 )
+				);
+
+				await shippingAddressChangeHandler( event, elements );
+
+				expect( cartApiSelectShippingRateMock ).not.toHaveBeenCalled();
+				expect( event.resolve ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						shippingRates: [
+							expect.objectContaining( {
+								id: 'pickup_location:0',
+							} ),
+						],
+					} )
+				);
+			} );
+
+			it( 'leaves the selection alone when a delivery rate is already selected', async () => {
+				cartApiUpdateCustomerMock.mockResolvedValue(
+					buildCart(
+						[
+							{ ...pickupRate, selected: false },
+							{ ...deliveryRate, selected: true },
+						],
+						1000
+					)
+				);
+
+				await shippingAddressChangeHandler( event, elements );
+
+				expect( cartApiSelectShippingRateMock ).not.toHaveBeenCalled();
+			} );
+
+			it( 'falls back to the original cart data if reselect fails', async () => {
+				cartApiUpdateCustomerMock.mockResolvedValue(
+					buildCart( [ pickupRate, deliveryRate ], 0 )
+				);
+				cartApiSelectShippingRateMock.mockRejectedValue(
+					new Error( 'network' )
+				);
+
+				await shippingAddressChangeHandler( event, elements );
+
+				expect( cartApiSelectShippingRateMock ).toHaveBeenCalled();
+				expect( event.reject ).not.toHaveBeenCalled();
+				expect( event.resolve ).toHaveBeenCalled();
+			} );
+		} );
 	} );
+
 
 	describe( 'shippingRateChangeHandler', () => {
 		let event;

--- a/client/express-checkout/__tests__/event-handlers.test.js
+++ b/client/express-checkout/__tests__/event-handlers.test.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { recordUserEvent } from 'tracks';
+
+/**
  * Internal dependencies
  */
 import {
@@ -11,6 +17,10 @@ import {
 	rememberElementCurrency,
 	__resetElementCurrencyForTests,
 } from '../utils/element-currency-cache';
+
+jest.mock( 'tracks', () => ( {
+	recordUserEvent: jest.fn(),
+} ) );
 
 describe( 'Express checkout event handlers', () => {
 	let cartApiUpdateCustomerMock;
@@ -601,8 +611,67 @@ describe( 'Express checkout event handlers', () => {
 					),
 					expect.any( Error )
 				);
+				// The failure must also be observable in production
+				// monitoring, not just the shopper's browser console.
+				expect( recordUserEvent ).toHaveBeenCalledWith(
+					'express_checkout_pickup_reselect_failed'
+				);
 
 				consoleWarnSpy.mockRestore();
+			} );
+
+			it( 'resolves rates and package id through the express-checkout filters (deferred-shipping carts)', async () => {
+				// Emulate the wc-subscriptions compatibility layer: for trial
+				// subscriptions with deferred shipping the main package has no
+				// rates and the effective rates/package id come from filters.
+				addFilter(
+					'wcpay.express-checkout.shipping-rates',
+					'wcpay-test/deferred-shipping',
+					( rates, cartData ) =>
+						rates.length > 0 ? rates : cartData.extensions.testRates
+				);
+				addFilter(
+					'wcpay.express-checkout.shipping-package-id',
+					'wcpay-test/deferred-shipping',
+					() => 3
+				);
+
+				try {
+					const deferredCart = buildCart( [], 0 );
+					deferredCart.extensions = {
+						testRates: [ pickupRate, deliveryRate ],
+					};
+					cartApiUpdateCustomerMock.mockResolvedValue( deferredCart );
+					cartApiSelectShippingRateMock.mockResolvedValue(
+						buildCart(
+							[
+								{ ...pickupRate, selected: false },
+								{ ...deliveryRate, selected: true },
+							],
+							1000
+						)
+					);
+
+					await shippingAddressChangeHandler( event, elements );
+
+					expect(
+						cartApiSelectShippingRateMock
+					).toHaveBeenCalledWith( {
+						package_id: 3,
+						rate_id: 'flat_rate:14',
+					} );
+					expect( event.reject ).not.toHaveBeenCalled();
+					expect( event.resolve ).toHaveBeenCalled();
+				} finally {
+					removeFilter(
+						'wcpay.express-checkout.shipping-rates',
+						'wcpay-test/deferred-shipping'
+					);
+					removeFilter(
+						'wcpay.express-checkout.shipping-package-id',
+						'wcpay-test/deferred-shipping'
+					);
+				}
 			} );
 		} );
 	} );

--- a/client/express-checkout/__tests__/event-handlers.test.js
+++ b/client/express-checkout/__tests__/event-handlers.test.js
@@ -542,9 +542,32 @@ describe( 'Express checkout event handlers', () => {
 				await shippingAddressChangeHandler( event, elements );
 
 				expect( cartApiSelectShippingRateMock ).not.toHaveBeenCalled();
+				expect( event.reject ).not.toHaveBeenCalled();
+				expect( elements.update ).toHaveBeenCalledWith( {
+					amount: 1000,
+				} );
+				expect( event.resolve ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						// Both rates remain in the package; the transformer
+						// sorts the selected one (Flat Rate) first.
+						shippingRates: expect.arrayContaining( [
+							expect.objectContaining( {
+								id: 'flat_rate:14',
+							} ),
+							expect.objectContaining( {
+								id: 'pickup_location:0',
+							} ),
+						] ),
+					} )
+				);
 			} );
 
 			it( 'falls back to the original cart data if reselect fails', async () => {
+				// Suppress the expected console.warn from the catch block so the
+				// test output stays clean; we still assert it was called below.
+				const consoleWarnSpy = jest
+					.spyOn( console, 'warn' )
+					.mockImplementation( () => {} );
 				cartApiUpdateCustomerMock.mockResolvedValue(
 					buildCart( [ pickupRate, deliveryRate ], 0 )
 				);
@@ -556,7 +579,28 @@ describe( 'Express checkout event handlers', () => {
 
 				expect( cartApiSelectShippingRateMock ).toHaveBeenCalled();
 				expect( event.reject ).not.toHaveBeenCalled();
-				expect( event.resolve ).toHaveBeenCalled();
+				expect( event.resolve ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						// Original cart from updateCustomer still has the
+						// pickup rate marked selected; transformer sorts it first.
+						shippingRates: expect.arrayContaining( [
+							expect.objectContaining( {
+								id: 'pickup_location:0',
+							} ),
+							expect.objectContaining( {
+								id: 'flat_rate:14',
+							} ),
+						] ),
+					} )
+				);
+				expect( consoleWarnSpy ).toHaveBeenCalledWith(
+					expect.stringContaining(
+						'preferDeliveryOverLocalPickup failed'
+					),
+					expect.any( Error )
+				);
+
+				consoleWarnSpy.mockRestore();
 			} );
 		} );
 	} );

--- a/client/express-checkout/event-handlers.js
+++ b/client/express-checkout/event-handlers.js
@@ -112,7 +112,9 @@ const isLocalPickupRate = ( rate ) =>
  * chosen method when the package's rate set changes, so when pickup and a
  * delivery rate are both available before the address arrives, this reselect
  * is the only thing that moves the selection off pickup. Keep it until core
- * also re-evaluates auto-defaulted choices on unchanged rate sets.
+ * also re-evaluates auto-defaulted choices on unchanged rate sets. When core
+ * reports the selection's provenance (`selected_rate_origin`), a pickup the
+ * customer explicitly chose ('manual') is never overridden.
  *
  * @param {Object} cartData Cart response from `updateCustomer`.
  * @return {Promise<Object>} Cart data with a non-pickup rate selected when applicable.
@@ -140,14 +142,36 @@ const preferDeliveryOverLocalPickup = async ( cartData ) => {
 		return cartData;
 	}
 
+	const packageId = applyFilters(
+		'wcpay.express-checkout.shipping-package-id',
+		0,
+		cartData,
+		firstDeliveryRate.rate_id
+	);
+
+	// WC core ≥ the origin-tracking fix (woocommerce/woocommerce#64795) exposes
+	// how the selected rate was chosen. A pickup the customer explicitly selected
+	// ('manual') must stay selected — overriding it would silently convert a free
+	// pickup order into a paid delivery one. Only an explicit 'manual' blocks the
+	// reselect: 'auto', null, and absent (older WC without the core fix, or a
+	// filtered package not present in shipping_rates) proceed, preserving the
+	// mitigation for merchants on WC versions without the field. Note: sessions
+	// predating origin tracking report 'manual' (core's conservative BC default),
+	// so those skip too until the session naturally expires.
+	const selectedRateOrigin = ( cartData.shipping_rates || [] ).find(
+		( shippingPackage ) => shippingPackage.package_id === packageId
+	)?.selected_rate_origin;
+	if ( selectedRateOrigin === 'manual' ) {
+		return cartData;
+	}
+
 	try {
+		// Core records this reselect as a 'manual' origin (it goes through the
+		// same select-shipping-rate route customers use). That's acceptable:
+		// the gate above guarantees it only ever replaces an auto-defaulted
+		// pickup, and origin-based stickiness only protects pickup rates.
 		return await cartApi.selectShippingRate( {
-			package_id: applyFilters(
-				'wcpay.express-checkout.shipping-package-id',
-				0,
-				cartData,
-				firstDeliveryRate.rate_id
-			),
+			package_id: packageId,
 			rate_id: firstDeliveryRate.rate_id,
 		} );
 	} catch ( e ) {

--- a/client/express-checkout/event-handlers.js
+++ b/client/express-checkout/event-handlers.js
@@ -85,6 +85,53 @@ const getElementsUpdateOptionsForCart = ( cartData ) => ( {
 		: {} ),
 } );
 
+// Matches WooCommerce core's `LocalPickupUtils::get_local_pickup_method_ids()`
+// seed list. Extension methods that opt in via `supports('local-pickup')` are
+// not covered, but the two core IDs handle the reported customer impact.
+const LOCAL_PICKUP_METHOD_IDS = [ 'local_pickup', 'pickup_location' ];
+
+const isLocalPickupRate = ( rate ) =>
+	LOCAL_PICKUP_METHOD_IDS.includes( rate?.method_id );
+
+/**
+ * When the wallet provides a shipping address the customer clearly wants
+ * delivery, but the Store API may still return Local Pickup as the selected
+ * rate because WooCommerce keeps the previously chosen pickup method sticky
+ * (see `wc_get_default_shipping_method_for_package()`). Reselect the first
+ * non-pickup rate so the modal — and the session used at place-order time —
+ * align with the customer's intent.
+ *
+ * @param {Object} cartData Cart response from `updateCustomer`.
+ * @return {Promise<Object>} Cart data with a non-pickup rate selected when applicable.
+ */
+const preferDeliveryOverLocalPickup = async ( cartData ) => {
+	const shippingPackage = cartData.shipping_rates?.[ 0 ];
+	const rates = shippingPackage?.shipping_rates ?? [];
+	const selectedRate = rates.find( ( rate ) => rate.selected );
+
+	if ( ! selectedRate || ! isLocalPickupRate( selectedRate ) ) {
+		return cartData;
+	}
+
+	const firstDeliveryRate = rates.find(
+		( rate ) => ! isLocalPickupRate( rate )
+	);
+	if ( ! firstDeliveryRate ) {
+		return cartData;
+	}
+
+	try {
+		return await cartApi.selectShippingRate( {
+			package_id: shippingPackage.package_id,
+			rate_id: firstDeliveryRate.rate_id,
+		} );
+	} catch ( e ) {
+		// Fall back to the original cart data; the wallet will still show
+		// Local Pickup as selected but the user can change it manually.
+		return cartData;
+	}
+};
+
 export const shippingAddressChangeHandler = async (
 	event,
 	elements,
@@ -95,19 +142,23 @@ export const shippingAddressChangeHandler = async (
 	try {
 		// Please note that the `event.address` might not contain all the fields.
 		// Some fields might not be present (like `line_1` or `line_2`) due to semi-anonymized data.
-		const cartData = await cartApi.updateCustomer( {
+		const updatedCustomerData = await cartApi.updateCustomer( {
 			shipping_address: transformStripeShippingAddressForStoreApi(
 				event.name,
 				event.address
 			),
 		} );
 
-		if ( cartCurrencyDriftedFromElement( cartData ) ) {
-			errorHandler?.( getCurrencyMismatchMessage( cartData ) );
+		if ( cartCurrencyDriftedFromElement( updatedCustomerData ) ) {
+			errorHandler?.( getCurrencyMismatchMessage( updatedCustomerData ) );
 			event.reject();
 
 			return;
 		}
+
+		const cartData = await preferDeliveryOverLocalPickup(
+			updatedCustomerData
+		);
 
 		const shippingRates = transformCartDataForShippingRates( cartData );
 

--- a/client/express-checkout/event-handlers.js
+++ b/client/express-checkout/event-handlers.js
@@ -16,6 +16,7 @@ import {
 	shouldUseConfirmationTokens,
 } from './utils';
 import { getElementCurrency } from './utils/element-currency-cache';
+import { recordUserEvent } from 'tracks';
 import {
 	trackExpressCheckoutButtonClick,
 	trackExpressCheckoutButtonLoad,
@@ -106,14 +107,26 @@ const isLocalPickupRate = ( rate ) =>
  *
  * Costs one extra Store API round-trip (`select-shipping-rate`) per address
  * change in the bug scenario, because the WC session must be updated server-
- * side. Once WOOPLUG-6671 lands the WC core fix, this helper can be removed.
+ * side. Note this is NOT fully superseded by the WC core origin-tracking fix
+ * (WOOPLUG-6671 / woocommerce/woocommerce#64795): core only re-evaluates the
+ * chosen method when the package's rate set changes, so when pickup and a
+ * delivery rate are both available before the address arrives, this reselect
+ * is the only thing that moves the selection off pickup. Keep it until core
+ * also re-evaluates auto-defaulted choices on unchanged rate sets.
  *
  * @param {Object} cartData Cart response from `updateCustomer`.
  * @return {Promise<Object>} Cart data with a non-pickup rate selected when applicable.
  */
 const preferDeliveryOverLocalPickup = async ( cartData ) => {
-	const shippingPackage = cartData.shipping_rates?.[ 0 ];
-	const rates = shippingPackage?.shipping_rates ?? [];
+	// Resolve the effective rates the same way the display path does — for
+	// trial subscriptions with deferred shipping the rates live in the
+	// subscription extensions rather than the main cart package.
+	const rates =
+		applyFilters(
+			'wcpay.express-checkout.shipping-rates',
+			cartData.shipping_rates?.[ 0 ]?.shipping_rates || [],
+			cartData
+		) || [];
 	const selectedRate = rates.find( ( rate ) => rate.selected );
 
 	if ( ! selectedRate || ! isLocalPickupRate( selectedRate ) ) {
@@ -129,14 +142,20 @@ const preferDeliveryOverLocalPickup = async ( cartData ) => {
 
 	try {
 		return await cartApi.selectShippingRate( {
-			package_id: shippingPackage.package_id,
+			package_id: applyFilters(
+				'wcpay.express-checkout.shipping-package-id',
+				0,
+				cartData,
+				firstDeliveryRate.rate_id
+			),
 			rate_id: firstDeliveryRate.rate_id,
 		} );
 	} catch ( e ) {
 		// Fall back to the original cart data; the wallet will still show
 		// Local Pickup as selected but the user can change it manually.
-		// Logged so we can tell the mitigation is failing in production vs.
-		// silently always falling back.
+		// Tracked so a production regression re-exposing the underlying bug
+		// is visible to operators, not just the shopper's browser console.
+		recordUserEvent( 'express_checkout_pickup_reselect_failed' );
 		// eslint-disable-next-line no-console
 		console.warn(
 			'[WCPay ECE] preferDeliveryOverLocalPickup failed, falling back to original cart:',

--- a/client/express-checkout/event-handlers.js
+++ b/client/express-checkout/event-handlers.js
@@ -85,9 +85,12 @@ const getElementsUpdateOptionsForCart = ( cartData ) => ( {
 		: {} ),
 } );
 
-// Matches WooCommerce core's `LocalPickupUtils::get_local_pickup_method_ids()`
-// seed list. Extension methods that opt in via `supports('local-pickup')` are
-// not covered, but the two core IDs handle the reported customer impact.
+// Mirrors the two built-in WooCommerce local-pickup method IDs: `local_pickup`
+// (the seed hardcoded in `LocalPickupUtils::get_local_pickup_method_ids()`) and
+// `pickup_location` (WC Blocks's PickupLocation method, which dynamically
+// appears in that list via `supports('local-pickup')`). Third-party methods
+// that opt in via the same `supports('local-pickup')` flag are not covered;
+// the two built-in IDs handle the reported customer impact.
 const LOCAL_PICKUP_METHOD_IDS = [ 'local_pickup', 'pickup_location' ];
 
 const isLocalPickupRate = ( rate ) =>
@@ -100,6 +103,10 @@ const isLocalPickupRate = ( rate ) =>
  * (see `wc_get_default_shipping_method_for_package()`). Reselect the first
  * non-pickup rate so the modal — and the session used at place-order time —
  * align with the customer's intent.
+ *
+ * Costs one extra Store API round-trip (`select-shipping-rate`) per address
+ * change in the bug scenario, because the WC session must be updated server-
+ * side. Once WOOPLUG-6671 lands the WC core fix, this helper can be removed.
  *
  * @param {Object} cartData Cart response from `updateCustomer`.
  * @return {Promise<Object>} Cart data with a non-pickup rate selected when applicable.
@@ -128,6 +135,13 @@ const preferDeliveryOverLocalPickup = async ( cartData ) => {
 	} catch ( e ) {
 		// Fall back to the original cart data; the wallet will still show
 		// Local Pickup as selected but the user can change it manually.
+		// Logged so we can tell the mitigation is failing in production vs.
+		// silently always falling back.
+		// eslint-disable-next-line no-console
+		console.warn(
+			'[WCPay ECE] preferDeliveryOverLocalPickup failed, falling back to original cart:',
+			e
+		);
 		return cartData;
 	}
 };


### PR DESCRIPTION
Closes WOOPMNT-6159

#### Changes proposed in this Pull Request

When the customer reaches Express Checkout with Local Pickup already selected in the WC session, the Apple Pay / Google Pay modal opens — and stays — on Local Pickup even after the wallet provides a real shipping address. WC core keeps a previously chosen pickup method sticky (`wc_get_default_shipping_method_for_package()`), and in the variant where pickup and a delivery rate are both available *before* the address arrives, the rate set doesn't change when the address lands, so core never re-evaluates the default — this is the one family of cases the core origin-tracking fix (woocommerce/woocommerce#64795) cannot reach, and customers have unknowingly confirmed pickup orders that were meant to be shipped (the same bug reproduces on the official Stripe gateway, STRIPE-1143).

After `cartApi.updateCustomer()` runs in `shippingAddressChangeHandler`, detect that:

1. the rate marked `selected: true` is a Local Pickup method (`local_pickup` or `pickup_location`), AND
2. a non-pickup rate is now available, AND
3. the pickup selection was **not** the customer's deliberate choice.

…then reselect the first delivery rate via the Store API, realigning the session, the cart totals, and the rate the wallet sheet shows with the customer's intent — they handed us a shipping address.

**How we know the choice wasn't deliberate (condition 3):** woocommerce/woocommerce#64795 adds a read-only `selected_rate_origin` field (`'auto' | 'manual' | null`) to Store API cart packages. The reselect is skipped **only** when the origin is explicitly `'manual'`. `'auto'`, `null`, and an absent field all proceed:

- On WC versions **with** the core fix, a pickup the customer explicitly chose is never overridden — no silent conversion of a free pickup order into a paid delivery one.
- On WC versions **without** it (the field is absent), behavior is unchanged from the original mitigation: the reselect fires whenever pickup is stuck and a delivery rate exists. This keeps the fix effective for merchants on current releases; the manual-choice protection activates automatically once their WC ships the core fix.
- On origin-aware WC, sessions that predate origin tracking report `'manual'` (core's conservative BC default) and are likewise left alone until the session expires.
- The origin's integrity on the block checkout depends on the companion guard in woocommerce/woocommerce#64795 (`select_shipping_rate` only records `'manual'` when the rate actually changes) — without it, the pickup block's mount re-assert would launder every auto-defaulted pickup to `'manual'` on page load and this gate would wrongly skip.

The origin is read from the package matching the (filterable) package id used for the reselect, so the `wcpay.express-checkout.shipping-package-id` / `wcpay.express-checkout.shipping-rates` compatibility layer for deferred-shipping trial subscriptions keeps working. Note for integrators: the package match is type-exact — a filter returning a string id against an integer `package_id` will not match, and the gate fails open (reselect proceeds).

If the reselect call fails, fall back to the original cart data so the flow still completes; a `express_checkout_pickup_reselect_failed` tracks event records the failure.

#### Testing instructions

##### Prerequisites

- Local environment with WooPayments dev mode enabled.
- Public HTTPS URL (wallets require HTTPS — use `npm run tube:start` for a Jurassic Tube tunnel).
- Apple Pay (Safari + Mac with a wallet card) or Google Pay (Chrome with a saved card) configured.

##### Store setup (the configuration that actually reproduces the bug)

> Note: this replaces earlier instructions that used block Local Pickup with "No location by default" — that path is already handled by WC core's block-checkout defaulting and does **not** reproduce the bug on current WC (as a reviewer correctly observed). The trigger needs pickup and a delivery rate *both* available before the address arrives, with pickup selected in the session.

1. WC → Settings → Shipping → Shipping zones → create a **United States** zone containing, **in this order**: a legacy **Local pickup** method first, then a **Flat rate** ($10).
2. WC → Settings → General → **Default customer location** = "Shop country/region", with the store address in the US (so the zone matches before any address is provided).
3. Checkout page: either the Checkout block or the `[woocommerce_checkout]` shortcode — the bug reproduces on both; the shortcode context is what the reporting merchant runs.
4. WC → WooPayments → Settings → enable Apple Pay / Google Pay.

##### Reproduce the bug first (on `develop`)

1. `git checkout develop && npm run build:client`
2. Fresh incognito Safari (Apple Pay) / Chrome (Google Pay) window on the tunnel URL.
3. Add a physical product to cart → visit the cart or checkout page (this renders with Local pickup auto-selected — no clicks needed).
4. Tap the Apple Pay / Google Pay button.

- [ ] Confirm the wallet modal opens with **Pickup** selected and stays there, even though the wallet card has a US address matching the Flat Rate (the bug).

##### Verify the fix

1. `git checkout fix/WOOPMNT-6159-ece-local-pickup-sticky && npm run build:client`
2. Repeat the repro steps in a fresh incognito window.

- [ ] The wallet modal settles on **Flat rate** as the selected method.
- [ ] DevTools → Network: a `POST /wc/store/v1/cart/select-shipping-rate` fires after `update-customer`, with `rate_id` set to the Flat rate ID.
- [ ] Complete a test purchase and confirm the resulting order is **shipped** (not pickup).

##### Regression checks

- [ ] **Deliberate pickup survives (needs WC with woocommerce/woocommerce#64795, e.g. a wp-env site on that branch):** on the checkout page, explicitly select Local pickup, then open the wallet sheet. Pickup must **stay** selected — no `select-shipping-rate` call fires. (On WC without the core fix the origin field doesn't exist, so this protection is not yet active — expected.)
- [ ] With a wallet address that falls outside any shipping zone (only pickup matches), pickup remains selected, no reselect, no errors, modal still resolves.
- [ ] With Local Pickup absent from the matched zone, delivery is selected, no reselect call.
- [ ] Apple Pay / Google Pay from the product page and cart page still work end-to-end.
- [ ] Deferred-shipping trial subscription cart (wc-subscriptions compatibility filters) still resolves rates and reselects against the filtered package.

#### Backward compatibility

- Reads a new **optional** Store API response field (`selected_rate_origin`, added in woocommerce/woocommerce#64795); no behavior change when the field is absent other than what this PR already shipped. No hooks, endpoints, or exposed signatures change. The two `wcpay.express-checkout.*` filters keep their existing signatures.

-------------------

- [x] Run `npm run changelog` to add a changelog file (see `changelog/WOOPMNT-6159`).
- [x] Covered with tests (`client/express-checkout/__tests__/event-handlers.test.js`, 8 cases for the mitigation incl. 4 origin-gate cases).
- [x] Tested on mobile (does not apply — desktop wallet flow).

**Post merge**

- [ ] Link to testing instructions from release testing doc.
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
