### PR TITLE
Add outcome banner component for the dispute outcome view

### DIFF
--- a/changelog/rsm-rsm-528-outcome-banner
+++ b/changelog/rsm-rsm-528-outcome-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add outcome banner component for the dispute outcome view (behind feature flag).

--- a/client/payment-details/dispute-outcome/__fixtures__/outcome-banner.ts
+++ b/client/payment-details/dispute-outcome/__fixtures__/outcome-banner.ts
@@ -1,0 +1,155 @@
+/** @format */
+
+/**
+ * Hand-built fixtures for the OutcomeBanner component. Shaped to mirror the
+ * `Dispute` and `Charge` types from `wcpay/types/disputes` and
+ * `wcpay/types/charges`, but only fields the banner reads are populated.
+ *
+ * Note on the Won case: in production, `dispute.balance_transactions[]` ships
+ * with null amounts on the reversal row due to a server-side bug tracked as
+ * RSM-1168. The fixture below populates realistic reversal amounts so the
+ * visual reads correctly; the real-data wiring (deferred to a follow-up)
+ * either waits on RSM-1168 or renders a fallback when amounts are missing.
+ */
+
+/**
+ * Internal dependencies
+ */
+import type { Charge } from 'wcpay/types/charges';
+import type { Dispute } from 'wcpay/types/disputes';
+
+const baseEvidenceDetails = {
+	has_evidence: true,
+	due_by: 1714780800,
+	past_due: false,
+	submission_count: 1,
+};
+
+const cardCharge = ( issuer: string ): Charge =>
+	( {
+		id: 'ch_test_outcome_banner',
+		amount: 5000,
+		amount_captured: 5000,
+		amount_refunded: 0,
+		application_fee_amount: 0,
+		balance_transaction: {
+			amount: 5000,
+			currency: 'usd',
+			fee: 145,
+		},
+		billing_details: {
+			email: 'buyer@example.com',
+			name: 'Jane Buyer',
+			phone: null,
+			address: {
+				city: null,
+				country: null,
+				line1: null,
+				line2: null,
+				postal_code: null,
+				state: null,
+			},
+		},
+		captured: true,
+		created: 1714003200,
+		dispute: null,
+		disputed: true,
+		order: null,
+		outcome: null,
+		paid: true,
+		paydown: null,
+		payment_intent: 'pi_test_outcome_banner',
+		payment_method: 'pm_test_card',
+		payment_method_details: {
+			type: 'card',
+			card: { issuer },
+		},
+		refunded: false,
+		refunds: null,
+		status: 'succeeded',
+	} as unknown as Charge );
+
+const klarnaCharge = (): Charge =>
+	( {
+		...cardCharge( 'Chase' ),
+		payment_method_details: {
+			type: 'klarna',
+			klarna: {},
+		},
+	} as unknown as Charge );
+
+const baseDispute = (): Omit<
+	Dispute,
+	'status' | 'balance_transactions' | 'created'
+> => ( {
+	id: 'dp_test_outcome_banner',
+	evidence_details: baseEvidenceDetails,
+	metadata: {},
+	order: null,
+	evidence: {},
+	issuer_evidence: null,
+	reason: 'fraudulent',
+	charge: cardCharge( 'Chase' ),
+	amount: 5000,
+	currency: 'usd',
+	payment_intent: 'pi_test_outcome_banner',
+} );
+
+export const wonFixture: { dispute: Dispute; charge: Charge } = {
+	dispute: {
+		...baseDispute(),
+		status: 'won',
+		created: 1714003200, // 2024-04-25 UTC
+		// Reversal carries the decision moment and reinstated funds.
+		// In production these arrive with null amounts (RSM-1168); the
+		// fixture populates them so the visual reads correctly.
+		balance_transactions: [
+			{
+				currency: 'usd',
+				amount: -5000,
+				fee: 1500,
+				reporting_category: 'dispute',
+				created: 1714003200,
+			},
+			{
+				currency: 'usd',
+				amount: 5000,
+				fee: -1500,
+				reporting_category: 'dispute_reversal',
+				created: 1715040000, // 2024-05-07 UTC
+			},
+		],
+	},
+	charge: cardCharge( 'Chase' ),
+};
+
+export const lostFixture: { dispute: Dispute; charge: Charge } = {
+	dispute: {
+		...baseDispute(),
+		status: 'lost',
+		reason: 'product_unacceptable',
+		created: 1714003200,
+		balance_transactions: [
+			{
+				currency: 'usd',
+				amount: -5000,
+				fee: 1500,
+				reporting_category: 'dispute',
+				created: 1714780800, // 2024-05-04 UTC
+			},
+		],
+	},
+	charge: cardCharge( 'Wells Fargo' ),
+};
+
+export const warningClosedFixture: { dispute: Dispute; charge: Charge } = {
+	dispute: {
+		...baseDispute(),
+		status: 'warning_closed',
+		reason: 'general',
+		created: 1714003200, // fallback when no balance_transactions
+		balance_transactions: [],
+	},
+	// BNPL path exercises the getBankName fallback in the issuer slot.
+	charge: klarnaCharge(),
+};

--- a/client/payment-details/dispute-outcome/__tests__/outcome-banner.test.tsx
+++ b/client/payment-details/dispute-outcome/__tests__/outcome-banner.test.tsx
@@ -1,0 +1,219 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import OutcomeBanner from '../outcome-banner';
+import {
+	wonFixture,
+	lostFixture,
+	warningClosedFixture,
+} from '../__fixtures__/outcome-banner';
+import type { Charge } from 'wcpay/types/charges';
+
+// Force the WP date formatter to UTC so day boundaries don't shift based on
+// the test runner's local timezone. Matches the pattern used in
+// `client/utils/__tests__/date-time.test.ts`.
+jest.mock( '@wordpress/date', () => ( {
+	dateI18n: jest.fn( ( format, date, timezone ) =>
+		jest
+			.requireActual( '@wordpress/date' )
+			.dateI18n( format, date, timezone || 'UTC' )
+	),
+} ) );
+
+const originalWcpaySettings = window.wcpaySettings;
+
+describe( 'OutcomeBanner', () => {
+	beforeAll( () => {
+		// Pin a deterministic date format and the multi-currency formatter's
+		// required settings: zero-decimal currencies list, store country,
+		// and the USD currencyData entry the fixtures exercise.
+		window.wcpaySettings = {
+			...originalWcpaySettings,
+			dateFormat: 'Y-m-d',
+			timeFormat: 'H:i',
+			zeroDecimalCurrencies: [ 'jpy', 'krw', 'vnd' ],
+			connect: { country: 'US' },
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
+		} as unknown as typeof wcpaySettings;
+	} );
+
+	afterAll( () => {
+		window.wcpaySettings = originalWcpaySettings;
+	} );
+
+	describe( 'status variants', () => {
+		it( 'renders "Disputed: Won" for won outcomes', () => {
+			render( <OutcomeBanner { ...wonFixture } /> );
+			expect(
+				screen.getByText( /Disputed:\s*Won/i )
+			).toBeInTheDocument();
+		} );
+
+		it( 'renders "Disputed: Lost" for lost outcomes', () => {
+			render( <OutcomeBanner { ...lostFixture } /> );
+			expect(
+				screen.getByText( /Disputed:\s*Lost/i )
+			).toBeInTheDocument();
+		} );
+
+		it( 'renders the inquiry-closed label for warning_closed outcomes', () => {
+			// Inquiries are not prefixed with "Disputed:" (the chip suppresses
+			// the prefix for any status that starts with `warning_`). The
+			// canonical label from the existing chip mapping is "Inquiry:
+			// Closed". This component reuses the chip rather than overriding
+			// the mapping.
+			render( <OutcomeBanner { ...warningClosedFixture } /> );
+			expect(
+				screen.getByText( /Inquiry:\s*Closed/i )
+			).toBeInTheDocument();
+			// Defense-in-depth: ensure the "Disputed:" prefix didn't sneak in.
+			expect(
+				screen.queryByText( /Disputed:/i )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'issuer name', () => {
+		it( 'renders the card issuer from the charge', () => {
+			render( <OutcomeBanner { ...lostFixture } /> );
+			expect( screen.getByText( 'Wells Fargo' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the BNPL provider name via getBankName fallback', () => {
+			// warningClosedFixture uses a klarna payment method, exercising
+			// the BNPL branch of getBankName which returns "Klarna" rather
+			// than a card issuer.
+			render( <OutcomeBanner { ...warningClosedFixture } /> );
+			expect( screen.getByText( 'Klarna' ) ).toBeInTheDocument();
+		} );
+
+		it( 'falls back to "Unknown bank" when no issuer is resolvable', () => {
+			const unknownIssuerCharge = {
+				...lostFixture.charge,
+				payment_method_details: {
+					type: 'card',
+					card: {}, // no `issuer` field
+				},
+			} as Charge;
+			render(
+				<OutcomeBanner
+					dispute={ lostFixture.dispute }
+					charge={ unknownIssuerCharge }
+				/>
+			);
+			expect( screen.getByText( 'Unknown bank' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'amounts row', () => {
+		it( 'renders Deducted / Fees / Net from the lost-case deduction transaction', () => {
+			render( <OutcomeBanner { ...lostFixture } /> );
+
+			const items = screen.getAllByRole( 'term' );
+			const labels = items.map( ( el ) => el.textContent );
+			expect( labels ).toEqual( [ 'Deducted', 'Fees', 'Net' ] );
+
+			// Deduction in the fixture: amount: -5000, fee: 1500 (cents).
+			// renderAmount uses absolute values + explicit currency.
+			expect( screen.getByText( /\$50\.00/ ) ).toBeInTheDocument();
+			expect( screen.getByText( /\$15\.00/ ) ).toBeInTheDocument();
+			expect( screen.getByText( /\$65\.00/ ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the won-case amounts from the reversal transaction', () => {
+			render( <OutcomeBanner { ...wonFixture } /> );
+			// Reversal in the fixture: amount: 5000, fee: -1500.
+			// Display uses magnitudes, so figures match the lost case.
+			expect( screen.getByText( /\$50\.00/ ) ).toBeInTheDocument();
+			expect( screen.getByText( /\$15\.00/ ) ).toBeInTheDocument();
+			expect( screen.getByText( /\$65\.00/ ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders placeholders when no relevant balance transaction exists (warning_closed)', () => {
+			render( <OutcomeBanner { ...warningClosedFixture } /> );
+			const banner = screen.getByTestId( 'dispute-outcome-banner' );
+			const definitions = within( banner ).getAllByRole( 'definition' );
+			// All three amount cells should render the em-dash placeholder.
+			expect( definitions ).toHaveLength( 3 );
+			definitions.forEach( ( dd ) => {
+				expect( dd ).toHaveTextContent( '—' );
+			} );
+		} );
+
+		it( 'renders placeholders when the reversal carries null amounts (RSM-1168 server bug)', () => {
+			// Real production payload for the won case ships the reversal row
+			// with `amount: null` and `fee: null`. The component should
+			// degrade to placeholders rather than rendering "$NaN".
+			const brokenWonReversal = {
+				dispute: {
+					...wonFixture.dispute,
+					balance_transactions: [
+						{
+							...wonFixture.dispute.balance_transactions[ 0 ],
+						},
+						{
+							currency: 'usd',
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							amount: null as any,
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							fee: null as any,
+							reporting_category: 'dispute_reversal' as const,
+							created: 1715040000,
+						},
+					],
+				},
+				charge: wonFixture.charge,
+			};
+			render( <OutcomeBanner { ...brokenWonReversal } /> );
+			const banner = screen.getByTestId( 'dispute-outcome-banner' );
+			const definitions = within( banner ).getAllByRole( 'definition' );
+			expect( definitions ).toHaveLength( 3 );
+			definitions.forEach( ( dd ) => {
+				expect( dd ).toHaveTextContent( '—' );
+			} );
+		} );
+	} );
+
+	describe( 'decision date', () => {
+		it( 'uses the reversal timestamp on a won outcome', () => {
+			render( <OutcomeBanner { ...wonFixture } /> );
+			// Reversal `created` = 1715040000 → 2024-05-07 UTC.
+			expect( screen.getByText( /Decision date:/ ) ).toHaveTextContent(
+				'2024-05-07'
+			);
+		} );
+
+		it( 'uses the deduction timestamp on a lost outcome', () => {
+			render( <OutcomeBanner { ...lostFixture } /> );
+			// Deduction `created` = 1714780800 → 2024-05-04 UTC.
+			expect( screen.getByText( /Decision date:/ ) ).toHaveTextContent(
+				'2024-05-04'
+			);
+		} );
+
+		it( 'falls back to dispute.created when balance transactions are absent', () => {
+			render( <OutcomeBanner { ...warningClosedFixture } /> );
+			// dispute.created = 1714003200 → 2024-04-25 UTC.
+			expect( screen.getByText( /Decision date:/ ) ).toHaveTextContent(
+				'2024-04-25'
+			);
+		} );
+	} );
+} );

--- a/client/payment-details/dispute-outcome/outcome-banner.scss
+++ b/client/payment-details/dispute-outcome/outcome-banner.scss
@@ -1,0 +1,63 @@
+/** @format */
+
+.dispute-outcome-banner {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-15;
+	padding: $grid-unit-20;
+	border: 1px solid $gray-200;
+	border-radius: 4px;
+	background: $white;
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: $grid-unit-10;
+		flex-wrap: wrap;
+	}
+
+	&__issuer {
+		font-size: 13px;
+		color: $gray-700;
+	}
+
+	&__amounts {
+		display: flex;
+		flex-wrap: wrap;
+		gap: $grid-unit-20;
+		margin: 0;
+		padding: $grid-unit-10 0;
+		border-top: 1px solid $gray-200;
+		border-bottom: 1px solid $gray-200;
+	}
+
+	&__amount {
+		display: flex;
+		flex-direction: column;
+		min-width: 96px;
+
+		dt {
+			font-size: 12px;
+			font-weight: 600;
+			text-transform: uppercase;
+			color: $gray-700;
+			margin: 0 0 $grid-unit-05 0;
+		}
+
+		dd {
+			font-size: 16px;
+			color: $gray-900;
+			margin: 0;
+		}
+	}
+
+	&__meta {
+		font-size: 13px;
+		color: $gray-700;
+	}
+
+	&__decision-date {
+		display: inline-block;
+	}
+}

--- a/client/payment-details/dispute-outcome/outcome-banner.tsx
+++ b/client/payment-details/dispute-outcome/outcome-banner.tsx
@@ -1,0 +1,117 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import DisputeStatusChip from 'wcpay/components/dispute-status-chip';
+import { formatExplicitCurrency } from 'multi-currency/interface/functions';
+import { formatDateTimeFromTimestamp } from 'wcpay/utils/date-time';
+import { getBankName } from 'wcpay/utils/charge';
+import type { Charge } from 'wcpay/types/charges';
+import type { Dispute } from 'wcpay/types/disputes';
+import type { BalanceTransaction } from 'wcpay/types/balance-transactions';
+import './outcome-banner.scss';
+
+interface Props {
+	dispute: Dispute;
+	charge: Charge;
+}
+
+const findTransaction = (
+	dispute: Dispute,
+	category: 'dispute' | 'dispute_reversal'
+): BalanceTransaction | undefined =>
+	dispute.balance_transactions.find(
+		( txn ) => txn.reporting_category === category
+	);
+
+// Picks the balance transaction whose timestamp and amounts represent the
+// outcome decision for the given status. Won outcomes are decided when the
+// reversal posts; lost outcomes when the original deduction posts.
+// Warning-closed inquiries typically have no balance_transactions.
+const selectPrimaryTransaction = (
+	dispute: Dispute
+): BalanceTransaction | undefined => {
+	if ( dispute.status === 'won' ) {
+		return findTransaction( dispute, 'dispute_reversal' );
+	}
+	if ( dispute.status === 'lost' ) {
+		return findTransaction( dispute, 'dispute' );
+	}
+	return undefined;
+};
+
+const placeholder = '—';
+
+const renderAmount = (
+	value: number | undefined,
+	currency: string
+): string => {
+	if ( typeof value !== 'number' ) {
+		return placeholder;
+	}
+	return formatExplicitCurrency( Math.abs( value ), currency );
+};
+
+const OutcomeBanner: React.FC< Props > = ( { dispute, charge } ) => {
+	const primaryTxn = selectPrimaryTransaction( dispute );
+
+	const deductedRaw = primaryTxn?.amount;
+	const feesRaw = primaryTxn?.fee;
+	const netRaw =
+		typeof deductedRaw === 'number' && typeof feesRaw === 'number'
+			? Math.abs( deductedRaw ) + Math.abs( feesRaw )
+			: undefined;
+
+	const decisionTimestamp = primaryTxn?.created ?? dispute.created;
+
+	const issuerName =
+		getBankName( charge ) ?? __( 'Unknown bank', 'woocommerce-payments' );
+
+	return (
+		<div
+			className="dispute-outcome-banner"
+			data-testid="dispute-outcome-banner"
+		>
+			<div className="dispute-outcome-banner__header">
+				<DisputeStatusChip
+					status={ dispute.status }
+					prefixDisputeType
+				/>
+				<span className="dispute-outcome-banner__issuer">
+					{ issuerName }
+				</span>
+			</div>
+
+			<dl className="dispute-outcome-banner__amounts">
+				<div className="dispute-outcome-banner__amount">
+					<dt>{ __( 'Deducted', 'woocommerce-payments' ) }</dt>
+					<dd>{ renderAmount( deductedRaw, dispute.currency ) }</dd>
+				</div>
+				<div className="dispute-outcome-banner__amount">
+					<dt>{ __( 'Fees', 'woocommerce-payments' ) }</dt>
+					<dd>{ renderAmount( feesRaw, dispute.currency ) }</dd>
+				</div>
+				<div className="dispute-outcome-banner__amount">
+					<dt>{ __( 'Net', 'woocommerce-payments' ) }</dt>
+					<dd>{ renderAmount( netRaw, dispute.currency ) }</dd>
+				</div>
+			</dl>
+
+			<div className="dispute-outcome-banner__meta">
+				<span className="dispute-outcome-banner__decision-date">
+					{ __( 'Decision date:', 'woocommerce-payments' ) }{ ' ' }
+					{ formatDateTimeFromTimestamp( decisionTimestamp ) }
+				</span>
+			</div>
+		</div>
+	);
+};
+
+export default OutcomeBanner;

--- a/client/types/balance-transactions.d.ts
+++ b/client/types/balance-transactions.d.ts
@@ -3,4 +3,10 @@ export interface BalanceTransaction {
 	amount: number;
 	fee: number;
 	reporting_category?: 'dispute' | 'dispute_reversal' | string;
+	/**
+	 * Unix timestamp (seconds since epoch) when the balance transaction posted.
+	 * Stripe always sends this; the field is optional here for back-compat with
+	 * mocks/fixtures that omit it.
+	 */
+	created?: number;
 }


### PR DESCRIPTION
Fixes RSM-1167

#### Changes proposed in this Pull Request

Adds the Outcome banner component for the RSM Dispute Outcome View workstream. Presentational, props-driven, fixtures-only. Not wired into the Slice 1 scaffold (`client/payment-details/dispute-outcome/index.tsx`) yet: that integration is a small follow-up after Slice 4 merges.

What the component renders, per the Section 4.4 spec:

1. **Status badge** via the existing `DisputeStatusChip` with `prefixDisputeType`. Won and Lost render as "Disputed: Won" / "Disputed: Lost". The chip suppresses the prefix for any status starting with `warning_`, so `warning_closed` renders as "Inquiry: Closed". The spec wording was "Disputed: Warning closed"; I reused the chip rather than overriding the canonical mapping (the dispute vs inquiry distinction is encoded there on purpose). Happy to revisit if reviewers prefer the spec wording.
2. **Amounts row** (Deducted / Fees / Net) sourced from `dispute.balance_transactions[]`. Magnitudes only; sign semantics are carried by the labels and the badge.
3. **Decision date** from the reversal `balance_transaction.created` on Won, the deduction transaction on Lost, and `dispute.created` as a fallback for Warning closed (where `balance_transactions` is typically empty).
4. **Issuer display name** via the existing `getBankName(charge)` (which already handles the BNPL fallbacks for affirm / afterpay_clearpay / klarna).

Three fixtures live in `__fixtures__/outcome-banner.ts`: `wonFixture`, `lostFixture`, `warningClosedFixture`. The Won fixture deliberately populates realistic reversal amounts because in production today `dispute.balance_transactions[]` ships with `null` amounts on the reversal row (server-side bug, RSM-1168). The component degrades to placeholders when those values are missing (test coverage for that path is included), so real-data wiring will work cleanly whether RSM-1168 lands first or not.

Type change: added an optional `created?: number` to `BalanceTransaction` so the banner can read the decision timestamp without per-call assertions. Additive, no consumer impact.

Feature flag: the component itself is not flag-gated; gating happens at the eventual integration site (`_wcpay_feature_dispute_outcome_view`, dev-only during RSM).

Out of scope for this PR (tracked separately):
- Wiring the banner into `client/payment-details/dispute-outcome/index.tsx` (Slice 4 follow-up).
- Real `useDispute()` consumption.
- Tracks events (RSM-1171).
- The reversal-null-amounts server fix (RSM-1168).

#### Testing instructions

Component is fixtures-only, no UI integration yet, so manual testing is limited to running the unit suite.

```
npx jest --config tests/js/jest.config.js client/payment-details/dispute-outcome/__tests__/outcome-banner.test.tsx
```

13 tests cover:
- Status variants (Disputed: Won, Disputed: Lost, Inquiry: Closed; confirms the "Disputed:" prefix is correctly suppressed for inquiries).
- Issuer name path: card issuer from `charge.payment_method_details.card.issuer`, BNPL fallback (Klarna), and "Unknown bank" fallback when neither resolves.
- Amount-rendering path: lost-case deduction figures, won-case reversal figures, placeholder rendering when no balance transaction exists (warning_closed), and placeholder rendering when reversal amounts arrive as `null` (the RSM-1168 production state).
- Decision date: reversal timestamp on won, deduction timestamp on lost, fallback to `dispute.created` for warning_closed.

Visual review: screenshots will be attached in the Slice 4 wiring PR (component is not mountable in the running app without that integration). For now, the fixtures and assertion text serve as the visual contract.

* 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description above)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from release testing doc: QA Testing Not Applicable (dev-only feature flag during RSM).
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
