### PR TITLE
Update @wordpress/dataviews to 14.3.0 for the Fees report

### DIFF
--- a/changelog/update-wordpress-dataviews-14.3.0
+++ b/changelog/update-wordpress-dataviews-14.3.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update @wordpress/dataviews to 14.3.0 (the latest React 18-compatible release) for the Fees report

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@woocommerce/explat": "2.4.0",
 				"@woocommerce/number": "2.5.0",
 				"@woocommerce/onboarding": "3.6.0",
-				"@wordpress/dataviews": "4.15.4",
+				"@wordpress/dataviews": "14.3.0",
 				"canvas-confetti": "1.9.4",
 				"decimal.js-light": "2.5.1",
 				"intl-tel-input": "17.0.15",
@@ -3457,6 +3457,76 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@base-ui/react": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.5.0.tgz",
+			"integrity": "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.2.9",
+				"@floating-ui/react-dom": "^2.1.8",
+				"@floating-ui/utils": "^0.2.11",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.7.6"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@base-ui/utils": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.9.tgz",
+			"integrity": "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.11",
+				"reselect": "^5.1.1",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@bcoe/v8-coverage": {
@@ -13913,6 +13983,27 @@
 				"@types/react": "^17.0.0"
 			}
 		},
+		"node_modules/@wordpress/compose/node_modules/@wordpress/deprecated": {
+			"version": "4.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.46.0.tgz",
+			"integrity": "sha512-d4Dy9GeJ/VIORTgYKYXT026/hhpV6VOf3VUDj10f+QFoIJ86VMBrzV6KQn8KUVH4T3oH1MSpo/A5t8ttYFemsg==",
+			"dependencies": {
+				"@wordpress/hooks": "^4.46.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/compose/node_modules/@wordpress/deprecated/node_modules/@wordpress/hooks": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.47.0.tgz",
+			"integrity": "sha512-OTbg9axYyz585FvrNzyi3hBV2LHfl2oYr2M8xmQKndkOftxQra/04Hqnrflim7IKOzKR4EfL/KpyoqhQ0mrVHQ==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/compose/node_modules/@wordpress/element": {
 			"version": "4.20.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
@@ -14739,6 +14830,45 @@
 				"react": "^17.0.0"
 			}
 		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/deprecated": {
+			"version": "4.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.46.0.tgz",
+			"integrity": "sha512-d4Dy9GeJ/VIORTgYKYXT026/hhpV6VOf3VUDj10f+QFoIJ86VMBrzV6KQn8KUVH4T3oH1MSpo/A5t8ttYFemsg==",
+			"dependencies": {
+				"@wordpress/hooks": "^4.46.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.46.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/hooks": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.47.0.tgz",
+			"integrity": "sha512-OTbg9axYyz585FvrNzyi3hBV2LHfl2oYr2M8xmQKndkOftxQra/04Hqnrflim7IKOzKR4EfL/KpyoqhQ0mrVHQ==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/data/node_modules/@wordpress/is-shallow-equal": {
 			"version": "4.58.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.58.0.tgz",
@@ -14763,23 +14893,30 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews": {
-			"version": "4.15.4",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-4.15.4.tgz",
-			"integrity": "sha512-LyXPcv9RiEBM7ko8l6TPAWVv+KURVH/4WcZw8z0/lBgemWo2vgYynoGopxSWbF+QbMzpsFnRN4OZuyWLWB8liQ==",
-			"license": "GPL-2.0-or-later",
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
+			"integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
-				"@babel/runtime": "7.25.7",
-				"@wordpress/components": "^29.5.4",
-				"@wordpress/compose": "^7.19.2",
-				"@wordpress/data": "^10.19.2",
-				"@wordpress/element": "^6.19.1",
-				"@wordpress/i18n": "^5.19.1",
-				"@wordpress/icons": "^10.19.1",
-				"@wordpress/primitives": "^4.19.1",
-				"@wordpress/private-apis": "^1.19.1",
-				"@wordpress/warning": "^3.19.1",
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/components": "^33.1.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/data": "^10.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/ui": "^0.13.0",
+				"@wordpress/warning": "^3.46.0",
 				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
+				"fast-deep-equal": "^3.1.3",
 				"remove-accents": "^0.5.0"
 			},
 			"engines": {
@@ -14787,19 +14924,100 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/@babel/runtime": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-			"license": "MIT",
+		"node_modules/@wordpress/dataviews/node_modules/@types/gradient-parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+			"integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw=="
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/a11y": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.47.0.tgz",
+			"integrity": "sha512-Gq0PRRg7/jXFD4V8UfQNQEMR5DX8KxYUK1QUbHgRedsaW/ZhlgsXJHmBMZfeLubBn/tf0xpdPYdp0MNA5oc3Rg==",
 			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
+				"@wordpress/dom-ready": "^4.47.0",
+				"@wordpress/i18n": "^6.20.0"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
+			"integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "33.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
+			"integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/hooks": "^4.46.0",
+				"@wordpress/html-entities": "^4.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/rich-text": "^7.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/warning": "^3.46.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/compose": {
@@ -14857,6 +15075,20 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/date": {
+			"version": "5.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.46.0.tgz",
+			"integrity": "sha512-phbKy1siTFGwFet5hQzaSZJB1mMDIXflMLKj+oJ/mT/m9ughp3seFDPvKoL+UzukLxNJh3l5G5h1l9XQFfC2cA==",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.46.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/deprecated": {
 			"version": "4.46.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.46.0.tgz",
@@ -14878,6 +15110,15 @@
 			"dependencies": {
 				"@wordpress/deprecated": "^4.46.0"
 			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/dom-ready": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.47.0.tgz",
+			"integrity": "sha512-j2s4GdhxxQi2pbgyqdSz+Xh59K626/ErASH/ZKF7GlnBk4fjf3X0Odg7wopZ5wQfJgZSfEjGr1sonRst5uMAVw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -14912,17 +15153,24 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/html-entities": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.47.0.tgz",
+			"integrity": "sha512-D3sVJF1uTkjTUJvaAVJsoV8dCkP8q8L29NpavP4qClVQAhlYEynhmMUpesoL163f65Fi7XHwfIVejGjGDrMoXA==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/i18n": {
-			"version": "5.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
-			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
-			"license": "GPL-2.0-or-later",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.20.0.tgz",
+			"integrity": "sha512-CRwh4/kRtetolDHL8qXUuvV4XV4lSbvqQ7TiqBK3t6OTtj+exQME9Jb/vQACaQFKJBGCHTHoEtwMfJ5tfrkggg==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.26.0",
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.47.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
@@ -14933,26 +15181,36 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/i18n/node_modules/@wordpress/hooks": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.47.0.tgz",
+			"integrity": "sha512-OTbg9axYyz585FvrNzyi3hBV2LHfl2oYr2M8xmQKndkOftxQra/04Hqnrflim7IKOzKR4EfL/KpyoqhQ0mrVHQ==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
-			"version": "10.32.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.32.0.tgz",
-			"integrity": "sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==",
-			"license": "GPL-2.0-or-later",
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.1.0.tgz",
+			"integrity": "sha512-KMZAeYghsLs6e5wKMZ3/Ynrsuu5yZt2gAlMHmZSkWJKQFld++Pz/pEj8nDCJ79z/zx9FO7q4teG49vHHvVosjQ==",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.32.0",
-				"@wordpress/primitives": "^4.32.0"
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"change-case": "4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/primitives": {
 			"version": "4.46.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.46.0.tgz",
 			"integrity": "sha512-x1IhEVa/aGDe6otGJ4VIqEioQGfIeK5B1VQm32+ycqinJRbtbw9F5bgx4ARIdnm5M1Lg63oV9Bhmg/XMyGSTZA==",
-			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "^6.46.0",
 				"clsx": "^2.1.1"
@@ -14983,11 +15241,66 @@
 				"redux": ">=4"
 			}
 		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/rich-text": {
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.46.0.tgz",
+			"integrity": "sha512-XxuCe0gWq5YYfN+EdL5RmL4/qMlVka0R+n51/DzEpWM/+CkPInpXBeYE+3z9Ip+sRcnEgE1zKkMo1wjXWTDOjw==",
+			"dependencies": {
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/data": "^10.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"colord": "2.9.3",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/gradient-parser": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
+			"integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/@wordpress/dataviews/node_modules/redux": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
 			"license": "MIT"
+		},
+		"node_modules/@wordpress/dataviews/node_modules/uuid": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
 		},
 		"node_modules/@wordpress/date": {
 			"version": "4.5.0",
@@ -15063,6 +15376,27 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/dom/node_modules/@wordpress/deprecated": {
+			"version": "4.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.46.0.tgz",
+			"integrity": "sha512-d4Dy9GeJ/VIORTgYKYXT026/hhpV6VOf3VUDj10f+QFoIJ86VMBrzV6KQn8KUVH4T3oH1MSpo/A5t8ttYFemsg==",
+			"dependencies": {
+				"@wordpress/hooks": "^4.46.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dom/node_modules/@wordpress/hooks": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.47.0.tgz",
+			"integrity": "sha512-OTbg9axYyz585FvrNzyi3hBV2LHfl2oYr2M8xmQKndkOftxQra/04Hqnrflim7IKOzKR4EfL/KpyoqhQ0mrVHQ==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
@@ -19651,6 +19985,15 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/style-runtime": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
+			"integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
 		"node_modules/@wordpress/stylelint-config": {
 			"version": "19.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-19.1.0.tgz",
@@ -19801,6 +20144,210 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
+			"integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
+			"dependencies": {
+				"@base-ui/react": "^1.4.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/theme": "^0.13.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/a11y": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.47.0.tgz",
+			"integrity": "sha512-Gq0PRRg7/jXFD4V8UfQNQEMR5DX8KxYUK1QUbHgRedsaW/ZhlgsXJHmBMZfeLubBn/tf0xpdPYdp0MNA5oc3Rg==",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.47.0",
+				"@wordpress/i18n": "^6.20.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/compose": {
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
+			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/priority-queue": "^3.46.0",
+				"@wordpress/undo-manager": "^1.46.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/deprecated": {
+			"version": "4.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.46.0.tgz",
+			"integrity": "sha512-d4Dy9GeJ/VIORTgYKYXT026/hhpV6VOf3VUDj10f+QFoIJ86VMBrzV6KQn8KUVH4T3oH1MSpo/A5t8ttYFemsg==",
+			"dependencies": {
+				"@wordpress/hooks": "^4.46.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/dom": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.47.0.tgz",
+			"integrity": "sha512-HD9pdNpS8dJnA70ZSBjx6FBbC4dChNaWWE+OxlvhgKisgETSIZaxvvc+W23WPIfC1WsKfD4amKtfLHXo+38TrQ==",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.47.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/dom-ready": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.47.0.tgz",
+			"integrity": "sha512-j2s4GdhxxQi2pbgyqdSz+Xh59K626/ErASH/ZKF7GlnBk4fjf3X0Odg7wopZ5wQfJgZSfEjGr1sonRst5uMAVw==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/element": {
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.46.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/hooks": {
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.47.0.tgz",
+			"integrity": "sha512-OTbg9axYyz585FvrNzyi3hBV2LHfl2oYr2M8xmQKndkOftxQra/04Hqnrflim7IKOzKR4EfL/KpyoqhQ0mrVHQ==",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/i18n": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.20.0.tgz",
+			"integrity": "sha512-CRwh4/kRtetolDHL8qXUuvV4XV4lSbvqQ7TiqBK3t6OTtj+exQME9Jb/vQACaQFKJBGCHTHoEtwMfJ5tfrkggg==",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.47.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.1.0.tgz",
+			"integrity": "sha512-KMZAeYghsLs6e5wKMZ3/Ynrsuu5yZt2gAlMHmZSkWJKQFld++Pz/pEj8nDCJ79z/zx9FO7q4teG49vHHvVosjQ==",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/primitives": {
+			"version": "4.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.46.0.tgz",
+			"integrity": "sha512-x1IhEVa/aGDe6otGJ4VIqEioQGfIeK5B1VQm32+ycqinJRbtbw9F5bgx4ARIdnm5M1Lg63oV9Bhmg/XMyGSTZA==",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.13.0.tgz",
+			"integrity": "sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
@@ -20218,9 +20765,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.45.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.45.0.tgz",
-			"integrity": "sha512-NQ9tAhPdwhfceVIzWra1rbumvgAFAEDTgZlWsX880zLiq1F8JTwBouwW6wfIhA3XLcY6Yj7cBBYLa8vnNiDZDw==",
+			"version": "3.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.46.0.tgz",
+			"integrity": "sha512-Z1CE6x732iMD+NcWziitqWUyhxVy1JlioHDtQUU2oqhDcA0d/P2ifOc/af02dDYFIuLh7umurU19LqpBX6EoWw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
@@ -22780,7 +23327,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
 			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
-			"dev": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/color"
@@ -35234,6 +35780,11 @@
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
 			"dev": true
 		},
+		"node_modules/reselect": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="
+		},
 		"node_modules/resolve": {
 			"version": "1.22.12",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -37549,6 +38100,11 @@
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
+		},
+		"node_modules/tabbable": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="
 		},
 		"node_modules/table": {
 			"version": "6.9.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"@woocommerce/explat": "2.4.0",
 		"@woocommerce/number": "2.5.0",
 		"@woocommerce/onboarding": "3.6.0",
-		"@wordpress/dataviews": "4.15.4",
+		"@wordpress/dataviews": "14.3.0",
 		"canvas-confetti": "1.9.4",
 		"decimal.js-light": "2.5.1",
 		"intl-tel-input": "17.0.15",
@@ -237,6 +237,19 @@
 		"@woocommerce/components": {
 			"@woocommerce/csv-export": "1.10.0",
 			"@woocommerce/currency": "5.0.0"
+		},
+		"@wordpress/dataviews": {
+			"@wordpress/data": "10.46.0",
+			"@wordpress/element": "6.46.0",
+			"@wordpress/compose": "7.46.0",
+			"@wordpress/primitives": "4.46.0",
+			"@wordpress/keycodes": "4.46.0",
+			"@wordpress/deprecated": "4.46.0",
+			"@wordpress/warning": "3.46.0",
+			"@wordpress/date": "5.46.0",
+			"@wordpress/private-apis": "1.46.0",
+			"@wordpress/icons": "13.1.0",
+			"@wordpress/rich-text": "7.46.0"
 		},
 		"@wordpress/scripts": {
 			"@wordpress/eslint-plugin": "15.1.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the **`@wordpress/dataviews`** dependency used by the Fees report from **4.15.4 → 14.3.0**, picking up upstream DataViews improvements without requiring React 19.

DataViews is force-bundled from `@wordpress/dataviews` (see `webpack/shared.js`) rather than used from the host `wp.dataviews`, because WordPress core does not reliably ship the DataViews API this report expects. **14.3.0 is the latest release on the React-18 line** — 15.0.0 moved to a `react ^19.2.4` peer, and WordPress core still vendors React 18, so 15.x cannot run on supported hosts yet.

Bumping to 14.3.0 made npm resolve DataViews' transitive `@wordpress/*` dependencies to the newly published ".47" wave, which flipped to a React 19 peer and pulled `react-dom@19` into the force-bundled subtree (a runtime crash against the host's React 18). To prevent that, this PR adds **scoped npm `overrides`** pinning the bundled `@wordpress/*` subtree (`data`, `element`, `compose`, `primitives`, `icons`, `rich-text`, etc.) to their last React-18 (".46") releases, so the force-bundled DataViews stays on React 18 — matching the tree the previous lockfile had frozen.

This is **dependency-only** — no application code changes, and **no React 19**. The large `package-lock.json` diff is the override-driven dedupe of the bundled DataViews subtree.

#### Testing instructions

- Check out the branch and run `npm ci && npm run build:client` (Node 20.11).
- [ ] Verify `npm run test:js -- client/reports/fees` passes.
- [ ] In wp-admin, open **Payments → Reports → Fees** and confirm the DataViews table renders.
- [ ] Confirm sorting, pagination, and the date/search filters work and update the results.
- [ ] Check the browser console for errors on the Fees report.

*
