### PR TITLE
[RSM] Add Outcome View recommendations sections (What Could Help / What to Keep Doing)

### DIFF
--- a/changelog/feat-dispute-outcome-view-recommendations
+++ b/changelog/feat-dispute-outcome-view-recommendations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add 'What Could Help' / 'What to Keep Doing' recommendations sections to Dispute Outcome View (behind feature flag, placeholder copy pending RiskOps).

--- a/client/disputes/new-evidence/__tests__/recommendation-fields.test.ts
+++ b/client/disputes/new-evidence/__tests__/recommendation-fields.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Internal dependencies
+ */
+import { getRecommendationFields } from '../recommendation-fields';
+
+describe( 'getRecommendationFields', () => {
+	describe( 'could_help branch', () => {
+		it( 'returns only expected_missing items from the helper output', () => {
+			const result = getRecommendationFields(
+				'product_not_received',
+				'physical_product',
+				{},
+				'could_help'
+			);
+
+			expect( result.length ).toBeGreaterThan( 0 );
+			expect(
+				result.every( ( field ) => field.state === 'expected_missing' )
+			).toBe( true );
+		} );
+
+		it( 'returns an empty array when every high-impact field is provided', () => {
+			const result = getRecommendationFields(
+				'product_not_received',
+				'physical_product',
+				{
+					shipping_address: '123 Main St',
+					shipping_tracking_number: '1Z999',
+					shipping_documentation: 'tracked',
+					shipping_carrier: 'UPS',
+					shipping_date: '2026-04-15',
+				},
+				'could_help'
+			);
+
+			expect( result ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'keep_doing branch', () => {
+		it( 'returns provided high-impact fields for the (reason × productType) cell', () => {
+			const result = getRecommendationFields(
+				'product_not_received',
+				'physical_product',
+				{
+					shipping_address: '123 Main St',
+					shipping_tracking_number: '1Z999',
+				},
+				'keep_doing'
+			);
+
+			expect( result.map( ( field ) => field.key ).sort() ).toEqual( [
+				'shipping_address',
+				'shipping_tracking_number',
+			] );
+			expect(
+				result.every( ( field ) => field.state === 'provided' )
+			).toBe( true );
+		} );
+
+		it( 'excludes provided topical-only fields (regression guard)', () => {
+			// `refund_policy` is `DISPUTE_TOPICAL_FIELDS` for fraudulent +
+			// physical_product, not `DISPUTE_HIGH_IMPACT_FIELDS`. Providing
+			// it should not surface in "what to keep doing".
+			const result = getRecommendationFields(
+				'fraudulent',
+				'physical_product',
+				{
+					shipping_date: '2026-04-15',
+					refund_policy: 'No returns after 30 days.',
+				},
+				'keep_doing'
+			);
+
+			expect( result.map( ( field ) => field.key ) ).toEqual( [
+				'shipping_date',
+			] );
+		} );
+
+		it( 'narrows on productType: provided high-impact for one cell is excluded for another', () => {
+			// `shipping_date` is high-impact for fraudulent + physical_product
+			// but not for fraudulent + digital_product_or_service (which uses
+			// `service_date` instead).
+			const evidence = {
+				shipping_date: '2026-04-15',
+				service_date: '2026-04-15',
+				customer_communication: 'email thread',
+			};
+
+			const physical = getRecommendationFields(
+				'fraudulent',
+				'physical_product',
+				evidence,
+				'keep_doing'
+			);
+			const digital = getRecommendationFields(
+				'fraudulent',
+				'digital_product_or_service',
+				evidence,
+				'keep_doing'
+			);
+
+			expect( physical.map( ( field ) => field.key ).sort() ).toEqual( [
+				'customer_communication',
+				'shipping_date',
+			] );
+			expect( digital.map( ( field ) => field.key ).sort() ).toEqual( [
+				'customer_communication',
+				'service_date',
+			] );
+		} );
+
+		it( 'returns an empty array when no high-impact fields are provided', () => {
+			const result = getRecommendationFields(
+				'product_not_received',
+				'physical_product',
+				{},
+				'keep_doing'
+			);
+
+			expect( result ).toEqual( [] );
+		} );
+
+		it( 'returns an empty array for a reason × productType cell with no high-impact entries', () => {
+			// `bank_cannot_process` is `emptyByProductType()` across the
+			// board; nothing should surface even when evidence is provided.
+			const result = getRecommendationFields(
+				'bank_cannot_process',
+				'physical_product',
+				{ refund_policy: 'No returns.' },
+				'keep_doing'
+			);
+
+			expect( result ).toEqual( [] );
+		} );
+	} );
+
+	it( 'returns an empty array for an unknown reason in both branches', () => {
+		const couldHelp = getRecommendationFields(
+			'totally_unknown_reason',
+			'physical_product',
+			{ shipping_address: '123 Main St' },
+			'could_help'
+		);
+		const keepDoing = getRecommendationFields(
+			'totally_unknown_reason',
+			'physical_product',
+			{ shipping_address: '123 Main St' },
+			'keep_doing'
+		);
+
+		expect( couldHelp ).toEqual( [] );
+		expect( keepDoing ).toEqual( [] );
+	} );
+} );

--- a/client/disputes/new-evidence/recommendation-fields.ts
+++ b/client/disputes/new-evidence/recommendation-fields.ts
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import type { DisputeReason, ProductType } from 'wcpay/types/disputes';
+import type { EvidenceFieldStatus } from './types';
+import { getExpectedFieldStatus } from './evidence-field-status';
+import { DISPUTE_HIGH_IMPACT_FIELDS } from './constants/high-impact-fields';
+
+export type RecommendationOutcome = 'could_help' | 'keep_doing';
+
+/**
+ * Returns the subset of `EvidenceFieldStatus` items that the post-resolution
+ * recommendations section should surface for the given outcome.
+ *
+ *   - `could_help` (lost) → fields the merchant didn't supply that would
+ *     likely have strengthened the response: `expected_missing` only.
+ *   - `keep_doing` (won)  → fields the merchant supplied that are in the
+ *     high-impact map for the (reason × productType) cell: `provided` items
+ *     filtered to high-impact keys.
+ *
+ * Composes `getExpectedFieldStatus` rather than touching the matrix or
+ * evidence directly, so any future field-status changes apply automatically.
+ */
+export const getRecommendationFields = (
+	reason: string,
+	productType: string,
+	evidence: Record< string, unknown >,
+	outcome: RecommendationOutcome
+): EvidenceFieldStatus[] => {
+	const fields = getExpectedFieldStatus( reason, productType, evidence );
+
+	if ( outcome === 'could_help' ) {
+		return fields.filter( ( field ) => field.state === 'expected_missing' );
+	}
+
+	const highImpactKeys = new Set(
+		DISPUTE_HIGH_IMPACT_FIELDS[ reason as DisputeReason ]?.[
+			productType as ProductType
+		] ?? []
+	);
+	return fields.filter(
+		( field ) =>
+			field.state === 'provided' && highImpactKeys.has( field.key )
+	);
+};

--- a/client/payment-details/dispute-outcome/__tests__/index.test.tsx
+++ b/client/payment-details/dispute-outcome/__tests__/index.test.tsx
@@ -38,7 +38,10 @@ const buildDispute = (
 		metadata: {},
 		payment_intent: 'pi_test',
 		reason: 'product_unacceptable',
-		status: 'lost',
+		// Default to warning_closed so existing tests focus on the
+		// Evidence Submitted section without the recommendations list
+		// also rendering. Won/lost behavior has its own dedicated tests.
+		status: 'warning_closed',
 		...overrides,
 	} as ChargeDispute );
 
@@ -126,5 +129,73 @@ describe( 'DisputeOutcomeView', () => {
 			screen.getByRole( 'heading', { name: 'Evidence Submitted' } )
 		).toBeInTheDocument();
 		expect( screen.queryAllByRole( 'listitem' ) ).toHaveLength( 0 );
+	} );
+
+	describe( 'recommendations section', () => {
+		it( 'renders "What could help" for a lost dispute', () => {
+			const dispute = buildDispute( {
+				status: 'lost',
+				metadata: { __product_type: 'physical_product' },
+			} );
+
+			render( <DisputeOutcomeView dispute={ dispute } /> );
+
+			expect(
+				screen.getByRole( 'heading', { name: /what could help/i } )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'heading', {
+					name: /what to keep doing/i,
+				} )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders "What to keep doing" for a won dispute when a high-impact field is provided', () => {
+			const dispute = buildDispute( {
+				status: 'won',
+				metadata: { __product_type: 'physical_product' },
+				// shipping_address + shipping_documentation are high-impact
+				// for product_unacceptable + physical_product? No — for
+				// product_unacceptable the high-impact set differs. Pin
+				// reason to product_not_received where shipping_address is
+				// high-impact to keep this test against the actual map.
+				reason: 'product_not_received',
+				evidence: {
+					shipping_address: '123 Main St',
+					shipping_tracking_number: '1Z999',
+				},
+			} );
+
+			render( <DisputeOutcomeView dispute={ dispute } /> );
+
+			expect(
+				screen.getByRole( 'heading', { name: /what to keep doing/i } )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'heading', { name: /what could help/i } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'renders neither recommendations heading for a warning_closed dispute', () => {
+			const dispute = buildDispute( {
+				status: 'warning_closed',
+				metadata: { __product_type: 'physical_product' },
+			} );
+
+			render( <DisputeOutcomeView dispute={ dispute } /> );
+
+			// Evidence Submitted still renders for warning_closed.
+			expect(
+				screen.getByRole( 'heading', { name: 'Evidence Submitted' } )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'heading', { name: /what could help/i } )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'heading', {
+					name: /what to keep doing/i,
+				} )
+			).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/payment-details/dispute-outcome/__tests__/recommendations-list.test.tsx
+++ b/client/payment-details/dispute-outcome/__tests__/recommendations-list.test.tsx
@@ -82,11 +82,11 @@ describe( 'RecommendationsList', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'includes TODO(catherine) placeholder markers in the rendered output', () => {
+	it( 'includes TODO(riskops) placeholder markers in the rendered output', () => {
 		// Defense against accidental removal of the TODO marker before
-		// Catherine's final copy lands. The marker is the canary; when she
-		// ships strings, the placeholder string disappears and this test
-		// updates with it.
+		// the final RiskOps copy lands. The marker is the canary; when
+		// the real strings ship, the placeholder string disappears and
+		// this test updates with it.
 		render(
 			<RecommendationsList
 				fields={ couldHelpFields }
@@ -94,7 +94,7 @@ describe( 'RecommendationsList', () => {
 			/>
 		);
 
-		const placeholders = screen.getAllByText( /TODO\(catherine\)/ );
+		const placeholders = screen.getAllByText( /TODO\(riskops\)/ );
 		expect( placeholders.length ).toBeGreaterThan( 0 );
 	} );
 } );

--- a/client/payment-details/dispute-outcome/__tests__/recommendations-list.test.tsx
+++ b/client/payment-details/dispute-outcome/__tests__/recommendations-list.test.tsx
@@ -1,0 +1,100 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import RecommendationsList from '../recommendations-list';
+import type { EvidenceFieldStatus } from 'wcpay/disputes/new-evidence/types';
+
+const couldHelpFields: EvidenceFieldStatus[] = [
+	{
+		key: 'shipping_address',
+		label: 'Shipping address',
+		state: 'expected_missing',
+	},
+	{
+		key: 'shipping_tracking_number',
+		label: 'Tracking number',
+		state: 'expected_missing',
+	},
+];
+
+const keepDoingFields: EvidenceFieldStatus[] = [
+	{
+		key: 'shipping_address',
+		label: 'Shipping address',
+		state: 'provided',
+	},
+];
+
+describe( 'RecommendationsList', () => {
+	it( 'renders the "What could help" heading for the could_help outcome', () => {
+		render(
+			<RecommendationsList
+				fields={ couldHelpFields }
+				outcome="could_help"
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'heading', { name: /what could help/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the "What to keep doing" heading for the keep_doing outcome', () => {
+		render(
+			<RecommendationsList
+				fields={ keepDoingFields }
+				outcome="keep_doing"
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'heading', { name: /what to keep doing/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders one list item per field with its label', () => {
+		render(
+			<RecommendationsList
+				fields={ couldHelpFields }
+				outcome="could_help"
+			/>
+		);
+
+		const items = screen.getAllByRole( 'listitem' );
+		expect( items ).toHaveLength( 2 );
+		expect( screen.getByText( 'Shipping address' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Tracking number' ) ).toBeInTheDocument();
+	} );
+
+	it( 'returns null for empty fields', () => {
+		const { container } = render(
+			<RecommendationsList fields={ [] } outcome="could_help" />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'includes TODO(catherine) placeholder markers in the rendered output', () => {
+		// Defense against accidental removal of the TODO marker before
+		// Catherine's final copy lands. The marker is the canary; when she
+		// ships strings, the placeholder string disappears and this test
+		// updates with it.
+		render(
+			<RecommendationsList
+				fields={ couldHelpFields }
+				outcome="could_help"
+			/>
+		);
+
+		const placeholders = screen.getAllByText( /TODO\(catherine\)/ );
+		expect( placeholders.length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/client/payment-details/dispute-outcome/index.tsx
+++ b/client/payment-details/dispute-outcome/index.tsx
@@ -12,13 +12,29 @@ import { CardDivider } from '@wordpress/components';
  */
 import type { ChargeDispute } from 'wcpay/types/charges';
 import { getExpectedFieldStatus } from 'wcpay/disputes/new-evidence/evidence-field-status';
+import {
+	getRecommendationFields,
+	type RecommendationOutcome,
+} from 'wcpay/disputes/new-evidence/recommendation-fields';
 import { resolveProductType } from 'wcpay/disputes/new-evidence/resolve-product-type';
 import EvidenceSubmittedList from './evidence-submitted-list';
+import RecommendationsList from './recommendations-list';
 import './style.scss';
 
 interface DisputeOutcomeViewProps {
 	dispute: ChargeDispute;
 }
+
+// Maps the dispute outcome status to the recommendation framing.
+// warning_closed has no entry: inquiries never carry merchant-submitted
+// evidence, so "what could help" / "what to keep doing" has no behavioral
+// hook to attach to.
+const recommendationOutcomeByStatus: Partial<
+	Record< ChargeDispute[ 'status' ], RecommendationOutcome >
+> = {
+	lost: 'could_help',
+	won: 'keep_doing',
+};
 
 const DisputeOutcomeView: React.FC< DisputeOutcomeViewProps > = ( {
 	dispute,
@@ -36,6 +52,17 @@ const DisputeOutcomeView: React.FC< DisputeOutcomeViewProps > = ( {
 		dispute.evidence
 	);
 
+	const recommendationOutcome =
+		recommendationOutcomeByStatus[ dispute.status ];
+	const recommendationFields = recommendationOutcome
+		? getRecommendationFields(
+				dispute.reason,
+				productType,
+				dispute.evidence,
+				recommendationOutcome
+		  )
+		: [];
+
 	return (
 		<section className="dispute-outcome-view">
 			<CardDivider />
@@ -43,6 +70,12 @@ const DisputeOutcomeView: React.FC< DisputeOutcomeViewProps > = ( {
 				{ __( 'Evidence Submitted', 'woocommerce-payments' ) }
 			</h3>
 			<EvidenceSubmittedList fields={ fields } />
+			{ recommendationOutcome && (
+				<RecommendationsList
+					fields={ recommendationFields }
+					outcome={ recommendationOutcome }
+				/>
+			) }
 		</section>
 	);
 };

--- a/client/payment-details/dispute-outcome/recommendations-list.tsx
+++ b/client/payment-details/dispute-outcome/recommendations-list.tsx
@@ -1,0 +1,75 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { CardDivider } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { EvidenceFieldStatus } from 'wcpay/disputes/new-evidence/types';
+import type { RecommendationOutcome } from 'wcpay/disputes/new-evidence/recommendation-fields';
+
+interface Props {
+	fields: EvidenceFieldStatus[];
+	outcome: RecommendationOutcome;
+}
+
+const headings: Record< RecommendationOutcome, string > = {
+	could_help: __( 'What could help', 'woocommerce-payments' ),
+	keep_doing: __( 'What to keep doing', 'woocommerce-payments' ),
+};
+
+// Placeholder copy until RiskOps (catkiinson) delivers final strings for
+// RSM-1169 (could_help) and RSM-1170 (keep_doing). Intentionally not
+// translated: throwaway strings would pollute .po files. When Catherine
+// ships final copy, wrap with `__()` and drop the TODO markers.
+const introCopy: Record< RecommendationOutcome, string > = {
+	could_help:
+		'TODO(catherine): RSM-1169 intro copy. Explains how the listed evidence types could have strengthened the response.',
+	keep_doing:
+		'TODO(catherine): RSM-1170 intro copy. Reinforces that the listed evidence types contributed to the win.',
+};
+
+const placeholderExplanation: Record< RecommendationOutcome, string > = {
+	could_help: 'TODO(catherine): per-field explanation for the lost path.',
+	keep_doing: 'TODO(catherine): per-field reinforcement for the won path.',
+};
+
+const RecommendationsList: React.FC< Props > = ( { fields, outcome } ) => {
+	if ( fields.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			<CardDivider />
+			<h3 className="dispute-outcome-view__section-heading">
+				{ headings[ outcome ] }
+			</h3>
+			<p className="dispute-outcome-recommendations-list__intro">
+				{ introCopy[ outcome ] }
+			</p>
+			<ul className="dispute-outcome-recommendations-list">
+				{ fields.map( ( { key, label } ) => (
+					<li
+						key={ key }
+						className="dispute-outcome-recommendations-list__item"
+					>
+						<span className="dispute-outcome-recommendations-list__label">
+							{ label }
+						</span>
+						<span className="dispute-outcome-recommendations-list__placeholder">
+							{ placeholderExplanation[ outcome ] }
+						</span>
+					</li>
+				) ) }
+			</ul>
+		</>
+	);
+};
+
+export default RecommendationsList;

--- a/client/payment-details/dispute-outcome/recommendations-list.tsx
+++ b/client/payment-details/dispute-outcome/recommendations-list.tsx
@@ -23,20 +23,20 @@ const headings: Record< RecommendationOutcome, string > = {
 	keep_doing: __( 'What to keep doing', 'woocommerce-payments' ),
 };
 
-// Placeholder copy until RiskOps (catkiinson) delivers final strings for
-// RSM-1169 (could_help) and RSM-1170 (keep_doing). Intentionally not
-// translated: throwaway strings would pollute .po files. When Catherine
-// ships final copy, wrap with `__()` and drop the TODO markers.
+// Placeholder copy pending final strings from RiskOps for RSM-1169
+// (could_help) and RSM-1170 (keep_doing). Intentionally not translated:
+// throwaway strings would pollute .po files. When final copy arrives,
+// wrap with `__()` and drop the TODO markers.
 const introCopy: Record< RecommendationOutcome, string > = {
 	could_help:
-		'TODO(catherine): RSM-1169 intro copy. Explains how the listed evidence types could have strengthened the response.',
+		'TODO(riskops): RSM-1169 intro copy. Explains how the listed evidence types could have strengthened the response.',
 	keep_doing:
-		'TODO(catherine): RSM-1170 intro copy. Reinforces that the listed evidence types contributed to the win.',
+		'TODO(riskops): RSM-1170 intro copy. Reinforces that the listed evidence types contributed to the win.',
 };
 
 const placeholderExplanation: Record< RecommendationOutcome, string > = {
-	could_help: 'TODO(catherine): per-field explanation for the lost path.',
-	keep_doing: 'TODO(catherine): per-field reinforcement for the won path.',
+	could_help: 'TODO(riskops): per-field explanation for the lost path.',
+	keep_doing: 'TODO(riskops): per-field reinforcement for the won path.',
 };
 
 const RecommendationsList: React.FC< Props > = ( { fields, outcome } ) => {

--- a/client/payment-details/dispute-outcome/style.scss
+++ b/client/payment-details/dispute-outcome/style.scss
@@ -75,3 +75,41 @@
 		}
 	}
 }
+
+.dispute-outcome-recommendations-list {
+	list-style: none;
+	margin: 0;
+	padding: 0 $grid-unit-30;
+
+	&__intro {
+		margin: 0 $grid-unit-30 $grid-unit-15;
+		font-size: 13px;
+		line-height: 20px;
+		color: $gray-700;
+	}
+
+	&__item {
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-05;
+		padding: $grid-unit-10 0;
+		font-size: 13px;
+		line-height: 20px;
+
+		& + & {
+			border-top: 1px solid $gray-100;
+		}
+	}
+
+	&__label {
+		color: $gray-900;
+		font-weight: 500;
+	}
+
+	&__placeholder {
+		// Placeholder copy is intentionally de-emphasized: it greps for
+		// `TODO(catherine)` and disappears entirely once RiskOps copy lands.
+		color: $gray-500;
+		font-style: italic;
+	}
+}

--- a/client/payment-details/dispute-outcome/style.scss
+++ b/client/payment-details/dispute-outcome/style.scss
@@ -108,7 +108,7 @@
 
 	&__placeholder {
 		// Placeholder copy is intentionally de-emphasized: it greps for
-		// `TODO(catherine)` and disappears entirely once RiskOps copy lands.
+		// `TODO(riskops)` and disappears entirely once final copy lands.
 		color: $gray-500;
 		font-style: italic;
 	}


### PR DESCRIPTION
## Summary

Adds the "What Could Help" (lost) and "What to Keep Doing" (won) recommendation sections to the Dispute Outcome View, rendered below the Evidence Submitted list inside the same wrapper.

- **Lost** → `expected_missing` fields from `getExpectedFieldStatus` (the high-impact evidence the merchant didn't supply).
- **Won** → `provided` fields that are in the high-impact map for the (reason × productType) cell.
- **warning_closed** → no recommendations section. Inquiries never carry merchant-submitted evidence, so neither framing has a behavioral hook to attach to.

Behind the existing `isDisputeOutcomeViewEnabled` flag (dev-only during RSM).

## Copy

Placeholder copy, intentionally marked `TODO(riskops)` so the RiskOps copy ramp greps cleanly. Placeholders are not `__()`-wrapped — throwaway strings shouldn't pollute `.po` files. Once final copy lands they get the wrap and the TODO markers come out.

Linear (left alone, not auto-progressed):
- RSM-1169 — What Could Help
- RSM-1170 — What to Keep Doing

## Stacking

Base: `feat/dispute-outcome-view-evidence-list-integration` (#11698). Retarget to `develop` once #11698 merges.

## Architecture notes

- New helper `getRecommendationFields(reason, productType, evidence, outcome)` composes `getExpectedFieldStatus` with `DISPUTE_HIGH_IMPACT_FIELDS`. Outcome ('could_help' | 'keep_doing') is mapped from dispute status in the wrapper, so the helper has no `DisputeStatus` coupling.
- Component `RecommendationsList` is purely presentational. Returns `null` for empty fields[] so warning_closed (and any other outcome with no recommendations) doesn't surface an empty section.
- Wrapper test default status switched to `warning_closed` so existing Evidence Submitted assertions stay focused; new dedicated tests cover won / lost / warning_closed recommendation rendering.

## Test plan

- [x] Unit: `recommendation-fields.test.ts` (8 tests) and `recommendations-list.test.tsx` (5 tests) pass
- [x] Unit: existing wrapper tests pass; new won / lost / warning_closed assertions pass
- [x] `tsc --noEmit` clean
- [x] ESLint clean
- [x] Full sweep across `client/disputes/new-evidence`, `client/payment-details/dispute-outcome`, `client/payment-details/summary` — 674 tests pass
- [x] Screenshots (preview.html since dev env has no live disputes): `.claude/tmp/screenshots/2026-05-12-recommendations-{lost,won,warning-closed,all}.png`

## Notes

Live in-app browser verification (real won / lost disputes) is deferred to the manual QA pass once final RiskOps copy lands and the flag is staged for ramp.