### PR TITLE
Notify Product Ambassadors in code freeze Slack message

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -24,6 +24,7 @@ jobs:
       freeze: ${{ steps.check-freeze.outputs.FREEZE }}
       nextReleaseVersion: ${{ steps.next-version.outputs.NEXT_RELEASE_VERSION }}
       nextReleaseDate: ${{ steps.define_var.outputs.RELEASE_PLANNED_DATE }}
+      currentVersion: ${{ steps.current-version.outputs.VERSION }}
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -87,6 +88,8 @@ jobs:
       RELEASE_DATE: ${{ needs.check-code-freeze.outputs.nextReleaseDate }}
       RELEASE_PR_ID: ${{ needs.create-release-pr.outputs.release-pr-id }}
       GITHUB_RUN_ID: ${{ github.run_id }}
+      CURRENT_VERSION: ${{ needs.check-code-freeze.outputs.currentVersion }}
+      PRODUCT_AMBASSADORS_SLACK_IDS: "<@U03BURMGS95> <@UA4763TED>"  # Aashik and Francois. Update directly if needed.
     steps:
       - name: "Slack ping"
         uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
@@ -124,6 +127,13 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": "If you absolutely need to include a PR that was not merged in `develop` yet, please consult the release lead."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*For Product Ambassadors:* ${{ env.PRODUCT_AMBASSADORS_SLACK_IDS }} <https://github.com/Automattic/woocommerce-payments/compare/${{ env.CURRENT_VERSION }}...release/${{ env.RELEASE_VERSION }}|Here is what changed> in the upcoming (${{ env.RELEASE_VERSION }})."
                   }
                 },
                 {

--- a/changelog/woopmnt-6173-simplify-some-of-the-manual-steps-during-release-rotation
+++ b/changelog/woopmnt-6173-simplify-some-of-the-manual-steps-during-release-rotation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Notify Product Ambassadors in code freeze Slack message with a compare link to what changed


### PR DESCRIPTION
Related WOOPMNT-6173

#### Changes proposed in this Pull Request

Adds a new section to the code freeze Slack notification that tags Product Ambassadors with a GitHub compare link showing what changed since the last release. The Product Ambassador Slack IDs are hardcoded in the workflow for easy updates via PR.

#### Testing instructions

* Trigger the workflow manually (`workflow_dispatch`) with `skipSlackPing: false` and verify the new section appears in the Slack message with the correct compare URL and mentions.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.