### PR TITLE
chore: Bump WC tested up to version to 10.9.0

### DIFF
--- a/changelog/bump-10-8-0-wc
+++ b/changelog/bump-10-8-0-wc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WC tested up to version to 10.9.0

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 10.8.0
+ * WC tested up to: 10.9.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Version: 10.8.0


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Bumps the "WC tested up to" version in `woocommerce-payments.php` from 10.8.0 to 10.9.0.

#### Testing instructions

* Verify the plugin header in `woocommerce-payments.php` shows `WC tested up to: 10.9.0`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.