### PR TITLE
fix: WC Blocks dependency on cart page

### DIFF
--- a/changelog/fix-wc-blocks-cart-dependency
+++ b/changelog/fix-wc-blocks-cart-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: dependency extraction of @woocommerce/blocks-checkout

--- a/client/cart/blocks/index.js
+++ b/client/cart/blocks/index.js
@@ -1,10 +1,13 @@
 /**
+ * External dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
  * Internal dependencies
  */
 import { renderBNPLCartMessaging } from './product-details';
 import './style.scss';
-
-const { registerPlugin } = window.wp.plugins;
 
 registerPlugin( 'bnpl-site-messaging', {
 	render: renderBNPLCartMessaging,

--- a/client/cart/blocks/product-details.js
+++ b/client/cart/blocks/product-details.js
@@ -6,6 +6,7 @@ import {
 	PaymentMethodMessagingElement,
 } from '@stripe/react-stripe-js';
 import { select } from '@wordpress/data';
+// eslint-disable-next-line import/no-unresolved
 import { ExperimentalOrderMeta } from '@woocommerce/blocks-checkout';
 
 /**

--- a/client/cart/blocks/product-details.js
+++ b/client/cart/blocks/product-details.js
@@ -6,6 +6,7 @@ import {
 	PaymentMethodMessagingElement,
 } from '@stripe/react-stripe-js';
 import { select } from '@wordpress/data';
+import { ExperimentalOrderMeta } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -44,8 +45,6 @@ const isInEditor = () => {
 const normalizeAmount = ( amount, decimalPlaces = 2 ) => {
 	return amount * Math.pow( 10, 2 - decimalPlaces );
 };
-
-const { ExperimentalOrderMeta } = window.wc.blocksCheckout;
 
 const ProductDetail = ( { cart, context } ) => {
 	const [ appearance, setAppearance ] = useState( () =>

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -7,6 +7,7 @@ import {
 	registerExpressPaymentMethod,
 	// eslint-disable-next-line import/no-unresolved
 } from '@woocommerce/blocks-registry';
+// eslint-disable-next-line import/no-unresolved
 import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
 
 /**

--- a/client/checkout/blocks/index.js
+++ b/client/checkout/blocks/index.js
@@ -7,6 +7,7 @@ import {
 	registerExpressPaymentMethod,
 	// eslint-disable-next-line import/no-unresolved
 } from '@woocommerce/blocks-registry';
+import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -156,8 +157,6 @@ window.addEventListener( 'load', () => {
 
 // If multi-currency is enabled, add currency code to total amount in cart and checkout blocks.
 if ( getConfig( 'isMultiCurrencyEnabled' ) ) {
-	const { registerCheckoutFilters } = window.wc.blocksCheckout;
-
 	const modifyTotalsPrice = ( defaultValue, extensions, args ) => {
 		const { cart } = args;
 


### PR DESCRIPTION
Fixes WOOPMNT-6162

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

`Uncaught TypeError: Cannot destructure property 'ExperimentalOrderMeta' of 'window.wc.blocksCheckout' as it is undefined.` was appearing in the console on the block-based cart page.
<img width="862" height="135" alt="Screenshot 2026-05-12 at 6 48 14 PM" src="https://github.com/user-attachments/assets/96eb349b-fc86-40a0-9067-f64852cef643" />

The script wasn't declaring `wc-blocks-checkout` as a dependency, it was relying on the Cart block enqueuing it as a side effect.

Switching the destructure to an `import` from `@woocommerce/blocks-checkout` to let the `dependency-extraction` webpack plugin emit `wc-blocks-checkout` into `dist/cart-block.asset.php` automatically.

Same anti-pattern was also present in `client/cart/blocks/index.js` (`window.wp.plugins.registerPlugin`, now emits `wp-plugins` into the same asset file) and `client/checkout/blocks/index.js` (`window.wc.blocksCheckout.registerCheckoutFilters`, now emits `wc-blocks-checkout` into `dist/checkout.asset.php`). Fixing those too.

##### A note on older WP/WC versions

Declaring the deps in the asset file changes enqueue behavior on sites where one of those handles isn't registered: before, the script enqueued and crashed on the destructure; now, WP refuses to print the script (and emits a `_doing_it_wrong` notice in `WP_DEBUG`).

For reference, both globals are old enough that this is academic under any reasonable support window:
- `window.wp.plugins` / `wp-plugins` ships with the WP block editor — in core since WP 5.0 (Dec 2018).
- `window.wc.blocksCheckout` / `wc-blocks-checkout` was introduced in the WooCommerce Blocks feature plugin via [woocommerce-blocks#3654](https://github.com/woocommerce/woocommerce-blocks/pull/3654) (Jan 2021), and shipped with WC core when WC Blocks was merged in WC 8.3 (Nov 2023). `ExperimentalOrderMeta` was part of that same PR.

I checked what's actually in `dist/cart-block.js` to see what we'd lose if it doesn't enqueue. The bundle is large (mostly Stripe Elements + WCPayAPI machinery), but its only contribution to the page is `registerPlugin('bnpl-site-messaging', …)`. No other code path reads `wcpayStripeSiteMessaging`, the CSS is enqueued separately via `wp_enqueue_style`, and `WCPayAPI` construction has no side effects beyond a local variable.

So the user-facing delta on an "older site" is: BNPL messaging on cart still doesn't appear (which was already the case, the script was crashing at module-eval), but the console is clean and we don't waste a download.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

1. Use the Storefront theme.
2. Add a product to the cart.
3. Navigate to the block-based cart page.
4. The `Cannot destructure property 'ExperimentalOrderMeta' of 'window.wc.blocksCheckout' as it is undefined.` error should no longer appear in the console.
5. Navigate to the block-based checkout page. No `Cannot destructure property 'registerPlugin' of 'window.wp.plugins'` or `Cannot destructure property 'registerCheckoutFilters' of 'window.wc.blocksCheckout'` errors either.
6. BNPL messaging (Klarna/Afterpay/Affirm) still renders in the cart summary for eligible totals.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.