### PR TITLE
chore: Bump WC tested up to version to 10.8.0 and WP tested up to 7.0

### DIFF
--- a/changelog/bump-wp-7-0
+++ b/changelog/bump-wp-7-0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bump the WP and WC tested up to versions.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
 Requires at least: 6.0
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.3
 Stable tag: 10.7.1
 License: GPLv2 or later

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 10.7.0
+ * WC tested up to: 10.8.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Version: 10.7.1


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Bumps the "WC tested up to" header from 10.7.0 to 10.8.0, ahead of the WooCommerce 10.8.0 release, and "Tested up to" header from 6.9 to 7.0 ahead of the WordPress 7.0 release.

#### Testing instructions
- Verify woocommerce-payments.php header shows WC tested up to: 10.8.0
- Verify readme.txt header shows Tested up to: 7.0
- Changelog entry present

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
