### PR TITLE
Make WooPay save-info copy smaller

### DIFF
--- a/changelog/fix-woopay-save-info-copy-size
+++ b/changelog/fix-woopay-save-info-copy-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make WooPay save-info supporting copy use the checkout x-small text size.

--- a/client/settings/phone-input/style.scss
+++ b/client/settings/phone-input/style.scss
@@ -58,14 +58,17 @@
 			margin-top: 0;
 		}
 
-		.additional-information {
-			font-size: var( --wp--preset--font-size--small, 14px );
-			line-height: 21px;
-			text-align: left;
+		.additional-information,
+		.tos {
+			font-size: var(
+				--wp--preset--font-size--x-small,
+				calc( var( --wp--preset--font-size--small, 14px ) * 0.875 )
+			);
+			line-height: 1.4;
 		}
 
-		.tos {
-			font-size: 13px;
+		.additional-information {
+			text-align: left;
 		}
 
 		#validate-error-invalid-woopay-phone-number {


### PR DESCRIPTION
Fixes no linked issue. I just faced this problem while I was trying to enable WooPay for the WordPress merch store and I'm thinking it should be fixed upstream. _Caveat that I'm not super familiar with WooPay, and I did this with Codex!_

#### Changes proposed in this Pull Request

This PR makes the secondary text in the WooPay "Save my info" form use the checkout x-small font-size token.

The checkbox label remains the main action, while the explanatory sentence and WooPay terms copy are treated as supporting copy. This keeps the WooPay opt-in section from making the legal/explanatory text feel as prominent as the primary label, especially on stores whose checkout typography uses a strong or compact theme style.

The fallback mirrors WooCommerce Blocks' `font-x-small-locked` scale:

`var( --wp--preset--font-size--x-small, calc( var( --wp--preset--font-size--small, 14px ) * 0.875 ) )`

If a theme provides an x-small preset, WooPay uses it. If not, WooPay derives a smaller value from the theme's small preset.

This avoids relying on x-small being commonly defined. Most block themes expose "small" as their smallest preset, and CSS cannot query the full theme preset list to pick an arbitrary smallest value such as a custom "tiny" slug. Deriving a smaller value from "small" keeps the text subordinate while still respecting theme scale.

#### Screenshots from an example store
<img width="1532" height="1602" alt="image" src="https://github.com/user-attachments/assets/16602a1a-4754-4934-bfff-991f0f500986" />


#### Testing instructions

* Enable WooPay.
* Add a product to the cart.
* Visit the checkout page using either the Checkout block or classic checkout.
* Check "Securely save my information for 1-click checkout".
* Confirm the "Next time you buy here..." sentence and the WooPay terms sentence render smaller than the checkbox label.
* Confirm the phone input and validation message still render normally.

-------------------

- [x] Added a patch changelog entry.
- [ ] Covered with tests (CSS-only visual hierarchy change; validated with CSS lint and changelog validation.)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
