### PR TITLE
fix: settings forms saving states

### DIFF
--- a/changelog/fix-4740-settings-form-saving-state
+++ b/changelog/fix-4740-settings-form-saving-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: showing saving state on settings forms and discard edits made while a save is in progress.

--- a/client/components/form-busy-state/index.tsx
+++ b/client/components/form-busy-state/index.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+interface FormBusyStateProps {
+	isBusy: boolean;
+	className?: string;
+	children: React.ReactNode;
+}
+
+/**
+ * Signals that a save is in progress, accessibly.
+ *
+ * Avoids `disabled`/`inert` on purpose: both drop inputs out of the tab order,
+ * which is what #4740 wants to keep. Completion isn't announced here — the save
+ * already fires a "saved" success notice, which screen readers pick up.
+ */
+const FormBusyState: React.FC< FormBusyStateProps > = ( {
+	isBusy,
+	className,
+	children,
+} ) => (
+	<div
+		className={ clsx( 'wcpay-form-busy-state', className, {
+			'is-busy': isBusy,
+		} ) }
+		aria-busy={ isBusy }
+	>
+		{ /* first child so it never becomes `:last-child` and shifts the section margins */ }
+		<div
+			className="wcpay-form-busy-state__status screen-reader-text"
+			role="status"
+			aria-live="polite"
+		>
+			{ isBusy ? __( 'Saving…', 'woocommerce-payments' ) : '' }
+		</div>
+		{ children }
+	</div>
+);
+
+export default FormBusyState;

--- a/client/components/form-busy-state/style.scss
+++ b/client/components/form-busy-state/style.scss
@@ -1,0 +1,9 @@
+.wcpay-form-busy-state {
+	// Dim as a visual "busy" cue without disabling, so inputs stay navigable.
+	transition: opacity 0.2s ease-in-out;
+
+	&.is-busy {
+		opacity: 0.6;
+		cursor: progress;
+	}
+}

--- a/client/components/form-busy-state/test/index.test.tsx
+++ b/client/components/form-busy-state/test/index.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import FormBusyState from '..';
+
+describe( 'FormBusyState', () => {
+	it( 'renders its children', () => {
+		render(
+			<FormBusyState isBusy={ false }>
+				<button>Save</button>
+			</FormBusyState>
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'Save' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'reflects the busy state via aria-busy without disabling children', () => {
+		const { container, rerender } = render(
+			<FormBusyState isBusy={ false }>
+				<input type="text" />
+			</FormBusyState>
+		);
+
+		const wrapper = container.querySelector( '.wcpay-form-busy-state' );
+
+		expect( wrapper ).toHaveAttribute( 'aria-busy', 'false' );
+		expect( wrapper ).not.toHaveClass( 'is-busy' );
+
+		rerender(
+			<FormBusyState isBusy={ true }>
+				<input type="text" />
+			</FormBusyState>
+		);
+
+		expect( wrapper ).toHaveAttribute( 'aria-busy', 'true' );
+		expect( wrapper ).toHaveClass( 'is-busy' );
+
+		// the #4740 point: never `disabled`/`inert`, which drops inputs out of the tab order
+		expect( screen.getByRole( 'textbox' ) ).not.toBeDisabled();
+		expect( wrapper ).not.toHaveAttribute( 'inert' );
+	} );
+
+	it( 'announces the in-flight state through a polite live region', () => {
+		const { rerender } = render(
+			<FormBusyState isBusy={ false }>
+				<input type="text" />
+			</FormBusyState>
+		);
+
+		const status = screen.getByRole( 'status' );
+
+		expect( status ).toHaveAttribute( 'aria-live', 'polite' );
+		expect( status ).toHaveTextContent( '' );
+
+		rerender(
+			<FormBusyState isBusy={ true }>
+				<input type="text" />
+			</FormBusyState>
+		);
+
+		expect( status ).toHaveTextContent( 'Saving…' );
+
+		// goes quiet on completion; the "saved" notice carries the confirmation
+		rerender(
+			<FormBusyState isBusy={ false }>
+				<input type="text" />
+			</FormBusyState>
+		);
+
+		expect( status ).toHaveTextContent( '' );
+	} );
+} );

--- a/client/data/settings/__tests__/actions.test.js
+++ b/client/data/settings/__tests__/actions.test.js
@@ -85,8 +85,8 @@ describe( 'Settings actions tests', () => {
 			// Since the actual fetching process is mocked, pass the apiResponse to the next saveGenerator step directly
 			next = saveGenerator.next( apiResponse );
 			expect( next.value ).toEqual( {
-				type: 'SET_SETTINGS_VALUES',
-				payload: {
+				type: 'SET_SETTINGS',
+				data: {
 					payment_method_statuses:
 						apiResponse.data.payment_method_statuses,
 				},
@@ -100,6 +100,38 @@ describe( 'Settings actions tests', () => {
 
 			// Check if the saveGenerator is complete
 			expect( saveGenerator.next().done ).toBeTruthy();
+		} );
+
+		test( 'on success, restores the saved snapshot (discarding mid-save edits)', () => {
+			// on success, we reset back the settings to the state they were when the saving started (so any mid-save edits get discarded)
+			const snapshot = {
+				enabled_payment_method_ids: [ 'card' ],
+				is_wcpay_enabled: true,
+			};
+			select.mockReturnValue( {
+				getSettings: () => snapshot,
+			} );
+
+			const apiResponse = {
+				data: {
+					payment_method_statuses: { card: 'active' },
+				},
+			};
+			apiFetch.mockReturnValue( apiResponse );
+
+			const saveGenerator = saveSettings();
+			saveGenerator.next(); // updateIsSavingSettings( true )
+			saveGenerator.next(); // apiFetch
+			const next = saveGenerator.next( apiResponse );
+
+			expect( next.value ).toEqual( {
+				type: 'SET_SETTINGS',
+				data: {
+					...snapshot,
+					payment_method_statuses:
+						apiResponse.data.payment_method_statuses,
+				},
+			} );
 		} );
 
 		test( 'displays success notice after saving', () => {

--- a/client/data/settings/actions.js
+++ b/client/data/settings/actions.js
@@ -192,7 +192,9 @@ export function* saveSettings() {
 			data: settings,
 		} );
 
-		yield updateSettingsValues( {
+		// otherwise mid-save edits linger in the store with `isDirty` falsely false
+		yield updateSettings( {
+			...settings,
 			payment_method_statuses: response.data.payment_method_statuses,
 		} );
 

--- a/client/settings/express-checkout-settings/index.js
+++ b/client/settings/express-checkout-settings/index.js
@@ -17,6 +17,8 @@ import SettingsLayout from '../settings-layout';
 import LoadableSettingsSection from '../loadable-settings-section';
 import SaveSettingsSection from '../save-settings-section';
 import ErrorBoundary from '../../components/error-boundary';
+import FormBusyState from 'wcpay/components/form-busy-state';
+import { useSettings } from 'wcpay/data';
 import { WooIcon } from 'wcpay/payment-methods-icons';
 import methodsConfiguration from 'wcpay/payment-methods-map';
 
@@ -164,6 +166,7 @@ const methods = {
 };
 
 const ExpressCheckoutSettings = ( { methodId } ) => {
+	const { isSaving } = useSettings();
 	const method = methods[ methodId ];
 
 	if ( ! method ) {
@@ -191,21 +194,23 @@ const ExpressCheckoutSettings = ( { methodId } ) => {
 
 	return (
 		<SettingsLayout>
-			{ sections.map( ( { section, description } ) => (
-				<SettingsSection
-					key={ section }
-					description={ description }
-					className={ `wcpay-express-checkout__${ section }` }
-				>
-					<LoadableSettingsSection numLines={ 30 }>
-						<ErrorBoundary>
-							<Controls section={ section } />
-						</ErrorBoundary>
-					</LoadableSettingsSection>
-				</SettingsSection>
-			) ) }
+			<FormBusyState isBusy={ isSaving }>
+				{ sections.map( ( { section, description } ) => (
+					<SettingsSection
+						key={ section }
+						description={ description }
+						className={ `wcpay-express-checkout__${ section }` }
+					>
+						<LoadableSettingsSection numLines={ 30 }>
+							<ErrorBoundary>
+								<Controls section={ section } />
+							</ErrorBoundary>
+						</LoadableSettingsSection>
+					</SettingsSection>
+				) ) }
 
-			<SaveSettingsSection />
+				<SaveSettingsSection />
+			</FormBusyState>
 		</SettingsLayout>
 	);
 };

--- a/client/settings/fraud-protection/advanced-settings/__tests__/__snapshots__/index.test.js.snap
+++ b/client/settings/fraud-protection/advanced-settings/__tests__/__snapshots__/index.test.js.snap
@@ -215,6 +215,1221 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
           class="wcpay-settings-layout"
         >
           <div
+            aria-busy="false"
+            class="wcpay-form-busy-state"
+          >
+            <div
+              aria-live="polite"
+              class="wcpay-form-busy-state__status screen-reader-text"
+              role="status"
+            />
+            <div
+              class="settings-section"
+              id="advanced-fraud"
+            >
+              <div
+                class="settings-section__details"
+              >
+                <h2>
+                  Filter configuration
+                </h2>
+                <p>
+                  Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
+                </p>
+              </div>
+              <div
+                class="settings-section__controls"
+              >
+                <div
+                  class="wcpay-inline-notice wcpay-inline-error-notice fraud-protection-advanced-settings-error-notice components-notice is-error is-dismissible"
+                >
+                  <div
+                    class="components-visually-hidden emotion-0 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="VisuallyHidden"
+                    style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                  >
+                    Error notice
+                  </div>
+                  <div
+                    class="components-notice__content"
+                  >
+                    <div
+                      class="components-flex emotion-2 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="Flex"
+                    >
+                      <div
+                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
+                        data-wp-c16t="true"
+                        data-wp-component="FlexItem"
+                      >
+                        Settings were not saved. Maximum purchase price must be greater than the minimum purchase price.
+                      </div>
+                    </div>
+                    <div
+                      class="components-notice__actions"
+                    />
+                  </div>
+                  <button
+                    aria-label="Close"
+                    class="components-button components-notice__dismiss is-small has-icon"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      focusable="false"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="avs-mismatch-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        AVS Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-12__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-12"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-12"
+                              >
+                                Enable AVS Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-12__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="international-ip-address-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        International IP Address
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-13__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-13"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-13"
+                              >
+                                Enable International IP Address filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-13__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for 
+                              <a
+                                class="components-external-link"
+                                href="https://simple.wikipedia.org/wiki/IP_address"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  IP addresses
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                               outside of your 
+                              <a
+                                href="admin.php?page=wc-settings&tab=general"
+                              >
+                                supported countries
+                              </a>
+                              . When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
+                        </p>
+                      </div>
+                      <div
+                        class="wcpay-inline-notice wcpay-inline-info-notice components-notice is-info"
+                      >
+                        <div
+                          class="components-visually-hidden emotion-0 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="VisuallyHidden"
+                          style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                        >
+                          Information notice
+                        </div>
+                        <div
+                          class="components-notice__content"
+                        >
+                          <div
+                            class="components-flex emotion-2 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Flex"
+                          >
+                            <div
+                              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-4 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                focusable="false"
+                                height="24"
+                                size="24"
+                                viewBox="0 0 24 24"
+                                width="24"
+                              >
+                                <path
+                                  d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-4 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              Orders from outside of the following countries will be blocked by the filter: 
+                              <strong>
+                                Canada, United States
+                              </strong>
+                            </div>
+                          </div>
+                          <div
+                            class="components-notice__actions"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="ip-address-mismatch"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        IP Address Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-14__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-14"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-14"
+                              >
+                                Enable IP Address Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-14__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for customer's 
+                              <a
+                                class="components-external-link"
+                                href="https://simple.wikipedia.org/wiki/IP_address"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  IP address
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                               to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="address-mismatch-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Address Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-15__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-15"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-15"
+                              >
+                                Enable Address Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-15__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="purchase-price-threshold-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Purchase Price Threshold
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle is-checked"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-16__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-16"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-16"
+                              >
+                                Enable Purchase Price Threshold filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-16__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-children-container"
+                      >
+                        <strong>
+                          Limits
+                        </strong>
+                        <div
+                          class="fraud-protection-rule-toggle-children-horizontal-form"
+                        >
+                          <div
+                            class="fraud-protection-rule-toggle-children-vertical-form"
+                          >
+                            <div>
+                              <div
+                                class="components-base-control wcpay-components-amount-input with-value emotion-110 emotion-13"
+                              >
+                                <div
+                                  class="components-base-control__field emotion-112 emotion-15"
+                                >
+                                  <label
+                                    class="components-base-control__label emotion-114 emotion-115"
+                                    for="inspector-text-control-with-affixes-0"
+                                  >
+                                    Minimum purchase price
+                                  </label>
+                                  <div
+                                    class="text-control-with-affixes text-control-with-prefix"
+                                  >
+                                    <span
+                                      class="text-control-with-affixes__prefix"
+                                      id="inspector-text-control-with-affixes-0__prefix"
+                                    >
+                                      $
+                                    </span>
+                                    <input
+                                      aria-describedby="inspector-text-control-with-affixes-0__help inspector-text-control-with-affixes-0__prefix"
+                                      class="components-text-control__input"
+                                      data-testid="amount-input"
+                                      id="fraud-protection-purchase-price-minimum"
+                                      placeholder="0.00"
+                                      type="text"
+                                      value="10"
+                                    />
+                                  </div>
+                                </div>
+                                <p
+                                  class="components-base-control__help emotion-116 emotion-21"
+                                  id="inspector-text-control-with-affixes-0__help"
+                                >
+                                  Leave blank for no limit
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="fraud-protection-rule-toggle-children-vertical-form"
+                          >
+                            <div>
+                              <div
+                                class="components-base-control wcpay-components-amount-input with-value emotion-110 emotion-13"
+                              >
+                                <div
+                                  class="components-base-control__field emotion-112 emotion-15"
+                                >
+                                  <label
+                                    class="components-base-control__label emotion-114 emotion-115"
+                                    for="inspector-text-control-with-affixes-1"
+                                  >
+                                    Maximum purchase price
+                                  </label>
+                                  <div
+                                    class="text-control-with-affixes text-control-with-prefix"
+                                  >
+                                    <span
+                                      class="text-control-with-affixes__prefix"
+                                      id="inspector-text-control-with-affixes-1__prefix"
+                                    >
+                                      $
+                                    </span>
+                                    <input
+                                      aria-describedby="inspector-text-control-with-affixes-1__help inspector-text-control-with-affixes-1__prefix"
+                                      class="components-text-control__input"
+                                      data-testid="amount-input"
+                                      id="fraud-protection-purchase-price-maximum"
+                                      placeholder="0.00"
+                                      type="text"
+                                      value="1"
+                                    />
+                                  </div>
+                                </div>
+                                <p
+                                  class="components-base-control__help emotion-116 emotion-21"
+                                  id="inspector-text-control-with-affixes-1__help"
+                                >
+                                  Leave blank for no limit
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="fraud-protection-rule-toggle-children-notice"
+                        >
+                          <div
+                            class="wcpay-inline-notice wcpay-inline-error-notice components-notice is-error"
+                          >
+                            <div
+                              class="components-visually-hidden emotion-0 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="VisuallyHidden"
+                              style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                            >
+                              Error notice
+                            </div>
+                            <div
+                              class="components-notice__content"
+                            >
+                              <div
+                                class="components-flex emotion-2 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="Flex"
+                              >
+                                <div
+                                  class="components-flex-item wcpay-inline-notice__icon wcpay-inline-error-notice__icon emotion-4 emotion-1"
+                                  data-wp-c16t="true"
+                                  data-wp-component="FlexItem"
+                                >
+                                  <svg
+                                    class="gridicon gridicons-notice-outline"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <g>
+                                      <path
+                                        d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                      />
+                                    </g>
+                                  </svg>
+                                </div>
+                                <div
+                                  class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
+                                  data-wp-c16t="true"
+                                  data-wp-component="FlexItem"
+                                >
+                                  Maximum purchase price must be greater than the minimum purchase price.
+                                </div>
+                              </div>
+                              <div
+                                class="components-notice__actions"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="order-items-threshold-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Order Items Threshold
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-17__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-17"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-17"
+                              >
+                                Enable Order Items Threshold filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-17__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="cvc-verification-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        CVC Verification
+                      </h4>
+                      <div
+                        class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
+                      >
+                        <div
+                          class="components-visually-hidden emotion-0 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="VisuallyHidden"
+                          style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                        >
+                          Warning notice
+                        </div>
+                        <div
+                          class="components-notice__content"
+                        >
+                          <div
+                            class="components-flex emotion-2 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Flex"
+                          >
+                            <div
+                              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-4 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              <svg
+                                class="gridicon gridicons-notice-outline"
+                                height="24"
+                                viewBox="0 0 24 24"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <g>
+                                  <path
+                                    d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                            <div
+                              class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-4 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                              <a
+                                class="components-external-link"
+                                href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  Learn more
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                            </div>
+                          </div>
+                          <div
+                            class="components-notice__actions"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <footer
+                  class="fraud-protection-advanced-settings__footer"
+                >
+                  <button
+                    class="components-button is-primary"
+                    type="button"
+                  >
+                    Save changes
+                  </button>
+                </footer>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": .emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.emotion-6 {
+  background-color: #fff;
+  color: #1e1e1e;
+  position: relative;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  outline: none;
+  border-radius: calc(8px - 1px);
+}
+
+.emotion-8 {
+  height: 100%;
+}
+
+.emotion-10 {
+  box-sizing: border-box;
+  height: auto;
+  max-height: 100%;
+  padding: calc(4px * 4) calc(4px * 6);
+}
+
+.emotion-10:first-of-type {
+  border-top-left-radius: calc(8px - 1px);
+  border-top-right-radius: calc(8px - 1px);
+}
+
+.emotion-10:last-of-type {
+  border-bottom-left-radius: calc(8px - 1px);
+  border-bottom-right-radius: calc(8px - 1px);
+}
+
+.emotion-12 {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.emotion-12 *,
+.emotion-12 *::before,
+.emotion-12 *::after {
+  box-sizing: inherit;
+}
+
+.components-panel__row .emotion-14 {
+  margin-bottom: inherit;
+}
+
+.emotion-18 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-20 {
+  margin-top: calc(4px * 2);
+  margin-bottom: 0;
+  font-size: 12px;
+  font-style: normal;
+  color: #757575;
+}
+
+.emotion-22 {
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
+  opacity: 1;
+  left: 0;
+  right: 0;
+  top: 0;
+  border-radius: 8px;
+}
+
+@media not ( prefers-reduced-motion ) {
+  .emotion-22 {
+    -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+    transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  }
+}
+
+.emotion-110 {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.emotion-110 *,
+.emotion-110 *::before,
+.emotion-110 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-112 {
+  margin-bottom: calc(4px * 2);
+}
+
+.components-panel__row .emotion-112 {
+  margin-bottom: inherit;
+}
+
+.emotion-114 {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  text-transform: uppercase;
+  display: inline-block;
+  margin-bottom: calc(4px * 2);
+  padding: 0;
+}
+
+.emotion-116 {
+  margin-top: calc(4px * 2);
+  margin-bottom: 0;
+  font-size: 12px;
+  font-style: normal;
+  color: #757575;
+  margin-bottom: revert;
+}
+
+<div>
+    <div>
+      <div
+        class="woocommerce-layout__header-wrapper"
+      >
+        <div
+          class="woocommerce-layout__header-heading"
+        />
+      </div>
+      <h2
+        class="fraud-protection-header-breadcrumb-legacy"
+      >
+        Advanced fraud protection
+        <small>
+          <a
+            data-link-type="wp-admin"
+            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+          >
+            ⤴︎
+          </a>
+        </small>
+      </h2>
+      <div
+        class="wcpay-settings-layout"
+      >
+        <div
+          aria-busy="false"
+          class="wcpay-form-busy-state"
+        >
+          <div
+            aria-live="polite"
+            class="wcpay-form-busy-state__status screen-reader-text"
+            role="status"
+          />
+          <div
             class="settings-section"
             id="advanced-fraud"
           >
@@ -1224,1201 +2439,6 @@ exports[`Advanced fraud protection settings doesn't save when there's a validati
         </div>
       </div>
     </div>
-  </body>,
-  "container": .emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  width: 100%;
-}
-
-.emotion-2>* {
-  min-width: 0;
-}
-
-.emotion-4 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-.emotion-6 {
-  background-color: #fff;
-  color: #1e1e1e;
-  position: relative;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
-  outline: none;
-  border-radius: calc(8px - 1px);
-}
-
-.emotion-8 {
-  height: 100%;
-}
-
-.emotion-10 {
-  box-sizing: border-box;
-  height: auto;
-  max-height: 100%;
-  padding: calc(4px * 4) calc(4px * 6);
-}
-
-.emotion-10:first-of-type {
-  border-top-left-radius: calc(8px - 1px);
-  border-top-right-radius: calc(8px - 1px);
-}
-
-.emotion-10:last-of-type {
-  border-bottom-left-radius: calc(8px - 1px);
-  border-bottom-right-radius: calc(8px - 1px);
-}
-
-.emotion-12 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
-  box-sizing: inherit;
-}
-
-.components-panel__row .emotion-14 {
-  margin-bottom: inherit;
-}
-
-.emotion-18 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-20 {
-  margin-top: calc(4px * 2);
-  margin-bottom: 0;
-  font-size: 12px;
-  font-style: normal;
-  color: #757575;
-}
-
-.emotion-22 {
-  background: transparent;
-  display: block;
-  margin: 0!important;
-  pointer-events: none;
-  position: absolute;
-  will-change: box-shadow;
-  border-radius: inherit;
-  bottom: 0;
-  box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
-  opacity: 1;
-  left: 0;
-  right: 0;
-  top: 0;
-  border-radius: 8px;
-}
-
-@media not ( prefers-reduced-motion ) {
-  .emotion-22 {
-    -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
-    transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
-  }
-}
-
-.emotion-110 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-.emotion-110 *,
-.emotion-110 *::before,
-.emotion-110 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-112 {
-  margin-bottom: calc(4px * 2);
-}
-
-.components-panel__row .emotion-112 {
-  margin-bottom: inherit;
-}
-
-.emotion-114 {
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.4;
-  text-transform: uppercase;
-  display: inline-block;
-  margin-bottom: calc(4px * 2);
-  padding: 0;
-}
-
-.emotion-116 {
-  margin-top: calc(4px * 2);
-  margin-bottom: 0;
-  font-size: 12px;
-  font-style: normal;
-  color: #757575;
-  margin-bottom: revert;
-}
-
-<div>
-    <div>
-      <div
-        class="woocommerce-layout__header-wrapper"
-      >
-        <div
-          class="woocommerce-layout__header-heading"
-        />
-      </div>
-      <h2
-        class="fraud-protection-header-breadcrumb-legacy"
-      >
-        Advanced fraud protection
-        <small>
-          <a
-            data-link-type="wp-admin"
-            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-          >
-            ⤴︎
-          </a>
-        </small>
-      </h2>
-      <div
-        class="wcpay-settings-layout"
-      >
-        <div
-          class="settings-section"
-          id="advanced-fraud"
-        >
-          <div
-            class="settings-section__details"
-          >
-            <h2>
-              Filter configuration
-            </h2>
-            <p>
-              Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
-            </p>
-          </div>
-          <div
-            class="settings-section__controls"
-          >
-            <div
-              class="wcpay-inline-notice wcpay-inline-error-notice fraud-protection-advanced-settings-error-notice components-notice is-error is-dismissible"
-            >
-              <div
-                class="components-visually-hidden emotion-0 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="VisuallyHidden"
-                style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-              >
-                Error notice
-              </div>
-              <div
-                class="components-notice__content"
-              >
-                <div
-                  class="components-flex emotion-2 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="Flex"
-                >
-                  <div
-                    class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="FlexItem"
-                  >
-                    Settings were not saved. Maximum purchase price must be greater than the minimum purchase price.
-                  </div>
-                </div>
-                <div
-                  class="components-notice__actions"
-                />
-              </div>
-              <button
-                aria-label="Close"
-                class="components-button components-notice__dismiss is-small has-icon"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  focusable="false"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="avs-mismatch-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    AVS Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-12__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-12"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-12"
-                          >
-                            Enable AVS Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-12__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="international-ip-address-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    International IP Address
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-13__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-13"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-13"
-                          >
-                            Enable International IP Address filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-13__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for 
-                          <a
-                            class="components-external-link"
-                            href="https://simple.wikipedia.org/wiki/IP_address"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              IP addresses
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                           outside of your 
-                          <a
-                            href="admin.php?page=wc-settings&tab=general"
-                          >
-                            supported countries
-                          </a>
-                          . When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
-                    </p>
-                  </div>
-                  <div
-                    class="wcpay-inline-notice wcpay-inline-info-notice components-notice is-info"
-                  >
-                    <div
-                      class="components-visually-hidden emotion-0 emotion-1"
-                      data-wp-c16t="true"
-                      data-wp-component="VisuallyHidden"
-                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                    >
-                      Information notice
-                    </div>
-                    <div
-                      class="components-notice__content"
-                    >
-                      <div
-                        class="components-flex emotion-2 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="Flex"
-                      >
-                        <div
-                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-4 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            focusable="false"
-                            height="24"
-                            size="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                          >
-                            <path
-                              d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
-                            />
-                          </svg>
-                        </div>
-                        <div
-                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-4 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          Orders from outside of the following countries will be blocked by the filter: 
-                          <strong>
-                            Canada, United States
-                          </strong>
-                        </div>
-                      </div>
-                      <div
-                        class="components-notice__actions"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="ip-address-mismatch"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    IP Address Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-14__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-14"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-14"
-                          >
-                            Enable IP Address Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-14__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for customer's 
-                          <a
-                            class="components-external-link"
-                            href="https://simple.wikipedia.org/wiki/IP_address"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              IP address
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                           to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="address-mismatch-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Address Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-15__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-15"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-15"
-                          >
-                            Enable Address Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-15__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="purchase-price-threshold-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Purchase Price Threshold
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle is-checked"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-16__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-16"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-16"
-                          >
-                            Enable Purchase Price Threshold filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-16__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-toggle-children-container"
-                  >
-                    <strong>
-                      Limits
-                    </strong>
-                    <div
-                      class="fraud-protection-rule-toggle-children-horizontal-form"
-                    >
-                      <div
-                        class="fraud-protection-rule-toggle-children-vertical-form"
-                      >
-                        <div>
-                          <div
-                            class="components-base-control wcpay-components-amount-input with-value emotion-110 emotion-13"
-                          >
-                            <div
-                              class="components-base-control__field emotion-112 emotion-15"
-                            >
-                              <label
-                                class="components-base-control__label emotion-114 emotion-115"
-                                for="inspector-text-control-with-affixes-0"
-                              >
-                                Minimum purchase price
-                              </label>
-                              <div
-                                class="text-control-with-affixes text-control-with-prefix"
-                              >
-                                <span
-                                  class="text-control-with-affixes__prefix"
-                                  id="inspector-text-control-with-affixes-0__prefix"
-                                >
-                                  $
-                                </span>
-                                <input
-                                  aria-describedby="inspector-text-control-with-affixes-0__help inspector-text-control-with-affixes-0__prefix"
-                                  class="components-text-control__input"
-                                  data-testid="amount-input"
-                                  id="fraud-protection-purchase-price-minimum"
-                                  placeholder="0.00"
-                                  type="text"
-                                  value="10"
-                                />
-                              </div>
-                            </div>
-                            <p
-                              class="components-base-control__help emotion-116 emotion-21"
-                              id="inspector-text-control-with-affixes-0__help"
-                            >
-                              Leave blank for no limit
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="fraud-protection-rule-toggle-children-vertical-form"
-                      >
-                        <div>
-                          <div
-                            class="components-base-control wcpay-components-amount-input with-value emotion-110 emotion-13"
-                          >
-                            <div
-                              class="components-base-control__field emotion-112 emotion-15"
-                            >
-                              <label
-                                class="components-base-control__label emotion-114 emotion-115"
-                                for="inspector-text-control-with-affixes-1"
-                              >
-                                Maximum purchase price
-                              </label>
-                              <div
-                                class="text-control-with-affixes text-control-with-prefix"
-                              >
-                                <span
-                                  class="text-control-with-affixes__prefix"
-                                  id="inspector-text-control-with-affixes-1__prefix"
-                                >
-                                  $
-                                </span>
-                                <input
-                                  aria-describedby="inspector-text-control-with-affixes-1__help inspector-text-control-with-affixes-1__prefix"
-                                  class="components-text-control__input"
-                                  data-testid="amount-input"
-                                  id="fraud-protection-purchase-price-maximum"
-                                  placeholder="0.00"
-                                  type="text"
-                                  value="1"
-                                />
-                              </div>
-                            </div>
-                            <p
-                              class="components-base-control__help emotion-116 emotion-21"
-                              id="inspector-text-control-with-affixes-1__help"
-                            >
-                              Leave blank for no limit
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="fraud-protection-rule-toggle-children-notice"
-                    >
-                      <div
-                        class="wcpay-inline-notice wcpay-inline-error-notice components-notice is-error"
-                      >
-                        <div
-                          class="components-visually-hidden emotion-0 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="VisuallyHidden"
-                          style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                        >
-                          Error notice
-                        </div>
-                        <div
-                          class="components-notice__content"
-                        >
-                          <div
-                            class="components-flex emotion-2 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="Flex"
-                          >
-                            <div
-                              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-error-notice__icon emotion-4 emotion-1"
-                              data-wp-c16t="true"
-                              data-wp-component="FlexItem"
-                            >
-                              <svg
-                                class="gridicon gridicons-notice-outline"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <g>
-                                  <path
-                                    d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                                  />
-                                </g>
-                              </svg>
-                            </div>
-                            <div
-                              class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
-                              data-wp-c16t="true"
-                              data-wp-component="FlexItem"
-                            >
-                              Maximum purchase price must be greater than the minimum purchase price.
-                            </div>
-                          </div>
-                          <div
-                            class="components-notice__actions"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="order-items-threshold-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Order Items Threshold
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-17__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-17"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-17"
-                          >
-                            Enable Order Items Threshold filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-17__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="cvc-verification-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    CVC Verification
-                  </h4>
-                  <div
-                    class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
-                  >
-                    <div
-                      class="components-visually-hidden emotion-0 emotion-1"
-                      data-wp-c16t="true"
-                      data-wp-component="VisuallyHidden"
-                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                    >
-                      Warning notice
-                    </div>
-                    <div
-                      class="components-notice__content"
-                    >
-                      <div
-                        class="components-flex emotion-2 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="Flex"
-                      >
-                        <div
-                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-4 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          <svg
-                            class="gridicon gridicons-notice-outline"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g>
-                              <path
-                                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                              />
-                            </g>
-                          </svg>
-                        </div>
-                        <div
-                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-4 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
-                          <a
-                            class="components-external-link"
-                            href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              Learn more
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                        </div>
-                      </div>
-                      <div
-                        class="components-notice__actions"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <footer
-              class="fraud-protection-advanced-settings__footer"
-            >
-              <button
-                class="components-button is-primary"
-                type="button"
-              >
-                Save changes
-              </button>
-            </footer>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],
@@ -2649,6 +2669,1009 @@ exports[`Advanced fraud protection settings renders an error message when settin
         <div
           class="wcpay-settings-layout"
         >
+          <div
+            aria-busy="false"
+            class="wcpay-form-busy-state"
+          >
+            <div
+              aria-live="polite"
+              class="wcpay-form-busy-state__status screen-reader-text"
+              role="status"
+            />
+            <div
+              class="settings-section"
+              id="advanced-fraud"
+            >
+              <div
+                class="settings-section__details"
+              >
+                <h2>
+                  Filter configuration
+                </h2>
+                <p>
+                  Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
+                </p>
+              </div>
+              <div
+                class="settings-section__controls"
+              >
+                <div
+                  class="wcpay-inline-notice wcpay-inline-error-notice fraud-protection-advanced-settings-error-notice components-notice is-error"
+                >
+                  <div
+                    class="components-visually-hidden emotion-0 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="VisuallyHidden"
+                    style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                  >
+                    Error notice
+                  </div>
+                  <div
+                    class="components-notice__content"
+                  >
+                    <div
+                      class="components-flex emotion-2 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="Flex"
+                    >
+                      <div
+                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
+                        data-wp-c16t="true"
+                        data-wp-component="FlexItem"
+                      >
+                        There was an error retrieving your fraud protection settings. Please refresh the page to try again.
+                      </div>
+                    </div>
+                    <div
+                      class="components-notice__actions"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="avs-mismatch-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        AVS Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-6__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-6"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-6"
+                              >
+                                Enable AVS Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-6__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="international-ip-address-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        International IP Address
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-7__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-7"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-7"
+                              >
+                                Enable International IP Address filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-7__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for 
+                              <a
+                                class="components-external-link"
+                                href="https://simple.wikipedia.org/wiki/IP_address"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  IP addresses
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                               outside of your 
+                              <a
+                                href="admin.php?page=wc-settings&tab=general"
+                              >
+                                supported countries
+                              </a>
+                              . When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
+                        </p>
+                      </div>
+                      <div
+                        class="wcpay-inline-notice wcpay-inline-info-notice components-notice is-info"
+                      >
+                        <div
+                          class="components-visually-hidden emotion-0 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="VisuallyHidden"
+                          style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                        >
+                          Information notice
+                        </div>
+                        <div
+                          class="components-notice__content"
+                        >
+                          <div
+                            class="components-flex emotion-2 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Flex"
+                          >
+                            <div
+                              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-4 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                focusable="false"
+                                height="24"
+                                size="24"
+                                viewBox="0 0 24 24"
+                                width="24"
+                              >
+                                <path
+                                  d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-4 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              Orders from outside of the following countries will be blocked by the filter: 
+                              <strong>
+                                Canada, United States
+                              </strong>
+                            </div>
+                          </div>
+                          <div
+                            class="components-notice__actions"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="ip-address-mismatch"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        IP Address Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-8__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-8"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-8"
+                              >
+                                Enable IP Address Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-8__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for customer's 
+                              <a
+                                class="components-external-link"
+                                href="https://simple.wikipedia.org/wiki/IP_address"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  IP address
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                               to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="address-mismatch-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Address Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-9__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-9"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-9"
+                              >
+                                Enable Address Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-9__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="purchase-price-threshold-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Purchase Price Threshold
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-10__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-10"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-10"
+                              >
+                                Enable Purchase Price Threshold filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-10__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="order-items-threshold-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Order Items Threshold
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-12 emotion-13"
+                        >
+                          <div
+                            class="components-base-control__field emotion-14 emotion-15"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-2 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-11__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-11"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-11"
+                              >
+                                Enable Order Items Threshold filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-20 emotion-21"
+                            id="inspector-toggle-control-11__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="cvc-verification-card"
+                >
+                  <div
+                    class="emotion-8 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        CVC Verification
+                      </h4>
+                      <div
+                        class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
+                      >
+                        <div
+                          class="components-visually-hidden emotion-0 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="VisuallyHidden"
+                          style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                        >
+                          Warning notice
+                        </div>
+                        <div
+                          class="components-notice__content"
+                        >
+                          <div
+                            class="components-flex emotion-2 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Flex"
+                          >
+                            <div
+                              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-4 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              <svg
+                                class="gridicon gridicons-notice-outline"
+                                height="24"
+                                viewBox="0 0 24 24"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <g>
+                                  <path
+                                    d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                            <div
+                              class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-4 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                              <a
+                                class="components-external-link"
+                                href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  Learn more
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                            </div>
+                          </div>
+                          <div
+                            class="components-notice__actions"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-22 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <footer
+                  class="fraud-protection-advanced-settings__footer"
+                >
+                  <button
+                    class="components-button is-primary"
+                    disabled=""
+                    type="button"
+                  >
+                    Save changes
+                  </button>
+                </footer>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": .emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.emotion-6 {
+  background-color: #fff;
+  color: #1e1e1e;
+  position: relative;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  outline: none;
+  border-radius: calc(8px - 1px);
+}
+
+.emotion-8 {
+  height: 100%;
+}
+
+.emotion-10 {
+  box-sizing: border-box;
+  height: auto;
+  max-height: 100%;
+  padding: calc(4px * 4) calc(4px * 6);
+}
+
+.emotion-10:first-of-type {
+  border-top-left-radius: calc(8px - 1px);
+  border-top-right-radius: calc(8px - 1px);
+}
+
+.emotion-10:last-of-type {
+  border-bottom-left-radius: calc(8px - 1px);
+  border-bottom-right-radius: calc(8px - 1px);
+}
+
+.emotion-12 {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.emotion-12 *,
+.emotion-12 *::before,
+.emotion-12 *::after {
+  box-sizing: inherit;
+}
+
+.components-panel__row .emotion-14 {
+  margin-bottom: inherit;
+}
+
+.emotion-18 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-20 {
+  margin-top: calc(4px * 2);
+  margin-bottom: 0;
+  font-size: 12px;
+  font-style: normal;
+  color: #757575;
+}
+
+.emotion-22 {
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
+  opacity: 1;
+  left: 0;
+  right: 0;
+  top: 0;
+  border-radius: 8px;
+}
+
+@media not ( prefers-reduced-motion ) {
+  .emotion-22 {
+    -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+    transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  }
+}
+
+<div>
+    <div>
+      <div
+        class="woocommerce-layout__header-wrapper"
+      >
+        <div
+          class="woocommerce-layout__header-heading"
+        />
+      </div>
+      <h2
+        class="fraud-protection-header-breadcrumb-legacy"
+      >
+        Advanced fraud protection
+        <small>
+          <a
+            data-link-type="wp-admin"
+            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+          >
+            ⤴︎
+          </a>
+        </small>
+      </h2>
+      <div
+        class="wcpay-settings-layout"
+      >
+        <div
+          aria-busy="false"
+          class="wcpay-form-busy-state"
+        >
+          <div
+            aria-live="polite"
+            class="wcpay-form-busy-state__status screen-reader-text"
+            role="status"
+          />
           <div
             class="settings-section"
             id="advanced-fraud"
@@ -3486,989 +4509,6 @@ exports[`Advanced fraud protection settings renders an error message when settin
         </div>
       </div>
     </div>
-  </body>,
-  "container": .emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  width: 100%;
-}
-
-.emotion-2>* {
-  min-width: 0;
-}
-
-.emotion-4 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-.emotion-6 {
-  background-color: #fff;
-  color: #1e1e1e;
-  position: relative;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
-  outline: none;
-  border-radius: calc(8px - 1px);
-}
-
-.emotion-8 {
-  height: 100%;
-}
-
-.emotion-10 {
-  box-sizing: border-box;
-  height: auto;
-  max-height: 100%;
-  padding: calc(4px * 4) calc(4px * 6);
-}
-
-.emotion-10:first-of-type {
-  border-top-left-radius: calc(8px - 1px);
-  border-top-right-radius: calc(8px - 1px);
-}
-
-.emotion-10:last-of-type {
-  border-bottom-left-radius: calc(8px - 1px);
-  border-bottom-right-radius: calc(8px - 1px);
-}
-
-.emotion-12 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-.emotion-12 *,
-.emotion-12 *::before,
-.emotion-12 *::after {
-  box-sizing: inherit;
-}
-
-.components-panel__row .emotion-14 {
-  margin-bottom: inherit;
-}
-
-.emotion-18 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-20 {
-  margin-top: calc(4px * 2);
-  margin-bottom: 0;
-  font-size: 12px;
-  font-style: normal;
-  color: #757575;
-}
-
-.emotion-22 {
-  background: transparent;
-  display: block;
-  margin: 0!important;
-  pointer-events: none;
-  position: absolute;
-  will-change: box-shadow;
-  border-radius: inherit;
-  bottom: 0;
-  box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
-  opacity: 1;
-  left: 0;
-  right: 0;
-  top: 0;
-  border-radius: 8px;
-}
-
-@media not ( prefers-reduced-motion ) {
-  .emotion-22 {
-    -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
-    transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
-  }
-}
-
-<div>
-    <div>
-      <div
-        class="woocommerce-layout__header-wrapper"
-      >
-        <div
-          class="woocommerce-layout__header-heading"
-        />
-      </div>
-      <h2
-        class="fraud-protection-header-breadcrumb-legacy"
-      >
-        Advanced fraud protection
-        <small>
-          <a
-            data-link-type="wp-admin"
-            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-          >
-            ⤴︎
-          </a>
-        </small>
-      </h2>
-      <div
-        class="wcpay-settings-layout"
-      >
-        <div
-          class="settings-section"
-          id="advanced-fraud"
-        >
-          <div
-            class="settings-section__details"
-          >
-            <h2>
-              Filter configuration
-            </h2>
-            <p>
-              Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
-            </p>
-          </div>
-          <div
-            class="settings-section__controls"
-          >
-            <div
-              class="wcpay-inline-notice wcpay-inline-error-notice fraud-protection-advanced-settings-error-notice components-notice is-error"
-            >
-              <div
-                class="components-visually-hidden emotion-0 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="VisuallyHidden"
-                style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-              >
-                Error notice
-              </div>
-              <div
-                class="components-notice__content"
-              >
-                <div
-                  class="components-flex emotion-2 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="Flex"
-                >
-                  <div
-                    class="components-flex-item wcpay-inline-notice__content wcpay-inline-error-notice__content emotion-4 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="FlexItem"
-                  >
-                    There was an error retrieving your fraud protection settings. Please refresh the page to try again.
-                  </div>
-                </div>
-                <div
-                  class="components-notice__actions"
-                />
-              </div>
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="avs-mismatch-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    AVS Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-6__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-6"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-6"
-                          >
-                            Enable AVS Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-6__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="international-ip-address-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    International IP Address
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-7__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-7"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-7"
-                          >
-                            Enable International IP Address filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-7__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for 
-                          <a
-                            class="components-external-link"
-                            href="https://simple.wikipedia.org/wiki/IP_address"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              IP addresses
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                           outside of your 
-                          <a
-                            href="admin.php?page=wc-settings&tab=general"
-                          >
-                            supported countries
-                          </a>
-                          . When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
-                    </p>
-                  </div>
-                  <div
-                    class="wcpay-inline-notice wcpay-inline-info-notice components-notice is-info"
-                  >
-                    <div
-                      class="components-visually-hidden emotion-0 emotion-1"
-                      data-wp-c16t="true"
-                      data-wp-component="VisuallyHidden"
-                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                    >
-                      Information notice
-                    </div>
-                    <div
-                      class="components-notice__content"
-                    >
-                      <div
-                        class="components-flex emotion-2 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="Flex"
-                      >
-                        <div
-                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-4 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            focusable="false"
-                            height="24"
-                            size="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                          >
-                            <path
-                              d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
-                            />
-                          </svg>
-                        </div>
-                        <div
-                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-4 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          Orders from outside of the following countries will be blocked by the filter: 
-                          <strong>
-                            Canada, United States
-                          </strong>
-                        </div>
-                      </div>
-                      <div
-                        class="components-notice__actions"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="ip-address-mismatch"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    IP Address Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-8__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-8"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-8"
-                          >
-                            Enable IP Address Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-8__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for customer's 
-                          <a
-                            class="components-external-link"
-                            href="https://simple.wikipedia.org/wiki/IP_address"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              IP address
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                           to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="address-mismatch-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Address Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-9__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-9"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-9"
-                          >
-                            Enable Address Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-9__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="purchase-price-threshold-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Purchase Price Threshold
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-10__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-10"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-10"
-                          >
-                            Enable Purchase Price Threshold filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-10__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="order-items-threshold-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Order Items Threshold
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-12 emotion-13"
-                    >
-                      <div
-                        class="components-base-control__field emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-2 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-11__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-11"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-18 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-11"
-                          >
-                            Enable Order Items Threshold filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-20 emotion-21"
-                        id="inspector-toggle-control-11__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-6 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="cvc-verification-card"
-            >
-              <div
-                class="emotion-8 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    CVC Verification
-                  </h4>
-                  <div
-                    class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
-                  >
-                    <div
-                      class="components-visually-hidden emotion-0 emotion-1"
-                      data-wp-c16t="true"
-                      data-wp-component="VisuallyHidden"
-                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                    >
-                      Warning notice
-                    </div>
-                    <div
-                      class="components-notice__content"
-                    >
-                      <div
-                        class="components-flex emotion-2 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="Flex"
-                      >
-                        <div
-                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-4 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          <svg
-                            class="gridicon gridicons-notice-outline"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g>
-                              <path
-                                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                              />
-                            </g>
-                          </svg>
-                        </div>
-                        <div
-                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-4 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
-                          <a
-                            class="components-external-link"
-                            href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              Learn more
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                        </div>
-                      </div>
-                      <div
-                        class="components-notice__actions"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-22 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <footer
-              class="fraud-protection-advanced-settings__footer"
-            >
-              <button
-                class="components-button is-primary"
-                disabled=""
-                type="button"
-              >
-                Save changes
-              </button>
-            </footer>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],
@@ -4691,6 +4731,968 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
       <div
         class="wcpay-settings-layout"
       >
+        <div
+          aria-busy="false"
+          class="wcpay-form-busy-state"
+        >
+          <div
+            aria-live="polite"
+            class="wcpay-form-busy-state__status screen-reader-text"
+            role="status"
+          />
+          <div
+            class="settings-section"
+            id="advanced-fraud"
+          >
+            <div
+              class="settings-section__details"
+            >
+              <h2>
+                Filter configuration
+              </h2>
+              <p>
+                Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
+              </p>
+            </div>
+            <div
+              class="settings-section__controls"
+            >
+              <div
+                class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="avs-mismatch-card"
+              >
+                <div
+                  class="emotion-2 emotion-1"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <h4>
+                      AVS Mismatch
+                    </h4>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control emotion-6 emotion-7"
+                      >
+                        <div
+                          class="components-base-control__field emotion-8 emotion-9"
+                        >
+                          <div
+                            class="components-flex components-h-stack emotion-10 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="HStack"
+                          >
+                            <span
+                              class="components-form-toggle"
+                            >
+                              <input
+                                aria-describedby="inspector-toggle-control-0__help"
+                                class="components-form-toggle__input"
+                                id="inspector-toggle-control-0"
+                                type="checkbox"
+                              />
+                              <span
+                                class="components-form-toggle__track"
+                              />
+                              <span
+                                class="components-form-toggle__thumb"
+                              />
+                            </span>
+                            <label
+                              class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexBlock"
+                              for="inspector-toggle-control-0"
+                            >
+                              Enable AVS Mismatch filter
+                            </label>
+                          </div>
+                        </div>
+                        <p
+                          class="components-base-control__help emotion-14 emotion-15"
+                          id="inspector-toggle-control-0__help"
+                        >
+                          <span
+                            class="components-toggle-control__help"
+                          >
+                            This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="international-ip-address-card"
+              >
+                <div
+                  class="emotion-2 emotion-1"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <h4>
+                      International IP Address
+                    </h4>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control emotion-6 emotion-7"
+                      >
+                        <div
+                          class="components-base-control__field emotion-8 emotion-9"
+                        >
+                          <div
+                            class="components-flex components-h-stack emotion-10 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="HStack"
+                          >
+                            <span
+                              class="components-form-toggle"
+                            >
+                              <input
+                                aria-describedby="inspector-toggle-control-1__help"
+                                class="components-form-toggle__input"
+                                id="inspector-toggle-control-1"
+                                type="checkbox"
+                              />
+                              <span
+                                class="components-form-toggle__track"
+                              />
+                              <span
+                                class="components-form-toggle__thumb"
+                              />
+                            </span>
+                            <label
+                              class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexBlock"
+                              for="inspector-toggle-control-1"
+                            >
+                              Enable International IP Address filter
+                            </label>
+                          </div>
+                        </div>
+                        <p
+                          class="components-base-control__help emotion-14 emotion-15"
+                          id="inspector-toggle-control-1__help"
+                        >
+                          <span
+                            class="components-toggle-control__help"
+                          >
+                            This filter screens for 
+                            <a
+                              class="components-external-link"
+                              href="https://simple.wikipedia.org/wiki/IP_address"
+                              rel="external noreferrer noopener"
+                              target="_blank"
+                            >
+                              <span
+                                class="components-external-link__contents"
+                              >
+                                IP addresses
+                              </span>
+                              <span
+                                aria-label="(opens in a new tab)"
+                                class="components-external-link__icon"
+                              >
+                                ↗
+                              </span>
+                            </a>
+                             outside of your 
+                            <a
+                              href="admin.php?page=wc-settings&tab=general"
+                            >
+                              supported countries
+                            </a>
+                            . When enabled the payment will be blocked.
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
+                      </p>
+                    </div>
+                    <div
+                      class="wcpay-inline-notice wcpay-inline-info-notice components-notice is-info"
+                    >
+                      <div
+                        class="components-visually-hidden emotion-36 emotion-1"
+                        data-wp-c16t="true"
+                        data-wp-component="VisuallyHidden"
+                        style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                      >
+                        Information notice
+                      </div>
+                      <div
+                        class="components-notice__content"
+                      >
+                        <div
+                          class="components-flex emotion-10 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="Flex"
+                        >
+                          <div
+                            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-40 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              focusable="false"
+                              height="24"
+                              size="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-40 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            Orders from outside of the following countries will be blocked by the filter: 
+                            <strong>
+                              Canada, United States
+                            </strong>
+                          </div>
+                        </div>
+                        <div
+                          class="components-notice__actions"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="ip-address-mismatch"
+              >
+                <div
+                  class="emotion-2 emotion-1"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <h4>
+                      IP Address Mismatch
+                    </h4>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control emotion-6 emotion-7"
+                      >
+                        <div
+                          class="components-base-control__field emotion-8 emotion-9"
+                        >
+                          <div
+                            class="components-flex components-h-stack emotion-10 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="HStack"
+                          >
+                            <span
+                              class="components-form-toggle"
+                            >
+                              <input
+                                aria-describedby="inspector-toggle-control-2__help"
+                                class="components-form-toggle__input"
+                                id="inspector-toggle-control-2"
+                                type="checkbox"
+                              />
+                              <span
+                                class="components-form-toggle__track"
+                              />
+                              <span
+                                class="components-form-toggle__thumb"
+                              />
+                            </span>
+                            <label
+                              class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexBlock"
+                              for="inspector-toggle-control-2"
+                            >
+                              Enable IP Address Mismatch filter
+                            </label>
+                          </div>
+                        </div>
+                        <p
+                          class="components-base-control__help emotion-14 emotion-15"
+                          id="inspector-toggle-control-2__help"
+                        >
+                          <span
+                            class="components-toggle-control__help"
+                          >
+                            This filter screens for customer's 
+                            <a
+                              class="components-external-link"
+                              href="https://simple.wikipedia.org/wiki/IP_address"
+                              rel="external noreferrer noopener"
+                              target="_blank"
+                            >
+                              <span
+                                class="components-external-link__contents"
+                              >
+                                IP address
+                              </span>
+                              <span
+                                aria-label="(opens in a new tab)"
+                                class="components-external-link__icon"
+                              >
+                                ↗
+                              </span>
+                            </a>
+                             to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="address-mismatch-card"
+              >
+                <div
+                  class="emotion-2 emotion-1"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <h4>
+                      Address Mismatch
+                    </h4>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control emotion-6 emotion-7"
+                      >
+                        <div
+                          class="components-base-control__field emotion-8 emotion-9"
+                        >
+                          <div
+                            class="components-flex components-h-stack emotion-10 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="HStack"
+                          >
+                            <span
+                              class="components-form-toggle"
+                            >
+                              <input
+                                aria-describedby="inspector-toggle-control-3__help"
+                                class="components-form-toggle__input"
+                                id="inspector-toggle-control-3"
+                                type="checkbox"
+                              />
+                              <span
+                                class="components-form-toggle__track"
+                              />
+                              <span
+                                class="components-form-toggle__thumb"
+                              />
+                            </span>
+                            <label
+                              class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexBlock"
+                              for="inspector-toggle-control-3"
+                            >
+                              Enable Address Mismatch filter
+                            </label>
+                          </div>
+                        </div>
+                        <p
+                          class="components-base-control__help emotion-14 emotion-15"
+                          id="inspector-toggle-control-3__help"
+                        >
+                          <span
+                            class="components-toggle-control__help"
+                          >
+                            This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="purchase-price-threshold-card"
+              >
+                <div
+                  class="emotion-2 emotion-1"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <h4>
+                      Purchase Price Threshold
+                    </h4>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control emotion-6 emotion-7"
+                      >
+                        <div
+                          class="components-base-control__field emotion-8 emotion-9"
+                        >
+                          <div
+                            class="components-flex components-h-stack emotion-10 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="HStack"
+                          >
+                            <span
+                              class="components-form-toggle"
+                            >
+                              <input
+                                aria-describedby="inspector-toggle-control-4__help"
+                                class="components-form-toggle__input"
+                                id="inspector-toggle-control-4"
+                                type="checkbox"
+                              />
+                              <span
+                                class="components-form-toggle__track"
+                              />
+                              <span
+                                class="components-form-toggle__thumb"
+                              />
+                            </span>
+                            <label
+                              class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexBlock"
+                              for="inspector-toggle-control-4"
+                            >
+                              Enable Purchase Price Threshold filter
+                            </label>
+                          </div>
+                        </div>
+                        <p
+                          class="components-base-control__help emotion-14 emotion-15"
+                          id="inspector-toggle-control-4__help"
+                        >
+                          <span
+                            class="components-toggle-control__help"
+                          >
+                            This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="order-items-threshold-card"
+              >
+                <div
+                  class="emotion-2 emotion-1"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <h4>
+                      Order Items Threshold
+                    </h4>
+                    <div
+                      class="fraud-protection-rule-toggle"
+                    >
+                      <div
+                        class="components-base-control components-toggle-control emotion-6 emotion-7"
+                      >
+                        <div
+                          class="components-base-control__field emotion-8 emotion-9"
+                        >
+                          <div
+                            class="components-flex components-h-stack emotion-10 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="HStack"
+                          >
+                            <span
+                              class="components-form-toggle"
+                            >
+                              <input
+                                aria-describedby="inspector-toggle-control-5__help"
+                                class="components-form-toggle__input"
+                                id="inspector-toggle-control-5"
+                                type="checkbox"
+                              />
+                              <span
+                                class="components-form-toggle__track"
+                              />
+                              <span
+                                class="components-form-toggle__thumb"
+                              />
+                            </span>
+                            <label
+                              class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexBlock"
+                              for="inspector-toggle-control-5"
+                            >
+                              Enable Order Items Threshold filter
+                            </label>
+                          </div>
+                        </div>
+                        <p
+                          class="components-base-control__help emotion-14 emotion-15"
+                          id="inspector-toggle-control-5__help"
+                        >
+                          <span
+                            class="components-toggle-control__help"
+                          >
+                            This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <div
+                class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Card"
+                id="cvc-verification-card"
+              >
+                <div
+                  class="emotion-2 emotion-1"
+                >
+                  <div
+                    class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="CardBody"
+                  >
+                    <h4>
+                      CVC Verification
+                    </h4>
+                    <div
+                      class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
+                    >
+                      <div
+                        class="components-visually-hidden emotion-36 emotion-1"
+                        data-wp-c16t="true"
+                        data-wp-component="VisuallyHidden"
+                        style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                      >
+                        Warning notice
+                      </div>
+                      <div
+                        class="components-notice__content"
+                      >
+                        <div
+                          class="components-flex emotion-10 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="Flex"
+                        >
+                          <div
+                            class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-40 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            <svg
+                              class="gridicon gridicons-notice-outline"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <g>
+                                <path
+                                  d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                          <div
+                            class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-40 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="FlexItem"
+                          >
+                            For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                            <a
+                              class="components-external-link"
+                              href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                              rel="external noreferrer noopener"
+                              target="_blank"
+                            >
+                              <span
+                                class="components-external-link__contents"
+                              >
+                                Learn more
+                              </span>
+                              <span
+                                aria-label="(opens in a new tab)"
+                                class="components-external-link__icon"
+                              >
+                                ↗
+                              </span>
+                            </a>
+                          </div>
+                        </div>
+                        <div
+                          class="components-notice__actions"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="fraud-protection-rule-description"
+                    >
+                      <strong>
+                        How does this filter protect me?
+                      </strong>
+                      <p>
+                        Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+                <div
+                  aria-hidden="true"
+                  class="components-elevation emotion-16 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Elevation"
+                />
+              </div>
+              <footer
+                class="fraud-protection-advanced-settings__footer"
+              >
+                <button
+                  class="components-button is-primary"
+                  disabled=""
+                  type="button"
+                >
+                  Save changes
+                </button>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": .emotion-0 {
+  background-color: #fff;
+  color: #1e1e1e;
+  position: relative;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  outline: none;
+  border-radius: calc(8px - 1px);
+}
+
+.emotion-2 {
+  height: 100%;
+}
+
+.emotion-4 {
+  box-sizing: border-box;
+  height: auto;
+  max-height: 100%;
+  padding: calc(4px * 4) calc(4px * 6);
+}
+
+.emotion-4:first-of-type {
+  border-top-left-radius: calc(8px - 1px);
+  border-top-right-radius: calc(8px - 1px);
+}
+
+.emotion-4:last-of-type {
+  border-bottom-left-radius: calc(8px - 1px);
+  border-bottom-right-radius: calc(8px - 1px);
+}
+
+.emotion-6 {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.emotion-6 *,
+.emotion-6 *::before,
+.emotion-6 *::after {
+  box-sizing: inherit;
+}
+
+.components-panel__row .emotion-8 {
+  margin-bottom: inherit;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-10>* {
+  min-width: 0;
+}
+
+.emotion-12 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-14 {
+  margin-top: calc(4px * 2);
+  margin-bottom: 0;
+  font-size: 12px;
+  font-style: normal;
+  color: #757575;
+}
+
+.emotion-16 {
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
+  opacity: 1;
+  left: 0;
+  right: 0;
+  top: 0;
+  border-radius: 8px;
+}
+
+@media not ( prefers-reduced-motion ) {
+  .emotion-16 {
+    -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+    transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  }
+}
+
+.emotion-40 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+<div>
+    <h2
+      class="fraud-protection-header-breadcrumb-legacy"
+    >
+      Advanced fraud protection
+      <small>
+        <a
+          data-link-type="wp-admin"
+          href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+        >
+          ⤴︎
+        </a>
+      </small>
+    </h2>
+    <div
+      class="wcpay-settings-layout"
+    >
+      <div
+        aria-busy="false"
+        class="wcpay-form-busy-state"
+      >
+        <div
+          aria-live="polite"
+          class="wcpay-form-busy-state__status screen-reader-text"
+          role="status"
+        />
         <div
           class="settings-section"
           id="advanced-fraud"
@@ -5495,948 +6497,6 @@ exports[`Advanced fraud protection settings renders correctly 1`] = `
         </div>
       </div>
     </div>
-  </body>,
-  "container": .emotion-0 {
-  background-color: #fff;
-  color: #1e1e1e;
-  position: relative;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
-  outline: none;
-  border-radius: calc(8px - 1px);
-}
-
-.emotion-2 {
-  height: 100%;
-}
-
-.emotion-4 {
-  box-sizing: border-box;
-  height: auto;
-  max-height: 100%;
-  padding: calc(4px * 4) calc(4px * 6);
-}
-
-.emotion-4:first-of-type {
-  border-top-left-radius: calc(8px - 1px);
-  border-top-right-radius: calc(8px - 1px);
-}
-
-.emotion-4:last-of-type {
-  border-bottom-left-radius: calc(8px - 1px);
-  border-bottom-right-radius: calc(8px - 1px);
-}
-
-.emotion-6 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-.emotion-6 *,
-.emotion-6 *::before,
-.emotion-6 *::after {
-  box-sizing: inherit;
-}
-
-.components-panel__row .emotion-8 {
-  margin-bottom: inherit;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  width: 100%;
-}
-
-.emotion-10>* {
-  min-width: 0;
-}
-
-.emotion-12 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-14 {
-  margin-top: calc(4px * 2);
-  margin-bottom: 0;
-  font-size: 12px;
-  font-style: normal;
-  color: #757575;
-}
-
-.emotion-16 {
-  background: transparent;
-  display: block;
-  margin: 0!important;
-  pointer-events: none;
-  position: absolute;
-  will-change: box-shadow;
-  border-radius: inherit;
-  bottom: 0;
-  box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
-  opacity: 1;
-  left: 0;
-  right: 0;
-  top: 0;
-  border-radius: 8px;
-}
-
-@media not ( prefers-reduced-motion ) {
-  .emotion-16 {
-    -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
-    transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
-  }
-}
-
-.emotion-40 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-<div>
-    <h2
-      class="fraud-protection-header-breadcrumb-legacy"
-    >
-      Advanced fraud protection
-      <small>
-        <a
-          data-link-type="wp-admin"
-          href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-        >
-          ⤴︎
-        </a>
-      </small>
-    </h2>
-    <div
-      class="wcpay-settings-layout"
-    >
-      <div
-        class="settings-section"
-        id="advanced-fraud"
-      >
-        <div
-          class="settings-section__details"
-        >
-          <h2>
-            Filter configuration
-          </h2>
-          <p>
-            Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
-          </p>
-        </div>
-        <div
-          class="settings-section__controls"
-        >
-          <div
-            class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="avs-mismatch-card"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <h4>
-                  AVS Mismatch
-                </h4>
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <div
-                    class="components-base-control components-toggle-control emotion-6 emotion-7"
-                  >
-                    <div
-                      class="components-base-control__field emotion-8 emotion-9"
-                    >
-                      <div
-                        class="components-flex components-h-stack emotion-10 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="HStack"
-                      >
-                        <span
-                          class="components-form-toggle"
-                        >
-                          <input
-                            aria-describedby="inspector-toggle-control-0__help"
-                            class="components-form-toggle__input"
-                            id="inspector-toggle-control-0"
-                            type="checkbox"
-                          />
-                          <span
-                            class="components-form-toggle__track"
-                          />
-                          <span
-                            class="components-form-toggle__thumb"
-                          />
-                        </span>
-                        <label
-                          class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexBlock"
-                          for="inspector-toggle-control-0"
-                        >
-                          Enable AVS Mismatch filter
-                        </label>
-                      </div>
-                    </div>
-                    <p
-                      class="components-base-control__help emotion-14 emotion-15"
-                      id="inspector-toggle-control-0__help"
-                    >
-                      <span
-                        class="components-toggle-control__help"
-                      >
-                        This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="international-ip-address-card"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <h4>
-                  International IP Address
-                </h4>
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <div
-                    class="components-base-control components-toggle-control emotion-6 emotion-7"
-                  >
-                    <div
-                      class="components-base-control__field emotion-8 emotion-9"
-                    >
-                      <div
-                        class="components-flex components-h-stack emotion-10 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="HStack"
-                      >
-                        <span
-                          class="components-form-toggle"
-                        >
-                          <input
-                            aria-describedby="inspector-toggle-control-1__help"
-                            class="components-form-toggle__input"
-                            id="inspector-toggle-control-1"
-                            type="checkbox"
-                          />
-                          <span
-                            class="components-form-toggle__track"
-                          />
-                          <span
-                            class="components-form-toggle__thumb"
-                          />
-                        </span>
-                        <label
-                          class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexBlock"
-                          for="inspector-toggle-control-1"
-                        >
-                          Enable International IP Address filter
-                        </label>
-                      </div>
-                    </div>
-                    <p
-                      class="components-base-control__help emotion-14 emotion-15"
-                      id="inspector-toggle-control-1__help"
-                    >
-                      <span
-                        class="components-toggle-control__help"
-                      >
-                        This filter screens for 
-                        <a
-                          class="components-external-link"
-                          href="https://simple.wikipedia.org/wiki/IP_address"
-                          rel="external noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="components-external-link__contents"
-                          >
-                            IP addresses
-                          </span>
-                          <span
-                            aria-label="(opens in a new tab)"
-                            class="components-external-link__icon"
-                          >
-                            ↗
-                          </span>
-                        </a>
-                         outside of your 
-                        <a
-                          href="admin.php?page=wc-settings&tab=general"
-                        >
-                          supported countries
-                        </a>
-                        . When enabled the payment will be blocked.
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
-                  </p>
-                </div>
-                <div
-                  class="wcpay-inline-notice wcpay-inline-info-notice components-notice is-info"
-                >
-                  <div
-                    class="components-visually-hidden emotion-36 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="VisuallyHidden"
-                    style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                  >
-                    Information notice
-                  </div>
-                  <div
-                    class="components-notice__content"
-                  >
-                    <div
-                      class="components-flex emotion-10 emotion-1"
-                      data-wp-c16t="true"
-                      data-wp-component="Flex"
-                    >
-                      <div
-                        class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-40 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          focusable="false"
-                          height="24"
-                          size="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                        >
-                          <path
-                            d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-40 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        Orders from outside of the following countries will be blocked by the filter: 
-                        <strong>
-                          Canada, United States
-                        </strong>
-                      </div>
-                    </div>
-                    <div
-                      class="components-notice__actions"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="ip-address-mismatch"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <h4>
-                  IP Address Mismatch
-                </h4>
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <div
-                    class="components-base-control components-toggle-control emotion-6 emotion-7"
-                  >
-                    <div
-                      class="components-base-control__field emotion-8 emotion-9"
-                    >
-                      <div
-                        class="components-flex components-h-stack emotion-10 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="HStack"
-                      >
-                        <span
-                          class="components-form-toggle"
-                        >
-                          <input
-                            aria-describedby="inspector-toggle-control-2__help"
-                            class="components-form-toggle__input"
-                            id="inspector-toggle-control-2"
-                            type="checkbox"
-                          />
-                          <span
-                            class="components-form-toggle__track"
-                          />
-                          <span
-                            class="components-form-toggle__thumb"
-                          />
-                        </span>
-                        <label
-                          class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexBlock"
-                          for="inspector-toggle-control-2"
-                        >
-                          Enable IP Address Mismatch filter
-                        </label>
-                      </div>
-                    </div>
-                    <p
-                      class="components-base-control__help emotion-14 emotion-15"
-                      id="inspector-toggle-control-2__help"
-                    >
-                      <span
-                        class="components-toggle-control__help"
-                      >
-                        This filter screens for customer's 
-                        <a
-                          class="components-external-link"
-                          href="https://simple.wikipedia.org/wiki/IP_address"
-                          rel="external noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="components-external-link__contents"
-                          >
-                            IP address
-                          </span>
-                          <span
-                            aria-label="(opens in a new tab)"
-                            class="components-external-link__icon"
-                          >
-                            ↗
-                          </span>
-                        </a>
-                         to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="address-mismatch-card"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <h4>
-                  Address Mismatch
-                </h4>
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <div
-                    class="components-base-control components-toggle-control emotion-6 emotion-7"
-                  >
-                    <div
-                      class="components-base-control__field emotion-8 emotion-9"
-                    >
-                      <div
-                        class="components-flex components-h-stack emotion-10 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="HStack"
-                      >
-                        <span
-                          class="components-form-toggle"
-                        >
-                          <input
-                            aria-describedby="inspector-toggle-control-3__help"
-                            class="components-form-toggle__input"
-                            id="inspector-toggle-control-3"
-                            type="checkbox"
-                          />
-                          <span
-                            class="components-form-toggle__track"
-                          />
-                          <span
-                            class="components-form-toggle__thumb"
-                          />
-                        </span>
-                        <label
-                          class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexBlock"
-                          for="inspector-toggle-control-3"
-                        >
-                          Enable Address Mismatch filter
-                        </label>
-                      </div>
-                    </div>
-                    <p
-                      class="components-base-control__help emotion-14 emotion-15"
-                      id="inspector-toggle-control-3__help"
-                    >
-                      <span
-                        class="components-toggle-control__help"
-                      >
-                        This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="purchase-price-threshold-card"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <h4>
-                  Purchase Price Threshold
-                </h4>
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <div
-                    class="components-base-control components-toggle-control emotion-6 emotion-7"
-                  >
-                    <div
-                      class="components-base-control__field emotion-8 emotion-9"
-                    >
-                      <div
-                        class="components-flex components-h-stack emotion-10 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="HStack"
-                      >
-                        <span
-                          class="components-form-toggle"
-                        >
-                          <input
-                            aria-describedby="inspector-toggle-control-4__help"
-                            class="components-form-toggle__input"
-                            id="inspector-toggle-control-4"
-                            type="checkbox"
-                          />
-                          <span
-                            class="components-form-toggle__track"
-                          />
-                          <span
-                            class="components-form-toggle__thumb"
-                          />
-                        </span>
-                        <label
-                          class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexBlock"
-                          for="inspector-toggle-control-4"
-                        >
-                          Enable Purchase Price Threshold filter
-                        </label>
-                      </div>
-                    </div>
-                    <p
-                      class="components-base-control__help emotion-14 emotion-15"
-                      id="inspector-toggle-control-4__help"
-                    >
-                      <span
-                        class="components-toggle-control__help"
-                      >
-                        This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="order-items-threshold-card"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <h4>
-                  Order Items Threshold
-                </h4>
-                <div
-                  class="fraud-protection-rule-toggle"
-                >
-                  <div
-                    class="components-base-control components-toggle-control emotion-6 emotion-7"
-                  >
-                    <div
-                      class="components-base-control__field emotion-8 emotion-9"
-                    >
-                      <div
-                        class="components-flex components-h-stack emotion-10 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="HStack"
-                      >
-                        <span
-                          class="components-form-toggle"
-                        >
-                          <input
-                            aria-describedby="inspector-toggle-control-5__help"
-                            class="components-form-toggle__input"
-                            id="inspector-toggle-control-5"
-                            type="checkbox"
-                          />
-                          <span
-                            class="components-form-toggle__track"
-                          />
-                          <span
-                            class="components-form-toggle__thumb"
-                          />
-                        </span>
-                        <label
-                          class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexBlock"
-                          for="inspector-toggle-control-5"
-                        >
-                          Enable Order Items Threshold filter
-                        </label>
-                      </div>
-                    </div>
-                    <p
-                      class="components-base-control__help emotion-14 emotion-15"
-                      id="inspector-toggle-control-5__help"
-                    >
-                      <span
-                        class="components-toggle-control__help"
-                      >
-                        This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <div
-            class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-            id="cvc-verification-card"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <h4>
-                  CVC Verification
-                </h4>
-                <div
-                  class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
-                >
-                  <div
-                    class="components-visually-hidden emotion-36 emotion-1"
-                    data-wp-c16t="true"
-                    data-wp-component="VisuallyHidden"
-                    style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                  >
-                    Warning notice
-                  </div>
-                  <div
-                    class="components-notice__content"
-                  >
-                    <div
-                      class="components-flex emotion-10 emotion-1"
-                      data-wp-c16t="true"
-                      data-wp-component="Flex"
-                    >
-                      <div
-                        class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-40 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        <svg
-                          class="gridicon gridicons-notice-outline"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <g>
-                            <path
-                              d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                            />
-                          </g>
-                        </svg>
-                      </div>
-                      <div
-                        class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-40 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="FlexItem"
-                      >
-                        For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
-                        <a
-                          class="components-external-link"
-                          href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
-                          rel="external noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="components-external-link__contents"
-                          >
-                            Learn more
-                          </span>
-                          <span
-                            aria-label="(opens in a new tab)"
-                            class="components-external-link__icon"
-                          >
-                            ↗
-                          </span>
-                        </a>
-                      </div>
-                    </div>
-                    <div
-                      class="components-notice__actions"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="fraud-protection-rule-description"
-                >
-                  <strong>
-                    How does this filter protect me?
-                  </strong>
-                  <p>
-                    Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-16 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-          <footer
-            class="fraud-protection-advanced-settings__footer"
-          >
-            <button
-              class="components-button is-primary"
-              disabled=""
-              type="button"
-            >
-              Save changes
-            </button>
-          </footer>
-        </div>
-      </div>
-    </div>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],
@@ -6706,6 +6766,1117 @@ exports[`Advanced fraud protection settings saves settings when there are no val
         <div
           class="wcpay-settings-layout"
         >
+          <div
+            aria-busy="false"
+            class="wcpay-form-busy-state"
+          >
+            <div
+              aria-live="polite"
+              class="wcpay-form-busy-state__status screen-reader-text"
+              role="status"
+            />
+            <div
+              class="settings-section"
+              id="advanced-fraud"
+            >
+              <div
+                class="settings-section__details"
+              >
+                <h2>
+                  Filter configuration
+                </h2>
+                <p>
+                  Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
+                </p>
+              </div>
+              <div
+                class="settings-section__controls"
+              >
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="avs-mismatch-card"
+                >
+                  <div
+                    class="emotion-2 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        AVS Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-6 emotion-7"
+                        >
+                          <div
+                            class="components-base-control__field emotion-8 emotion-9"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-10 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-18__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-18"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-18"
+                              >
+                                Enable AVS Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-14 emotion-15"
+                            id="inspector-toggle-control-18__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="international-ip-address-card"
+                >
+                  <div
+                    class="emotion-2 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        International IP Address
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-6 emotion-7"
+                        >
+                          <div
+                            class="components-base-control__field emotion-8 emotion-9"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-10 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-19__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-19"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-19"
+                              >
+                                Enable International IP Address filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-14 emotion-15"
+                            id="inspector-toggle-control-19__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for 
+                              <a
+                                class="components-external-link"
+                                href="https://simple.wikipedia.org/wiki/IP_address"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  IP addresses
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                               outside of your 
+                              <a
+                                href="admin.php?page=wc-settings&tab=general"
+                              >
+                                supported countries
+                              </a>
+                              . When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
+                        </p>
+                      </div>
+                      <div
+                        class="wcpay-inline-notice wcpay-inline-info-notice components-notice is-info"
+                      >
+                        <div
+                          class="components-visually-hidden emotion-36 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="VisuallyHidden"
+                          style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                        >
+                          Information notice
+                        </div>
+                        <div
+                          class="components-notice__content"
+                        >
+                          <div
+                            class="components-flex emotion-10 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Flex"
+                          >
+                            <div
+                              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-40 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                focusable="false"
+                                height="24"
+                                size="24"
+                                viewBox="0 0 24 24"
+                                width="24"
+                              >
+                                <path
+                                  d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-40 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              Orders from outside of the following countries will be blocked by the filter: 
+                              <strong>
+                                Canada, United States
+                              </strong>
+                            </div>
+                          </div>
+                          <div
+                            class="components-notice__actions"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="ip-address-mismatch"
+                >
+                  <div
+                    class="emotion-2 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        IP Address Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-6 emotion-7"
+                        >
+                          <div
+                            class="components-base-control__field emotion-8 emotion-9"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-10 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-20__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-20"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-20"
+                              >
+                                Enable IP Address Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-14 emotion-15"
+                            id="inspector-toggle-control-20__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for customer's 
+                              <a
+                                class="components-external-link"
+                                href="https://simple.wikipedia.org/wiki/IP_address"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  IP address
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                               to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="address-mismatch-card"
+                >
+                  <div
+                    class="emotion-2 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Address Mismatch
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-6 emotion-7"
+                        >
+                          <div
+                            class="components-base-control__field emotion-8 emotion-9"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-10 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-21__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-21"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-21"
+                              >
+                                Enable Address Mismatch filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-14 emotion-15"
+                            id="inspector-toggle-control-21__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="purchase-price-threshold-card"
+                >
+                  <div
+                    class="emotion-2 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Purchase Price Threshold
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-6 emotion-7"
+                        >
+                          <div
+                            class="components-base-control__field emotion-8 emotion-9"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-10 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle is-checked"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-22__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-22"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-22"
+                              >
+                                Enable Purchase Price Threshold filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-14 emotion-15"
+                            id="inspector-toggle-control-22__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-toggle-children-container"
+                      >
+                        <strong>
+                          Limits
+                        </strong>
+                        <div
+                          class="fraud-protection-rule-toggle-children-horizontal-form"
+                        >
+                          <div
+                            class="fraud-protection-rule-toggle-children-vertical-form"
+                          >
+                            <div>
+                              <div
+                                class="components-base-control wcpay-components-amount-input with-value emotion-104 emotion-7"
+                              >
+                                <div
+                                  class="components-base-control__field emotion-106 emotion-9"
+                                >
+                                  <label
+                                    class="components-base-control__label emotion-108 emotion-109"
+                                    for="inspector-text-control-with-affixes-2"
+                                  >
+                                    Minimum purchase price
+                                  </label>
+                                  <div
+                                    class="text-control-with-affixes text-control-with-prefix"
+                                  >
+                                    <span
+                                      class="text-control-with-affixes__prefix"
+                                      id="inspector-text-control-with-affixes-2__prefix"
+                                    >
+                                      $
+                                    </span>
+                                    <input
+                                      aria-describedby="inspector-text-control-with-affixes-2__help inspector-text-control-with-affixes-2__prefix"
+                                      class="components-text-control__input"
+                                      data-testid="amount-input"
+                                      id="fraud-protection-purchase-price-minimum"
+                                      placeholder="0.00"
+                                      type="text"
+                                      value="1"
+                                    />
+                                  </div>
+                                </div>
+                                <p
+                                  class="components-base-control__help emotion-110 emotion-15"
+                                  id="inspector-text-control-with-affixes-2__help"
+                                >
+                                  Leave blank for no limit
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="fraud-protection-rule-toggle-children-vertical-form"
+                          >
+                            <div>
+                              <div
+                                class="components-base-control wcpay-components-amount-input with-value emotion-104 emotion-7"
+                              >
+                                <div
+                                  class="components-base-control__field emotion-106 emotion-9"
+                                >
+                                  <label
+                                    class="components-base-control__label emotion-108 emotion-109"
+                                    for="inspector-text-control-with-affixes-3"
+                                  >
+                                    Maximum purchase price
+                                  </label>
+                                  <div
+                                    class="text-control-with-affixes text-control-with-prefix"
+                                  >
+                                    <span
+                                      class="text-control-with-affixes__prefix"
+                                      id="inspector-text-control-with-affixes-3__prefix"
+                                    >
+                                      $
+                                    </span>
+                                    <input
+                                      aria-describedby="inspector-text-control-with-affixes-3__help inspector-text-control-with-affixes-3__prefix"
+                                      class="components-text-control__input"
+                                      data-testid="amount-input"
+                                      id="fraud-protection-purchase-price-maximum"
+                                      placeholder="0.00"
+                                      type="text"
+                                      value="10"
+                                    />
+                                  </div>
+                                </div>
+                                <p
+                                  class="components-base-control__help emotion-110 emotion-15"
+                                  id="inspector-text-control-with-affixes-3__help"
+                                >
+                                  Leave blank for no limit
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="order-items-threshold-card"
+                >
+                  <div
+                    class="emotion-2 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        Order Items Threshold
+                      </h4>
+                      <div
+                        class="fraud-protection-rule-toggle"
+                      >
+                        <div
+                          class="components-base-control components-toggle-control emotion-6 emotion-7"
+                        >
+                          <div
+                            class="components-base-control__field emotion-8 emotion-9"
+                          >
+                            <div
+                              class="components-flex components-h-stack emotion-10 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="HStack"
+                            >
+                              <span
+                                class="components-form-toggle"
+                              >
+                                <input
+                                  aria-describedby="inspector-toggle-control-23__help"
+                                  class="components-form-toggle__input"
+                                  id="inspector-toggle-control-23"
+                                  type="checkbox"
+                                />
+                                <span
+                                  class="components-form-toggle__track"
+                                />
+                                <span
+                                  class="components-form-toggle__thumb"
+                                />
+                              </span>
+                              <label
+                                class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexBlock"
+                                for="inspector-toggle-control-23"
+                              >
+                                Enable Order Items Threshold filter
+                              </label>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-14 emotion-15"
+                            id="inspector-toggle-control-23__help"
+                          >
+                            <span
+                              class="components-toggle-control__help"
+                            >
+                              This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <div
+                  class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="Card"
+                  id="cvc-verification-card"
+                >
+                  <div
+                    class="emotion-2 emotion-1"
+                  >
+                    <div
+                      class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
+                      data-wp-c16t="true"
+                      data-wp-component="CardBody"
+                    >
+                      <h4>
+                        CVC Verification
+                      </h4>
+                      <div
+                        class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
+                      >
+                        <div
+                          class="components-visually-hidden emotion-36 emotion-1"
+                          data-wp-c16t="true"
+                          data-wp-component="VisuallyHidden"
+                          style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                        >
+                          Warning notice
+                        </div>
+                        <div
+                          class="components-notice__content"
+                        >
+                          <div
+                            class="components-flex emotion-10 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="Flex"
+                          >
+                            <div
+                              class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-40 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              <svg
+                                class="gridicon gridicons-notice-outline"
+                                height="24"
+                                viewBox="0 0 24 24"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <g>
+                                  <path
+                                    d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                            <div
+                              class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-40 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="FlexItem"
+                            >
+                              For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
+                              <a
+                                class="components-external-link"
+                                href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
+                                rel="external noreferrer noopener"
+                                target="_blank"
+                              >
+                                <span
+                                  class="components-external-link__contents"
+                                >
+                                  Learn more
+                                </span>
+                                <span
+                                  aria-label="(opens in a new tab)"
+                                  class="components-external-link__icon"
+                                >
+                                  ↗
+                                </span>
+                              </a>
+                            </div>
+                          </div>
+                          <div
+                            class="components-notice__actions"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="fraud-protection-rule-description"
+                      >
+                        <strong>
+                          How does this filter protect me?
+                        </strong>
+                        <p>
+                          Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="components-elevation emotion-16 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="Elevation"
+                  />
+                </div>
+                <footer
+                  class="fraud-protection-advanced-settings__footer"
+                >
+                  <button
+                    class="components-button is-primary"
+                    disabled=""
+                    type="button"
+                  >
+                    Save changes
+                  </button>
+                </footer>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": .emotion-0 {
+  background-color: #fff;
+  color: #1e1e1e;
+  position: relative;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  outline: none;
+  border-radius: calc(8px - 1px);
+}
+
+.emotion-2 {
+  height: 100%;
+}
+
+.emotion-4 {
+  box-sizing: border-box;
+  height: auto;
+  max-height: 100%;
+  padding: calc(4px * 4) calc(4px * 6);
+}
+
+.emotion-4:first-of-type {
+  border-top-left-radius: calc(8px - 1px);
+  border-top-right-radius: calc(8px - 1px);
+}
+
+.emotion-4:last-of-type {
+  border-bottom-left-radius: calc(8px - 1px);
+  border-bottom-right-radius: calc(8px - 1px);
+}
+
+.emotion-6 {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.emotion-6 *,
+.emotion-6 *::before,
+.emotion-6 *::after {
+  box-sizing: inherit;
+}
+
+.components-panel__row .emotion-8 {
+  margin-bottom: inherit;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.emotion-10>* {
+  min-width: 0;
+}
+
+.emotion-12 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-14 {
+  margin-top: calc(4px * 2);
+  margin-bottom: 0;
+  font-size: 12px;
+  font-style: normal;
+  color: #757575;
+}
+
+.emotion-16 {
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
+  opacity: 1;
+  left: 0;
+  right: 0;
+  top: 0;
+  border-radius: 8px;
+}
+
+@media not ( prefers-reduced-motion ) {
+  .emotion-16 {
+    -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+    transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  }
+}
+
+.emotion-40 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.emotion-104 {
+  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.emotion-104 *,
+.emotion-104 *::before,
+.emotion-104 *::after {
+  box-sizing: inherit;
+}
+
+.emotion-106 {
+  margin-bottom: calc(4px * 2);
+}
+
+.components-panel__row .emotion-106 {
+  margin-bottom: inherit;
+}
+
+.emotion-108 {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  text-transform: uppercase;
+  display: inline-block;
+  margin-bottom: calc(4px * 2);
+  padding: 0;
+}
+
+.emotion-110 {
+  margin-top: calc(4px * 2);
+  margin-bottom: 0;
+  font-size: 12px;
+  font-style: normal;
+  color: #757575;
+  margin-bottom: revert;
+}
+
+<div>
+    <div>
+      <div
+        class="woocommerce-layout__header-wrapper"
+      >
+        <div
+          class="woocommerce-layout__header-heading"
+        />
+      </div>
+      <h2
+        class="fraud-protection-header-breadcrumb-legacy"
+      >
+        Advanced fraud protection
+        <small>
+          <a
+            data-link-type="wp-admin"
+            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+          >
+            ⤴︎
+          </a>
+        </small>
+      </h2>
+      <div
+        class="wcpay-settings-layout"
+      >
+        <div
+          aria-busy="false"
+          class="wcpay-form-busy-state"
+        >
+          <div
+            aria-live="polite"
+            class="wcpay-form-busy-state__status screen-reader-text"
+            role="status"
+          />
           <div
             class="settings-section"
             id="advanced-fraud"
@@ -7608,1097 +8779,6 @@ exports[`Advanced fraud protection settings saves settings when there are no val
                 </button>
               </footer>
             </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": .emotion-0 {
-  background-color: #fff;
-  color: #1e1e1e;
-  position: relative;
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
-  outline: none;
-  border-radius: calc(8px - 1px);
-}
-
-.emotion-2 {
-  height: 100%;
-}
-
-.emotion-4 {
-  box-sizing: border-box;
-  height: auto;
-  max-height: 100%;
-  padding: calc(4px * 4) calc(4px * 6);
-}
-
-.emotion-4:first-of-type {
-  border-top-left-radius: calc(8px - 1px);
-  border-top-right-radius: calc(8px - 1px);
-}
-
-.emotion-4:last-of-type {
-  border-bottom-left-radius: calc(8px - 1px);
-  border-bottom-right-radius: calc(8px - 1px);
-}
-
-.emotion-6 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-.emotion-6 *,
-.emotion-6 *::before,
-.emotion-6 *::after {
-  box-sizing: inherit;
-}
-
-.components-panel__row .emotion-8 {
-  margin-bottom: inherit;
-}
-
-.emotion-10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  width: 100%;
-}
-
-.emotion-10>* {
-  min-width: 0;
-}
-
-.emotion-12 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-14 {
-  margin-top: calc(4px * 2);
-  margin-bottom: 0;
-  font-size: 12px;
-  font-style: normal;
-  color: #757575;
-}
-
-.emotion-16 {
-  background: transparent;
-  display: block;
-  margin: 0!important;
-  pointer-events: none;
-  position: absolute;
-  will-change: box-shadow;
-  border-radius: inherit;
-  bottom: 0;
-  box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0);
-  opacity: 1;
-  left: 0;
-  right: 0;
-  top: 0;
-  border-radius: 8px;
-}
-
-@media not ( prefers-reduced-motion ) {
-  .emotion-16 {
-    -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
-    transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
-  }
-}
-
-.emotion-40 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-.emotion-104 {
-  font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen-Sans,Ubuntu,Cantarell,'Helvetica Neue',sans-serif;
-  font-size: 13px;
-  box-sizing: border-box;
-}
-
-.emotion-104 *,
-.emotion-104 *::before,
-.emotion-104 *::after {
-  box-sizing: inherit;
-}
-
-.emotion-106 {
-  margin-bottom: calc(4px * 2);
-}
-
-.components-panel__row .emotion-106 {
-  margin-bottom: inherit;
-}
-
-.emotion-108 {
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.4;
-  text-transform: uppercase;
-  display: inline-block;
-  margin-bottom: calc(4px * 2);
-  padding: 0;
-}
-
-.emotion-110 {
-  margin-top: calc(4px * 2);
-  margin-bottom: 0;
-  font-size: 12px;
-  font-style: normal;
-  color: #757575;
-  margin-bottom: revert;
-}
-
-<div>
-    <div>
-      <div
-        class="woocommerce-layout__header-wrapper"
-      >
-        <div
-          class="woocommerce-layout__header-heading"
-        />
-      </div>
-      <h2
-        class="fraud-protection-header-breadcrumb-legacy"
-      >
-        Advanced fraud protection
-        <small>
-          <a
-            data-link-type="wp-admin"
-            href="admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
-          >
-            ⤴︎
-          </a>
-        </small>
-      </h2>
-      <div
-        class="wcpay-settings-layout"
-      >
-        <div
-          class="settings-section"
-          id="advanced-fraud"
-        >
-          <div
-            class="settings-section__details"
-          >
-            <h2>
-              Filter configuration
-            </h2>
-            <p>
-              Set up advanced fraud filters. Enable at least one filter to activate advanced protection.
-            </p>
-          </div>
-          <div
-            class="settings-section__controls"
-          >
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="avs-mismatch-card"
-            >
-              <div
-                class="emotion-2 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    AVS Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-6 emotion-7"
-                    >
-                      <div
-                        class="components-base-control__field emotion-8 emotion-9"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-10 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-18__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-18"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-18"
-                          >
-                            Enable AVS Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-14 emotion-15"
-                        id="inspector-toggle-control-18__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the post code submitted by the customer against the post code on file with the card issuer. The payment will be blocked if the two post codes do not match.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Buyers who can provide correct post code on file with the issuing bank are more likely to be the actual account holder.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="international-ip-address-card"
-            >
-              <div
-                class="emotion-2 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    International IP Address
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-6 emotion-7"
-                    >
-                      <div
-                        class="components-base-control__field emotion-8 emotion-9"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-10 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-19__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-19"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-19"
-                          >
-                            Enable International IP Address filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-14 emotion-15"
-                        id="inspector-toggle-control-19__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for 
-                          <a
-                            class="components-external-link"
-                            href="https://simple.wikipedia.org/wiki/IP_address"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              IP addresses
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                           outside of your 
-                          <a
-                            href="admin.php?page=wc-settings&tab=general"
-                          >
-                            supported countries
-                          </a>
-                          . When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      You should be especially wary when a customer has an international IP address but uses domestic billing and shipping information. Fraudsters often pretend to live in one location, but live and shop from another.
-                    </p>
-                  </div>
-                  <div
-                    class="wcpay-inline-notice wcpay-inline-info-notice components-notice is-info"
-                  >
-                    <div
-                      class="components-visually-hidden emotion-36 emotion-1"
-                      data-wp-c16t="true"
-                      data-wp-component="VisuallyHidden"
-                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                    >
-                      Information notice
-                    </div>
-                    <div
-                      class="components-notice__content"
-                    >
-                      <div
-                        class="components-flex emotion-10 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="Flex"
-                      >
-                        <div
-                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-info-notice__icon emotion-40 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            focusable="false"
-                            height="24"
-                            size="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                          >
-                            <path
-                              d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8  6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z"
-                            />
-                          </svg>
-                        </div>
-                        <div
-                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-info-notice__content emotion-40 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          Orders from outside of the following countries will be blocked by the filter: 
-                          <strong>
-                            Canada, United States
-                          </strong>
-                        </div>
-                      </div>
-                      <div
-                        class="components-notice__actions"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="ip-address-mismatch"
-            >
-              <div
-                class="emotion-2 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    IP Address Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-6 emotion-7"
-                    >
-                      <div
-                        class="components-base-control__field emotion-8 emotion-9"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-10 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-20__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-20"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-20"
-                          >
-                            Enable IP Address Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-14 emotion-15"
-                        id="inspector-toggle-control-20__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for customer's 
-                          <a
-                            class="components-external-link"
-                            href="https://simple.wikipedia.org/wiki/IP_address"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              IP address
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                           to see if it is in a different country than indicated in their billing address. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Fraudulent transactions often use fake addresses to place orders. If the IP address seems to be in one country, but the billing address is in another, that could signal potential fraud.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="address-mismatch-card"
-            >
-              <div
-                class="emotion-2 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Address Mismatch
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-6 emotion-7"
-                    >
-                      <div
-                        class="components-base-control__field emotion-8 emotion-9"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-10 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-21__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-21"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-21"
-                          >
-                            Enable Address Mismatch filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-14 emotion-15"
-                        id="inspector-toggle-control-21__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter screens for differences between the shipping information and the billing information (country). When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      There are legitimate reasons for a billing/shipping mismatch with a customer purchase, but a mismatch could also indicate that someone is using a stolen identity to complete a purchase.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="purchase-price-threshold-card"
-            >
-              <div
-                class="emotion-2 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Purchase Price Threshold
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-6 emotion-7"
-                    >
-                      <div
-                        class="components-base-control__field emotion-8 emotion-9"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-10 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle is-checked"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-22__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-22"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-22"
-                          >
-                            Enable Purchase Price Threshold filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-14 emotion-15"
-                        id="inspector-toggle-control-22__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the purchase price of an order to the minimum and maximum purchase amounts that you specify. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-toggle-children-container"
-                  >
-                    <strong>
-                      Limits
-                    </strong>
-                    <div
-                      class="fraud-protection-rule-toggle-children-horizontal-form"
-                    >
-                      <div
-                        class="fraud-protection-rule-toggle-children-vertical-form"
-                      >
-                        <div>
-                          <div
-                            class="components-base-control wcpay-components-amount-input with-value emotion-104 emotion-7"
-                          >
-                            <div
-                              class="components-base-control__field emotion-106 emotion-9"
-                            >
-                              <label
-                                class="components-base-control__label emotion-108 emotion-109"
-                                for="inspector-text-control-with-affixes-2"
-                              >
-                                Minimum purchase price
-                              </label>
-                              <div
-                                class="text-control-with-affixes text-control-with-prefix"
-                              >
-                                <span
-                                  class="text-control-with-affixes__prefix"
-                                  id="inspector-text-control-with-affixes-2__prefix"
-                                >
-                                  $
-                                </span>
-                                <input
-                                  aria-describedby="inspector-text-control-with-affixes-2__help inspector-text-control-with-affixes-2__prefix"
-                                  class="components-text-control__input"
-                                  data-testid="amount-input"
-                                  id="fraud-protection-purchase-price-minimum"
-                                  placeholder="0.00"
-                                  type="text"
-                                  value="1"
-                                />
-                              </div>
-                            </div>
-                            <p
-                              class="components-base-control__help emotion-110 emotion-15"
-                              id="inspector-text-control-with-affixes-2__help"
-                            >
-                              Leave blank for no limit
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="fraud-protection-rule-toggle-children-vertical-form"
-                      >
-                        <div>
-                          <div
-                            class="components-base-control wcpay-components-amount-input with-value emotion-104 emotion-7"
-                          >
-                            <div
-                              class="components-base-control__field emotion-106 emotion-9"
-                            >
-                              <label
-                                class="components-base-control__label emotion-108 emotion-109"
-                                for="inspector-text-control-with-affixes-3"
-                              >
-                                Maximum purchase price
-                              </label>
-                              <div
-                                class="text-control-with-affixes text-control-with-prefix"
-                              >
-                                <span
-                                  class="text-control-with-affixes__prefix"
-                                  id="inspector-text-control-with-affixes-3__prefix"
-                                >
-                                  $
-                                </span>
-                                <input
-                                  aria-describedby="inspector-text-control-with-affixes-3__help inspector-text-control-with-affixes-3__prefix"
-                                  class="components-text-control__input"
-                                  data-testid="amount-input"
-                                  id="fraud-protection-purchase-price-maximum"
-                                  placeholder="0.00"
-                                  type="text"
-                                  value="10"
-                                />
-                              </div>
-                            </div>
-                            <p
-                              class="components-base-control__help emotion-110 emotion-15"
-                              id="inspector-text-control-with-affixes-3__help"
-                            >
-                              Leave blank for no limit
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      An unusually high purchase amount, compared to the average for your business, can indicate potential fraudulent activity.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="order-items-threshold-card"
-            >
-              <div
-                class="emotion-2 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    Order Items Threshold
-                  </h4>
-                  <div
-                    class="fraud-protection-rule-toggle"
-                  >
-                    <div
-                      class="components-base-control components-toggle-control emotion-6 emotion-7"
-                    >
-                      <div
-                        class="components-base-control__field emotion-8 emotion-9"
-                      >
-                        <div
-                          class="components-flex components-h-stack emotion-10 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="HStack"
-                        >
-                          <span
-                            class="components-form-toggle"
-                          >
-                            <input
-                              aria-describedby="inspector-toggle-control-23__help"
-                              class="components-form-toggle__input"
-                              id="inspector-toggle-control-23"
-                              type="checkbox"
-                            />
-                            <span
-                              class="components-form-toggle__track"
-                            />
-                            <span
-                              class="components-form-toggle__thumb"
-                            />
-                          </span>
-                          <label
-                            class="components-flex-item components-flex-block components-toggle-control__label emotion-12 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="FlexBlock"
-                            for="inspector-toggle-control-23"
-                          >
-                            Enable Order Items Threshold filter
-                          </label>
-                        </div>
-                      </div>
-                      <p
-                        class="components-base-control__help emotion-14 emotion-15"
-                        id="inspector-toggle-control-23__help"
-                      >
-                        <span
-                          class="components-toggle-control__help"
-                        >
-                          This filter compares the amount of items in an order to the minimum and maximum counts that you specify. When enabled the payment will be blocked.
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      An unusually high item count, compared to the average for your business, can indicate potential fraudulent activity.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <div
-              class="components-surface components-card fraud-protection-rule-card emotion-0 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Card"
-              id="cvc-verification-card"
-            >
-              <div
-                class="emotion-2 emotion-1"
-              >
-                <div
-                  class="components-card__body components-card-body wcpay-card-body wcpay-card-body emotion-4 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="CardBody"
-                >
-                  <h4>
-                    CVC Verification
-                  </h4>
-                  <div
-                    class="wcpay-inline-notice wcpay-inline-warning-notice components-notice is-warning"
-                  >
-                    <div
-                      class="components-visually-hidden emotion-36 emotion-1"
-                      data-wp-c16t="true"
-                      data-wp-component="VisuallyHidden"
-                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
-                    >
-                      Warning notice
-                    </div>
-                    <div
-                      class="components-notice__content"
-                    >
-                      <div
-                        class="components-flex emotion-10 emotion-1"
-                        data-wp-c16t="true"
-                        data-wp-component="Flex"
-                      >
-                        <div
-                          class="components-flex-item wcpay-inline-notice__icon wcpay-inline-warning-notice__icon emotion-40 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          <svg
-                            class="gridicon gridicons-notice-outline"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <g>
-                              <path
-                                d="M12 4c4.411 0 8 3.589 8 8s-3.589 8-8 8-8-3.589-8-8 3.589-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-                              />
-                            </g>
-                          </svg>
-                        </div>
-                        <div
-                          class="components-flex-item wcpay-inline-notice__content wcpay-inline-warning-notice__content emotion-40 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="FlexItem"
-                        >
-                          For security, this filter is enabled and cannot be modified. Payments failing CVC verification will be blocked. 
-                          <a
-                            class="components-external-link"
-                            href="https://woocommerce.com/document/woopayments/fraud-and-disputes/fraud-protection/#advanced-configuration"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              Learn more
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                        </div>
-                      </div>
-                      <div
-                        class="components-notice__actions"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    class="fraud-protection-rule-description"
-                  >
-                    <strong>
-                      How does this filter protect me?
-                    </strong>
-                    <p>
-                      Because the card security code appears only on the card and not on receipts or statements, the card security code provides some assurance that the physical card is in the possession of the buyer.
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-              <div
-                aria-hidden="true"
-                class="components-elevation emotion-16 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="Elevation"
-              />
-            </div>
-            <footer
-              class="fraud-protection-advanced-settings__footer"
-            >
-              <button
-                class="components-button is-primary"
-                disabled=""
-                type="button"
-              >
-                Save changes
-              </button>
-            </footer>
           </div>
         </div>
       </div>

--- a/client/settings/fraud-protection/advanced-settings/index.tsx
+++ b/client/settings/fraud-protection/advanced-settings/index.tsx
@@ -19,6 +19,7 @@ import {
 } from 'wcpay/data';
 import InlineNotice from 'wcpay/components/inline-notice';
 import ErrorBoundary from 'wcpay/components/error-boundary';
+import FormBusyState from 'wcpay/components/form-busy-state';
 import { getAdminUrl, isVersionGreaterOrEqual } from 'wcpay/utils';
 import SettingsLayout from 'wcpay/settings/settings-layout';
 import AVSMismatchRuleCard from './cards/avs-mismatch';
@@ -314,83 +315,109 @@ const FraudProtectionAdvancedSettingsPage: React.FC = () => {
 		>
 			<Breadcrumb />
 			<SettingsLayout>
-				<SettingsSection
-					description={ AdvancedFraudSettingsDescription }
-					id="advanced-fraud"
-				>
-					<ErrorBoundary>
-						{ validationError && (
-							<InlineNotice
-								className="fraud-protection-advanced-settings-error-notice"
-								status="error"
-								isDismissible
-								onRemove={ () => {
-									setValidationError( null );
-								} }
-							>
-								{ sprintf(
-									'%s %s',
-									__(
-										'Settings were not saved.',
+				<FormBusyState isBusy={ isSaving }>
+					<SettingsSection
+						description={ AdvancedFraudSettingsDescription }
+						id="advanced-fraud"
+					>
+						<ErrorBoundary>
+							{ validationError && (
+								<InlineNotice
+									className="fraud-protection-advanced-settings-error-notice"
+									status="error"
+									isDismissible
+									onRemove={ () => {
+										setValidationError( null );
+									} }
+								>
+									{ sprintf(
+										'%s %s',
+										__(
+											'Settings were not saved.',
+											'woocommerce-payments'
+										),
+										validationError
+									) }
+								</InlineNotice>
+							) }
+							{ advancedFraudProtectionSettings === 'error' && (
+								<InlineNotice
+									className="fraud-protection-advanced-settings-error-notice"
+									status="error"
+									isDismissible={ false }
+								>
+									{ __(
+										'There was an error retrieving your fraud protection settings.' +
+											' Please refresh the page to try again.',
 										'woocommerce-payments'
-									),
-									validationError
-								) }
-							</InlineNotice>
-						) }
-						{ advancedFraudProtectionSettings === 'error' && (
-							<InlineNotice
-								className="fraud-protection-advanced-settings-error-notice"
-								status="error"
-								isDismissible={ false }
+									) }
+								</InlineNotice>
+							) }
+							<LoadableBlock
+								isLoading={ isLoading }
+								numLines={ 20 }
 							>
-								{ __(
-									'There was an error retrieving your fraud protection settings.' +
-										' Please refresh the page to try again.',
-									'woocommerce-payments'
-								) }
-							</InlineNotice>
-						) }
-						<LoadableBlock isLoading={ isLoading } numLines={ 20 }>
-							<AVSMismatchRuleCard />
-						</LoadableBlock>
-						<LoadableBlock isLoading={ isLoading } numLines={ 20 }>
-							<InternationalIPAddressRuleCard />
-						</LoadableBlock>
-						<LoadableBlock isLoading={ isLoading } numLines={ 20 }>
-							<IPAddressMismatchRuleCard />
-						</LoadableBlock>
-						<LoadableBlock isLoading={ isLoading } numLines={ 20 }>
-							<AddressMismatchRuleCard />
-						</LoadableBlock>
-						<LoadableBlock isLoading={ isLoading } numLines={ 20 }>
-							<PurchasePriceThresholdRuleCard />
-						</LoadableBlock>
-						<LoadableBlock isLoading={ isLoading } numLines={ 20 }>
-							<OrderItemsThresholdRuleCard />
-						</LoadableBlock>
-						<LoadableBlock isLoading={ isLoading } numLines={ 20 }>
-							<CVCVerificationRuleCard />
-						</LoadableBlock>
+								<AVSMismatchRuleCard />
+							</LoadableBlock>
+							<LoadableBlock
+								isLoading={ isLoading }
+								numLines={ 20 }
+							>
+								<InternationalIPAddressRuleCard />
+							</LoadableBlock>
+							<LoadableBlock
+								isLoading={ isLoading }
+								numLines={ 20 }
+							>
+								<IPAddressMismatchRuleCard />
+							</LoadableBlock>
+							<LoadableBlock
+								isLoading={ isLoading }
+								numLines={ 20 }
+							>
+								<AddressMismatchRuleCard />
+							</LoadableBlock>
+							<LoadableBlock
+								isLoading={ isLoading }
+								numLines={ 20 }
+							>
+								<PurchasePriceThresholdRuleCard />
+							</LoadableBlock>
+							<LoadableBlock
+								isLoading={ isLoading }
+								numLines={ 20 }
+							>
+								<OrderItemsThresholdRuleCard />
+							</LoadableBlock>
+							<LoadableBlock
+								isLoading={ isLoading }
+								numLines={ 20 }
+							>
+								<CVCVerificationRuleCard />
+							</LoadableBlock>
 
-						<footer className="fraud-protection-advanced-settings__footer">
-							<Button
-								variant="primary"
-								isBusy={ isSaving }
-								onClick={ handleSaveSettings }
-								disabled={
-									isSaving ||
-									isLoading ||
-									advancedFraudProtectionSettings ===
-										'error' ||
-									! isDirty
-								}
-							>
-								{ __( 'Save changes', 'woocommerce-payments' ) }
-							</Button>
-						</footer>
-					</ErrorBoundary>
-				</SettingsSection>
+							<footer className="fraud-protection-advanced-settings__footer">
+								<Button
+									variant="primary"
+									isBusy={ isSaving }
+									onClick={ handleSaveSettings }
+									disabled={
+										isSaving ||
+										isLoading ||
+										advancedFraudProtectionSettings ===
+											'error' ||
+										! isDirty
+									}
+								>
+									{ __(
+										'Save changes',
+										'woocommerce-payments'
+									) }
+								</Button>
+							</footer>
+						</ErrorBoundary>
+					</SettingsSection>
+				</FormBusyState>
 			</SettingsLayout>
 		</FraudPreventionSettingsContext.Provider>
 	);

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -23,6 +23,7 @@ import LoadableSettingsSection from '../loadable-settings-section';
 import PaymentMethodsSection from '../payment-methods-section';
 import BuyNowPayLaterSection from '../buy-now-pay-later-section';
 import ErrorBoundary from '../../components/error-boundary';
+import FormBusyState from 'wcpay/components/form-busy-state';
 import NotificationSettings, {
 	NotificationSettingsDescription,
 } from '../notification-settings';
@@ -152,7 +153,7 @@ const SettingsManager = () => {
 	const [ isNotificationEmailValid, setNotificationEmailValid ] =
 		useState( true );
 
-	const { isLoading, isDirty } = useSettings();
+	const { isLoading, isDirty, isSaving } = useSettings();
 
 	useEffect( () => {
 		if ( ! isDirty ) {
@@ -230,106 +231,112 @@ const SettingsManager = () => {
 
 	return (
 		<SettingsLayout>
-			<SettingsSection
-				description={ GeneralSettingsDescription }
-				id="general"
-			>
-				<LoadableSettingsSection numLines={ 20 }>
-					<ErrorBoundary>
-						<GeneralSettings />
-					</ErrorBoundary>
-				</LoadableSettingsSection>
-			</SettingsSection>
-			<DuplicatedPaymentMethodsContext.Provider
-				value={ {
-					duplicates: useGetDuplicatedPaymentMethodIds(),
-					dismissedDuplicateNotices: dismissedDuplicateNotices,
-					setDismissedDuplicateNotices: setDismissedDuplicateNotices,
-				} }
-			>
-				<PaymentMethodsSection />
-				<BuyNowPayLaterSection />
+			<FormBusyState isBusy={ isSaving }>
 				<SettingsSection
-					id="express-checkouts"
-					description={ ExpressCheckoutDescription }
+					description={ GeneralSettingsDescription }
+					id="general"
 				>
 					<LoadableSettingsSection numLines={ 20 }>
 						<ErrorBoundary>
-							<ExpressCheckout />
+							<GeneralSettings />
 						</ErrorBoundary>
 					</LoadableSettingsSection>
 				</SettingsSection>
-			</DuplicatedPaymentMethodsContext.Provider>
-			<SettingsSection
-				description={ TransactionsDescription }
-				id="transactions"
-			>
-				<LoadableSettingsSection numLines={ 20 }>
-					<ErrorBoundary>
-						<Transactions
-							setTransactionInputsValid={
-								setTransactionInputsValid
-							}
-						/>
-					</ErrorBoundary>
-				</LoadableSettingsSection>
-			</SettingsSection>
-			<SettingsSection description={ DepositsDescription } id="deposits">
-				<div id="payout-schedule">
+				<DuplicatedPaymentMethodsContext.Provider
+					value={ {
+						duplicates: useGetDuplicatedPaymentMethodIds(),
+						dismissedDuplicateNotices: dismissedDuplicateNotices,
+						setDismissedDuplicateNotices:
+							setDismissedDuplicateNotices,
+					} }
+				>
+					<PaymentMethodsSection />
+					<BuyNowPayLaterSection />
+					<SettingsSection
+						id="express-checkouts"
+						description={ ExpressCheckoutDescription }
+					>
+						<LoadableSettingsSection numLines={ 20 }>
+							<ErrorBoundary>
+								<ExpressCheckout />
+							</ErrorBoundary>
+						</LoadableSettingsSection>
+					</SettingsSection>
+				</DuplicatedPaymentMethodsContext.Provider>
+				<SettingsSection
+					description={ TransactionsDescription }
+					id="transactions"
+				>
 					<LoadableSettingsSection numLines={ 20 }>
 						<ErrorBoundary>
-							<Deposits />
+							<Transactions
+								setTransactionInputsValid={
+									setTransactionInputsValid
+								}
+							/>
 						</ErrorBoundary>
 					</LoadableSettingsSection>
-				</div>
-			</SettingsSection>
-			<SettingsSection
-				description={ NotificationSettingsDescription }
-				id="notification-settings"
-			>
-				<LoadableSettingsSection numLines={ 20 }>
-					<ErrorBoundary>
-						<NotificationSettings
-							setNotificationEmailValid={
-								setNotificationEmailValid
-							}
-						/>
-					</ErrorBoundary>
-				</LoadableSettingsSection>
-			</SettingsSection>
-			<SettingsSection
-				description={ FraudProtectionDescription }
-				id="fp-settings"
-			>
-				<LoadableSettingsSection numLines={ 20 }>
-					<ErrorBoundary>
-						<FraudProtection />
-					</ErrorBoundary>
-				</LoadableSettingsSection>
-			</SettingsSection>
-			<SettingsSection
-				description={ AdvancedDescription }
-				id="advanced-settings"
-			>
-				<LoadableSettingsSection numLines={ 20 }>
-					<ErrorBoundary>
-						<AdvancedSettings />
-					</ErrorBoundary>
-				</LoadableSettingsSection>
-			</SettingsSection>
-			<SaveSettingsSection
-				disabled={
-					! isTransactionInputsValid || ! isNotificationEmailValid
-				}
-			/>
-			<VatFormModal
-				isModalOpen={ isVatFormModalOpen }
-				setModalOpen={ handleVatFormModalClose }
-				onCompleted={ handleVatFormModalCompleted }
-			/>
-			<ErrorBoundary>
-				<SpotlightPromotion />
-			</ErrorBoundary>
+				</SettingsSection>
+				<SettingsSection
+					description={ DepositsDescription }
+					id="deposits"
+				>
+					<div id="payout-schedule">
+						<LoadableSettingsSection numLines={ 20 }>
+							<ErrorBoundary>
+								<Deposits />
+							</ErrorBoundary>
+						</LoadableSettingsSection>
+					</div>
+				</SettingsSection>
+				<SettingsSection
+					description={ NotificationSettingsDescription }
+					id="notification-settings"
+				>
+					<LoadableSettingsSection numLines={ 20 }>
+						<ErrorBoundary>
+							<NotificationSettings
+								setNotificationEmailValid={
+									setNotificationEmailValid
+								}
+							/>
+						</ErrorBoundary>
+					</LoadableSettingsSection>
+				</SettingsSection>
+				<SettingsSection
+					description={ FraudProtectionDescription }
+					id="fp-settings"
+				>
+					<LoadableSettingsSection numLines={ 20 }>
+						<ErrorBoundary>
+							<FraudProtection />
+						</ErrorBoundary>
+					</LoadableSettingsSection>
+				</SettingsSection>
+				<SettingsSection
+					description={ AdvancedDescription }
+					id="advanced-settings"
+				>
+					<LoadableSettingsSection numLines={ 20 }>
+						<ErrorBoundary>
+							<AdvancedSettings />
+						</ErrorBoundary>
+					</LoadableSettingsSection>
+				</SettingsSection>
+				<SaveSettingsSection
+					disabled={
+						! isTransactionInputsValid || ! isNotificationEmailValid
+					}
+				/>
+				<VatFormModal
+					isModalOpen={ isVatFormModalOpen }
+					setModalOpen={ handleVatFormModalClose }
+					onCompleted={ handleVatFormModalCompleted }
+				/>
+				<ErrorBoundary>
+					<SpotlightPromotion />
+				</ErrorBoundary>
+			</FormBusyState>
 		</SettingsLayout>
 	);
 };

--- a/includes/multi-currency/client/settings/multi-currency/store-settings/__tests__/__snapshots__/index.test.js.snap
+++ b/includes/multi-currency/client/settings/multi-currency/store-settings/__tests__/__snapshots__/index.test.js.snap
@@ -105,180 +105,190 @@ exports[`Multi-Currency store settings store settings task renders correctly: sn
 
 <div>
   <div
-    class="settings-section multi-currency-settings-store-settings-section"
+    aria-busy="false"
+    class="wcpay-form-busy-state"
   >
     <div
-      class="settings-section__details"
-    >
-      <h2>
-        Store settings
-      </h2>
-      <p>
-        Store settings allow your customers to choose which currency they would like to use when shopping at your store. 
-        <a
-          class="components-external-link"
-          href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#store-settings"
-          rel="external noreferrer noopener"
-          target="_blank"
-        >
-          <span
-            class="components-external-link__contents"
-          >
-            Learn more
-          </span>
-          <span
-            aria-label="(opens in a new tab)"
-            class="components-external-link__icon"
-          >
-            ↗
-          </span>
-        </a>
-      </p>
-    </div>
-    <div
-      class="settings-section__controls"
-    >
-      <div
-        class="components-surface components-card multi-currency-settings__wrapper emotion-0 emotion-1"
-        data-wp-c16t="true"
-        data-wp-component="Card"
-      >
-        <div
-          class="emotion-2 emotion-1"
-        >
-          <div
-            class="components-card__body components-card-body wcpay-card-body emotion-4 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="CardBody"
-          >
-            <div
-              class="components-base-control components-checkbox-control emotion-6 emotion-7"
-            >
-              <div
-                class="components-base-control__field emotion-8 emotion-9"
-              >
-                <div
-                  class="components-flex components-h-stack emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
-                >
-                  <span
-                    class="components-checkbox-control__input-container"
-                  >
-                    <input
-                      aria-describedby="inspector-checkbox-control-0__help"
-                      class="components-checkbox-control__input"
-                      data-testid="enable_auto_currency"
-                      id="inspector-checkbox-control-0"
-                      type="checkbox"
-                      value="1"
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-0"
-                  >
-                    Automatically switch customers to their local currency if it has been enabled
-                  </label>
-                </div>
-              </div>
-              <p
-                class="components-base-control__help emotion-12 emotion-13"
-                id="inspector-checkbox-control-0__help"
-              >
-                <span
-                  class="components-checkbox-control__help"
-                >
-                  Customers will be notified via store alert banner. 
-                  <button
-                    class="components-button is-next-40px-default-size is-link"
-                    type="button"
-                  >
-                    Preview
-                  </button>
-                </span>
-              </p>
-            </div>
-            <div
-              class="components-base-control components-checkbox-control emotion-6 emotion-7"
-            >
-              <div
-                class="components-base-control__field emotion-8 emotion-9"
-              >
-                <div
-                  class="components-flex components-h-stack emotion-10 emotion-1"
-                  data-wp-c16t="true"
-                  data-wp-component="HStack"
-                >
-                  <span
-                    class="components-checkbox-control__input-container"
-                  >
-                    <input
-                      aria-describedby="inspector-checkbox-control-1__help"
-                      class="components-checkbox-control__input"
-                      data-testid="enable_storefront_switcher"
-                      id="inspector-checkbox-control-1"
-                      type="checkbox"
-                      value="1"
-                    />
-                  </span>
-                  <label
-                    class="components-checkbox-control__label"
-                    for="inspector-checkbox-control-1"
-                  >
-                    Add a currency switcher to the Storefront theme on breadcrumb section.
-                  </label>
-                </div>
-              </div>
-              <p
-                class="components-base-control__help emotion-12 emotion-13"
-                id="inspector-checkbox-control-1__help"
-              >
-                <span
-                  class="components-checkbox-control__help"
-                >
-                  A currency switcher is also available in your widgets. 
-                  <a
-                    href="widgets.php"
-                  >
-                    Configure now
-                  </a>
-                </span>
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          aria-hidden="true"
-          class="components-elevation emotion-22 emotion-1"
-          data-wp-c16t="true"
-          data-wp-component="Elevation"
-        />
-        <div
-          aria-hidden="true"
-          class="components-elevation emotion-22 emotion-1"
-          data-wp-c16t="true"
-          data-wp-component="Elevation"
-        />
-      </div>
-    </div>
-  </div>
-  <div
-    class="settings-section multi-currency-settings-save-settings-section"
-  >
-    <div
-      class="settings-section__details"
+      aria-live="polite"
+      class="wcpay-form-busy-state__status screen-reader-text"
+      role="status"
     />
     <div
-      class="settings-section__controls"
+      class="settings-section multi-currency-settings-store-settings-section"
     >
-      <button
-        class="components-button is-next-40px-default-size is-primary"
-        disabled=""
-        type="button"
+      <div
+        class="settings-section__details"
       >
-        Save changes
-      </button>
+        <h2>
+          Store settings
+        </h2>
+        <p>
+          Store settings allow your customers to choose which currency they would like to use when shopping at your store. 
+          <a
+            class="components-external-link"
+            href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#store-settings"
+            rel="external noreferrer noopener"
+            target="_blank"
+          >
+            <span
+              class="components-external-link__contents"
+            >
+              Learn more
+            </span>
+            <span
+              aria-label="(opens in a new tab)"
+              class="components-external-link__icon"
+            >
+              ↗
+            </span>
+          </a>
+        </p>
+      </div>
+      <div
+        class="settings-section__controls"
+      >
+        <div
+          class="components-surface components-card multi-currency-settings__wrapper emotion-0 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="Card"
+        >
+          <div
+            class="emotion-2 emotion-1"
+          >
+            <div
+              class="components-card__body components-card-body wcpay-card-body emotion-4 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="CardBody"
+            >
+              <div
+                class="components-base-control components-checkbox-control emotion-6 emotion-7"
+              >
+                <div
+                  class="components-base-control__field emotion-8 emotion-9"
+                >
+                  <div
+                    class="components-flex components-h-stack emotion-10 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
+                  >
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        aria-describedby="inspector-checkbox-control-0__help"
+                        class="components-checkbox-control__input"
+                        data-testid="enable_auto_currency"
+                        id="inspector-checkbox-control-0"
+                        type="checkbox"
+                        value="1"
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="inspector-checkbox-control-0"
+                    >
+                      Automatically switch customers to their local currency if it has been enabled
+                    </label>
+                  </div>
+                </div>
+                <p
+                  class="components-base-control__help emotion-12 emotion-13"
+                  id="inspector-checkbox-control-0__help"
+                >
+                  <span
+                    class="components-checkbox-control__help"
+                  >
+                    Customers will be notified via store alert banner. 
+                    <button
+                      class="components-button is-next-40px-default-size is-link"
+                      type="button"
+                    >
+                      Preview
+                    </button>
+                  </span>
+                </p>
+              </div>
+              <div
+                class="components-base-control components-checkbox-control emotion-6 emotion-7"
+              >
+                <div
+                  class="components-base-control__field emotion-8 emotion-9"
+                >
+                  <div
+                    class="components-flex components-h-stack emotion-10 emotion-1"
+                    data-wp-c16t="true"
+                    data-wp-component="HStack"
+                  >
+                    <span
+                      class="components-checkbox-control__input-container"
+                    >
+                      <input
+                        aria-describedby="inspector-checkbox-control-1__help"
+                        class="components-checkbox-control__input"
+                        data-testid="enable_storefront_switcher"
+                        id="inspector-checkbox-control-1"
+                        type="checkbox"
+                        value="1"
+                      />
+                    </span>
+                    <label
+                      class="components-checkbox-control__label"
+                      for="inspector-checkbox-control-1"
+                    >
+                      Add a currency switcher to the Storefront theme on breadcrumb section.
+                    </label>
+                  </div>
+                </div>
+                <p
+                  class="components-base-control__help emotion-12 emotion-13"
+                  id="inspector-checkbox-control-1__help"
+                >
+                  <span
+                    class="components-checkbox-control__help"
+                  >
+                    A currency switcher is also available in your widgets. 
+                    <a
+                      href="widgets.php"
+                    >
+                      Configure now
+                    </a>
+                  </span>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            class="components-elevation emotion-22 emotion-1"
+            data-wp-c16t="true"
+            data-wp-component="Elevation"
+          />
+          <div
+            aria-hidden="true"
+            class="components-elevation emotion-22 emotion-1"
+            data-wp-c16t="true"
+            data-wp-component="Elevation"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="settings-section multi-currency-settings-save-settings-section"
+    >
+      <div
+        class="settings-section__details"
+      />
+      <div
+        class="settings-section__controls"
+      >
+        <button
+          class="components-button is-next-40px-default-size is-primary"
+          disabled=""
+          type="button"
+        >
+          Save changes
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/includes/multi-currency/client/settings/multi-currency/store-settings/index.js
+++ b/includes/multi-currency/client/settings/multi-currency/store-settings/index.js
@@ -22,6 +22,7 @@ import {
 	SettingsSection,
 } from 'multi-currency/interface/components';
 import PreviewModal from 'multi-currency/components/preview-modal';
+import FormBusyState from 'wcpay/components/form-busy-state';
 
 const StoreSettingsDescription = () => (
 	<>
@@ -64,7 +65,7 @@ const StoreSettings = () => {
 	const [ isPreviewModalOpen, setPreviewModalOpen ] = useState( false );
 
 	return (
-		<>
+		<FormBusyState isBusy={ isSaving }>
 			<SettingsSection
 				description={ StoreSettingsDescription }
 				className="multi-currency-settings-store-settings-section"
@@ -198,7 +199,7 @@ const StoreSettings = () => {
 					{ __( 'Save changes', 'woocommerce-payments' ) }
 				</Button>
 			</SettingsSection>
-		</>
+		</FormBusyState>
 	);
 };
 

--- a/includes/multi-currency/client/settings/single-currency/__tests__/__snapshots__/index.test.js.snap
+++ b/includes/multi-currency/client/settings/single-currency/__tests__/__snapshots__/index.test.js.snap
@@ -342,494 +342,504 @@ exports[`Single currency settings screen Page renders correctly 1`] = `
         🇪🇺
       </h2>
       <div
-        class="settings-section"
+        aria-busy="false"
+        class="wcpay-form-busy-state"
       >
         <div
-          class="settings-section__details"
-        >
-          <h2>
-            Currency settings
-          </h2>
-          <p>
-            Choose between automatic or manual exchange rates and modify formatting rules to refine the display of your prices.
-          </p>
-        </div>
-        <div
-          class="settings-section__controls"
-        >
-          <div
-            class="components-surface components-card single-currency-settings-currency-settings emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <h4>
-                  Exchange rate
-                </h4>
-                <fieldset>
-                  <ul>
-                    <li>
-                      <fieldset
-                        class="components-radio-control"
-                        id="inspector-radio-control-0"
-                      >
-                        <legend
-                          class="components-base-control__label emotion-6 emotion-7"
-                        />
-                        <div
-                          class="components-flex components-h-stack components-v-stack components-radio-control__group-wrapper emotion-8 emotion-1"
-                          data-wp-c16t="true"
-                          data-wp-component="VStack"
-                        >
-                          <div
-                            class="components-radio-control__option"
-                          >
-                            <input
-                              aria-describedby="inspector-radio-control-0-0-option-description"
-                              checked=""
-                              class="components-radio-control__input"
-                              id="inspector-radio-control-0-0"
-                              name="inspector-radio-control-0"
-                              type="radio"
-                              value="automatic"
-                            />
-                            <label
-                              class="components-radio-control__label"
-                              for="inspector-radio-control-0-0"
-                            >
-                              Fetch rates automatically
-                            </label>
-                            <p
-                              class="components-radio-control__option-description emotion-10 emotion-11"
-                              id="inspector-radio-control-0-0-option-description"
-                            >
-                              Current rate: 1 USD = 0.826381 EUR (Last updated: Sep 24, 2021 1:14AM)
-                            </p>
-                          </div>
-                          <div
-                            class="components-radio-control__option"
-                          >
-                            <input
-                              aria-describedby="inspector-radio-control-0-1-option-description"
-                              class="components-radio-control__input"
-                              id="inspector-radio-control-0-1"
-                              name="inspector-radio-control-0"
-                              type="radio"
-                              value="manual"
-                            />
-                            <label
-                              class="components-radio-control__label"
-                              for="inspector-radio-control-0-1"
-                            >
-                              Manual
-                            </label>
-                            <p
-                              class="components-radio-control__option-description emotion-10 emotion-11"
-                              id="inspector-radio-control-0-1-option-description"
-                            >
-                              Enter your fixed rate of exchange
-                            </p>
-                          </div>
-                        </div>
-                      </fieldset>
-                    </li>
-                  </ul>
-                </fieldset>
-                <h4>
-                  Formatting rules
-                </h4>
-                <fieldset>
-                  <ul>
-                    <li>
-                      <div
-                        class="components-base-control emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-base-control__field emotion-16 emotion-17"
-                        >
-                          <div
-                            class="components-flex components-input-base components-select-control emotion-18 emotion-19 emotion-20 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="InputBase"
-                          >
-                            <div
-                              class="components-flex-item emotion-22 emotion-23 emotion-1"
-                              data-wp-c16t="true"
-                              data-wp-component="FlexItem"
-                            >
-                              <label
-                                class="components-truncate components-text components-input-control__label emotion-25 emotion-26 emotion-1"
-                                data-wp-c16t="true"
-                                data-wp-component="Text"
-                                for="inspector-select-control-0"
-                              >
-                                Price rounding
-                              </label>
-                            </div>
-                            <div
-                              class="components-input-control__container emotion-28 emotion-29"
-                            >
-                              <select
-                                aria-describedby="inspector-select-control-0__help"
-                                class="components-select-control__input emotion-30 emotion-31"
-                                data-testid="price_rounding"
-                                id="inspector-select-control-0"
-                              >
-                                <option
-                                  value="0"
-                                >
-                                  None
-                                </option>
-                                <option
-                                  value="0.25"
-                                >
-                                  0.25
-                                </option>
-                                <option
-                                  value="0.5"
-                                >
-                                  0.50
-                                </option>
-                                <option
-                                  value="1"
-                                >
-                                  1.00 (recommended)
-                                </option>
-                                <option
-                                  value="5"
-                                >
-                                  5.00
-                                </option>
-                                <option
-                                  value="10"
-                                >
-                                  10.00
-                                </option>
-                              </select>
-                              <span
-                                class="components-input-control__suffix emotion-32 emotion-33"
-                              >
-                                <div
-                                  class="components-input-control-suffix-wrapper emotion-34 emotion-35 emotion-36"
-                                  data-wp-c16t="true"
-                                  data-wp-component="InputControlSuffixWrapper"
-                                >
-                                  <div
-                                    class="emotion-37 emotion-38"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      focusable="false"
-                                      height="18"
-                                      viewBox="0 0 24 24"
-                                      width="18"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </span>
-                              <div
-                                aria-hidden="true"
-                                class="components-input-control__backdrop emotion-39 emotion-40"
-                              />
-                            </div>
-                          </div>
-                        </div>
-                        <p
-                          class="components-base-control__help emotion-10 emotion-11"
-                          id="inspector-select-control-0__help"
-                        >
-                          Make your EUR prices consistent by rounding them up after they're converted. 
-                          <a
-                            class="components-external-link"
-                            href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#price-rounding"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              Learn more
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                        </p>
-                      </div>
-                    </li>
-                    <li>
-                      <div
-                        class="components-base-control emotion-14 emotion-15"
-                      >
-                        <div
-                          class="components-base-control__field emotion-16 emotion-17"
-                        >
-                          <div
-                            class="components-flex components-input-base components-select-control emotion-18 emotion-19 emotion-20 emotion-1"
-                            data-wp-c16t="true"
-                            data-wp-component="InputBase"
-                          >
-                            <div
-                              class="components-flex-item emotion-22 emotion-23 emotion-1"
-                              data-wp-c16t="true"
-                              data-wp-component="FlexItem"
-                            >
-                              <label
-                                class="components-truncate components-text components-input-control__label emotion-25 emotion-26 emotion-1"
-                                data-wp-c16t="true"
-                                data-wp-component="Text"
-                                for="inspector-select-control-1"
-                              >
-                                Charm pricing
-                              </label>
-                            </div>
-                            <div
-                              class="components-input-control__container emotion-28 emotion-29"
-                            >
-                              <select
-                                aria-describedby="inspector-select-control-1__help"
-                                class="components-select-control__input emotion-30 emotion-31"
-                                data-testid="price_charm"
-                                id="inspector-select-control-1"
-                              >
-                                <option
-                                  value="0"
-                                >
-                                  None
-                                </option>
-                                <option
-                                  value="-0.01"
-                                >
-                                  -0.01
-                                </option>
-                                <option
-                                  value="-0.05"
-                                >
-                                  -0.05
-                                </option>
-                              </select>
-                              <span
-                                class="components-input-control__suffix emotion-32 emotion-33"
-                              >
-                                <div
-                                  class="components-input-control-suffix-wrapper emotion-34 emotion-35 emotion-36"
-                                  data-wp-c16t="true"
-                                  data-wp-component="InputControlSuffixWrapper"
-                                >
-                                  <div
-                                    class="emotion-37 emotion-38"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      focusable="false"
-                                      height="18"
-                                      viewBox="0 0 24 24"
-                                      width="18"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-                                      />
-                                    </svg>
-                                  </div>
-                                </div>
-                              </span>
-                              <div
-                                aria-hidden="true"
-                                class="components-input-control__backdrop emotion-39 emotion-40"
-                              />
-                            </div>
-                          </div>
-                        </div>
-                        <p
-                          class="components-base-control__help emotion-10 emotion-11"
-                          id="inspector-select-control-1__help"
-                        >
-                          Reduce the converted price for a specific amount. 
-                          <a
-                            class="components-external-link"
-                            href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#charm-pricing"
-                            rel="external noreferrer noopener"
-                            target="_blank"
-                          >
-                            <span
-                              class="components-external-link__contents"
-                            >
-                              Learn more
-                            </span>
-                            <span
-                              aria-label="(opens in a new tab)"
-                              class="components-external-link__icon"
-                            >
-                              ↗
-                            </span>
-                          </a>
-                        </p>
-                      </div>
-                    </li>
-                  </ul>
-                </fieldset>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-72 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-72 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="settings-section"
-      >
-        <div
-          class="settings-section__details"
-        >
-          <h2>
-            Preview
-          </h2>
-          <p>
-            Enter a price in your default currency (United States (US) dollar) to see it converted to Euro using the exchange rate and formatting rules above.
-          </p>
-        </div>
-        <div
-          class="settings-section__controls"
-        >
-          <div
-            class="components-surface components-card single-currency-settings-preview-wrapper emotion-0 emotion-1"
-            data-wp-c16t="true"
-            data-wp-component="Card"
-          >
-            <div
-              class="emotion-2 emotion-1"
-            >
-              <div
-                class="components-card__body components-card-body wcpay-card-body emotion-4 emotion-1"
-                data-wp-c16t="true"
-                data-wp-component="CardBody"
-              >
-                <div>
-                  <div>
-                    <div
-                      class="components-base-control with-value emotion-82 emotion-15"
-                    >
-                      <div
-                        class="components-base-control__field emotion-84 emotion-17"
-                      >
-                        <label
-                          class="components-base-control__label emotion-86 emotion-87"
-                          for="inspector-text-control-with-affixes-0"
-                        >
-                          United States (US) dollar
-                        </label>
-                        <div
-                          class="text-control-with-affixes text-control-with-suffix"
-                        >
-                          <input
-                            aria-describedby="inspector-text-control-with-affixes-0__suffix"
-                            class="components-text-control__input"
-                            data-testid="store_currency_value"
-                            id="inspector-text-control-with-affixes-0"
-                            type="text"
-                            value="20"
-                          />
-                          <span
-                            class="text-control-with-affixes__suffix"
-                            id="inspector-text-control-with-affixes-0__suffix"
-                          >
-                            $
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div>
-                  <div>
-                    <div
-                      class="components-base-control with-value emotion-82 emotion-15"
-                    >
-                      <div
-                        class="components-base-control__field emotion-84 emotion-17"
-                      >
-                        <label
-                          class="components-base-control__label emotion-86 emotion-87"
-                          for="inspector-text-control-with-affixes-1"
-                        >
-                          Euro
-                        </label>
-                        <div
-                          class="text-control-with-affixes disabled"
-                        >
-                          <input
-                            aria-describedby=""
-                            class="components-text-control__input"
-                            data-testid="calculated_value"
-                            disabled=""
-                            id="inspector-text-control-with-affixes-1"
-                            type="text"
-                            value="€17.00"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-72 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-            <div
-              aria-hidden="true"
-              class="components-elevation emotion-72 emotion-1"
-              data-wp-c16t="true"
-              data-wp-component="Elevation"
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="settings-section single-currency-settings-save-settings-section"
-      >
-        <div
-          class="settings-section__details"
+          aria-live="polite"
+          class="wcpay-form-busy-state__status screen-reader-text"
+          role="status"
         />
         <div
-          class="settings-section__controls"
+          class="settings-section"
         >
-          <button
-            class="components-button is-next-40px-default-size is-primary"
-            disabled=""
-            type="button"
+          <div
+            class="settings-section__details"
           >
-            Save changes
-          </button>
+            <h2>
+              Currency settings
+            </h2>
+            <p>
+              Choose between automatic or manual exchange rates and modify formatting rules to refine the display of your prices.
+            </p>
+          </div>
+          <div
+            class="settings-section__controls"
+          >
+            <div
+              class="components-surface components-card single-currency-settings-currency-settings emotion-0 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+            >
+              <div
+                class="emotion-2 emotion-1"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body emotion-4 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <h4>
+                    Exchange rate
+                  </h4>
+                  <fieldset>
+                    <ul>
+                      <li>
+                        <fieldset
+                          class="components-radio-control"
+                          id="inspector-radio-control-0"
+                        >
+                          <legend
+                            class="components-base-control__label emotion-6 emotion-7"
+                          />
+                          <div
+                            class="components-flex components-h-stack components-v-stack components-radio-control__group-wrapper emotion-8 emotion-1"
+                            data-wp-c16t="true"
+                            data-wp-component="VStack"
+                          >
+                            <div
+                              class="components-radio-control__option"
+                            >
+                              <input
+                                aria-describedby="inspector-radio-control-0-0-option-description"
+                                checked=""
+                                class="components-radio-control__input"
+                                id="inspector-radio-control-0-0"
+                                name="inspector-radio-control-0"
+                                type="radio"
+                                value="automatic"
+                              />
+                              <label
+                                class="components-radio-control__label"
+                                for="inspector-radio-control-0-0"
+                              >
+                                Fetch rates automatically
+                              </label>
+                              <p
+                                class="components-radio-control__option-description emotion-10 emotion-11"
+                                id="inspector-radio-control-0-0-option-description"
+                              >
+                                Current rate: 1 USD = 0.826381 EUR (Last updated: Sep 24, 2021 1:14AM)
+                              </p>
+                            </div>
+                            <div
+                              class="components-radio-control__option"
+                            >
+                              <input
+                                aria-describedby="inspector-radio-control-0-1-option-description"
+                                class="components-radio-control__input"
+                                id="inspector-radio-control-0-1"
+                                name="inspector-radio-control-0"
+                                type="radio"
+                                value="manual"
+                              />
+                              <label
+                                class="components-radio-control__label"
+                                for="inspector-radio-control-0-1"
+                              >
+                                Manual
+                              </label>
+                              <p
+                                class="components-radio-control__option-description emotion-10 emotion-11"
+                                id="inspector-radio-control-0-1-option-description"
+                              >
+                                Enter your fixed rate of exchange
+                              </p>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </li>
+                    </ul>
+                  </fieldset>
+                  <h4>
+                    Formatting rules
+                  </h4>
+                  <fieldset>
+                    <ul>
+                      <li>
+                        <div
+                          class="components-base-control emotion-14 emotion-15"
+                        >
+                          <div
+                            class="components-base-control__field emotion-16 emotion-17"
+                          >
+                            <div
+                              class="components-flex components-input-base components-select-control emotion-18 emotion-19 emotion-20 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="InputBase"
+                            >
+                              <div
+                                class="components-flex-item emotion-22 emotion-23 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexItem"
+                              >
+                                <label
+                                  class="components-truncate components-text components-input-control__label emotion-25 emotion-26 emotion-1"
+                                  data-wp-c16t="true"
+                                  data-wp-component="Text"
+                                  for="inspector-select-control-0"
+                                >
+                                  Price rounding
+                                </label>
+                              </div>
+                              <div
+                                class="components-input-control__container emotion-28 emotion-29"
+                              >
+                                <select
+                                  aria-describedby="inspector-select-control-0__help"
+                                  class="components-select-control__input emotion-30 emotion-31"
+                                  data-testid="price_rounding"
+                                  id="inspector-select-control-0"
+                                >
+                                  <option
+                                    value="0"
+                                  >
+                                    None
+                                  </option>
+                                  <option
+                                    value="0.25"
+                                  >
+                                    0.25
+                                  </option>
+                                  <option
+                                    value="0.5"
+                                  >
+                                    0.50
+                                  </option>
+                                  <option
+                                    value="1"
+                                  >
+                                    1.00 (recommended)
+                                  </option>
+                                  <option
+                                    value="5"
+                                  >
+                                    5.00
+                                  </option>
+                                  <option
+                                    value="10"
+                                  >
+                                    10.00
+                                  </option>
+                                </select>
+                                <span
+                                  class="components-input-control__suffix emotion-32 emotion-33"
+                                >
+                                  <div
+                                    class="components-input-control-suffix-wrapper emotion-34 emotion-35 emotion-36"
+                                    data-wp-c16t="true"
+                                    data-wp-component="InputControlSuffixWrapper"
+                                  >
+                                    <div
+                                      class="emotion-37 emotion-38"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        focusable="false"
+                                        height="18"
+                                        viewBox="0 0 24 24"
+                                        width="18"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </span>
+                                <div
+                                  aria-hidden="true"
+                                  class="components-input-control__backdrop emotion-39 emotion-40"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-10 emotion-11"
+                            id="inspector-select-control-0__help"
+                          >
+                            Make your EUR prices consistent by rounding them up after they're converted. 
+                            <a
+                              class="components-external-link"
+                              href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#price-rounding"
+                              rel="external noreferrer noopener"
+                              target="_blank"
+                            >
+                              <span
+                                class="components-external-link__contents"
+                              >
+                                Learn more
+                              </span>
+                              <span
+                                aria-label="(opens in a new tab)"
+                                class="components-external-link__icon"
+                              >
+                                ↗
+                              </span>
+                            </a>
+                          </p>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          class="components-base-control emotion-14 emotion-15"
+                        >
+                          <div
+                            class="components-base-control__field emotion-16 emotion-17"
+                          >
+                            <div
+                              class="components-flex components-input-base components-select-control emotion-18 emotion-19 emotion-20 emotion-1"
+                              data-wp-c16t="true"
+                              data-wp-component="InputBase"
+                            >
+                              <div
+                                class="components-flex-item emotion-22 emotion-23 emotion-1"
+                                data-wp-c16t="true"
+                                data-wp-component="FlexItem"
+                              >
+                                <label
+                                  class="components-truncate components-text components-input-control__label emotion-25 emotion-26 emotion-1"
+                                  data-wp-c16t="true"
+                                  data-wp-component="Text"
+                                  for="inspector-select-control-1"
+                                >
+                                  Charm pricing
+                                </label>
+                              </div>
+                              <div
+                                class="components-input-control__container emotion-28 emotion-29"
+                              >
+                                <select
+                                  aria-describedby="inspector-select-control-1__help"
+                                  class="components-select-control__input emotion-30 emotion-31"
+                                  data-testid="price_charm"
+                                  id="inspector-select-control-1"
+                                >
+                                  <option
+                                    value="0"
+                                  >
+                                    None
+                                  </option>
+                                  <option
+                                    value="-0.01"
+                                  >
+                                    -0.01
+                                  </option>
+                                  <option
+                                    value="-0.05"
+                                  >
+                                    -0.05
+                                  </option>
+                                </select>
+                                <span
+                                  class="components-input-control__suffix emotion-32 emotion-33"
+                                >
+                                  <div
+                                    class="components-input-control-suffix-wrapper emotion-34 emotion-35 emotion-36"
+                                    data-wp-c16t="true"
+                                    data-wp-component="InputControlSuffixWrapper"
+                                  >
+                                    <div
+                                      class="emotion-37 emotion-38"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        focusable="false"
+                                        height="18"
+                                        viewBox="0 0 24 24"
+                                        width="18"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </span>
+                                <div
+                                  aria-hidden="true"
+                                  class="components-input-control__backdrop emotion-39 emotion-40"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <p
+                            class="components-base-control__help emotion-10 emotion-11"
+                            id="inspector-select-control-1__help"
+                          >
+                            Reduce the converted price for a specific amount. 
+                            <a
+                              class="components-external-link"
+                              href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#charm-pricing"
+                              rel="external noreferrer noopener"
+                              target="_blank"
+                            >
+                              <span
+                                class="components-external-link__contents"
+                              >
+                                Learn more
+                              </span>
+                              <span
+                                aria-label="(opens in a new tab)"
+                                class="components-external-link__icon"
+                              >
+                                ↗
+                              </span>
+                            </a>
+                          </p>
+                        </div>
+                      </li>
+                    </ul>
+                  </fieldset>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation emotion-72 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation emotion-72 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="settings-section"
+        >
+          <div
+            class="settings-section__details"
+          >
+            <h2>
+              Preview
+            </h2>
+            <p>
+              Enter a price in your default currency (United States (US) dollar) to see it converted to Euro using the exchange rate and formatting rules above.
+            </p>
+          </div>
+          <div
+            class="settings-section__controls"
+          >
+            <div
+              class="components-surface components-card single-currency-settings-preview-wrapper emotion-0 emotion-1"
+              data-wp-c16t="true"
+              data-wp-component="Card"
+            >
+              <div
+                class="emotion-2 emotion-1"
+              >
+                <div
+                  class="components-card__body components-card-body wcpay-card-body emotion-4 emotion-1"
+                  data-wp-c16t="true"
+                  data-wp-component="CardBody"
+                >
+                  <div>
+                    <div>
+                      <div
+                        class="components-base-control with-value emotion-82 emotion-15"
+                      >
+                        <div
+                          class="components-base-control__field emotion-84 emotion-17"
+                        >
+                          <label
+                            class="components-base-control__label emotion-86 emotion-87"
+                            for="inspector-text-control-with-affixes-0"
+                          >
+                            United States (US) dollar
+                          </label>
+                          <div
+                            class="text-control-with-affixes text-control-with-suffix"
+                          >
+                            <input
+                              aria-describedby="inspector-text-control-with-affixes-0__suffix"
+                              class="components-text-control__input"
+                              data-testid="store_currency_value"
+                              id="inspector-text-control-with-affixes-0"
+                              type="text"
+                              value="20"
+                            />
+                            <span
+                              class="text-control-with-affixes__suffix"
+                              id="inspector-text-control-with-affixes-0__suffix"
+                            >
+                              $
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="components-base-control with-value emotion-82 emotion-15"
+                      >
+                        <div
+                          class="components-base-control__field emotion-84 emotion-17"
+                        >
+                          <label
+                            class="components-base-control__label emotion-86 emotion-87"
+                            for="inspector-text-control-with-affixes-1"
+                          >
+                            Euro
+                          </label>
+                          <div
+                            class="text-control-with-affixes disabled"
+                          >
+                            <input
+                              aria-describedby=""
+                              class="components-text-control__input"
+                              data-testid="calculated_value"
+                              disabled=""
+                              id="inspector-text-control-with-affixes-1"
+                              type="text"
+                              value="€17.00"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                class="components-elevation emotion-72 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+              <div
+                aria-hidden="true"
+                class="components-elevation emotion-72 emotion-1"
+                data-wp-c16t="true"
+                data-wp-component="Elevation"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="settings-section single-currency-settings-save-settings-section"
+        >
+          <div
+            class="settings-section__details"
+          />
+          <div
+            class="settings-section__controls"
+          >
+            <button
+              class="components-button is-next-40px-default-size is-primary"
+              disabled=""
+              type="button"
+            >
+              Save changes
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/includes/multi-currency/client/settings/single-currency/__tests__/index.test.js
+++ b/includes/multi-currency/client/settings/single-currency/__tests__/index.test.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -168,7 +168,7 @@ describe( 'Single currency settings screen', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	test( 'Settings work correctly', () => {
+	test( 'Settings work correctly', async () => {
 		getContainer();
 		expect(
 			screen.queryByText( /Currency Settings/i )
@@ -231,12 +231,14 @@ describe( 'Single currency settings screen', () => {
 			'€17.45'
 		);
 
-		// Submit settings test.
+		// the save handler is async now, so flush it inside act()
 		const { submitCurrencySettings } = useCurrencySettings();
 
-		fireEvent.click(
-			screen.getByRole( 'button', { name: /Save Changes/i } )
-		);
+		await act( async () => {
+			fireEvent.click(
+				screen.getByRole( 'button', { name: /Save Changes/i } )
+			);
+		} );
 
 		expect( submitCurrencySettings ).toHaveBeenCalledWith( 'EUR', {
 			exchange_rate_type: 'manual',

--- a/includes/multi-currency/client/settings/single-currency/index.js
+++ b/includes/multi-currency/client/settings/single-currency/index.js
@@ -39,6 +39,7 @@ import {
 	SettingsLayout,
 	SettingsSection,
 } from 'multi-currency/interface/components';
+import FormBusyState from 'wcpay/components/form-busy-state';
 import interpolateComponents from '@automattic/interpolate-components';
 
 const CurrencySettingsDescription = () => (
@@ -67,11 +68,8 @@ const SingleCurrencySettings = () => {
 	const { enabledCurrencies } = useEnabledCurrencies();
 	const { storeSettings } = useStoreSettings();
 
-	const {
-		currencySettings,
-		isLoading,
-		submitCurrencySettings,
-	} = useCurrencySettings( currency );
+	const { currencySettings, isLoading, submitCurrencySettings } =
+		useCurrencySettings( currency );
 
 	const storeCurrency = currencies.default ? currencies.default : {};
 	const targetCurrency = currencies.available
@@ -154,9 +152,11 @@ const SingleCurrencySettings = () => {
 		</>
 	);
 
-	const saveSingleCurrencySettings = () => {
+	const saveSingleCurrencySettings = async () => {
 		setIsSaving( true );
-		submitCurrencySettings( targetCurrency.code, {
+
+		// otherwise `isSaving` flips back before the request finishes
+		await submitCurrencySettings( targetCurrency.code, {
 			exchange_rate_type: exchangeRateType,
 			manual_rate: manualRate,
 			price_rounding: priceRoundingType,
@@ -165,9 +165,8 @@ const SingleCurrencySettings = () => {
 
 		// Update the rate to display it in the Currency list if is set as manual
 		if ( ! isNaN( manualRate ) ) {
-			enabledCurrencies[ targetCurrency.code ].rate = Number(
-				manualRate
-			);
+			enabledCurrencies[ targetCurrency.code ].rate =
+				Number( manualRate );
 		}
 
 		setIsSaving( false );
@@ -190,232 +189,253 @@ const SingleCurrencySettings = () => {
 					&gt; { targetCurrency.name } ({ targetCurrency.code }){ ' ' }
 					{ targetCurrency.flag }
 				</h2>
-				<SettingsSection description={ CurrencySettingsDescription }>
-					<LoadableBlock isLoading={ isLoading } numLines={ 33 }>
-						<Card className="single-currency-settings-currency-settings">
-							<CardBody className="wcpay-card-body">
-								<h4>
-									{ __(
-										'Exchange rate',
-										'woocommerce-payments'
-									) }
-								</h4>
+				<FormBusyState isBusy={ isSaving }>
+					<SettingsSection
+						description={ CurrencySettingsDescription }
+					>
+						<LoadableBlock isLoading={ isLoading } numLines={ 33 }>
+							<Card className="single-currency-settings-currency-settings">
+								<CardBody className="wcpay-card-body">
+									<h4>
+										{ __(
+											'Exchange rate',
+											'woocommerce-payments'
+										) }
+									</h4>
 
-								<fieldset>
-									<ul>
-										<li>
-											<RadioControl
-												onChange={ ( value ) => {
-													setExchangeRateType(
-														value
-													);
-													setIsDirty( true );
-													if ( value === 'manual' ) {
-														setManualRate(
+									<fieldset>
+										<ul>
+											<li>
+												<RadioControl
+													onChange={ ( value ) => {
+														setExchangeRateType(
+															value
+														);
+														setIsDirty( true );
+														if (
+															value === 'manual'
+														) {
+															setManualRate(
+																manualRate
+																	? manualRate
+																	: targetCurrency.rate
+															);
+														}
+													} }
+													options={ [
+														{
+															description:
+																targetCurrency.last_updated
+																	? sprintf(
+																			__(
+																				'Current rate: 1 %s = %s %s (Last updated: %s)',
+																				'woocommerce-payments'
+																			),
+																			storeCurrency.code,
+																			targetCurrency.rate,
+																			targetCurrency.code,
+																			formattedLastUpdatedDateTime
+																	  )
+																	: __(
+																			'Error - Unable to fetch automatic rate for this currency',
+																			'woocommerce-payments'
+																	  ),
+															label: __(
+																'Fetch rates automatically',
+																'woocommerce-payments'
+															),
+															value: 'automatic',
+														},
+														{
+															description: __(
+																'Enter your fixed rate of exchange',
+																'woocommerce-payments'
+															),
+															label: __(
+																'Manual',
+																'woocommerce-payments'
+															),
+															value: 'manual',
+														},
+													] }
+													selected={
+														exchangeRateType
+													}
+												/>
+											</li>
+											{ exchangeRateType === 'manual' && (
+												<li>
+													<TextControl
+														data-testid="manual_rate_input"
+														label={ __(
+															'Manual Rate',
+															'woocommerce-payments'
+														) }
+														help={ __(
+															'Enter the manual rate you would like to use. Must be a positive number.',
+															'woocommerce-payments'
+														) }
+														value={
 															manualRate
 																? manualRate
 																: targetCurrency.rate
-														);
-													}
-												} }
-												options={ [
-													{
-														description: targetCurrency.last_updated
-															? sprintf(
+														}
+														onChange={ (
+															value
+														) => {
+															setManualRate(
+																value.replace(
+																	/,/g,
+																	'.'
+																)
+															);
+															setIsDirty( true );
+														} }
+														__nextHasNoMarginBottom
+														__next40pxDefaultSize
+													/>
+												</li>
+											) }
+										</ul>
+									</fieldset>
+									<h4>
+										{ __(
+											'Formatting rules',
+											'woocommerce-payments'
+										) }
+									</h4>
+									<fieldset>
+										<ul>
+											<li>
+												<SelectControl
+													data-testid="price_rounding"
+													label={ __(
+														'Price rounding',
+														'woocommerce-payments'
+													) }
+													help={ interpolateComponents(
+														{
+															mixedString:
+																sprintf(
 																	__(
-																		'Current rate: 1 %s = %s %s (Last updated: %s)',
+																		"Make your %s prices consistent by rounding them up after they're converted. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
 																		'woocommerce-payments'
 																	),
-																	storeCurrency.code,
-																	targetCurrency.rate,
-																	targetCurrency.code,
-																	formattedLastUpdatedDateTime
-															  )
-															: __(
-																	'Error - Unable to fetch automatic rate for this currency',
-																	'woocommerce-payments'
-															  ),
-														label: __(
-															'Fetch rates automatically',
-															'woocommerce-payments'
-														),
-														value: 'automatic',
-													},
-													{
-														description: __(
-															'Enter your fixed rate of exchange',
-															'woocommerce-payments'
-														),
-														label: __(
-															'Manual',
-															'woocommerce-payments'
-														),
-														value: 'manual',
-													},
-												] }
-												selected={ exchangeRateType }
-											/>
-										</li>
-										{ exchangeRateType === 'manual' && (
-											<li>
-												<TextControl
-													data-testid="manual_rate_input"
-													label={ __(
-														'Manual Rate',
-														'woocommerce-payments'
+																	targetCurrency.code
+																),
+															components: {
+																learnMoreLink: (
+																	// @ts-expect-error: children is provided when interpolating the component
+																	<ExternalLink href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#price-rounding" />
+																),
+															},
+														}
 													) }
-													help={ __(
-														'Enter the manual rate you would like to use. Must be a positive number.',
-														'woocommerce-payments'
+													value={ parseFloat(
+														priceRoundingType
 													) }
-													value={
-														manualRate
-															? manualRate
-															: targetCurrency.rate
-													}
 													onChange={ ( value ) => {
-														setManualRate(
-															value.replace(
-																/,/g,
-																'.'
-															)
+														setPriceRoundingType(
+															value
 														);
 														setIsDirty( true );
 													} }
+													options={ Object.keys(
+														targetCurrencyRoundingOptions
+													).map( ( value ) => ( {
+														value: parseFloat(
+															value
+														),
+														label: targetCurrencyRoundingOptions[
+															value
+														],
+													} ) ) }
 													__nextHasNoMarginBottom
 													__next40pxDefaultSize
 												/>
 											</li>
-										) }
-									</ul>
-								</fieldset>
-								<h4>
-									{ __(
-										'Formatting rules',
-										'woocommerce-payments'
-									) }
-								</h4>
-								<fieldset>
-									<ul>
-										<li>
-											<SelectControl
-												data-testid="price_rounding"
-												label={ __(
-													'Price rounding',
-													'woocommerce-payments'
-												) }
-												help={ interpolateComponents( {
-													mixedString: sprintf(
-														__(
-															"Make your %s prices consistent by rounding them up after they're converted. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
-															'woocommerce-payments'
+											<li>
+												<SelectControl
+													data-testid="price_charm"
+													label={ __(
+														'Charm pricing',
+														'woocommerce-payments'
+													) }
+													help={ interpolateComponents(
+														{
+															mixedString:
+																sprintf(
+																	__(
+																		'Reduce the converted price for a specific amount. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+																		'woocommerce-payments'
+																	),
+																	targetCurrency.code
+																),
+															components: {
+																learnMoreLink: (
+																	// @ts-expect-error: children is provided when interpolating the component
+																	<ExternalLink href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#charm-pricing" />
+																),
+															},
+														}
+													) }
+													value={ parseFloat(
+														priceCharmType
+													) }
+													onChange={ ( value ) => {
+														setPriceCharmType(
+															value
+														);
+														setIsDirty( true );
+													} }
+													options={ Object.keys(
+														targetCurrencyCharmOptions
+													).map( ( value ) => ( {
+														value: parseFloat(
+															value
 														),
-														targetCurrency.code
-													),
-													components: {
-														learnMoreLink: (
-															// @ts-expect-error: children is provided when interpolating the component
-															<ExternalLink href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#price-rounding" />
-														),
-													},
-												} ) }
-												value={ parseFloat(
-													priceRoundingType
-												) }
-												onChange={ ( value ) => {
-													setPriceRoundingType(
-														value
-													);
-													setIsDirty( true );
-												} }
-												options={ Object.keys(
-													targetCurrencyRoundingOptions
-												).map( ( value ) => ( {
-													value: parseFloat( value ),
-													label:
-														targetCurrencyRoundingOptions[
+														label: targetCurrencyCharmOptions[
 															value
 														],
-												} ) ) }
-												__nextHasNoMarginBottom
-												__next40pxDefaultSize
-											/>
-										</li>
-										<li>
-											<SelectControl
-												data-testid="price_charm"
-												label={ __(
-													'Charm pricing',
-													'woocommerce-payments'
-												) }
-												help={ interpolateComponents( {
-													mixedString: sprintf(
-														__(
-															'Reduce the converted price for a specific amount. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
-															'woocommerce-payments'
-														),
-														targetCurrency.code
-													),
-													components: {
-														learnMoreLink: (
-															// @ts-expect-error: children is provided when interpolating the component
-															<ExternalLink href="https://woocommerce.com/document/woopayments/currencies/multi-currency-setup/#charm-pricing" />
-														),
-													},
-												} ) }
-												value={ parseFloat(
-													priceCharmType
-												) }
-												onChange={ ( value ) => {
-													setPriceCharmType( value );
-													setIsDirty( true );
-												} }
-												options={ Object.keys(
-													targetCurrencyCharmOptions
-												).map( ( value ) => ( {
-													value: parseFloat( value ),
-													label:
-														targetCurrencyCharmOptions[
-															value
-														],
-												} ) ) }
-												__nextHasNoMarginBottom
-												__next40pxDefaultSize
-											/>
-										</li>
-									</ul>
-								</fieldset>
-							</CardBody>
-						</Card>
-					</LoadableBlock>
-				</SettingsSection>
-				<SettingsSection description={ CurrencyPreviewDescription }>
-					<LoadableBlock isLoading={ isLoading } numLines={ 8 }>
-						<CurrencyPreview
-							className="single-currency-settings-currency-preview"
-							storeCurrency={ storeCurrency }
-							targetCurrency={ targetCurrency }
-							currencyRate={
-								exchangeRateType === 'manual'
-									? manualRate
-									: null
-							}
-							roundingValue={ priceRoundingType }
-							charmValue={ priceCharmType }
-						/>
-					</LoadableBlock>
-				</SettingsSection>
-				<SettingsSection className="single-currency-settings-save-settings-section">
-					<Button
-						isPrimary
-						isBusy={ isSaving }
-						disabled={ isSaving || ! isDirty }
-						onClick={ saveSingleCurrencySettings }
-						__next40pxDefaultSize
-					>
-						{ __( 'Save changes', 'woocommerce-payments' ) }
-					</Button>
-				</SettingsSection>
+													} ) ) }
+													__nextHasNoMarginBottom
+													__next40pxDefaultSize
+												/>
+											</li>
+										</ul>
+									</fieldset>
+								</CardBody>
+							</Card>
+						</LoadableBlock>
+					</SettingsSection>
+					<SettingsSection description={ CurrencyPreviewDescription }>
+						<LoadableBlock isLoading={ isLoading } numLines={ 8 }>
+							<CurrencyPreview
+								className="single-currency-settings-currency-preview"
+								storeCurrency={ storeCurrency }
+								targetCurrency={ targetCurrency }
+								currencyRate={
+									exchangeRateType === 'manual'
+										? manualRate
+										: null
+								}
+								roundingValue={ priceRoundingType }
+								charmValue={ priceCharmType }
+							/>
+						</LoadableBlock>
+					</SettingsSection>
+					<SettingsSection className="single-currency-settings-save-settings-section">
+						<Button
+							isPrimary
+							isBusy={ isSaving }
+							disabled={ isSaving || ! isDirty }
+							onClick={ saveSingleCurrencySettings }
+							__next40pxDefaultSize
+						>
+							{ __( 'Save changes', 'woocommerce-payments' ) }
+						</Button>
+					</SettingsSection>
+				</FormBusyState>
 			</SettingsLayout>
 		</div>
 	);


### PR DESCRIPTION
Fixes #4740

#### Changes proposed in this Pull Request

The settings forms stay editable while a save is in progress, which is confusing on a slow connection.

The form now dims while the request is being made, and any edits made mid-save are discarded once it is completed (so you don't end up with changes that look saved but never actually reached the server).

Applies to "Payments > Settings", the express checkout method pages, advanced fraud protection, and the multi-currency store and single-currency settings.

#### Testing instructions

1. Go to **Payments > Settings**.
2. Throttle the connection (DevTools → Network → Slow 3G) so the save is slow enough to watch.
3. Change a setting and click **Save changes**. The form dims while it saves.
4. Repeat on the other settings screens:
    - any express checkout method page (e.g. Apple Pay / Google Pay)
    - Fraud protection → Advanced
    - Multi-currency store settings, and an individual currency's details page

https://github.com/user-attachments/assets/be5552c1-2f82-478b-9a54-eacf3324ccc7


https://github.com/user-attachments/assets/7a06fc58-d9b0-495b-9f3e-c0b127b2d1e4


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
