### PR TITLE
fix: skip customer update when changing a subscription's payment method

### DIFF
--- a/changelog/fix-1293-no-customer-update-on-subscription-payment-change
+++ b/changelog/fix-1293-no-customer-update-on-subscription-payment-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop overwriting a customer's billing details on the WCPay/Stripe backend with stale order data when only the payment method of a subscription is changed.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1470,7 +1470,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$customer_data = WC_Payments_Customer_Service::map_customer_data( $order, new WC_Customer( $user->ID ) );
 			// Create a new customer.
 			$customer_id = $this->customer_service->create_customer_for_user( $user, $customer_data );
-		} else {
+		} elseif ( empty( $options['is_changing_payment_method_for_subscription'] ) ) {
+			// A subscription carries the billing details from when it was created, which can be years
+			// behind whatever the customer last gave us elsewhere. Swapping the payment method isn't a
+			// signal that those details changed, so refreshing from them here risks overwriting fresher
+			// data with stale data — we leave the existing customer untouched in that case.
+
 			/**
 			 * Update customer data asynchronously via shutdown hook to avoid blocking the payment response.
 			 *
@@ -1555,7 +1560,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		$metadata = $this->get_metadata_from_order( $order, $payment_information->get_payment_type() );
 
 		$customer_details_options = [
-			'is_woopay' => filter_var( $metadata['paid_on_woopay'] ?? false, FILTER_VALIDATE_BOOLEAN ),
+			'is_woopay'                                   => filter_var( $metadata['paid_on_woopay'] ?? false, FILTER_VALIDATE_BOOLEAN ),
+			'is_changing_payment_method_for_subscription' => $is_changing_payment_method_for_subscription,
 		];
 
 		if ( $payment_information->get_customer_id() ) {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2650,6 +2650,58 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'seti_mock_123', $result->get_id() );
 	}
 
+	public function test_manage_customer_details_for_order_skips_customer_update_when_changing_subscription_payment_method() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->mock_customer_service
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_existing' );
+
+		// The subscription's billing details may be stale, so a payment-method swap must not push
+		// them onto the backend customer where they could overwrite more recent data.
+		$this->mock_customer_service
+			->expects( $this->never() )
+			->method( 'update_customer_for_user' );
+
+		// Isolate the deferred-update hook so do_action() only fires what the method registers.
+		remove_all_actions( 'shutdown' );
+
+		$manage = new ReflectionMethod( $this->card_gateway, 'manage_customer_details_for_order' );
+		$manage->setAccessible( true );
+		[ , $customer_id ] = $manage->invoke(
+			$this->card_gateway,
+			$order,
+			[ 'is_changing_payment_method_for_subscription' => true ]
+		);
+
+		do_action( 'shutdown' );
+
+		$this->assertSame( 'cus_existing', $customer_id );
+	}
+
+	public function test_manage_customer_details_for_order_updates_existing_customer_on_shutdown() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->mock_customer_service
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_existing' );
+
+		// A regular payment must still refresh the backend customer with the order's data,
+		// so the skip above stays narrowly scoped to the payment-method-change flow.
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'update_customer_for_user' )
+			->willReturn( 'cus_existing' );
+
+		remove_all_actions( 'shutdown' );
+
+		$manage = new ReflectionMethod( $this->card_gateway, 'manage_customer_details_for_order' );
+		$manage->setAccessible( true );
+		$manage->invoke( $this->card_gateway, $order, [] );
+
+		do_action( 'shutdown' );
+	}
+
 	public function test_add_payment_method_no_intent() {
 		$result = $this->card_gateway->add_payment_method();
 		$this->assertEquals( 'error', $result['result'] );


### PR DESCRIPTION
Fixes #1293

#### Changes proposed in this Pull Request

When a subscriber changes their payment method from My Account, we run the same `process_payment()` path as a purchase. As a side effect, `manage_customer_details_for_order()` schedules a `shutdown` hook that syncs the subscription's billing details (name, email, address) onto the WCPay/Stripe customer.

The billing data lives on the subscription, and it can be stale: someone swapping their card a year in still carries the address from when they first subscribed, so the sync overwrites fresher backend data with older data. The decision was to leave customer data alone when only the payment method changes: p1612461591341600-slack-CGGCLBN58.

Gating the customer refresh behind the `is_changing_payment_method_for_subscription` flag that's already on `Payment_Information`. We still create the customer if one doesn't exist (otherwise the order could reference a customer that isn't there, which was flagged on the issue), but skip the update. Regular checkout and renewals are untouched.

I considered overriding `process_payment()` in the subscriptions class like the issue originally suggested, but the flag is already available on `Payment_Information`, and threading it through `manage_customer_details_for_order()` is a smaller change that keeps everything on one path.

How this can break: only if something relied on a payment-method change refreshing the customer. The payment method's own billing details are still updated separately, and the regular create/update path is unchanged, so I don't think anything does. The unit tests below pin both sides down.

#### Testing instructions

Easiest with WooPayments logging on (Payments → Settings → Enable logging) so you can watch the API requests.

1. Buy a subscription product, so the customer ends up with a saved card and a WCPay customer.
2. Edit the subscription's billing details (WooCommerce → Subscriptions → edit → Billing) to something recognizable, e.g. first name `STALE`, email `stale-do-not-sync@example.com`.
3. Go to My Account → Subscriptions → open the subscription → Change payment method, and submit (re-selecting the saved card is enough).
4. Open the WooPayments log. On `develop` you'll see a `POST .../wcpay/customers/cus_...` fire on shutdown, with the stale billing in the request body. On this branch that request is gone, and only the read-only `payment_methods` lookups remain.
5. Sanity check the regular path still works: place a normal order and confirm the `customers/cus_...` request still fires.

I tested this end to end on a local store against a test account. Side by side:

- Without the fix: one `POST customers/cus_...` on the payment method change, with `Name: STALE Subscriber` in the body.
- With the fix: zero `customers/cus_...` calls on the change. The create/update still happens on the initial purchase.

Also covered by unit tests in `tests/unit/test-class-wc-payment-gateway-wcpay.php`: one for the skip on a payment-method change, plus a positive control that the regular path still updates the customer on shutdown.

**Screenshots** (customer-facing flow, test data only):

| Subscription with deliberately-stale billing | Change payment method (saved card) |
|---|---|
| ![Subscription detail](https://raw.githubusercontent.com/Automattic/woocommerce-payments/db48b940613207e72779217731976a9124defb9a/screenshots/2026-05-30-subscription-detail.png) | ![Change payment method](https://raw.githubusercontent.com/Automattic/woocommerce-payments/db48b940613207e72779217731976a9124defb9a/screenshots/2026-05-30-change-payment-method.png) |

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description)
- [x] Tested on mobile (or does not apply): backend-only change, does not apply.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions): _Add link here / 'QA Testing Not Applicable'_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

