### PR TITLE
fix: MCCY table padding

### DIFF
--- a/changelog/fix-mccy-table-padding
+++ b/changelog/fix-mccy-table-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: padding on the enabled currencies table in the Multi-currency settings page

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/__tests__/__snapshots__/index.test.js.snap
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/__tests__/__snapshots__/index.test.js.snap
@@ -43,22 +43,6 @@ exports[`Multi-Currency enabled currencies list Enabled currencies list renders 
   border-color: rgba(0, 0, 0, 0.1);
 }
 
-.emotion-8 {
-  box-sizing: border-box;
-  height: auto;
-  max-height: 100%;
-}
-
-.emotion-8:first-of-type {
-  border-top-left-radius: calc(8px - 1px);
-  border-top-right-radius: calc(8px - 1px);
-}
-
-.emotion-8:last-of-type {
-  border-bottom-left-radius: calc(8px - 1px);
-  border-bottom-right-radius: calc(8px - 1px);
-}
-
 .emotion-14 {
   background: transparent;
   display: block;
@@ -147,7 +131,7 @@ exports[`Multi-Currency enabled currencies list Enabled currencies list renders 
             role="separator"
           />
           <div
-            class="components-card__body components-card-body emotion-8 emotion-1"
+            class="components-card__body components-card-body wcpay-multi-currency__enabled-currencies-list-body emotion-4 emotion-1"
             data-wp-c16t="true"
             data-wp-component="CardBody"
           >

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/index.js
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/index.js
@@ -47,10 +47,8 @@ const EnabledCurrenciesSettingsDescription = () => (
 
 const EnabledCurrencies = () => {
 	const { isLoading } = useCurrencies();
-	const {
-		enabledCurrencies,
-		submitEnabledCurrenciesUpdate,
-	} = useEnabledCurrencies();
+	const { enabledCurrencies, submitEnabledCurrenciesUpdate } =
+		useEnabledCurrencies();
 	const classBase = 'wcpay-multi-currency';
 
 	const handleDeleteClick = ( code ) => {
@@ -77,7 +75,9 @@ const EnabledCurrencies = () => {
 					<div />
 				</CardBody>
 				<CardDivider />
-				<CardBody size={ null }>
+				<CardBody
+					className={ `${ classBase }__enabled-currencies-list-body` }
+				>
 					<EnabledCurrenciesList className="enabled-currencies-list">
 						{ ! isLoading &&
 							enabledCurrencies &&

--- a/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/style.scss
+++ b/includes/multi-currency/client/settings/multi-currency/enabled-currencies-list/style.scss
@@ -22,6 +22,15 @@
 	}
 }
 
+.wcpay-multi-currency__enabled-currencies-list-body {
+	// Drop the card body padding so each row's own `7px 24px` owns the spacing
+	// and lines the currency name up with the "Name" column header. Doubling the
+	// class raises specificity enough to beat the Gutenberg default.
+	&#{&} {
+		padding: 0;
+	}
+}
+
 .enabled-currencies-list {
 	margin: 0;
 


### PR DESCRIPTION
Fixes WOOPMNT-6180

#### Changes proposed in this Pull Request

The enabled currencies table on the Multi-currency settings page had some extra padding around it, and the rows weren't lining up with the `Name` / `Exchange rate` column headers.

Fixing. 

Before:
<img width="1087" height="787" alt="Screenshot 2026-05-30 at 10 20 51 AM" src="https://github.com/user-attachments/assets/db172f45-aa54-4ac6-8192-427e52a93066" />

After:
<img width="1079" height="759" alt="Screenshot 2026-05-30 at 10 31 42 AM" src="https://github.com/user-attachments/assets/464e203a-7013-4191-9b8b-fb1b66b1b2bf" />

#### Testing instructions

1. With Multi-currency enabled, go to **Payments > Settings > Multi-currency** (`/wp-admin/admin.php?page=wc-settings&tab=wcpay_multi_currency`).
2. Look at the **Enabled currencies** table.
3. Confirm the currency rows line up with the `Name` / `Exchange rate` headers, and there's no extra padding above/below the list.
4. For good measure, you can also check the main **Payments > Settings** page (and the WooPay / Apple & Google Pay / Advanced fraud sub-pages) to confirm their cards are unaffected - but I ensured to scope the class name so they won't be.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️) - CSS-only change, verified visually.
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
