### PR TITLE
Fix WOOPMNT-3696: Hide future payments notice when automatic payments are disabled

### DIFF
--- a/changelog/fix-WOOPMNT-3696-hide-future-payments-manual-renewal
+++ b/changelog/fix-WOOPMNT-3696-hide-future-payments-manual-renewal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide future payments terms on checkout when WooCommerce Subscriptions has automatic payments disabled

--- a/client/checkout/blocks/utils.js
+++ b/client/checkout/blocks/utils.js
@@ -64,10 +64,11 @@ export const getStripeElementOptions = (
 		},
 	};
 
+	const hasAutoRenewingSubscription =
+		getUPEConfig( 'cartContainsSubscription' ) &&
+		! getUPEConfig( 'subscriptionRequiresManualRenewal' );
 	const showTerms =
-		shouldSavePayment || getUPEConfig( 'cartContainsSubscription' )
-			? 'always'
-			: 'never';
+		shouldSavePayment || hasAutoRenewingSubscription ? 'always' : 'never';
 
 	options.terms = getTerms( paymentMethodsConfig, showTerms );
 

--- a/client/checkout/classic/upe-utils.js
+++ b/client/checkout/classic/upe-utils.js
@@ -84,7 +84,8 @@ export const getHiddenBillingFields = ( enabledBillingFields ) => {
  */
 function shouldIncludeTerms( paymentMethodType ) {
 	if ( getUPEConfig( 'cartContainsSubscription' ) ) {
-		return true;
+		// Don't show terms when manual renewal is required — the card won't be charged automatically.
+		return ! getUPEConfig( 'subscriptionRequiresManualRenewal' );
 	}
 
 	const paymentsForm = document.querySelector(

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -323,6 +323,7 @@ declare global {
 		isCheckout: boolean;
 		paymentMethodsConfig: typeof wooPaymentsPaymentMethodsConfig;
 		cartContainsSubscription: boolean;
+		subscriptionRequiresManualRenewal: boolean;
 		currency: string;
 		cartTotal: number;
 		enabledBillingFields: Record<

--- a/includes/class-wc-payments-checkout.php
+++ b/includes/class-wc-payments-checkout.php
@@ -221,15 +221,16 @@ class WC_Payments_Checkout {
 
 		$payment_fields = $js_config;
 
-		$payment_fields['gatewayId']                = WC_Payment_Gateway_WCPay::GATEWAY_ID;
-		$payment_fields['isCheckout']               = is_checkout();
-		$payment_fields['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
-		$payment_fields['testMode']                 = WC_Payments::mode()->is_test();
-		$payment_fields['cartContainsSubscription'] = $this->gateway->is_subscription_item_in_cart();
-		$payment_fields['currency']                 = get_woocommerce_currency();
-		$payment_fields['stylesCacheVersion']       = WC_Payments_Styles_Cache::get_styles_cache_version();
-		$cart_total                                 = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
-		$payment_fields['cartTotal']                = WC_Payments_Utils::prepare_amount( $cart_total, get_woocommerce_currency() );
+		$payment_fields['gatewayId']                         = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$payment_fields['isCheckout']                        = is_checkout();
+		$payment_fields['paymentMethodsConfig']              = $this->get_enabled_payment_method_config();
+		$payment_fields['testMode']                          = WC_Payments::mode()->is_test();
+		$payment_fields['cartContainsSubscription']          = $this->gateway->is_subscription_item_in_cart();
+		$payment_fields['subscriptionRequiresManualRenewal'] = function_exists( 'wcs_is_manual_renewal_required' ) && wcs_is_manual_renewal_required();
+		$payment_fields['currency']                          = get_woocommerce_currency();
+		$payment_fields['stylesCacheVersion']                = WC_Payments_Styles_Cache::get_styles_cache_version();
+		$cart_total                  = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
+		$payment_fields['cartTotal'] = WC_Payments_Utils::prepare_amount( $cart_total, get_woocommerce_currency() );
 
 		$enabled_billing_fields = [];
 		foreach ( WC()->checkout()->get_checkout_fields( 'billing' ) as $billing_field => $billing_field_options ) {

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -374,8 +374,10 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		// Subs-specific behavior starts here.
 		$payment_information->set_payment_type( Payment_Type::RECURRING() );
-		// The payment method is always saved for subscriptions.
-		$payment_information->must_save_payment_method_to_store();
+		// Save the payment method for subscriptions, unless manual renewal is required.
+		if ( ! ( function_exists( 'wcs_is_manual_renewal_required' ) && wcs_is_manual_renewal_required() ) ) {
+			$payment_information->must_save_payment_method_to_store();
+		}
 		$payment_information->set_is_changing_payment_method_for_subscription( $this->is_changing_payment_method_for_subscription() );
 
 		return $payment_information;


### PR DESCRIPTION
## Summary

When WooCommerce Subscriptions has "Turn off Automatic Payments" enabled, the Stripe mandate text ("By providing your card information, you allow [Store] to charge your card for future payments...") still showed on checkout. This is misleading because the customer won't actually be auto-charged.

The fix adds a `subscriptionRequiresManualRenewal` flag to the JS config and checks it before showing Stripe terms and before force-saving the payment method. This ports the same approach used in Stripe for WooCommerce ([PR #4340](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4340), fixing [STRIPE-460](https://linear.app/a8c/issue/STRIPE-460)).

## Bug

[WOOPMNT-3696](https://linear.app/a8c/issue/WOOPMNT-3696): Future payments notice visible with subscriptions even if automatic payments are disabled
[GitHub #7987](https://github.com/Automattic/woocommerce-payments/issues/7987)

## Changes

- **PHP**: Pass `subscriptionRequiresManualRenewal` (via `wcs_is_manual_renewal_required()`) to the frontend JS config
- **PHP**: Skip force-saving payment method for subscriptions when manual renewal is required
- **JS (classic checkout)**: Check `subscriptionRequiresManualRenewal` before showing Stripe terms
- **JS (block checkout)**: Same check for block-based checkout
- **TypeScript**: Add type definition for new config field

## Testing

1. Install WooCommerce Subscriptions alongside WooPayments
2. Create a simple subscription product
3. Go to **WooCommerce > Settings > Subscriptions** and check **Turn off Automatic Payments**
4. Add the subscription product to cart and go to checkout
5. Confirm the "By providing your card information..." mandate text is **not** displayed
6. Uncheck "Turn off Automatic Payments", refresh checkout, and confirm the mandate text **is** displayed (regression check)

Tested on shortcode checkout. Block checkout uses the same config flag.

## Notes

This PR was created during the [Woo Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/) via team Ceres' [`/bug-blitz` Claude skill](https://github.com/Automattic/public-resources-squad/blob/trunk/.claude/skills/bug-blitz/skill.md). The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.