### PR TITLE
Add WooPayments CLI browser authorization

### DIFF
--- a/assets/css/wcpay-cli-auth.css
+++ b/assets/css/wcpay-cli-auth.css
@@ -1,0 +1,103 @@
+body.wc-auth {
+	box-sizing: border-box;
+	max-width: 760px;
+	margin-top: 56px;
+	color: #1e1e1e;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	font-size: 14px;
+}
+
+#wc-logo {
+	margin: 0 0 28px;
+	text-align: center;
+}
+
+#wc-logo img {
+	width: 145px;
+	max-width: 145px;
+	min-height: 0;
+}
+
+.wc-auth-content {
+	box-sizing: border-box;
+	max-width: none;
+	margin: 0;
+	padding-top: 28px;
+	border: 0;
+	box-shadow: none;
+}
+
+.wc-auth-content h1 {
+	margin-bottom: 20px;
+	color: #1e1e1e;
+	font-size: 20px;
+	font-weight: 500;
+	line-height: 28px;
+}
+
+.wc-auth-content p,
+.wc-auth-content ul {
+	margin-bottom: 20px;
+	color: #50575e;
+	font-size: 14px;
+	line-height: 20px;
+}
+
+.wc-auth-permissions {
+	list-style-position: outside;
+	padding-left: 20px;
+}
+
+.wc-auth-permissions li {
+	margin-bottom: 8px;
+	font-size: 14px;
+	line-height: 20px;
+}
+
+.wc-auth-content .wcpay-cli-auth__detail {
+	margin: 20px 0;
+	padding: 12px 16px;
+	background: #f6f7f7;
+	border-left: 4px solid #674399;
+}
+
+.wc-auth-content .wcpay-cli-auth__detail p {
+	margin: 0;
+}
+
+.wc-auth-logged-in-as {
+	margin-bottom: 20px;
+}
+
+.wc-auth .wc-auth-actions {
+	display: flex;
+	gap: 12px;
+	padding: 0 0 24px;
+}
+
+.wc-auth-actions form {
+	display: flex;
+	gap: 12px;
+}
+
+.wc-auth .wc-auth-actions .button {
+	float: none;
+	width: auto;
+	min-height: 36px;
+	padding: 8px 16px;
+	font-size: 14px;
+	line-height: 18px;
+}
+
+.wc-auth .wc-auth-actions .wc-auth-approve,
+.wc-auth .wc-auth-actions .wc-auth-deny {
+	float: none;
+	margin: 0;
+}
+
+.wc-auth-actions .wcpay-cli-auth__deny {
+	color: #50575e;
+	background: #f6f7f7;
+	border-color: #8c8f94;
+}

--- a/changelog/dev-wcpay-cli-browser-auth
+++ b/changelog/dev-wcpay-cli-browser-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add WooPayments CLI browser authorization endpoints

--- a/docs/cli-browser-auth.md
+++ b/docs/cli-browser-auth.md
@@ -1,0 +1,14 @@
+# WooPayments CLI browser authorization
+
+WooPayments exposes a local-browser authorization flow for the WooPayments CLI.
+
+## Endpoints
+
+- `POST /wp-json/wc/v3/payments/cli/authorize`
+- `POST /wp-json/wc/v3/payments/cli/token`
+
+The authorize endpoint is intentionally unauthenticated so the CLI can discover support for the browser flow. Callback URLs must be valid HTTPS URLs. HTTP is allowed only for local loopback callbacks (`http://127.0.0.1:<port>/...`, `http://localhost:<port>/...`, or `http://[::1]:<port>/...`).
+
+The browser approval page requires an authenticated WordPress user with `manage_woocommerce`. Approval creates a short-lived one-time code and redirects the browser back to the local CLI callback. The CLI exchanges that code for WooCommerce REST API credentials through the token endpoint. The consumer secret is only returned in the token response and is never included in browser redirect URLs.
+
+Codes expire after five minutes and are single-use.

--- a/docs/cli-browser-auth.md
+++ b/docs/cli-browser-auth.md
@@ -7,7 +7,7 @@ WooPayments exposes a local-browser authorization flow for the WooPayments CLI.
 - `POST /wp-json/wc/v3/payments/cli/authorize`
 - `POST /wp-json/wc/v3/payments/cli/token`
 
-The authorize endpoint is intentionally unauthenticated so the CLI can discover support for the browser flow. Callback URLs must be local loopback callbacks (`http://127.0.0.1:<port>/...`, `http://localhost:<port>/...`, or `http://[::1]:<port>/...`). The WooPayments store can be remote; only the CLI callback listener must be local.
+The authorize endpoint is intentionally unauthenticated so the CLI can discover support for the browser flow. Callback URLs must be local loopback callbacks (`http://127.0.0.1:<port>/...`, `http://localhost:<port>/...`, or `http://[::1]:<port>/...`). The WooPayments store can be remote; only the CLI callback listener must be local. State values must be 32-200 URL-safe characters with enough variation.
 
 The browser approval page requires an authenticated WordPress user with `manage_woocommerce`. Approval creates a short-lived one-time code and redirects the browser back to the local CLI callback. The CLI exchanges that code for WooCommerce REST API credentials through the token endpoint. The consumer secret is only returned in the token response and is never included in browser redirect URLs.
 

--- a/docs/cli-browser-auth.md
+++ b/docs/cli-browser-auth.md
@@ -7,7 +7,7 @@ WooPayments exposes a local-browser authorization flow for the WooPayments CLI.
 - `POST /wp-json/wc/v3/payments/cli/authorize`
 - `POST /wp-json/wc/v3/payments/cli/token`
 
-The authorize endpoint is intentionally unauthenticated so the CLI can discover support for the browser flow. Callback URLs must be valid HTTPS URLs. HTTP is allowed only for local loopback callbacks (`http://127.0.0.1:<port>/...`, `http://localhost:<port>/...`, or `http://[::1]:<port>/...`).
+The authorize endpoint is intentionally unauthenticated so the CLI can discover support for the browser flow. Callback URLs must be local loopback callbacks (`http://127.0.0.1:<port>/...`, `http://localhost:<port>/...`, or `http://[::1]:<port>/...`). The WooPayments store can be remote; only the CLI callback listener must be local.
 
 The browser approval page requires an authenticated WordPress user with `manage_woocommerce`. Approval creates a short-lived one-time code and redirects the browser back to the local CLI callback. The CLI exchanges that code for WooCommerce REST API credentials through the token endpoint. The consumer secret is only returned in the token response and is never included in browser redirect URLs.
 

--- a/includes/admin/class-wc-rest-payments-cli-controller.php
+++ b/includes/admin/class-wc-rest-payments-cli-controller.php
@@ -36,6 +36,31 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 	private const TTL = 5 * MINUTE_IN_SECONDS;
 
 	/**
+	 * Maximum pending authorization records to retain.
+	 */
+	private const MAX_RECORDS = 100;
+
+	/**
+	 * Minimum state length.
+	 */
+	private const MIN_STATE_LENGTH = 32;
+
+	/**
+	 * Maximum state length.
+	 */
+	private const MAX_STATE_LENGTH = 200;
+
+	/**
+	 * Authorization exchange lock option prefix.
+	 */
+	private const LOCK_OPTION_PREFIX = 'wcpay_cli_authorization_lock_';
+
+	/**
+	 * Authorization exchange lock TTL in seconds.
+	 */
+	private const LOCK_TTL = MINUTE_IN_SECONDS;
+
+	/**
 	 * Initialize admin-post hooks for browser approval.
 	 */
 	public static function init_admin_hooks(): void {
@@ -81,6 +106,8 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $validation ) ) {
 			return $validation;
 		}
+
+		self::prune_records_to_limit( self::MAX_RECORDS - 1 );
 
 		$now     = time();
 		$auth_id = self::generate_random_token();
@@ -129,31 +156,47 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 				continue;
 			}
 
-			if ( ! hash_equals( (string) $record['state'], $state ) ) {
-				return self::rest_error( 'state_mismatch', __( 'The authorization state does not match.', 'woocommerce-payments' ) );
-			}
-
-			if ( self::is_expired( $record ) ) {
-				unset( $records[ $auth_id ] );
-				self::save_records( $records );
-				return self::rest_error( 'code_expired', __( 'The authorization code has expired.', 'woocommerce-payments' ) );
-			}
-
-			if ( ! empty( $record['used_at'] ) || 'approved' !== ( $record['status'] ?? '' ) ) {
+			if ( ! self::acquire_record_lock( (string) $auth_id ) ) {
 				return self::rest_error( 'code_used', __( 'The authorization code has already been used.', 'woocommerce-payments' ) );
 			}
 
-			$credentials = self::create_api_key( $record );
-			if ( is_wp_error( $credentials ) ) {
-				return $credentials;
+			try {
+				$records = self::get_records();
+				if ( ! isset( $records[ $auth_id ] ) || ! is_array( $records[ $auth_id ] ) ) {
+					return self::rest_error( 'code_used', __( 'The authorization code has already been used.', 'woocommerce-payments' ) );
+				}
+
+				$record = $records[ $auth_id ];
+				if ( empty( $record['code_hash'] ) || ! wp_check_password( $code, $record['code_hash'] ) ) {
+					return self::rest_error( 'invalid_code', __( 'The authorization code is invalid.', 'woocommerce-payments' ) );
+				}
+
+				if ( ! hash_equals( (string) $record['state'], $state ) ) {
+					return self::rest_error( 'state_mismatch', __( 'The authorization state does not match.', 'woocommerce-payments' ) );
+				}
+
+				if ( self::is_expired( $record ) ) {
+					unset( $records[ $auth_id ] );
+					self::save_records( $records );
+					return self::rest_error( 'code_expired', __( 'The authorization code has expired.', 'woocommerce-payments' ) );
+				}
+
+				if ( ! empty( $record['used_at'] ) || 'approved' !== ( $record['status'] ?? '' ) ) {
+					return self::rest_error( 'code_used', __( 'The authorization code has already been used.', 'woocommerce-payments' ) );
+				}
+
+				$credentials = self::create_api_key( $record );
+				if ( is_wp_error( $credentials ) ) {
+					return $credentials;
+				}
+
+				unset( $records[ $auth_id ] );
+				self::save_records( $records );
+
+				return rest_ensure_response( $credentials );
+			} finally {
+				self::release_record_lock( (string) $auth_id );
 			}
-
-			$record['used_at'] = time();
-			$record['status']  = 'used';
-			unset( $records[ $auth_id ] );
-			self::save_records( $records );
-
-			return rest_ensure_response( $credentials );
 		}
 
 		return self::rest_error( 'invalid_code', __( 'The authorization code is invalid.', 'woocommerce-payments' ) );
@@ -355,8 +398,8 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 			return self::rest_error( 'invalid_scope', __( 'The scope parameter must be read, write, or read_write.', 'woocommerce-payments' ) );
 		}
 
-		if ( strlen( $state ) < 16 ) {
-			return self::rest_error( 'invalid_state', __( 'The state parameter must be at least 16 characters.', 'woocommerce-payments' ) );
+		if ( ! self::is_valid_state( $state ) ) {
+			return self::rest_error( 'invalid_state', __( 'The state parameter must be 32-200 URL-safe characters and include enough variation.', 'woocommerce-payments' ) );
 		}
 
 		if ( ! self::is_localhost_callback_url( $callback_url ) ) {
@@ -364,6 +407,25 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check whether a state value is sufficiently random-looking.
+	 *
+	 * @param string $state State value.
+	 * @return bool
+	 */
+	private static function is_valid_state( string $state ): bool {
+		$state_length = strlen( $state );
+		if ( $state_length < self::MIN_STATE_LENGTH || $state_length > self::MAX_STATE_LENGTH ) {
+			return false;
+		}
+
+		if ( 1 !== preg_match( '/\A[A-Za-z0-9._~-]+\z/', $state ) ) {
+			return false;
+		}
+
+		return strlen( count_chars( $state, 3 ) ) >= 8;
 	}
 
 	/**
@@ -381,6 +443,10 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 		$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
 		$host   = strtolower( trim( (string) ( $parts['host'] ?? '' ), '[]' ) );
 		$port   = $parts['port'] ?? 0;
+
+		if ( isset( $parts['user'] ) || isset( $parts['pass'] ) || isset( $parts['fragment'] ) ) {
+			return false;
+		}
 
 		return 'http' === $scheme
 			&& in_array( $host, [ '127.0.0.1', 'localhost', '::1' ], true )
@@ -499,6 +565,81 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 			}
 		}
 		self::save_records( $records );
+	}
+
+	/**
+	 * Prune oldest authorization records to keep option size bounded.
+	 *
+	 * @param int $max_records Maximum records to keep.
+	 */
+	private static function prune_records_to_limit( int $max_records ): void {
+		$records = self::get_records();
+		if ( count( $records ) <= $max_records ) {
+			return;
+		}
+
+		uasort(
+			$records,
+			function ( array $a, array $b ): int {
+				$created_comparison = (int) ( $a['created_at'] ?? 0 ) <=> (int) ( $b['created_at'] ?? 0 );
+				if ( 0 !== $created_comparison ) {
+					return $created_comparison;
+				}
+
+				return (int) ( $a['expires_at'] ?? 0 ) <=> (int) ( $b['expires_at'] ?? 0 );
+			}
+		);
+
+		$records_count = count( $records );
+		while ( $records_count > $max_records ) {
+			$oldest_auth_id = array_key_first( $records );
+			unset( $records[ $oldest_auth_id ] );
+			--$records_count;
+		}
+
+		self::save_records( $records );
+	}
+
+	/**
+	 * Acquire a short-lived lock for an authorization record.
+	 *
+	 * @param string $auth_id Authorization ID.
+	 * @return bool Whether the lock was acquired.
+	 */
+	private static function acquire_record_lock( string $auth_id ): bool {
+		$lock_option = self::get_lock_option_name( $auth_id );
+		$now         = time();
+
+		if ( add_option( $lock_option, $now, '', false ) ) {
+			return true;
+		}
+
+		$locked_at = (int) get_option( $lock_option, 0 );
+		if ( $locked_at && $locked_at < ( $now - self::LOCK_TTL ) ) {
+			delete_option( $lock_option );
+			return add_option( $lock_option, $now, '', false );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Release an authorization record lock.
+	 *
+	 * @param string $auth_id Authorization ID.
+	 */
+	private static function release_record_lock( string $auth_id ): void {
+		delete_option( self::get_lock_option_name( $auth_id ) );
+	}
+
+	/**
+	 * Get a lock option name for an authorization record.
+	 *
+	 * @param string $auth_id Authorization ID.
+	 * @return string
+	 */
+	private static function get_lock_option_name( string $auth_id ): string {
+		return self::LOCK_OPTION_PREFIX . hash( 'sha256', $auth_id );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-cli-controller.php
+++ b/includes/admin/class-wc-rest-payments-cli-controller.php
@@ -240,26 +240,8 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 				<?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- Match WooCommerce auth template output. ?>
 				<link rel="stylesheet" href="<?php echo esc_url( str_replace( [ 'http:', 'https:' ], '', WC()->plugin_url() ) . '/assets/css/auth.css' ); ?>" type="text/css" />
 			<?php endif; ?>
-			<style>
-				body.wc-auth { box-sizing: border-box; max-width: 760px; margin-top: 56px; color: #1e1e1e; background: #fff; border: 1px solid #c3c4c7; font-size: 14px; }
-				#wc-logo { margin: 0 0 28px; text-align: center; }
-				#wc-logo img { width: 145px; max-width: 145px; min-height: 0; }
-				.wc-auth-content { box-sizing: border-box; max-width: none; margin: 0; padding-top: 28px; border: 0; box-shadow: none; }
-				.wc-auth-content h1 { margin-bottom: 20px; color: #1e1e1e; font-size: 20px; font-weight: 500; line-height: 28px; }
-				.wc-auth-content p,
-				.wc-auth-content ul { margin-bottom: 20px; color: #50575e; font-size: 14px; line-height: 20px; }
-				.wc-auth-permissions { list-style-position: outside; padding-left: 20px; }
-				.wc-auth-permissions li { margin-bottom: 8px; font-size: 14px; line-height: 20px; }
-				.wc-auth-content .wcpay-cli-auth__detail { margin: 20px 0; padding: 12px 16px; background: #f6f7f7; border-left: 4px solid #674399; }
-				.wc-auth-content .wcpay-cli-auth__detail p { margin: 0; }
-				.wc-auth-logged-in-as { margin-bottom: 20px; }
-				.wc-auth .wc-auth-actions { display: flex; gap: 12px; padding: 0 0 24px; }
-				.wc-auth-actions form { display: flex; gap: 12px; }
-				.wc-auth .wc-auth-actions .button { float: none; width: auto; min-height: 36px; padding: 8px 16px; font-size: 14px; line-height: 18px; }
-				.wc-auth .wc-auth-actions .wc-auth-approve,
-				.wc-auth .wc-auth-actions .wc-auth-deny { float: none; margin: 0; }
-				.wc-auth-actions .wcpay-cli-auth__deny { color: #50575e; background: #f6f7f7; border-color: #8c8f94; }
-			</style>
+			<?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- Standalone admin-post auth page. ?>
+			<link rel="stylesheet" href="<?php echo esc_url( plugins_url( 'assets/css/wcpay-cli-auth.css', WCPAY_PLUGIN_FILE ) ); ?>" type="text/css" />
 		</head>
 		<body class="wc-auth wp-core-ui">
 			<div class="wc-auth-content">

--- a/includes/admin/class-wc-rest-payments-cli-controller.php
+++ b/includes/admin/class-wc-rest-payments-cli-controller.php
@@ -206,7 +206,7 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 			$record['expires_at']  = time() + self::TTL;
 			self::save_record( $auth_id, $record );
 
-			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Callback URL is validated before it is stored.
+			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Callback URL is validated to localhost before it is stored.
 			wp_redirect(
 				add_query_arg(
 					[
@@ -359,27 +359,20 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 			return self::rest_error( 'invalid_state', __( 'The state parameter must be at least 16 characters.', 'woocommerce-payments' ) );
 		}
 
-		if ( ! self::is_allowed_callback_url( $callback_url ) ) {
-			return self::rest_error( 'invalid_callback_url', __( 'The callback_url must be a valid HTTPS URL, or an HTTP localhost URL with an explicit port.', 'woocommerce-payments' ) );
+		if ( ! self::is_localhost_callback_url( $callback_url ) ) {
+			return self::rest_error( 'invalid_callback_url', __( 'The callback_url must be an HTTP localhost URL with an explicit port.', 'woocommerce-payments' ) );
 		}
 
 		return true;
 	}
 
 	/**
-	 * Check whether a callback URL is allowed.
-	 *
-	 * External callbacks must use HTTPS. HTTP is only allowed for local CLI loopback
-	 * callbacks with an explicit port.
+	 * Check whether a callback URL is an allowed localhost URL.
 	 *
 	 * @param string $url Callback URL.
 	 * @return bool
 	 */
-	private static function is_allowed_callback_url( string $url ): bool {
-		if ( false === filter_var( $url, FILTER_VALIDATE_URL ) ) {
-			return false;
-		}
-
+	private static function is_localhost_callback_url( string $url ): bool {
 		$parts = wp_parse_url( $url );
 		if ( ! is_array( $parts ) ) {
 			return false;
@@ -388,10 +381,6 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 		$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
 		$host   = strtolower( trim( (string) ( $parts['host'] ?? '' ), '[]' ) );
 		$port   = $parts['port'] ?? 0;
-
-		if ( 'https' === $scheme ) {
-			return '' !== $host;
-		}
 
 		return 'http' === $scheme
 			&& in_array( $host, [ '127.0.0.1', 'localhost', '::1' ], true )
@@ -453,7 +442,7 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 	 * @param string $description Human-readable description.
 	 */
 	private static function redirect_error( array $record, string $code, string $description ): void {
-		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Callback URL is validated before it is stored.
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Callback URL is validated to localhost before it is stored.
 		wp_redirect(
 			add_query_arg(
 				[

--- a/includes/admin/class-wc-rest-payments-cli-controller.php
+++ b/includes/admin/class-wc-rest-payments-cli-controller.php
@@ -1,0 +1,555 @@
+<?php
+/**
+ * Class WC_REST_Payments_CLI_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for WooPayments CLI browser authentication.
+ */
+class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'payments/cli';
+
+	/**
+	 * Pending authorization option name.
+	 */
+	private const OPTION_NAME = 'wcpay_cli_authorizations';
+
+	/**
+	 * Authorization and token TTL in seconds.
+	 */
+	private const TTL = 5 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Initialize admin-post hooks for browser approval.
+	 */
+	public static function init_admin_hooks(): void {
+		add_action( 'admin_post_wcpay_cli_authorize', [ __CLASS__, 'handle_admin_authorize' ] );
+	}
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/authorize',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'authorize' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/token',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'token' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+
+	/**
+	 * Create a pending CLI browser authorization.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function authorize( WP_REST_Request $request ) {
+		self::cleanup_expired_records();
+
+		$validation = self::validate_authorize_request( $request );
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
+
+		$now     = time();
+		$auth_id = self::generate_random_token();
+		$record  = [
+			'id'           => $auth_id,
+			'app_name'     => sanitize_text_field( $request->get_param( 'app_name' ) ),
+			'scope'        => sanitize_key( $request->get_param( 'scope' ) ),
+			'state'        => sanitize_text_field( $request->get_param( 'state' ) ),
+			'callback_url' => esc_url_raw( $request->get_param( 'callback_url' ) ),
+			'profile_name' => sanitize_text_field( (string) $request->get_param( 'profile_name' ) ),
+			'created_at'   => $now,
+			'expires_at'   => $now + self::TTL,
+			'status'       => 'pending',
+			'code_hash'    => null,
+			'approved_by'  => 0,
+			'used_at'      => 0,
+		];
+
+		self::save_record( $auth_id, $record );
+
+		return rest_ensure_response(
+			[
+				'authorize_url' => add_query_arg(
+					[
+						'action'  => 'wcpay_cli_authorize',
+						'auth_id' => rawurlencode( $auth_id ),
+					],
+					admin_url( 'admin-post.php' )
+				),
+				'expires_at'    => gmdate( 'Y-m-d\TH:i:s\Z', $record['expires_at'] ),
+			]
+		);
+	}
+
+	/**
+	 * Exchange an approved one-time code for WooCommerce REST API credentials.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function token( WP_REST_Request $request ) {
+		$code  = (string) $request->get_param( 'code' );
+		$state = (string) $request->get_param( 'state' );
+
+		if ( '' === $code || '' === $state ) {
+			return self::rest_error( 'missing_token_parameter', __( 'The code and state parameters are required.', 'woocommerce-payments' ) );
+		}
+
+		$records = self::get_records();
+		foreach ( $records as $auth_id => $record ) {
+			if ( empty( $record['code_hash'] ) || ! wp_check_password( $code, $record['code_hash'] ) ) {
+				continue;
+			}
+
+			if ( ! hash_equals( (string) $record['state'], $state ) ) {
+				return self::rest_error( 'state_mismatch', __( 'The authorization state does not match.', 'woocommerce-payments' ) );
+			}
+
+			if ( self::is_expired( $record ) ) {
+				unset( $records[ $auth_id ] );
+				self::save_records( $records );
+				return self::rest_error( 'code_expired', __( 'The authorization code has expired.', 'woocommerce-payments' ) );
+			}
+
+			if ( ! empty( $record['used_at'] ) || 'approved' !== ( $record['status'] ?? '' ) ) {
+				return self::rest_error( 'code_used', __( 'The authorization code has already been used.', 'woocommerce-payments' ) );
+			}
+
+			$credentials = self::create_api_key( $record );
+			if ( is_wp_error( $credentials ) ) {
+				return $credentials;
+			}
+
+			$record['used_at'] = time();
+			$record['status']  = 'used';
+			unset( $records[ $auth_id ] );
+			self::save_records( $records );
+
+			return rest_ensure_response( $credentials );
+		}
+
+		return self::rest_error( 'invalid_code', __( 'The authorization code is invalid.', 'woocommerce-payments' ) );
+	}
+
+	/**
+	 * Handle browser approval or denial.
+	 */
+	public static function handle_admin_authorize(): void {
+		self::cleanup_expired_records();
+
+		$auth_id = isset( $_REQUEST['auth_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['auth_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
+		$record  = self::get_record( $auth_id );
+
+		if ( ! $record ) {
+			wp_die( esc_html__( 'The WooPayments CLI authorization request is invalid or has expired.', 'woocommerce-payments' ), esc_html__( 'WooPayments CLI authorization', 'woocommerce-payments' ), [ 'response' => 400 ] );
+		}
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You do not have permission to approve WooPayments CLI access.', 'woocommerce-payments' ), esc_html__( 'WooPayments CLI authorization', 'woocommerce-payments' ), [ 'response' => 403 ] );
+		}
+
+		if ( self::is_expired( $record ) ) {
+			self::delete_record( $auth_id );
+			self::redirect_error( $record, 'expired', __( 'The WooPayments CLI authorization request has expired.', 'woocommerce-payments' ) );
+		}
+
+		if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			check_admin_referer( 'wcpay_cli_authorize_' . $auth_id );
+			$decision = isset( $_POST['wcpay_cli_decision'] ) ? sanitize_key( wp_unslash( $_POST['wcpay_cli_decision'] ) ) : '';
+
+			if ( 'approve' !== $decision ) {
+				self::delete_record( $auth_id );
+				self::redirect_error( $record, 'access_denied', __( 'WooPayments CLI access was denied.', 'woocommerce-payments' ) );
+			}
+
+			$code                  = self::generate_random_token();
+			$record['code_hash']   = wp_hash_password( $code );
+			$record['approved_by'] = get_current_user_id();
+			$record['status']      = 'approved';
+			$record['expires_at']  = time() + self::TTL;
+			self::save_record( $auth_id, $record );
+
+			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Callback URL is validated before it is stored.
+			wp_redirect(
+				add_query_arg(
+					[
+						'success' => 1,
+						'state'   => rawurlencode( (string) $record['state'] ),
+						'code'    => rawurlencode( $code ),
+					],
+					$record['callback_url']
+				)
+			);
+			exit;
+		}
+
+		self::render_approval_screen( $record );
+	}
+
+	/**
+	 * Render the approval form.
+	 *
+	 * @param array $record Authorization record.
+	 */
+	private static function render_approval_screen( array $record ): void {
+		$auth_id       = (string) $record['id'];
+		$callback_host = wp_parse_url( (string) $record['callback_url'], PHP_URL_HOST );
+		?>
+		<!doctype html>
+		<html <?php language_attributes(); ?>>
+		<head>
+			<meta name="viewport" content="width=device-width" />
+			<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+			<meta name="robots" content="noindex, nofollow" />
+			<title><?php esc_html_e( 'WooPayments CLI authorization', 'woocommerce-payments' ); ?></title>
+			<?php wp_admin_css( 'install', true ); ?>
+			<?php if ( function_exists( 'WC' ) && WC() ) : ?>
+				<?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet -- Match WooCommerce auth template output. ?>
+				<link rel="stylesheet" href="<?php echo esc_url( str_replace( [ 'http:', 'https:' ], '', WC()->plugin_url() ) . '/assets/css/auth.css' ); ?>" type="text/css" />
+			<?php endif; ?>
+			<style>
+				body.wc-auth { box-sizing: border-box; max-width: 760px; margin-top: 56px; color: #1e1e1e; background: #fff; border: 1px solid #c3c4c7; font-size: 14px; }
+				#wc-logo { margin: 0 0 28px; text-align: center; }
+				#wc-logo img { width: 145px; max-width: 145px; min-height: 0; }
+				.wc-auth-content { box-sizing: border-box; max-width: none; margin: 0; padding-top: 28px; border: 0; box-shadow: none; }
+				.wc-auth-content h1 { margin-bottom: 20px; color: #1e1e1e; font-size: 20px; font-weight: 500; line-height: 28px; }
+				.wc-auth-content p,
+				.wc-auth-content ul { margin-bottom: 20px; color: #50575e; font-size: 14px; line-height: 20px; }
+				.wc-auth-permissions { list-style-position: outside; padding-left: 20px; }
+				.wc-auth-permissions li { margin-bottom: 8px; font-size: 14px; line-height: 20px; }
+				.wc-auth-content .wcpay-cli-auth__detail { margin: 20px 0; padding: 12px 16px; background: #f6f7f7; border-left: 4px solid #674399; }
+				.wc-auth-content .wcpay-cli-auth__detail p { margin: 0; }
+				.wc-auth-logged-in-as { margin-bottom: 20px; }
+				.wc-auth .wc-auth-actions { display: flex; gap: 12px; padding: 0 0 24px; }
+				.wc-auth-actions form { display: flex; gap: 12px; }
+				.wc-auth .wc-auth-actions .button { float: none; width: auto; min-height: 36px; padding: 8px 16px; font-size: 14px; line-height: 18px; }
+				.wc-auth .wc-auth-actions .wc-auth-approve,
+				.wc-auth .wc-auth-actions .wc-auth-deny { float: none; margin: 0; }
+				.wc-auth-actions .wcpay-cli-auth__deny { color: #50575e; background: #f6f7f7; border-color: #8c8f94; }
+			</style>
+		</head>
+		<body class="wc-auth wp-core-ui">
+			<div class="wc-auth-content">
+				<div id="wc-logo">
+					<img src="<?php echo esc_url( plugins_url( 'assets/images/woopayments.svg', WCPAY_PLUGIN_FILE ) ); ?>" alt="<?php esc_attr_e( 'WooPayments', 'woocommerce-payments' ); ?>" />
+				</div>
+				<h1>
+					<?php
+					echo esc_html(
+						sprintf(
+							/* translators: %s: application name. */
+							__( '%s would like to connect to your store', 'woocommerce-payments' ),
+							$record['app_name']
+						)
+					);
+					?>
+				</h1>
+				<p>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+							/* translators: 1: application name, 2: scope. */
+							__( 'This will create WooCommerce REST API keys for <strong>%1$s</strong> with <strong>%2$s</strong> access.', 'woocommerce-payments' ),
+							esc_html( $record['app_name'] ),
+							esc_html( $record['scope'] )
+						)
+					);
+					?>
+				</p>
+				<ul class="wc-auth-permissions">
+					<li><?php esc_html_e( 'View and manage WooCommerce data through the WooPayments CLI.', 'woocommerce-payments' ); ?></li>
+					<li><?php esc_html_e( 'Create the API keys for your administrator account.', 'woocommerce-payments' ); ?></li>
+				</ul>
+				<p>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: callback URL host. */
+							__( 'Approving will share a one-time authorization code with <strong>%s</strong>. Do not proceed if this looks suspicious.', 'woocommerce-payments' ),
+							esc_html( $callback_host ? $callback_host : $record['callback_url'] )
+						)
+					);
+					?>
+				</p>
+				<div class="wcpay-cli-auth__detail">
+					<p><?php esc_html_e( 'The consumer secret will only be returned to the CLI token exchange and will not appear in the browser URL.', 'woocommerce-payments' ); ?></p>
+				</div>
+				<div class="wc-auth-actions">
+					<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+						<input type="hidden" name="action" value="wcpay_cli_authorize" />
+						<input type="hidden" name="auth_id" value="<?php echo esc_attr( $auth_id ); ?>" />
+						<?php wp_nonce_field( 'wcpay_cli_authorize_' . $auth_id ); ?>
+						<button type="submit" class="button button-primary wc-auth-approve" name="wcpay_cli_decision" value="approve"><?php esc_html_e( 'Approve', 'woocommerce-payments' ); ?></button>
+						<button type="submit" class="button wc-auth-deny wcpay-cli-auth__deny" name="wcpay_cli_decision" value="deny"><?php esc_html_e( 'Deny', 'woocommerce-payments' ); ?></button>
+					</form>
+				</div>
+			</div>
+		</body>
+		</html>
+		<?php
+		exit;
+	}
+
+	/**
+	 * Validate authorize request.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return true|WP_Error
+	 */
+	private static function validate_authorize_request( WP_REST_Request $request ) {
+		$app_name     = (string) $request->get_param( 'app_name' );
+		$scope        = (string) $request->get_param( 'scope' );
+		$state        = (string) $request->get_param( 'state' );
+		$callback_url = (string) $request->get_param( 'callback_url' );
+
+		if ( '' === trim( $app_name ) ) {
+			return self::rest_error( 'missing_app_name', __( 'The app_name parameter is required.', 'woocommerce-payments' ) );
+		}
+
+		if ( ! in_array( $scope, [ 'read', 'write', 'read_write' ], true ) ) {
+			return self::rest_error( 'invalid_scope', __( 'The scope parameter must be read, write, or read_write.', 'woocommerce-payments' ) );
+		}
+
+		if ( strlen( $state ) < 16 ) {
+			return self::rest_error( 'invalid_state', __( 'The state parameter must be at least 16 characters.', 'woocommerce-payments' ) );
+		}
+
+		if ( ! self::is_allowed_callback_url( $callback_url ) ) {
+			return self::rest_error( 'invalid_callback_url', __( 'The callback_url must be a valid HTTPS URL, or an HTTP localhost URL with an explicit port.', 'woocommerce-payments' ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a callback URL is allowed.
+	 *
+	 * External callbacks must use HTTPS. HTTP is only allowed for local CLI loopback
+	 * callbacks with an explicit port.
+	 *
+	 * @param string $url Callback URL.
+	 * @return bool
+	 */
+	private static function is_allowed_callback_url( string $url ): bool {
+		if ( false === filter_var( $url, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
+
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) ) {
+			return false;
+		}
+
+		$scheme = strtolower( (string) ( $parts['scheme'] ?? '' ) );
+		$host   = strtolower( trim( (string) ( $parts['host'] ?? '' ), '[]' ) );
+		$port   = $parts['port'] ?? 0;
+
+		if ( 'https' === $scheme ) {
+			return '' !== $host;
+		}
+
+		return 'http' === $scheme
+			&& in_array( $host, [ '127.0.0.1', 'localhost', '::1' ], true )
+			&& is_int( $port )
+			&& $port > 0
+			&& $port <= 65535;
+	}
+
+	/**
+	 * Create a WooCommerce REST API key for the approving user.
+	 *
+	 * @param array $record Authorization record.
+	 * @return array|WP_Error
+	 */
+	private static function create_api_key( array $record ) {
+		global $wpdb;
+
+		$user_id = absint( $record['approved_by'] ?? 0 );
+		if ( ! $user_id ) {
+			return self::rest_error( 'missing_approver', __( 'The authorization has no approving user.', 'woocommerce-payments' ) );
+		}
+
+		$consumer_key    = 'ck_' . wc_rand_hash();
+		$consumer_secret = 'cs_' . wc_rand_hash();
+		$description     = sprintf(
+			'WooPayments CLI - API (%s)',
+			gmdate( 'Y-m-d H:i:s' )
+		);
+
+		$inserted = $wpdb->insert(
+			$wpdb->prefix . 'woocommerce_api_keys',
+			[
+				'user_id'         => $user_id,
+				'description'     => $description,
+				'permissions'     => sanitize_key( $record['scope'] ),
+				'consumer_key'    => wc_api_hash( $consumer_key ),
+				'consumer_secret' => $consumer_secret,
+				'truncated_key'   => substr( $consumer_key, -7 ),
+			],
+			[ '%d', '%s', '%s', '%s', '%s', '%s' ]
+		);
+
+		if ( ! $inserted ) {
+			return self::rest_error( 'key_creation_failed', __( 'Unable to create WooCommerce REST API credentials.', 'woocommerce-payments' ), 500 );
+		}
+
+		return [
+			'consumer_key'    => $consumer_key,
+			'consumer_secret' => $consumer_secret,
+			'key_id'          => (string) $wpdb->insert_id,
+		];
+	}
+
+	/**
+	 * Redirect an error to the local CLI callback.
+	 *
+	 * @param array  $record Authorization record.
+	 * @param string $code Error code.
+	 * @param string $description Human-readable description.
+	 */
+	private static function redirect_error( array $record, string $code, string $description ): void {
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Callback URL is validated before it is stored.
+		wp_redirect(
+			add_query_arg(
+				[
+					'success'           => 0,
+					'state'             => rawurlencode( (string) $record['state'] ),
+					'error'             => rawurlencode( $code ),
+					'error_description' => rawurlencode( $description ),
+				],
+				$record['callback_url']
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Return a REST error.
+	 *
+	 * @param string $code Error code.
+	 * @param string $message Error message.
+	 * @param int    $status HTTP status.
+	 * @return WP_Error
+	 */
+	private static function rest_error( string $code, string $message, int $status = 400 ): WP_Error {
+		return new WP_Error( 'wcpay_cli_' . $code, $message, [ 'status' => $status ] );
+	}
+
+	/**
+	 * Generate a high-entropy URL-safe token.
+	 *
+	 * @return string
+	 */
+	private static function generate_random_token(): string {
+		return bin2hex( random_bytes( 32 ) );
+	}
+
+	/**
+	 * Check whether a record has expired.
+	 *
+	 * @param array $record Authorization record.
+	 * @return bool
+	 */
+	private static function is_expired( array $record ): bool {
+		return empty( $record['expires_at'] ) || time() > (int) $record['expires_at'];
+	}
+
+	/**
+	 * Delete expired records.
+	 */
+	private static function cleanup_expired_records(): void {
+		$records = self::get_records();
+		foreach ( $records as $auth_id => $record ) {
+			if ( self::is_expired( $record ) ) {
+				unset( $records[ $auth_id ] );
+			}
+		}
+		self::save_records( $records );
+	}
+
+	/**
+	 * Get all records.
+	 *
+	 * @return array
+	 */
+	private static function get_records(): array {
+		$records = get_option( self::OPTION_NAME, [] );
+		return is_array( $records ) ? $records : [];
+	}
+
+	/**
+	 * Save all records.
+	 *
+	 * @param array $records Records.
+	 */
+	private static function save_records( array $records ): void {
+		update_option( self::OPTION_NAME, $records, false );
+	}
+
+	/**
+	 * Get a single record.
+	 *
+	 * @param string $auth_id Authorization ID.
+	 * @return array|null
+	 */
+	private static function get_record( string $auth_id ): ?array {
+		$records = self::get_records();
+		return isset( $records[ $auth_id ] ) && is_array( $records[ $auth_id ] ) ? $records[ $auth_id ] : null;
+	}
+
+	/**
+	 * Save a single record.
+	 *
+	 * @param string $auth_id Authorization ID.
+	 * @param array  $record Record.
+	 */
+	private static function save_record( string $auth_id, array $record ): void {
+		$records             = self::get_records();
+		$records[ $auth_id ] = $record;
+		self::save_records( $records );
+	}
+
+	/**
+	 * Delete a single record.
+	 *
+	 * @param string $auth_id Authorization ID.
+	 */
+	private static function delete_record( string $auth_id ): void {
+		$records = self::get_records();
+		unset( $records[ $auth_id ] );
+		self::save_records( $records );
+	}
+}

--- a/includes/admin/class-wc-rest-payments-cli-controller.php
+++ b/includes/admin/class-wc-rest-payments-cli-controller.php
@@ -40,6 +40,7 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 	 */
 	public static function init_admin_hooks(): void {
 		add_action( 'admin_post_wcpay_cli_authorize', [ __CLASS__, 'handle_admin_authorize' ] );
+		add_action( 'admin_post_nopriv_wcpay_cli_authorize', [ __CLASS__, 'redirect_admin_authorize_to_login' ] );
 	}
 
 	/**
@@ -102,13 +103,7 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 
 		return rest_ensure_response(
 			[
-				'authorize_url' => add_query_arg(
-					[
-						'action'  => 'wcpay_cli_authorize',
-						'auth_id' => rawurlencode( $auth_id ),
-					],
-					admin_url( 'admin-post.php' )
-				),
+				'authorize_url' => self::get_authorize_login_url( $auth_id ),
 				'expires_at'    => gmdate( 'Y-m-d\TH:i:s\Z', $record['expires_at'] ),
 			]
 		);
@@ -165,6 +160,15 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Redirect unauthenticated browser approval attempts through WordPress login.
+	 */
+	public static function redirect_admin_authorize_to_login(): void {
+		$auth_id = isset( $_REQUEST['auth_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['auth_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
+		wp_safe_redirect( self::get_authorize_login_url( $auth_id ) );
+		exit;
+	}
+
+	/**
 	 * Handle browser approval or denial.
 	 */
 	public static function handle_admin_authorize(): void {
@@ -217,6 +221,32 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 		}
 
 		self::render_approval_screen( $record );
+	}
+
+	/**
+	 * Get the admin approval URL.
+	 *
+	 * @param string $auth_id Authorization ID.
+	 * @return string
+	 */
+	private static function get_authorize_url( string $auth_id ): string {
+		return add_query_arg(
+			[
+				'action'  => 'wcpay_cli_authorize',
+				'auth_id' => rawurlencode( $auth_id ),
+			],
+			admin_url( 'admin-post.php' )
+		);
+	}
+
+	/**
+	 * Get the admin approval URL wrapped in the WordPress login flow.
+	 *
+	 * @param string $auth_id Authorization ID.
+	 * @return string
+	 */
+	private static function get_authorize_login_url( string $auth_id ): string {
+		return wp_login_url( self::get_authorize_url( $auth_id ) );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-payments-cli-controller.php
+++ b/includes/admin/class-wc-rest-payments-cli-controller.php
@@ -91,6 +91,16 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 				'permission_callback' => '__return_true',
 			]
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/revoke',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'revoke' ],
+				'permission_callback' => '__return_true',
+			]
+		);
 	}
 
 	/**
@@ -200,6 +210,43 @@ class WC_REST_Payments_CLI_Controller extends WP_REST_Controller {
 		}
 
 		return self::rest_error( 'invalid_code', __( 'The authorization code is invalid.', 'woocommerce-payments' ) );
+	}
+
+	/**
+	 * Revoke a WooCommerce REST API key using exact credential proof.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function revoke( WP_REST_Request $request ) {
+		global $wpdb;
+
+		$key_id          = absint( $request->get_param( 'key_id' ) );
+		$consumer_key    = (string) $request->get_param( 'consumer_key' );
+		$consumer_secret = (string) $request->get_param( 'consumer_secret' );
+
+		if ( ! $key_id || '' === $consumer_key || '' === $consumer_secret ) {
+			return self::rest_error( 'missing_revoke_parameter', __( 'The key_id, consumer_key, and consumer_secret parameters are required.', 'woocommerce-payments' ) );
+		}
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT key_id, consumer_key, consumer_secret FROM {$wpdb->prefix}woocommerce_api_keys WHERE key_id = %d",
+				$key_id
+			),
+			ARRAY_A
+		);
+
+		if ( ! $row || ! hash_equals( (string) $row['consumer_key'], wc_api_hash( $consumer_key ) ) || ! hash_equals( (string) $row['consumer_secret'], $consumer_secret ) ) {
+			return self::rest_error( 'invalid_revoke_credentials', __( 'The WooCommerce REST API key could not be verified for revocation.', 'woocommerce-payments' ), 403 );
+		}
+
+		$deleted = $wpdb->delete( $wpdb->prefix . 'woocommerce_api_keys', [ 'key_id' => $key_id ], [ '%d' ] );
+		if ( false === $deleted ) {
+			return self::rest_error( 'revoke_failed', __( 'Unable to revoke WooCommerce REST API credentials.', 'woocommerce-payments' ), 500 );
+		}
+
+		return rest_ensure_response( [ 'revoked' => true ] );
 	}
 
 	/**

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -821,6 +821,9 @@ class WC_Payments {
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'maybe_disable_wcpay_subscriptions_on_update' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'maybe_update_stripe_billing_deprecation_note' ] );
 
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-cli-controller.php';
+		WC_REST_Payments_CLI_Controller::init_admin_hooks();
+
 		add_action( 'rest_api_init', [ __CLASS__, 'init_rest_api' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ __CLASS__, 'set_plugin_activation_timestamp' ] );
 
@@ -1162,6 +1165,10 @@ class WC_Payments {
 
 		include_once WCPAY_ABSPATH . 'includes/exceptions/class-rest-request-exception.php';
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-payments-rest-controller.php';
+
+		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-cli-controller.php';
+		$cli_controller = new WC_REST_Payments_CLI_Controller();
+		$cli_controller->register_routes();
 
 		include_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-accounts-controller.php';
 		$accounts_controller = new WC_REST_Payments_Accounts_Controller( self::$api_client );

--- a/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
@@ -67,7 +67,7 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'wcpay_cli_invalid_callback_url', $response->get_error_code() );
 	}
 
-	public function test_authorize_allows_https_callback_url(): void {
+	public function test_authorize_rejects_https_callback_url(): void {
 		$response = $this->controller->authorize(
 			$this->create_authorize_request(
 				[
@@ -76,8 +76,8 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 			)
 		);
 
-		$this->assertNotInstanceOf( WP_Error::class, $response );
-		$this->assertArrayHasKey( 'authorize_url', $response->get_data() );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_callback_url', $response->get_error_code() );
 	}
 
 	public function test_authorize_rejects_invalid_scope(): void {

--- a/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
@@ -106,14 +106,22 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'wcpay_cli_invalid_state', $response->get_error_code() );
 	}
 
-	public function test_authorize_returns_authorize_url_for_valid_input(): void {
+	public function test_authorize_returns_login_wrapped_authorize_url_for_valid_input(): void {
 		$response = $this->controller->authorize( $this->create_authorize_request() );
 		$data     = $response->get_data();
 
-		$this->assertStringContainsString( admin_url( 'admin-post.php' ), $data['authorize_url'] );
-		$this->assertStringContainsString( 'action=wcpay_cli_authorize', $data['authorize_url'] );
+		$this->assertStringStartsWith( wp_login_url(), $data['authorize_url'] );
+		$this->assertStringContainsString( rawurlencode( admin_url( 'admin-post.php' ) ), $data['authorize_url'] );
+		$this->assertStringContainsString( rawurlencode( 'action=wcpay_cli_authorize' ), $data['authorize_url'] );
 		$this->assertNotEmpty( $data['expires_at'] );
 		$this->assertCount( 1, get_option( 'wcpay_cli_authorizations', [] ) );
+	}
+
+	public function test_init_admin_hooks_registers_authenticated_and_unauthenticated_authorize_handlers(): void {
+		WC_REST_Payments_CLI_Controller::init_admin_hooks();
+
+		$this->assertNotFalse( has_action( 'admin_post_wcpay_cli_authorize', [ WC_REST_Payments_CLI_Controller::class, 'handle_admin_authorize' ] ) );
+		$this->assertNotFalse( has_action( 'admin_post_nopriv_wcpay_cli_authorize', [ WC_REST_Payments_CLI_Controller::class, 'redirect_admin_authorize_to_login' ] ) );
 	}
 
 	public function test_admin_approval_requires_manage_woocommerce(): void {

--- a/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * WC_REST_Payments_CLI_Controller tests.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+/**
+ * Class WC_REST_Payments_CLI_Controller_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+require_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-cli-controller.php';
+
+/**
+ * WC_REST_Payments_CLI_Controller unit tests.
+ */
+class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
+	/**
+	 * Controller under test.
+	 *
+	 * @var WC_REST_Payments_CLI_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Previous user ID.
+	 *
+	 * @var int
+	 */
+	private $previous_user_id;
+
+	public function set_up() {
+		parent::set_up();
+		$this->controller       = new WC_REST_Payments_CLI_Controller();
+		$this->previous_user_id = get_current_user_id();
+		delete_option( 'wcpay_cli_authorizations' );
+	}
+
+	public function tear_down() {
+		delete_option( 'wcpay_cli_authorizations' );
+		wp_set_current_user( $this->previous_user_id );
+		parent::tear_down();
+	}
+
+	public function test_register_routes_registers_cli_endpoints(): void {
+		$this->setExpectedIncorrectUsage( 'register_rest_route' );
+		$this->controller->register_routes();
+
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/wc/v3/payments/cli/authorize', $routes );
+		$this->assertArrayHasKey( '/wc/v3/payments/cli/token', $routes );
+	}
+
+	public function test_authorize_rejects_insecure_non_local_callback_url(): void {
+		$response = $this->controller->authorize(
+			$this->create_authorize_request(
+				[
+					'callback_url' => 'http://example.com/callback',
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_callback_url', $response->get_error_code() );
+	}
+
+	public function test_authorize_allows_https_callback_url(): void {
+		$response = $this->controller->authorize(
+			$this->create_authorize_request(
+				[
+					'callback_url' => 'https://example.com/callback',
+				]
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertArrayHasKey( 'authorize_url', $response->get_data() );
+	}
+
+	public function test_authorize_rejects_invalid_scope(): void {
+		$response = $this->controller->authorize(
+			$this->create_authorize_request(
+				[
+					'scope' => 'admin',
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_scope', $response->get_error_code() );
+	}
+
+	public function test_authorize_rejects_short_state(): void {
+		$response = $this->controller->authorize(
+			$this->create_authorize_request(
+				[
+					'state' => 'short',
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_state', $response->get_error_code() );
+	}
+
+	public function test_authorize_returns_authorize_url_for_valid_input(): void {
+		$response = $this->controller->authorize( $this->create_authorize_request() );
+		$data     = $response->get_data();
+
+		$this->assertStringContainsString( admin_url( 'admin-post.php' ), $data['authorize_url'] );
+		$this->assertStringContainsString( 'action=wcpay_cli_authorize', $data['authorize_url'] );
+		$this->assertNotEmpty( $data['expires_at'] );
+		$this->assertCount( 1, get_option( 'wcpay_cli_authorizations', [] ) );
+	}
+
+	public function test_admin_approval_requires_manage_woocommerce(): void {
+		$subscriber = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber );
+
+		$this->assertFalse( current_user_can( 'manage_woocommerce' ) );
+	}
+
+	public function test_token_rejects_invalid_code(): void {
+		$response = $this->controller->token( $this->create_token_request( 'invalid-code', 'valid-random-state' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_code', $response->get_error_code() );
+	}
+
+	public function test_token_rejects_expired_code(): void {
+		$this->store_authorized_record(
+			'auth-id',
+			'valid-code',
+			[
+				'expires_at' => time() - 1,
+			]
+		);
+
+		$response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_code_expired', $response->get_error_code() );
+	}
+
+	public function test_token_rejects_used_code(): void {
+		$this->store_authorized_record(
+			'auth-id',
+			'valid-code',
+			[
+				'used_at' => time(),
+				'status'  => 'used',
+			]
+		);
+
+		$response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_code_used', $response->get_error_code() );
+	}
+
+	public function test_token_rejects_mismatched_state(): void {
+		$this->store_authorized_record( 'auth-id', 'valid-code' );
+
+		$response = $this->controller->token( $this->create_token_request( 'valid-code', 'different-valid-state' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_state_mismatch', $response->get_error_code() );
+	}
+
+	public function test_token_creates_credentials_and_returns_consumer_key_and_secret(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->store_authorized_record(
+			'auth-id',
+			'valid-code',
+			[
+				'approved_by' => $admin_id,
+			]
+		);
+
+		$response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+		$data     = $response->get_data();
+
+		$this->assertStringStartsWith( 'ck_', $data['consumer_key'] );
+		$this->assertStringStartsWith( 'cs_', $data['consumer_secret'] );
+		$this->assertNotEmpty( $data['key_id'] );
+
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT user_id, permissions, consumer_key, consumer_secret FROM {$wpdb->prefix}woocommerce_api_keys WHERE key_id = %d",
+				$data['key_id']
+			),
+			ARRAY_A
+		);
+
+		$this->assertSame( $admin_id, (int) $row['user_id'] );
+		$this->assertSame( 'read_write', $row['permissions'] );
+		$this->assertSame( wc_api_hash( $data['consumer_key'] ), $row['consumer_key'] );
+		$this->assertSame( $data['consumer_secret'], $row['consumer_secret'] );
+	}
+
+	public function test_token_cannot_be_reused(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->store_authorized_record(
+			'auth-id',
+			'valid-code',
+			[
+				'approved_by' => $admin_id,
+			]
+		);
+
+		$first_response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+		$this->assertNotInstanceOf( WP_Error::class, $first_response );
+
+		$second_response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+		$this->assertInstanceOf( WP_Error::class, $second_response );
+		$this->assertSame( 'wcpay_cli_invalid_code', $second_response->get_error_code() );
+	}
+
+	private function create_authorize_request( array $overrides = [] ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/wc/v3/payments/cli/authorize' );
+		$request->set_body_params(
+			array_merge(
+				[
+					'app_name'     => 'WooPayments CLI',
+					'scope'        => 'read_write',
+					'state'        => 'valid-random-state',
+					'callback_url' => 'http://127.0.0.1:3456/callback',
+				],
+				$overrides
+			)
+		);
+
+		return $request;
+	}
+
+	private function create_token_request( string $code, string $state ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/wc/v3/payments/cli/token' );
+		$request->set_body_params(
+			[
+				'code'  => $code,
+				'state' => $state,
+			]
+		);
+
+		return $request;
+	}
+
+	private function store_authorized_record( string $auth_id, string $code, array $overrides = [] ): void {
+		update_option(
+			'wcpay_cli_authorizations',
+			[
+				$auth_id => array_merge(
+					[
+						'id'           => $auth_id,
+						'app_name'     => 'WooPayments CLI',
+						'scope'        => 'read_write',
+						'state'        => 'valid-random-state',
+						'callback_url' => 'http://127.0.0.1:3456/callback',
+						'created_at'   => time(),
+						'expires_at'   => time() + 300,
+						'status'       => 'approved',
+						'code_hash'    => wp_hash_password( $code ),
+						'approved_by'  => self::factory()->user->create( [ 'role' => 'administrator' ] ),
+						'used_at'      => 0,
+					],
+					$overrides
+				),
+			]
+		);
+	}
+}

--- a/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
@@ -55,6 +55,7 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 
 		$this->assertArrayHasKey( '/wc/v3/payments/cli/authorize', $routes );
 		$this->assertArrayHasKey( '/wc/v3/payments/cli/token', $routes );
+		$this->assertArrayHasKey( '/wc/v3/payments/cli/revoke', $routes );
 	}
 
 	public function test_authorize_rejects_insecure_non_local_callback_url(): void {
@@ -284,6 +285,35 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $data['consumer_secret'], $row['consumer_secret'] );
 	}
 
+	public function test_revoke_deletes_matching_key(): void {
+		$key = $this->create_api_key_record();
+
+		$response = $this->controller->revoke( $this->create_revoke_request( $key ) );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['revoked'] );
+
+		global $wpdb;
+		$this->assertSame(
+			'0',
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_api_keys WHERE key_id = %d",
+					$key['key_id']
+				)
+			)
+		);
+	}
+
+	public function test_revoke_rejects_mismatched_secret(): void {
+		$key                    = $this->create_api_key_record();
+		$key['consumer_secret'] = 'cs_wrong';
+		$response               = $this->controller->revoke( $this->create_revoke_request( $key ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_revoke_credentials', $response->get_error_code() );
+	}
+
 	public function test_token_cannot_be_reused(): void {
 		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		$this->store_authorized_record(
@@ -329,6 +359,44 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 		);
 
 		return $request;
+	}
+
+	private function create_revoke_request( array $key ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/wc/v3/payments/cli/revoke' );
+		$request->set_body_params(
+			[
+				'key_id'          => $key['key_id'],
+				'consumer_key'    => $key['consumer_key'],
+				'consumer_secret' => $key['consumer_secret'],
+			]
+		);
+
+		return $request;
+	}
+
+	private function create_api_key_record(): array {
+		global $wpdb;
+
+		$consumer_key    = 'ck_' . wc_rand_hash();
+		$consumer_secret = 'cs_' . wc_rand_hash();
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_api_keys',
+			[
+				'user_id'         => self::factory()->user->create( [ 'role' => 'administrator' ] ),
+				'description'     => 'WooPayments CLI revoke test',
+				'permissions'     => 'read',
+				'consumer_key'    => wc_api_hash( $consumer_key ),
+				'consumer_secret' => $consumer_secret,
+				'truncated_key'   => substr( $consumer_key, -7 ),
+			],
+			[ '%d', '%s', '%s', '%s', '%s', '%s' ]
+		);
+
+		return [
+			'key_id'          => (string) $wpdb->insert_id,
+			'consumer_key'    => $consumer_key,
+			'consumer_secret' => $consumer_secret,
+		];
 	}
 
 	private function store_authorized_record( string $auth_id, string $code, array $overrides = [] ): void {

--- a/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-cli-controller.php
@@ -17,6 +17,8 @@ require_once WCPAY_ABSPATH . 'includes/admin/class-wc-rest-payments-cli-controll
  * WC_REST_Payments_CLI_Controller unit tests.
  */
 class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
+	private const VALID_STATE = 'valid-random-state-1234567890abcdef';
+
 	/**
 	 * Controller under test.
 	 *
@@ -40,6 +42,7 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 
 	public function tear_down() {
 		delete_option( 'wcpay_cli_authorizations' );
+		delete_option( 'wcpay_cli_authorization_lock_' . hash( 'sha256', 'auth-id' ) );
 		wp_set_current_user( $this->previous_user_id );
 		parent::tear_down();
 	}
@@ -106,6 +109,67 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'wcpay_cli_invalid_state', $response->get_error_code() );
 	}
 
+	public function test_authorize_rejects_low_variation_state(): void {
+		$response = $this->controller->authorize(
+			$this->create_authorize_request(
+				[
+					'state' => str_repeat( 'a', 32 ),
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_state', $response->get_error_code() );
+	}
+
+	public function test_authorize_rejects_callback_url_with_credentials(): void {
+		$response = $this->controller->authorize(
+			$this->create_authorize_request(
+				[
+					'callback_url' => 'http://user:pass@127.0.0.1:3456/callback',
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_callback_url', $response->get_error_code() );
+	}
+
+	public function test_authorize_rejects_callback_url_with_fragment(): void {
+		$response = $this->controller->authorize(
+			$this->create_authorize_request(
+				[
+					'callback_url' => 'http://127.0.0.1:3456/callback#fragment',
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_invalid_callback_url', $response->get_error_code() );
+	}
+
+	public function test_authorize_prunes_oldest_records_to_keep_option_bounded(): void {
+		$records = [];
+		for ( $i = 0; $i < 100; $i++ ) {
+			$records[ 'auth-' . $i ] = [
+				'id'         => 'auth-' . $i,
+				'created_at' => time() - 200 + $i,
+				'expires_at' => time() + 300,
+			];
+		}
+		update_option( 'wcpay_cli_authorizations', $records );
+
+		$response = $this->controller->authorize( $this->create_authorize_request() );
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+
+		$records = get_option( 'wcpay_cli_authorizations', [] );
+		$this->assertCount( 100, $records );
+		$this->assertArrayNotHasKey( 'auth-0', $records );
+		$this->assertNotFalse(
+			array_search( self::VALID_STATE, array_column( $records, 'state' ), true )
+		);
+	}
+
 	public function test_authorize_returns_login_wrapped_authorize_url_for_valid_input(): void {
 		$response = $this->controller->authorize( $this->create_authorize_request() );
 		$data     = $response->get_data();
@@ -132,7 +196,7 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_token_rejects_invalid_code(): void {
-		$response = $this->controller->token( $this->create_token_request( 'invalid-code', 'valid-random-state' ) );
+		$response = $this->controller->token( $this->create_token_request( 'invalid-code', self::VALID_STATE ) );
 
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'wcpay_cli_invalid_code', $response->get_error_code() );
@@ -147,7 +211,7 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+		$response = $this->controller->token( $this->create_token_request( 'valid-code', self::VALID_STATE ) );
 
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'wcpay_cli_code_expired', $response->get_error_code() );
@@ -163,7 +227,17 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+		$response = $this->controller->token( $this->create_token_request( 'valid-code', self::VALID_STATE ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wcpay_cli_code_used', $response->get_error_code() );
+	}
+
+	public function test_token_rejects_locked_code(): void {
+		$this->store_authorized_record( 'auth-id', 'valid-code' );
+		add_option( 'wcpay_cli_authorization_lock_' . hash( 'sha256', 'auth-id' ), time(), '', false );
+
+		$response = $this->controller->token( $this->create_token_request( 'valid-code', self::VALID_STATE ) );
 
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'wcpay_cli_code_used', $response->get_error_code() );
@@ -188,7 +262,7 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+		$response = $this->controller->token( $this->create_token_request( 'valid-code', self::VALID_STATE ) );
 		$data     = $response->get_data();
 
 		$this->assertStringStartsWith( 'ck_', $data['consumer_key'] );
@@ -220,10 +294,10 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 			]
 		);
 
-		$first_response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+		$first_response = $this->controller->token( $this->create_token_request( 'valid-code', self::VALID_STATE ) );
 		$this->assertNotInstanceOf( WP_Error::class, $first_response );
 
-		$second_response = $this->controller->token( $this->create_token_request( 'valid-code', 'valid-random-state' ) );
+		$second_response = $this->controller->token( $this->create_token_request( 'valid-code', self::VALID_STATE ) );
 		$this->assertInstanceOf( WP_Error::class, $second_response );
 		$this->assertSame( 'wcpay_cli_invalid_code', $second_response->get_error_code() );
 	}
@@ -235,7 +309,7 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 				[
 					'app_name'     => 'WooPayments CLI',
 					'scope'        => 'read_write',
-					'state'        => 'valid-random-state',
+					'state'        => self::VALID_STATE,
 					'callback_url' => 'http://127.0.0.1:3456/callback',
 				],
 				$overrides
@@ -266,7 +340,7 @@ class WC_REST_Payments_CLI_Controller_Test extends WCPAY_UnitTestCase {
 						'id'           => $auth_id,
 						'app_name'     => 'WooPayments CLI',
 						'scope'        => 'read_write',
-						'state'        => 'valid-random-state',
+						'state'        => self::VALID_STATE,
 						'callback_url' => 'http://127.0.0.1:3456/callback',
 						'created_at'   => time(),
 						'expires_at'   => time() + 300,


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Adds plugin-side support for the WooPayments CLI browser authentication flow:

* Adds `POST /wp-json/wc/v3/payments/cli/authorize` to create short-lived browser authorization requests.
* Adds `POST /wp-json/wc/v3/payments/cli/token` to exchange approved one-time codes for WooCommerce REST API credentials.
* Adds a WooPayments-styled approval screen requiring `manage_woocommerce`.
* Creates API keys using WooCommerce API key storage conventions.
* Validates callback URLs, scopes, state, expiry, and single-use code behavior.
* Adds cleanup for expired pending authorization records.
* Adds unit coverage and docs for the endpoint contract.

The consumer secret is only returned from the token endpoint and is not included in browser redirects.

Screenshots captured locally:

* Approval screen: `.claude/tmp/screenshots/wcpay-cli-auth-one-box-centered-logo.png`
* CLI success callback: `.claude/tmp/screenshots/wcpay-cli-auth-success-real-cli.png`

#### Testing instructions

* Run the focused PHP test coverage:

```bash
npm run test:php -- --filter WC_REST_Payments_CLI_Controller_Test
```

* Run PHPCS on the touched PHP files:

```bash
vendor/bin/phpcs --standard=phpcs.xml.dist includes/admin/class-wc-rest-payments-cli-controller.php tests/unit/admin/test-class-wc-rest-payments-cli-controller.php includes/class-wc-payments.php
```

* Manual browser flow smoke test:
  1. Start the local WooPayments site with `npm run up`.
  2. In `/Users/mal/projects/wcpay-cli`, run:
     ```bash
     npm run dev -- login --site http://localhost:8082 --name cli-browser-auth-test --allow-insecure-local --yes --no-verify
     ```
  3. Approve the browser authorization screen as an admin user.
  4. Confirm the CLI callback page says WooPayments CLI connected and the CLI receives credentials.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
