### PR TITLE
feat(ci): route QIT E2E failures to #wcpay-bots Slack channel

### DIFF
--- a/.github/actions/qit-slack-summary/action.yml
+++ b/.github/actions/qit-slack-summary/action.yml
@@ -1,0 +1,84 @@
+name: "QIT E2E Slack summary"
+description: "Post a single Slack message summarising the failed matrix cells of a QIT E2E run."
+
+inputs:
+  slack-token:
+    description: "Slack bot token. When empty, the action no-ops (no creds = no post)."
+    required: false
+    default: ""
+  channel-id:
+    description: "Slack channel ID to post into. When empty, the action no-ops."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: "Post failure summary to Slack"
+      shell: bash
+      env:
+        SLACK_TOKEN: ${{ inputs.slack-token }}
+        CHANNEL_ID: ${{ inputs.channel-id }}
+        # Reads this run's jobs; the default workflow token has actions:read.
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
+        SERVER_URL: ${{ github.server_url }}
+        WORKFLOW: ${{ github.workflow }}
+        BRANCH: ${{ github.ref_name }}
+        SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$SLACK_TOKEN" ] || [ -z "$CHANNEL_ID" ]; then
+          echo "Slack credentials not set; skipping post."
+          exit 0
+        fi
+
+        RUN_URL="$SERVER_URL/$REPO/actions/runs/$RUN_ID/attempts/${RUN_ATTEMPT:-1}"
+        COMMIT_URL="$SERVER_URL/$REPO/commit/$SHA"
+        SHORT_SHA="${SHA:0:7}"
+
+        # Collect the failed matrix cells (jobs concluding "failure"). @tsv keeps
+        # names with spaces intact; the in-progress summary job has a null
+        # conclusion so it is naturally excluded.
+        FAILED_LINES=""
+        COUNT=0
+        while IFS=$'\t' read -r name url; do
+          [ -z "$name" ] && continue
+          FAILED_LINES+="• <${url}|${name}>"$'\n'
+          COUNT=$((COUNT + 1))
+        done < <(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+          --jq '.jobs[] | select(.conclusion == "failure") | [.name, .html_url] | @tsv')
+
+        FAILED_LINES="${FAILED_LINES%$'\n'}"
+        NOUN=$([ "$COUNT" -eq 1 ] && echo "failure" || echo "failures")
+
+        # Assemble the message body in jq to avoid bash quoting of backticks and
+        # newlines; jq then encodes the real newlines as \n in the payload.
+        TEXT=$(jq -n -r \
+          --arg wf "$WORKFLOW" --arg count "$COUNT" --arg noun "$NOUN" \
+          --arg runurl "$RUN_URL" --arg branch "$BRANCH" \
+          --arg commiturl "$COMMIT_URL" --arg sha "$SHORT_SHA" \
+          --arg failed "$FAILED_LINES" \
+          '":red_circle: *\($wf) — \($count) \($noun)* | <\($runurl)|run>\n`\($branch)` | <\($commiturl)|`\($sha)`>"
+           + (if $failed != "" then "\n" + $failed else "" end)')
+
+        # Best-effort join so the bot can post even if it is not yet a member.
+        curl -sS -X POST https://slack.com/api/conversations.join \
+          -H "Authorization: Bearer $SLACK_TOKEN" \
+          -H "Content-type: application/json; charset=utf-8" \
+          -d "$(jq -n --arg ch "$CHANNEL_ID" '{channel: $ch}')" >/dev/null || true
+
+        PAYLOAD=$(jq -n --arg ch "$CHANNEL_ID" --arg txt "$TEXT" '{channel: $ch, text: $txt}')
+        RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+          -H "Authorization: Bearer $SLACK_TOKEN" \
+          -H "Content-type: application/json; charset=utf-8" \
+          -d "$PAYLOAD")
+
+        if ! echo "$RESP" | jq -e '.ok' >/dev/null; then
+          echo "::error::Slack post failed: $(echo "$RESP" | jq -r '.error // "unknown"')"
+          exit 1
+        fi
+        echo "Posted QIT E2E failure summary ($COUNT $NOUN) to Slack."

--- a/.github/actions/qit-slack-summary/action.yml
+++ b/.github/actions/qit-slack-summary/action.yml
@@ -19,7 +19,7 @@ runs:
       env:
         SLACK_TOKEN: ${{ inputs.slack-token }}
         CHANNEL_ID: ${{ inputs.channel-id }}
-        # Reads this run's jobs; the default workflow token has actions:read.
+        # Default token has actions:read for the jobs API.
         GH_TOKEN: ${{ github.token }}
         REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
@@ -40,18 +40,15 @@ runs:
         COMMIT_URL="$SERVER_URL/$REPO/commit/$SHA"
         SHORT_SHA="${SHA:0:7}"
 
-        # Fetch the run's jobs. Capture separately rather than piping straight
-        # into the loop: a `gh api` failure inside a process substitution is not
-        # caught by `set -e`/`pipefail`, which would leave COUNT=0 and post a
-        # misleading "0 failures" message during a real failure event.
+        # Capture separately, not `< <(gh api ...)`: a failure inside a process
+        # substitution escapes set -e and would post a bogus "0 failures".
         JOBS_JSON=$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs") || {
           echo "::error::Failed to fetch run jobs from the GitHub API; cannot build the failure list."
           exit 1
         }
 
-        # Collect the failed matrix cells (jobs concluding "failure"). @tsv keeps
-        # names with spaces intact; the in-progress summary job has a null
-        # conclusion so it is naturally excluded.
+        # Failed cells only. The summary job's own conclusion is still null, so
+        # it is excluded.
         FAILED_LINES=""
         COUNT=0
         while IFS=$'\t' read -r name url; do
@@ -64,8 +61,7 @@ runs:
         FAILED_LINES="${FAILED_LINES%$'\n'}"
         NOUN=$([ "$COUNT" -eq 1 ] && echo "failure" || echo "failures")
 
-        # Assemble the message body in jq to avoid bash quoting of backticks and
-        # newlines; jq then encodes the real newlines as \n in the payload.
+        # Assemble in jq to avoid bash-quoting backticks/newlines (jq encodes them).
         TEXT=$(jq -n -r \
           --arg wf "$WORKFLOW" --arg count "$COUNT" --arg noun "$NOUN" \
           --arg runurl "$RUN_URL" --arg branch "$BRANCH" \
@@ -74,7 +70,7 @@ runs:
           '":red_circle: *\($wf) — \($count) \($noun)* | <\($runurl)|run>\n`\($branch)` | <\($commiturl)|`\($sha)`>"
            + (if $failed != "" then "\n" + $failed else "" end)')
 
-        # Best-effort join so the bot can post even if it is not yet a member.
+        # Join in case the bot isn't a channel member yet.
         curl -sS -X POST https://slack.com/api/conversations.join \
           -H "Authorization: Bearer $SLACK_TOKEN" \
           -H "Content-type: application/json; charset=utf-8" \

--- a/.github/actions/qit-slack-summary/action.yml
+++ b/.github/actions/qit-slack-summary/action.yml
@@ -40,6 +40,15 @@ runs:
         COMMIT_URL="$SERVER_URL/$REPO/commit/$SHA"
         SHORT_SHA="${SHA:0:7}"
 
+        # Fetch the run's jobs. Capture separately rather than piping straight
+        # into the loop: a `gh api` failure inside a process substitution is not
+        # caught by `set -e`/`pipefail`, which would leave COUNT=0 and post a
+        # misleading "0 failures" message during a real failure event.
+        JOBS_JSON=$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs") || {
+          echo "::error::Failed to fetch run jobs from the GitHub API; cannot build the failure list."
+          exit 1
+        }
+
         # Collect the failed matrix cells (jobs concluding "failure"). @tsv keeps
         # names with spaces intact; the in-progress summary job has a null
         # conclusion so it is naturally excluded.
@@ -49,8 +58,8 @@ runs:
           [ -z "$name" ] && continue
           FAILED_LINES+="• <${url}|${name}>"$'\n'
           COUNT=$((COUNT + 1))
-        done < <(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
-          --jq '.jobs[] | select(.conclusion == "failure") | [.name, .html_url] | @tsv')
+        done < <(printf '%s' "$JOBS_JSON" \
+          | jq -r '.jobs[] | select(.conclusion == "failure") | [.name, .html_url] | @tsv')
 
         FAILED_LINES="${FAILED_LINES%$'\n'}"
         NOUN=$([ "$COUNT" -eq 1 ] && echo "failure" || echo "failures")

--- a/.github/workflows/qit-e2e-prerelease.yml
+++ b/.github/workflows/qit-e2e-prerelease.yml
@@ -69,3 +69,24 @@ jobs:
       E2E_QIT_JP_SITE_ID: ${{ secrets.E2E_QIT_JP_SITE_ID }}
       E2E_QIT_JP_BLOG_TOKEN: ${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}
       E2E_QIT_JP_USER_TOKEN: ${{ secrets.E2E_QIT_JP_USER_TOKEN }}
+
+  summarize:
+    name: "Report failures to Slack"
+    needs: [qit-e2e]
+    # Post only when a matrix cell actually failed (not on cancel or a skipped
+    # upstream build). This workflow is workflow_dispatch only, so the post is
+    # gated by presence here alone — no event_name conditional needed.
+    if: ${{ !cancelled() && needs.qit-e2e.result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Post Slack summary
+        uses: ./.github/actions/qit-slack-summary
+        with:
+          slack-token: ${{ secrets.E2E_SLACK_TOKEN }}
+          channel-id: ${{ secrets.E2E_SLACK_CHANNEL_ID }}

--- a/.github/workflows/qit-e2e.yml
+++ b/.github/workflows/qit-e2e.yml
@@ -111,3 +111,24 @@ jobs:
       E2E_QIT_JP_SITE_ID: ${{ secrets.E2E_QIT_JP_SITE_ID }}
       E2E_QIT_JP_BLOG_TOKEN: ${{ secrets.E2E_QIT_JP_BLOG_TOKEN }}
       E2E_QIT_JP_USER_TOKEN: ${{ secrets.E2E_QIT_JP_USER_TOKEN }}
+
+  summarize:
+    name: "Report failures to Slack"
+    needs: [qit-e2e]
+    # Post only when a matrix cell actually failed (not on cancel or a skipped
+    # upstream build). This workflow has no pull_request trigger, so the post is
+    # gated by presence here alone — no event_name conditional needed.
+    if: ${{ !cancelled() && needs.qit-e2e.result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Post Slack summary
+        uses: ./.github/actions/qit-slack-summary
+        with:
+          slack-token: ${{ secrets.E2E_SLACK_TOKEN }}
+          channel-id: ${{ secrets.E2E_SLACK_CHANNEL_ID }}

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -34,16 +34,16 @@ jobs:
           set +e
           qit run:security woocommerce-payments --zip=woocommerce-payments.zip
           EXIT_CODE=$?
-          # QIT exit codes (v1.0.0):
+          # QIT exit codes (qit-cli 1.1.x):
           # 0 = success
-          # 1 = invalid (bad arguments/config)
-          # 2 = failed (critical security errors)
+          # 1 = failed (critical security errors)
+          # 2 = invalid (bad arguments/config)
           # 3 = warning (non-critical issues)
           if [ $EXIT_CODE -eq 1 ]; then
-            echo "Security test failed: invalid arguments or configuration."
+            echo "Security test failed with critical errors."
             exit 1
           elif [ $EXIT_CODE -eq 2 ]; then
-            echo "Security test failed with critical errors."
+            echo "Security test failed: invalid arguments or configuration."
             exit 1
           elif [ $EXIT_CODE -eq 3 ]; then
             echo "Security test completed with warnings (non-critical issues). CI will pass."
@@ -59,16 +59,16 @@ jobs:
           set +e
           qit run:malware woocommerce-payments --zip=woocommerce-payments.zip
           EXIT_CODE=$?
-          # QIT exit codes (v1.0.0):
+          # QIT exit codes (qit-cli 1.1.x):
           # 0 = success
-          # 1 = invalid (bad arguments/config)
-          # 2 = failed (critical malware detected)
+          # 1 = failed (critical malware detected)
+          # 2 = invalid (bad arguments/config)
           # 3 = warning
           if [ $EXIT_CODE -eq 1 ]; then
-            echo "Malware test failed: invalid arguments or configuration."
+            echo "Malware test failed."
             exit 1
           elif [ $EXIT_CODE -eq 2 ]; then
-            echo "Malware test failed."
+            echo "Malware test failed: invalid arguments or configuration."
             exit 1
           elif [ $EXIT_CODE -eq 3 ]; then
             echo "Malware test completed with warnings. CI will pass."

--- a/changelog/dev-qit-e2e-slack-failure-routing
+++ b/changelog/dev-qit-e2e-slack-failure-routing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Route QIT E2E test failures to the #wcpay-bots Slack channel on develop/trunk pushes and pre-release runs.


### PR DESCRIPTION
Part of WOOPMNT-6174

#### Changes proposed in this Pull Request

QIT E2E workflows previously emitted no Slack signal. This adds QIT E2E failure routing to the channel.

Also corrects the stale QIT exit-code comments in `qit.yml` (`1=failed, 2=invalid). Comment/message accuracy only; CI behavior unchanged.

You can check a test run p1780055505186129-slack-CQ0Q6N62D

<img width="686" height="107" alt="Screenshot 2026-05-29 at 16 50 53" src="https://github.com/user-attachments/assets/38e08989-d8c1-41fa-80d6-9136f21f899c" />


#### Testing instructions

CI-only change:

1. From this branch, `gh workflow run qit-e2e.yml --ref dev/qit-e2e-slack-reporter` (or merge to a test branch with a forced failing spec).
2. When at least one matrix cell fails, confirm exactly **one** message appears in #wcpay-bots: red-circle header with the run link, branch + commit, and each failed cell linked to its job.
3. Confirm a fully green run posts **nothing**.
4. Confirm PR runs of `qit-e2e-pr.yml` still post nothing (unchanged).

-------------------

- [x] Run \`npm run changelog\` to add a changelog file (added \`dev-qit-e2e-slack-failure-routing\`).
- [ ] Covered with tests (CI infra change; verified by triggering a run, see testing instructions).
- [x] Tested on mobile (does not apply).