### PR TITLE
Add Reports shell behind feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ CLAUDE.local.md
 .serena/
 .zed/
 .phpactor.json
+.superpowers/
 
 # Bundle
 dist

--- a/changelog/rsm-2124-rsm-engineering-reports-shell-route-navigation-and-feature
+++ b/changelog/rsm-2124-rsm-engineering-reports-shell-route-navigation-and-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add Reports shell behind feature flag

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -37,6 +37,7 @@ declare global {
 			isFRTReviewFeatureActive: boolean;
 			isDynamicCheckoutPlaceOrderButtonEnabled: boolean;
 			amazonPay: boolean;
+			reportsArea: boolean;
 		};
 		accountFees: Record< string, any >;
 		fraudServices: unknown[];

--- a/client/index.js
+++ b/client/index.js
@@ -27,10 +27,12 @@ import CardReadersPage from 'card-readers';
 import CapitalPage from 'capital';
 import OverviewPage from 'overview';
 import DocumentsPage from 'documents';
+import ReportsPage from 'reports';
 import OnboardingPage from 'onboarding';
 import OnboardingKycPage from 'onboarding/kyc';
 import FraudProtectionAdvancedSettingsPage from './settings/fraud-protection/advanced-settings';
 import { getTasks } from 'overview/task-list/tasks';
+import { maybeAddReportsPage } from 'reports/page-config';
 
 addFilter(
 	'woocommerce_admin_pages_list',
@@ -200,6 +202,12 @@ addFilter(
 				parentPath: '/payments/disputes',
 			},
 			capability: 'manage_woocommerce',
+		} );
+		// Reports has additional feature-flag setup, so its route config lives with the Reports shell.
+		maybeAddReportsPage( pages, {
+			container: ReportsPage,
+			menuID,
+			rootLink,
 		} );
 
 		pages.push( {

--- a/client/reports/__tests__/page-config.test.ts
+++ b/client/reports/__tests__/page-config.test.ts
@@ -1,0 +1,90 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { maybeAddReportsPage } from '../page-config';
+
+declare const global: {
+	wcpaySettings: {
+		featureFlags: {
+			reportsArea?: boolean;
+		};
+		isJetpackConnected: boolean;
+		isAccountValid: boolean;
+		accountStatus: {
+			status?: string;
+		};
+	};
+};
+
+describe( 'Reports page config', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			featureFlags: {},
+			isJetpackConnected: true,
+			isAccountValid: true,
+			accountStatus: {
+				status: 'complete',
+			},
+		};
+	} );
+
+	it( 'does not register the Reports route when the feature flag is disabled', () => {
+		const pages: Record< string, unknown >[] = [];
+
+		maybeAddReportsPage( pages, {
+			container: jest.fn(),
+			menuID: 'toplevel_page_wc-admin-path--payments-overview',
+			rootLink: [ '/payments/overview', 'Payments' ],
+		} );
+
+		expect( pages ).toHaveLength( 0 );
+	} );
+
+	it( 'registers the Reports route when the feature flag is enabled', () => {
+		const ReportsContainer = jest.fn();
+		const pages: Record< string, unknown >[] = [];
+		global.wcpaySettings.featureFlags.reportsArea = true;
+
+		maybeAddReportsPage( pages, {
+			container: ReportsContainer,
+			menuID: 'toplevel_page_wc-admin-path--payments-overview',
+			rootLink: [ '/payments/overview', 'Payments' ],
+		} );
+
+		expect( pages ).toContainEqual(
+			expect.objectContaining( {
+				container: ReportsContainer,
+				path: '/payments/reports',
+				wpOpenMenu: 'toplevel_page_wc-admin-path--payments-overview',
+				breadcrumbs: [
+					[ '/payments/overview', 'Payments' ],
+					'Reports',
+				],
+				navArgs: { id: 'wc-payments-reports' },
+				capability: 'manage_woocommerce',
+			} )
+		);
+	} );
+
+	it( 'registers the feature-gated Reports route regardless of account state', () => {
+		const pages: Record< string, unknown >[] = [];
+		global.wcpaySettings.featureFlags.reportsArea = true;
+		global.wcpaySettings.isAccountValid = false;
+		global.wcpaySettings.isJetpackConnected = false;
+		global.wcpaySettings.accountStatus.status = 'rejected.other';
+
+		maybeAddReportsPage( pages, {
+			container: jest.fn(),
+			menuID: 'toplevel_page_wc-admin-path--payments-overview',
+			rootLink: [ '/payments/overview', 'Payments' ],
+		} );
+
+		expect( pages ).toContainEqual(
+			expect.objectContaining( {
+				path: '/payments/reports',
+			} )
+		);
+	} );
+} );

--- a/client/reports/__tests__/period-selector.test.tsx
+++ b/client/reports/__tests__/period-selector.test.tsx
@@ -1,0 +1,66 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getLastFullCalendarMonthUTC } from '../period-selector';
+
+describe( 'Reports period selector', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'calculates the last full calendar month in UTC', () => {
+		const range = getLastFullCalendarMonthUTC(
+			new Date( '2026-05-06T12:00:00Z' )
+		);
+
+		expect( range ).toEqual( {
+			start: '2026-04-01T00:00:00.000Z',
+			end: '2026-04-30T23:59:59.999Z',
+		} );
+	} );
+
+	it( 'rolls back across the year boundary in January', () => {
+		const range = getLastFullCalendarMonthUTC(
+			new Date( '2026-01-15T12:00:00Z' )
+		);
+
+		expect( range ).toEqual( {
+			start: '2025-12-01T00:00:00.000Z',
+			end: '2025-12-31T23:59:59.999Z',
+		} );
+	} );
+
+	it( 'returns 29 days for a leap-year February', () => {
+		const range = getLastFullCalendarMonthUTC(
+			new Date( '2024-03-10T12:00:00Z' )
+		);
+
+		expect( range ).toEqual( {
+			start: '2024-02-01T00:00:00.000Z',
+			end: '2024-02-29T23:59:59.999Z',
+		} );
+	} );
+
+	it( 'returns 28 days for a non-leap-year February', () => {
+		const range = getLastFullCalendarMonthUTC(
+			new Date( '2025-03-10T12:00:00Z' )
+		);
+
+		expect( range ).toEqual( {
+			start: '2025-02-01T00:00:00.000Z',
+			end: '2025-02-28T23:59:59.999Z',
+		} );
+	} );
+
+	it( 'uses the current date when no date is provided', () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( new Date( '2026-05-06T12:00:00Z' ) );
+
+		expect( getLastFullCalendarMonthUTC() ).toEqual( {
+			start: '2026-04-01T00:00:00.000Z',
+			end: '2026-04-30T23:59:59.999Z',
+		} );
+	} );
+} );

--- a/client/reports/__tests__/state.test.tsx
+++ b/client/reports/__tests__/state.test.tsx
@@ -1,0 +1,166 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { ReportsTabPanel } from '../tabs';
+
+describe( 'Reports tab states', () => {
+	it( 'renders the Balance empty state', () => {
+		const { container } = render(
+			<ReportsTabPanel
+				tab="balance"
+				status="empty"
+				onReload={ jest.fn() }
+			/>
+		);
+
+		expect( container.firstChild ).toHaveClass(
+			'wcpay-reports-state--empty'
+		);
+		expect(
+			screen.getByRole( 'heading', { level: 2 } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the Fees empty state', () => {
+		const { container } = render(
+			<ReportsTabPanel tab="fees" status="empty" onReload={ jest.fn() } />
+		);
+
+		expect( container.firstChild ).toHaveClass(
+			'wcpay-reports-state--empty'
+		);
+		expect(
+			screen.getByRole( 'heading', { level: 2 } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders a loading placeholder state', () => {
+		render(
+			<ReportsTabPanel
+				tab="balance"
+				status="loading"
+				onReload={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'status' ) ).toContainElement(
+			screen.getByRole( 'heading', { level: 2 } )
+		);
+	} );
+
+	it( 'renders a partial placeholder state', () => {
+		render(
+			<ReportsTabPanel
+				tab="balance"
+				status="partial"
+				onReload={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'status' ) ).toContainElement(
+			screen.getByRole( 'heading', { level: 2 } )
+		);
+	} );
+
+	it( 'renders Balance error state with reload action', async () => {
+		const onReload = jest.fn();
+		render(
+			<ReportsTabPanel
+				tab="balance"
+				status="error"
+				onReload={ onReload }
+			/>
+		);
+
+		const group = screen.getByRole( 'group' );
+
+		expect(
+			within( group ).getByRole( 'heading', { level: 2 } )
+		).toBeInTheDocument();
+
+		await userEvent.click(
+			within( group ).getByRole( 'button', { name: /Reload/i } )
+		);
+
+		expect( onReload ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'renders Fees error state with reload action', async () => {
+		const onReload = jest.fn();
+		render(
+			<ReportsTabPanel tab="fees" status="error" onReload={ onReload } />
+		);
+
+		const group = screen.getByRole( 'group' );
+
+		expect(
+			within( group ).getByRole( 'heading', { level: 2 } )
+		).toBeInTheDocument();
+
+		await userEvent.click(
+			within( group ).getByRole( 'button', { name: /Reload/i } )
+		);
+
+		expect( onReload ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'moves focus to the error heading after entering an error state', async () => {
+		const onReload = jest.fn();
+		const { rerender } = render(
+			<ReportsTabPanel
+				tab="balance"
+				status="loading"
+				onReload={ jest.fn() }
+			/>
+		);
+
+		rerender(
+			<ReportsTabPanel tab="fees" status="error" onReload={ onReload } />
+		);
+
+		await waitFor( () => {
+			expect(
+				within( screen.getByRole( 'group' ) ).getByRole( 'heading', {
+					level: 2,
+				} )
+			).toHaveFocus();
+		} );
+	} );
+
+	it( 'moves focus to the persistent content heading after recovering from an error', async () => {
+		const onReload = jest.fn();
+		const { rerender } = render(
+			<ReportsTabPanel
+				tab="balance"
+				status="error"
+				onReload={ onReload }
+			/>
+		);
+		const reloadButton = screen.getByRole( 'button', { name: /Reload/i } );
+
+		await userEvent.click( reloadButton );
+		expect( onReload ).toHaveBeenCalledTimes( 1 );
+		expect( reloadButton ).toHaveFocus();
+
+		rerender(
+			<ReportsTabPanel
+				tab="balance"
+				status="empty"
+				onReload={ jest.fn() }
+			/>
+		);
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'heading', { level: 2 } ) ).toHaveFocus();
+		} );
+	} );
+} );

--- a/client/reports/__tests__/tabs.test.tsx
+++ b/client/reports/__tests__/tabs.test.tsx
@@ -1,0 +1,224 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { ReportsPage } from '..';
+import { STORE_NAME as WCPAY_STORE_NAME } from 'wcpay/data/constants';
+import { getQuery, updateQueryString } from '@woocommerce/navigation';
+import { useDispatch } from '@wordpress/data';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	getQuery: jest.fn(),
+	updateQueryString: jest.fn(),
+} ) );
+
+// Explicit, narrow mock of @wordpress/data. We only rely on `useDispatch` in
+// this test, but stub the other commonly-imported helpers so that components
+// elsewhere in the render tree fail visibly (rather than silently receiving
+// `undefined`) if they grow a new dependency on the data module.
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn( ( mapSelect: ( fn: () => unknown ) => unknown ) =>
+		typeof mapSelect === 'function' ? mapSelect( () => ( {} ) ) : undefined
+	),
+	select: jest.fn( () => ( {} ) ),
+	dispatch: jest.fn( () => ( {} ) ),
+	withSelect:
+		( mapSelect: unknown ) =>
+		( Component: React.ComponentType< unknown > ) => {
+			void mapSelect;
+			return Component;
+		},
+	withDispatch:
+		( mapDispatch: unknown ) =>
+		( Component: React.ComponentType< unknown > ) => {
+			void mapDispatch;
+			return Component;
+		},
+	register: jest.fn(),
+	combineReducers: ( reducers: Record< string, unknown > ) => reducers,
+	createReduxStore: jest.fn(),
+} ) );
+
+const mockGetQuery = getQuery as jest.Mock;
+const mockUpdateQueryString = updateQueryString as jest.Mock;
+const mockUseDispatch = useDispatch as jest.Mock;
+
+declare const global: {
+	wcpaySettings: {
+		featureFlags: Record< string, boolean >;
+		fraudServices: unknown[];
+	};
+};
+
+describe( 'Reports page tabs', () => {
+	const invalidateResolution = jest.fn();
+
+	const renderReportsPage = async ( props = {} ) => {
+		const result = render( <ReportsPage { ...props } /> );
+
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'tab', { name: 'Balance' } )
+			).toBeInTheDocument();
+		} );
+
+		return result;
+	};
+
+	beforeEach( () => {
+		global.wcpaySettings = {
+			featureFlags: {},
+			fraudServices: [],
+		};
+		mockGetQuery.mockReturnValue( {} );
+		mockUpdateQueryString.mockClear();
+		invalidateResolution.mockClear();
+		mockUseDispatch.mockImplementation( ( storeName ) => {
+			if ( WCPAY_STORE_NAME === storeName ) {
+				return { invalidateResolution };
+			}
+			return {};
+		} );
+	} );
+
+	it( 'defaults to the Balance tab and renders Balance before Fees', async () => {
+		await renderReportsPage( {
+			now: new Date( '2026-05-06T12:00:00Z' ),
+		} );
+
+		const tabs = screen.getAllByRole( 'tab' );
+
+		expect( tabs.map( ( tab ) => tab.textContent ) ).toEqual( [
+			'Balance',
+			'Fees',
+		] );
+		expect(
+			screen.getByRole( 'tab', { name: 'Balance' } )
+		).toHaveAttribute( 'aria-selected', 'true' );
+		expect(
+			screen.getByText( /reconciliation reports/i )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'heading', { name: 'Reports', level: 1 } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'navigation', { name: 'Breadcrumb' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'uses the tab query parameter for direct Fees navigation', async () => {
+		mockGetQuery.mockReturnValue( { tab: 'fees' } );
+
+		await renderReportsPage( {
+			now: new Date( '2026-05-06T12:00:00Z' ),
+		} );
+
+		expect( screen.getByRole( 'tab', { name: 'Fees' } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		expect(
+			screen.queryByRole( 'navigation', { name: 'Breadcrumb' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'syncs the active tab from browser history changes', async () => {
+		mockGetQuery.mockReturnValue( { tab: 'fees' } );
+
+		await renderReportsPage( {
+			now: new Date( '2026-05-06T12:00:00Z' ),
+		} );
+
+		expect( screen.getByRole( 'tab', { name: 'Fees' } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+
+		mockGetQuery.mockReturnValue( { tab: 'balance' } );
+		await act( async () => {
+			window.dispatchEvent( new Event( 'popstate' ) );
+		} );
+
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'tab', { name: 'Balance' } )
+			).toHaveAttribute( 'aria-selected', 'true' );
+		} );
+	} );
+
+	it( 'updates the query string when switching tabs', async () => {
+		await renderReportsPage( {
+			now: new Date( '2026-05-06T12:00:00Z' ),
+		} );
+
+		// TabPanel schedules an internal Ariakit tab update outside userEvent's
+		// act boundary, so this click needs a narrow wrapper.
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'tab', { name: 'Fees' } )
+			);
+		} );
+
+		await waitFor( () => {
+			expect( mockUpdateQueryString ).toHaveBeenCalledWith(
+				{ tab: 'fees' },
+				'/payments/reports'
+			);
+		} );
+		expect( mockUpdateQueryString ).toHaveBeenCalledTimes( 1 );
+		expect( screen.getByRole( 'tab', { name: 'Fees' } ) ).toHaveFocus();
+	} );
+
+	it( 'reloads the active tab in place by invalidating the placeholder resolver', async () => {
+		await renderReportsPage( {
+			tabStatus: 'error',
+			now: new Date( '2026-05-06T12:00:00Z' ),
+		} );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: /Reload/i } )
+		);
+
+		expect( invalidateResolution ).toHaveBeenCalledWith(
+			expect.any( String ),
+			[
+				{
+					start: '2026-04-01T00:00:00.000Z',
+					end: '2026-04-30T23:59:59.999Z',
+				},
+			]
+		);
+	} );
+
+	it( 'reloads the Fees tab with the current period range', async () => {
+		mockGetQuery.mockReturnValue( { tab: 'fees' } );
+
+		await renderReportsPage( {
+			tabStatus: 'error',
+			now: new Date( '2026-05-06T12:00:00Z' ),
+		} );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: /Reload/i } )
+		);
+
+		expect( invalidateResolution ).toHaveBeenCalledWith(
+			expect.any( String ),
+			[
+				{
+					start: '2026-04-01T00:00:00.000Z',
+					end: '2026-04-30T23:59:59.999Z',
+				},
+			]
+		);
+	} );
+} );

--- a/client/reports/header.tsx
+++ b/client/reports/header.tsx
@@ -1,0 +1,20 @@
+/** @format */
+
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+export const ReportsHeader: React.FC = () => {
+	return (
+		<div className="wcpay-reports-header">
+			<h1 className="screen-reader-text">
+				{ __( 'Reports', 'woocommerce-payments' ) }
+			</h1>
+			<p>
+				{ __(
+					'View your reconciliation reports.',
+					'woocommerce-payments'
+				) }
+			</p>
+		</div>
+	);
+};

--- a/client/reports/hooks.ts
+++ b/client/reports/hooks.ts
@@ -1,0 +1,38 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME as WCPAY_STORE_NAME } from 'wcpay/data/constants';
+import type { ReportsPeriodRange } from './period-selector';
+import type { ReportsTab } from './types';
+
+// Shell placeholder — replaced once real selectors land. Until then, reload
+// no-ops on unregistered resolvers (invalidateResolution is safe in that case).
+const reportsPlaceholderSelectors: Record< ReportsTab, string > = {
+	balance: 'getReportsBalanceSummary',
+	fees: 'getReportsFees',
+};
+
+interface WCPayResolutionDispatch {
+	invalidateResolution: ( selectorName: string, args: unknown[] ) => void;
+}
+
+export function useReportsTabReload(
+	tab: ReportsTab,
+	period: ReportsPeriodRange
+): () => void {
+	const { invalidateResolution } = useDispatch(
+		WCPAY_STORE_NAME
+	) as unknown as WCPayResolutionDispatch;
+
+	return useCallback( () => {
+		invalidateResolution( reportsPlaceholderSelectors[ tab ], [ period ] );
+	}, [ invalidateResolution, period, tab ] );
+}

--- a/client/reports/index.tsx
+++ b/client/reports/index.tsx
@@ -1,0 +1,111 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { TabPanel } from '@wordpress/components';
+import { getQuery, updateQueryString } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import Page from 'components/page';
+import { ReportsHeader } from './header';
+import { getLastFullCalendarMonthUTC } from './period-selector';
+import { reportsTabs, ReportsTabPanel, normalizeReportsTab } from './tabs';
+import { useReportsTabReload } from './hooks';
+import type { ReportsTab, ReportsTabStatus } from './types';
+import './style.scss';
+
+interface ReportsPageProps {
+	tabStatus?: ReportsTabStatus;
+	now?: Date;
+}
+
+export const ReportsPage: React.FC< ReportsPageProps > = ( {
+	tabStatus = 'empty',
+	now,
+} ) => {
+	const [ activeTab, setActiveTab ] = useState( () =>
+		normalizeReportsTab( getQuery().tab )
+	);
+	const [ tabPanelKey, setTabPanelKey ] = useState( 0 );
+	const tabPanelWrapperRef = useRef< HTMLDivElement >( null );
+	const previousActiveTabRef = useRef< ReportsTab >( activeTab );
+	const period = useMemo(
+		() => getLastFullCalendarMonthUTC( now ?? new Date() ),
+		[ now ]
+	);
+	const reload = useReportsTabReload( activeTab, period );
+
+	useEffect( () => {
+		const syncActiveTabFromUrl = () => {
+			const nextTab = normalizeReportsTab( getQuery().tab );
+
+			setActiveTab( nextTab );
+			setTabPanelKey( ( key ) => key + 1 );
+		};
+
+		window.addEventListener( 'popstate', syncActiveTabFromUrl );
+		return () => {
+			window.removeEventListener( 'popstate', syncActiveTabFromUrl );
+		};
+	}, [] );
+
+	useEffect( () => {
+		if ( previousActiveTabRef.current !== activeTab ) {
+			tabPanelWrapperRef.current
+				?.querySelector< HTMLElement >(
+					'[role="tab"][aria-selected="true"]'
+				)
+				?.focus();
+		}
+
+		previousActiveTabRef.current = activeTab;
+	}, [ activeTab ] );
+
+	const onTabSelected = ( tab: string ) => {
+		const nextTab = normalizeReportsTab( tab );
+
+		if ( nextTab === activeTab ) {
+			return;
+		}
+
+		setActiveTab( nextTab );
+		updateQueryString(
+			{
+				tab: nextTab,
+			},
+			'/payments/reports'
+		);
+	};
+
+	return (
+		<Page className="wcpay-reports-page">
+			<ReportsHeader />
+			<div ref={ tabPanelWrapperRef }>
+				<TabPanel
+					key={ tabPanelKey }
+					className="wcpay-reports-tab-panel"
+					activeClass="active-tab"
+					onSelect={ onTabSelected }
+					initialTabName={ activeTab }
+					tabs={ reportsTabs }
+				>
+					{ ( tab ) => (
+						<div className="wcpay-reports-content">
+							<ReportsTabPanel
+								tab={ tab.name as ReportsTab }
+								status={ tabStatus }
+								onReload={ reload }
+							/>
+						</div>
+					) }
+				</TabPanel>
+			</div>
+		</Page>
+	);
+};
+
+export default ReportsPage;

--- a/client/reports/page-config.ts
+++ b/client/reports/page-config.ts
@@ -1,0 +1,50 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const reportsPath = '/payments/reports';
+export const reportsNavId = 'wc-payments-reports';
+
+type PageConfig = Record< string, unknown >;
+
+interface ReportsPageConfigArgs {
+	container: unknown;
+	menuID: string;
+	rootLink: [ string, string ];
+}
+
+function getReportsPageConfig( {
+	container,
+	menuID,
+	rootLink,
+}: ReportsPageConfigArgs ): PageConfig {
+	return {
+		container,
+		path: reportsPath,
+		wpOpenMenu: menuID,
+		breadcrumbs: [ rootLink, __( 'Reports', 'woocommerce-payments' ) ],
+		navArgs: {
+			id: reportsNavId,
+		},
+		capability: 'manage_woocommerce',
+	};
+}
+
+function isReportsRouteAvailable(): boolean {
+	return !! wcpaySettings?.featureFlags?.reportsArea;
+}
+
+export function maybeAddReportsPage(
+	pages: PageConfig[],
+	args: ReportsPageConfigArgs
+): PageConfig[] {
+	// Keep the feature-gated Reports route aligned with sibling payment routes; PHP controls account gating and redirects.
+	if ( isReportsRouteAvailable() ) {
+		pages.push( getReportsPageConfig( args ) );
+	}
+
+	return pages;
+}

--- a/client/reports/period-selector.tsx
+++ b/client/reports/period-selector.tsx
@@ -1,0 +1,22 @@
+/** @format */
+
+export interface ReportsPeriodRange {
+	start: string;
+	end: string;
+}
+
+export function getLastFullCalendarMonthUTC(
+	now: Date = new Date()
+): ReportsPeriodRange {
+	const start = new Date(
+		Date.UTC( now.getUTCFullYear(), now.getUTCMonth() - 1, 1, 0, 0, 0 )
+	);
+	const end = new Date(
+		Date.UTC( now.getUTCFullYear(), now.getUTCMonth(), 0, 23, 59, 59, 999 )
+	);
+
+	return {
+		start: start.toISOString(),
+		end: end.toISOString(),
+	};
+}

--- a/client/reports/style.scss
+++ b/client/reports/style.scss
@@ -1,0 +1,79 @@
+/** @format */
+
+.wcpay-reports-page {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	min-height: calc( 100vh - 32px );
+
+	.components-tab-panel__tabs {
+		box-shadow: inset 0 -1px 0 #ccc;
+		margin-bottom: $gap-large;
+
+		.components-tab-panel__tabs-item {
+			&.active-tab {
+				box-shadow: inset 0 -4px 0 0 var( --wp-admin-theme-color );
+			}
+
+			&:focus-visible {
+				outline: 2px solid var( --wp-admin-theme-color );
+				outline-offset: -2px;
+			}
+		}
+	}
+}
+
+@media ( forced-colors: active ) {
+	.wcpay-reports-page {
+		.components-tab-panel__tabs {
+			.components-tab-panel__tabs-item {
+				&.active-tab {
+					border-bottom: 4px solid ButtonText;
+					box-shadow: none;
+				}
+
+				&:focus-visible {
+					outline-color: ButtonText;
+				}
+			}
+		}
+	}
+}
+
+.wcpay-reports-header {
+	margin-bottom: $gap-large;
+
+	p {
+		max-width: 660px;
+		margin: 0;
+		color: $gray-700;
+		font-size: 13px;
+		line-height: 20px;
+	}
+}
+
+.wcpay-reports-state {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 8px;
+	max-width: 660px;
+
+	h2,
+	p {
+		margin: 0;
+	}
+
+	h2 {
+		color: $studio-gray-100;
+		font-size: 15px;
+		font-weight: 500;
+		line-height: 20px;
+	}
+
+	p {
+		color: $gray-700;
+		font-size: 13px;
+		line-height: 20px;
+	}
+}

--- a/client/reports/tabs.tsx
+++ b/client/reports/tabs.tsx
@@ -1,0 +1,168 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { useEffect, useId, useRef } from 'react';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { ReportsTab, ReportsTabStatus } from './types';
+
+interface ReportsTabPanelProps {
+	tab: ReportsTab;
+	status: ReportsTabStatus;
+	onReload: () => void;
+}
+
+export const reportsTabs: Array< {
+	name: ReportsTab;
+	title: string;
+	className: string;
+} > = [
+	{
+		name: 'balance',
+		title: __( 'Balance', 'woocommerce-payments' ),
+		className: 'wcpay-reports-tab--balance',
+	},
+	{
+		name: 'fees',
+		title: __( 'Fees', 'woocommerce-payments' ),
+		className: 'wcpay-reports-tab--fees',
+	},
+];
+
+export function normalizeReportsTab( tab?: unknown ): ReportsTab {
+	return tab === 'fees' ? 'fees' : 'balance';
+}
+
+function getEmptyContent( tab: ReportsTab ): {
+	title: string;
+	description?: string;
+} {
+	if ( tab === 'fees' ) {
+		return {
+			title: __( 'No fees yet', 'woocommerce-payments' ),
+		};
+	}
+
+	return {
+		title: __( 'No balance activity', 'woocommerce-payments' ),
+		description: __(
+			"Your Balance summary will appear here once there's enough data to display.",
+			'woocommerce-payments'
+		),
+	};
+}
+
+function getErrorTitle( tab: ReportsTab ): string {
+	return tab === 'fees'
+		? __( 'Fees report unavailable', 'woocommerce-payments' )
+		: __( 'Balance unavailable', 'woocommerce-payments' );
+}
+
+function getPartialContent( tab: ReportsTab ): {
+	title: string;
+	description: string;
+} {
+	if ( tab === 'fees' ) {
+		return {
+			title: __( 'Fees report partially loaded', 'woocommerce-payments' ),
+			description: __(
+				'Some fees data is still being prepared.',
+				'woocommerce-payments'
+			),
+		};
+	}
+
+	return {
+		title: __( 'Balance partially loaded', 'woocommerce-payments' ),
+		description: __(
+			'Some balance data is still being prepared.',
+			'woocommerce-payments'
+		),
+	};
+}
+
+export const ReportsTabPanel: React.FC< ReportsTabPanelProps > = ( {
+	tab,
+	status,
+	onReload,
+} ) => {
+	const contentHeadingRef = useRef< HTMLHeadingElement >( null );
+	const previousStatusRef = useRef< ReportsTabStatus >( status );
+	const headingId = useId();
+
+	useEffect( () => {
+		const previousStatus = previousStatusRef.current;
+
+		if (
+			previousStatus !== status &&
+			( previousStatus === 'error' || status === 'error' )
+		) {
+			contentHeadingRef.current?.focus();
+		}
+
+		previousStatusRef.current = status;
+	}, [ status ] );
+
+	if ( status === 'loading' ) {
+		return (
+			<div
+				className="wcpay-reports-state wcpay-reports-state--loading"
+				role="status"
+			>
+				<h2 ref={ contentHeadingRef } tabIndex={ -1 }>
+					{ __( 'Loading report', 'woocommerce-payments' ) }
+				</h2>
+			</div>
+		);
+	}
+
+	if ( status === 'partial' ) {
+		const { title, description } = getPartialContent( tab );
+
+		return (
+			<div
+				className="wcpay-reports-state wcpay-reports-state--partial"
+				role="status"
+			>
+				<h2 id={ headingId } ref={ contentHeadingRef } tabIndex={ -1 }>
+					{ title }
+				</h2>
+				<p>{ description }</p>
+			</div>
+		);
+	}
+
+	if ( status === 'error' ) {
+		return (
+			<div
+				className="wcpay-reports-state wcpay-reports-state--error"
+				role="group"
+				aria-labelledby={ headingId }
+			>
+				<h2 id={ headingId } ref={ contentHeadingRef } tabIndex={ -1 }>
+					{ getErrorTitle( tab ) }
+				</h2>
+				<Button variant="secondary" onClick={ onReload }>
+					{ __( 'Reload report', 'woocommerce-payments' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	const { title, description } = getEmptyContent( tab );
+
+	return (
+		<div className="wcpay-reports-state wcpay-reports-state--empty">
+			<h2 ref={ contentHeadingRef } tabIndex={ -1 }>
+				{ title }
+			</h2>
+			{ description && <p>{ description }</p> }
+		</div>
+	);
+};

--- a/client/reports/types.ts
+++ b/client/reports/types.ts
@@ -1,0 +1,4 @@
+/** @format */
+
+export type ReportsTab = 'balance' | 'fees';
+export type ReportsTabStatus = 'loading' | 'partial' | 'empty' | 'error';

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -366,6 +366,19 @@ class WC_Payments_Admin {
 			],
 		];
 
+		if ( WC_Payments_Features::is_reports_area_enabled() ) {
+			$this->admin_child_pages['wc-payments-reports'] = [
+				'id'       => 'wc-payments-reports',
+				'title'    => __( 'Reports', 'woocommerce-payments' ),
+				'parent'   => 'wc-payments',
+				'path'     => '/payments/reports',
+				'nav_args' => [
+					'parent' => 'wc-payments',
+					'order'  => 35,
+				],
+			];
+		}
+
 		try {
 			// Render full payments menu with sub-items only if:
 			// - we have working WPCOM/Jetpack connection;

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -32,6 +32,7 @@ class WC_Payments_Features {
 	const WCPAY_DYNAMIC_CHECKOUT_PLACE_ORDER_BUTTON_FLAG_NAME = '_wcpay_feature_dynamic_checkout_place_order_button';
 	const AMAZON_PAY_FLAG_NAME                                = '_wcpay_feature_amazon_pay';
 	const MC_CACHE_OPTIMIZED_FLAG_NAME                        = '_wcpay_feature_mc_cache_optimized';
+	const REPORTS_AREA_FLAG_NAME                              = '_wcpay_feature_reports_area';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -340,6 +341,15 @@ class WC_Payments_Features {
 	}
 
 	/**
+	 * Checks whether the Reports area is enabled. Disabled by default.
+	 *
+	 * @return bool
+	 */
+	public static function is_reports_area_enabled(): bool {
+		return '1' === get_option( self::REPORTS_AREA_FLAG_NAME, '0' );
+	}
+
+	/**
 	 * Checks whether the next deposit notice on the deposits list screen has been dismissed.
 	 *
 	 * @return bool
@@ -417,6 +427,7 @@ class WC_Payments_Features {
 				'isDynamicCheckoutPlaceOrderButtonEnabled' => self::is_dynamic_checkout_place_order_button_enabled(),
 				'amazonPay'                                => self::is_amazon_pay_enabled(),
 				'isEceUsingConfirmationTokens'             => self::is_ece_confirmation_tokens_enabled(),
+				'reportsArea'                              => self::is_reports_area_enabled(),
 			]
 		);
 	}

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -229,6 +229,13 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 	public function test_rejected_or_under_review_account_registers_limited_menu( bool $is_rejected, bool $is_under_review ) {
 		global $submenu;
 
+		add_filter(
+			'pre_option_' . WC_Payments_Features::REPORTS_AREA_FLAG_NAME,
+			function () {
+				return '1';
+			}
+		);
+
 		$this->mock_current_user_is_admin();
 
 		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
@@ -236,19 +243,24 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		$this->mock_account->method( 'is_account_rejected' )->willReturn( $is_rejected );
 		$this->mock_account->method( 'is_account_under_review' )->willReturn( $is_under_review );
 
-		$this->payments_admin->add_payments_menu();
+		try {
+			$this->payments_admin->add_payments_menu();
 
-		$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
+			$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
 
-		// These pages should be registered for rejected/under-review accounts.
-		$this->assertArrayHasKey( 'wc-admin&path=/payments/overview', $item_names_by_urls );
-		$this->assertArrayHasKey( 'wc-admin&path=/payments/transactions', $item_names_by_urls );
-		$this->assertArrayHasKey( 'wc-admin&path=/payments/disputes', $item_names_by_urls );
+			// These pages should be registered for rejected/under-review accounts.
+			$this->assertArrayHasKey( 'wc-admin&path=/payments/overview', $item_names_by_urls );
+			$this->assertArrayHasKey( 'wc-admin&path=/payments/transactions', $item_names_by_urls );
+			$this->assertArrayHasKey( 'wc-admin&path=/payments/disputes', $item_names_by_urls );
 
-		// These pages should NOT be registered.
-		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/deposits', $item_names_by_urls );
-		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/settings/regular', $item_names_by_urls );
-		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/documents', $item_names_by_urls );
+			// These pages should NOT be registered.
+			$this->assertArrayNotHasKey( 'wc-admin&path=/payments/deposits', $item_names_by_urls );
+			$this->assertArrayNotHasKey( 'wc-admin&path=/payments/reports', $item_names_by_urls );
+			$this->assertArrayNotHasKey( 'wc-admin&path=/payments/settings/regular', $item_names_by_urls );
+			$this->assertArrayNotHasKey( 'wc-admin&path=/payments/documents', $item_names_by_urls );
+		} finally {
+			remove_all_filters( 'pre_option_' . WC_Payments_Features::REPORTS_AREA_FLAG_NAME );
+		}
 	}
 
 	public function data_rejected_or_under_review_menu(): array {
@@ -256,6 +268,79 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 			'rejected account'     => [ true, false ],
 			'under review account' => [ false, true ],
 		];
+	}
+
+	public function test_reports_menu_item_is_hidden_when_feature_flag_is_disabled() {
+		global $submenu;
+
+		$this->mock_current_user_is_admin();
+
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_account->method( 'has_working_jetpack_connection' )->willReturn( true );
+
+		$this->payments_admin->add_payments_menu();
+
+		$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
+
+		$this->assertArrayNotHasKey( 'wc-admin&path=/payments/reports', $item_names_by_urls );
+	}
+
+	public function test_reports_route_redirects_when_feature_flag_is_enabled_but_account_is_invalid() {
+		add_filter(
+			'pre_option_' . WC_Payments_Features::REPORTS_AREA_FLAG_NAME,
+			function () {
+				return '1';
+			}
+		);
+
+		$this->mock_current_user_is_admin();
+
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( false );
+		$this->mock_account->method( 'has_working_jetpack_connection' )->willReturn( true );
+
+		try {
+			$this->payments_admin->add_payments_menu();
+
+			$_GET = [
+				'page' => 'wc-admin',
+				'path' => '/payments/reports',
+			];
+
+			$this->mock_account
+				->expects( $this->once() )
+				->method( 'redirect_to_onboarding_welcome_page' );
+
+			$this->assertTrue( $this->payments_admin->maybe_redirect_from_payments_admin_child_pages() );
+		} finally {
+			$_GET = [];
+			remove_all_filters( 'pre_option_' . WC_Payments_Features::REPORTS_AREA_FLAG_NAME );
+		}
+	}
+
+	public function test_reports_menu_item_is_visible_when_feature_flag_is_enabled() {
+		global $submenu;
+
+		add_filter(
+			'pre_option_' . WC_Payments_Features::REPORTS_AREA_FLAG_NAME,
+			function () {
+				return '1';
+			}
+		);
+
+		$this->mock_current_user_is_admin();
+
+		$this->mock_account->method( 'is_stripe_account_valid' )->willReturn( true );
+		$this->mock_account->method( 'has_working_jetpack_connection' )->willReturn( true );
+
+		try {
+			$this->payments_admin->add_payments_menu();
+
+			$item_names_by_urls = wp_list_pluck( $submenu[ WC_Payments_Admin::PAYMENTS_SUBMENU_SLUG ], 0, 2 );
+
+			$this->assertArrayHasKey( 'wc-admin&path=/payments/reports', $item_names_by_urls );
+		} finally {
+			remove_all_filters( 'pre_option_' . WC_Payments_Features::REPORTS_AREA_FLAG_NAME );
+		}
 	}
 
 	private function mock_current_user_is_admin() {


### PR DESCRIPTION
Closes RSM-2124

#### Changes proposed in this Pull Request

Resubmits #11700 after #11707 reverted it from `develop` for release timing because it should not ship in 10.8.

This PR adds the WooPayments Reports shell behind the default-off `wcpay_reports_area_enabled` feature flag. It includes the `WooPayments → Reports` admin entry, `/payments/reports` route, Balance and Fees tabs, placeholder empty/error/loading/partial states, in-place reload affordance scaffolding, last-full-calendar-month UTC period scaffold, and focused unit coverage.

This is shell only. Data wiring remains out of scope and lands in RSM-2125 / RSM-2126.

#### Testing instructions

* Run `npm run test:js -- --watchAll=false client/reports`.
* Run `npm run test:php -- --filter WC_Payments_Admin_Test`.
* Run `npm run lint:php`.
* Run `composer run phpstan -- --memory-limit=4G`.
* Run `npx eslint client/reports client/index.js client/globals.d.ts --ext=js,jsx,ts,tsx`.
* Note: `npm run lint:js` currently crashes while scanning the unrelated checked-in `tags/10.7.0/dist/index.js` file in the WordPress i18n ESLint rule. TypeScript completes before that crash, and the touched JS/TS paths pass the targeted ESLint command above.
* Enable the `wcpay_reports_area_enabled` feature flag using the existing WooPayments feature-flag option/testing convention.
* Visit `WooPayments → Reports`.
* Confirm the Reports menu entry appears only while the feature flag is enabled.
* Confirm `/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Freports` opens the Balance tab by default.
* Confirm `?tab=fees` opens the Fees tab, and switching between Balance and Fees keeps the active tab indicator.
* Confirm the page renders placeholder shell content only, with no report data fetches.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
