### PR TITLE
Add WooPayments agent write abilities (refund, dispute evidence/accept) + balance/fraud/fee reads

### DIFF
--- a/changelog/add-woopayments-write-abilities
+++ b/changelog/add-woopayments-write-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add WooPayments refund, dispute-evidence, and dispute-accept agent abilities (Abilities API).

--- a/changelog/add-woopayments-write-abilities#2
+++ b/changelog/add-woopayments-write-abilities#2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add balance, fraud-outcome, and processing-fee-summary read agent abilities (Abilities API).

--- a/changelog/add-woopayments-write-abilities#3
+++ b/changelog/add-woopayments-write-abilities#3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Support a caller-supplied idempotency key on outbound payment API requests.

--- a/changelog/add-woopayments-write-abilities#4
+++ b/changelog/add-woopayments-write-abilities#4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a WooPayments dispute-evidence file-upload agent ability (Abilities API).

--- a/includes/admin/class-wc-rest-payments-transactions-controller.php
+++ b/includes/admin/class-wc-rest-payments-transactions-controller.php
@@ -126,6 +126,8 @@ class WC_REST_Payments_Transactions_Controller extends WC_Payments_REST_Controll
 	/**
 	 * Retrieve fraud outcome transactions to respond with via API.
 	 *
+	 * @see \WCPay\Internal\Abilities\Domain\GetFraudOutcomes
+	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_fraud_outcome_transactions( $request ) {

--- a/includes/core/server/request/class-refund-charge.php
+++ b/includes/core/server/request/class-refund-charge.php
@@ -113,6 +113,19 @@ class Refund_Charge extends Request {
 	}
 
 	/**
+	 * Sets a caller-supplied idempotency key so duplicate retries of the same
+	 * refund dedupe to the original result at the payment processor. The API
+	 * client lifts this into the `Idempotency-Key` header and strips it from
+	 * the request body.
+	 *
+	 * @param string $idempotency_key Caller-supplied idempotency key.
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_idempotency_key( string $idempotency_key ) {
+		$this->set_param( 'idempotency_key', $idempotency_key );
+	}
+
+	/**
 	 * Returns the request's API.
 	 *
 	 * @return string

--- a/includes/reports/class-wc-rest-payments-reports-balance-controller.php
+++ b/includes/reports/class-wc-rest-payments-reports-balance-controller.php
@@ -46,6 +46,8 @@ class WC_REST_Payments_Reports_Balance_Controller extends WC_Payments_REST_Contr
 	/**
 	 * Retrieves the Balance report summary.
 	 *
+	 * @see \WCPay\Internal\Abilities\Domain\GetBalance
+	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response

--- a/includes/reports/class-wc-rest-payments-reports-fees-controller.php
+++ b/includes/reports/class-wc-rest-payments-reports-fees-controller.php
@@ -139,6 +139,8 @@ class WC_REST_Payments_Reports_Fees_Controller extends WC_REST_Payments_Reports_
 	/**
 	 * Retrieves the Fees report summary.
 	 *
+	 * @see \WCPay\Internal\Abilities\Domain\GetFeesSummary
+	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_fees_summary( $request ) {

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -836,11 +836,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	 * @throws API_Exception - If request throws.
 	 */
 	public function upload_file( $request ) {
-		$purpose     = $request->get_param( 'purpose' );
 		$file_params = $request->get_file_params();
-		$file_name   = $file_params['file']['name'];
-		$file_type   = $file_params['file']['type'];
-		$as_account  = (bool) $request->get_param( 'as_account' );
 
 		// Sometimes $file_params is empty array for large files (8+ MB).
 		$file_error = empty( $file_params ) || $file_params['file']['error'];
@@ -854,13 +850,42 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			);
 		}
 
-		$body = [
+		return $this->upload_evidence_file_contents(
 			// We disable php linting here because otherwise it will show a warning on improper
 			// use of `file_get_contents()` and say you should "use `wp_remote_get()` for
 			// remote URLs instead", which is unrelated to our use here.
 			// phpcs:disable
-			'file'      => base64_encode( file_get_contents( $file_params['file']['tmp_name'] ) ),
+			base64_encode( file_get_contents( $file_params['file']['tmp_name'] ) ),
 			// phpcs:enable
+			$file_params['file']['name'],
+			$file_params['file']['type'],
+			(string) $request->get_param( 'purpose' ),
+			(bool) $request->get_param( 'as_account' )
+		);
+	}
+
+	/**
+	 * Upload already-read evidence file contents (base64) to the Files API.
+	 *
+	 * Shared by the multipart REST upload path (`WC_REST_Payments_Files_Controller`)
+	 * and the agent file-upload ability, so both reach the same Files API call
+	 * with no logic drift. Callers that have a raw `$_FILES` upload should use
+	 * `upload_file()`; callers that already hold the file contents (e.g. an
+	 * ability receiving a base64 payload) call this directly.
+	 *
+	 * @param string $file_content_base64 Base64-encoded file contents.
+	 * @param string $file_name           File name including extension.
+	 * @param string $file_type           File MIME type (e.g. `image/png`).
+	 * @param string $purpose             Stripe file purpose (e.g. `dispute_evidence`).
+	 * @param bool   $as_account          Whether to upload on behalf of the connected account.
+	 *
+	 * @return array File object returned by the Files API.
+	 *
+	 * @throws API_Exception When the upload request fails.
+	 */
+	public function upload_evidence_file_contents( string $file_content_base64, string $file_name, string $file_type, string $purpose, bool $as_account = false ) {
+		$body = [
+			'file'       => $file_content_base64,
 			'file_name'  => $file_name,
 			'file_type'  => $file_type,
 			'purpose'    => $purpose,

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2566,6 +2566,10 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 	/**
 	 * Send the request to the WooCommerce Payment API
 	 *
+	 * Note: `idempotency_key` is a reserved transport-layer param key. When present
+	 * in $params it is lifted into the `Idempotency-Key` header and stripped from
+	 * the body — it is never sent to the server as request data.
+	 *
 	 * @param array  $params           - Request parameters to send as either JSON or GET string. Defaults to test_mode=1 if either in dev or test mode, 0 otherwise.
 	 * @param string $api              - The API endpoint to call.
 	 * @param string $method           - The HTTP method to make the request with.
@@ -2588,6 +2592,19 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		);
 
 		$params = apply_filters( 'wcpay_api_request_params', $params, $api, $method );
+
+		// Honor a caller-supplied idempotency key (e.g. from an agent-driven
+		// ability) so duplicate retries dedupe to the original result. Lift it out
+		// of the body params either way — it is a transport-layer header, never
+		// request data sent to the server. The (string) cast guards against a
+		// non-string value injected via the wcpay_api_request_params filter. For
+		// GET/DELETE the key is stripped from the params here but intentionally
+		// not added as a header (those methods build a query string, not a body).
+		$caller_idempotency_key = '';
+		if ( is_array( $params ) && isset( $params['idempotency_key'] ) ) {
+			$caller_idempotency_key = (string) $params['idempotency_key'];
+			unset( $params['idempotency_key'] );
+		}
 
 		// Build the URL we want to send the request to.
 		$url = self::ENDPOINT_BASE;
@@ -2613,7 +2630,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			$url          .= '?' . http_build_query( $params );
 			$redacted_url .= '?' . http_build_query( $redacted_params );
 		} else {
-			$headers['Idempotency-Key'] = $this->uuid();
+			$headers['Idempotency-Key'] = '' !== $caller_idempotency_key ? $caller_idempotency_key : $this->uuid();
 			$body                       = wp_json_encode( $params );
 			if ( ! $body ) {
 				throw new API_Exception(

--- a/src/Internal/Abilities/AbilitiesRegistrar.php
+++ b/src/Internal/Abilities/AbilitiesRegistrar.php
@@ -72,6 +72,7 @@ class AbilitiesRegistrar {
 		\WCPay\Internal\Abilities\Domain\AcceptDispute::class,
 		\WCPay\Internal\Abilities\Domain\GetBalance::class,
 		\WCPay\Internal\Abilities\Domain\GetFraudOutcomes::class,
+		\WCPay\Internal\Abilities\Domain\GetFeesSummary::class,
 	];
 
 	/**

--- a/src/Internal/Abilities/AbilitiesRegistrar.php
+++ b/src/Internal/Abilities/AbilitiesRegistrar.php
@@ -70,6 +70,7 @@ class AbilitiesRegistrar {
 		\WCPay\Internal\Abilities\Domain\RefundCharge::class,
 		\WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence::class,
 		\WCPay\Internal\Abilities\Domain\AcceptDispute::class,
+		\WCPay\Internal\Abilities\Domain\UploadDisputeEvidenceFile::class,
 		\WCPay\Internal\Abilities\Domain\GetBalance::class,
 		\WCPay\Internal\Abilities\Domain\GetFraudOutcomes::class,
 		\WCPay\Internal\Abilities\Domain\GetFeesSummary::class,

--- a/src/Internal/Abilities/AbilitiesRegistrar.php
+++ b/src/Internal/Abilities/AbilitiesRegistrar.php
@@ -14,7 +14,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Registers WooPayments with the WordPress Abilities API.
  *
- * Registers 15 read-only abilities under the shared `woocommerce` category.
+ * Registers WooPayments read and write abilities under the shared
+ * `woocommerce` category.
  * All abilities gate on `manage_woocommerce` and are gated by the
  * `woocommerce_payments_abilities_enabled` filter (default `false`).
  *
@@ -66,6 +67,7 @@ class AbilitiesRegistrar {
 		\WCPay\Internal\Abilities\Domain\GetDisputes::class,
 		\WCPay\Internal\Abilities\Domain\GetAuthorizations::class,
 		\WCPay\Internal\Abilities\Domain\GetDeposits::class,
+		\WCPay\Internal\Abilities\Domain\RefundCharge::class,
 	];
 
 	/**

--- a/src/Internal/Abilities/AbilitiesRegistrar.php
+++ b/src/Internal/Abilities/AbilitiesRegistrar.php
@@ -68,6 +68,7 @@ class AbilitiesRegistrar {
 		\WCPay\Internal\Abilities\Domain\GetAuthorizations::class,
 		\WCPay\Internal\Abilities\Domain\GetDeposits::class,
 		\WCPay\Internal\Abilities\Domain\RefundCharge::class,
+		\WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence::class,
 	];
 
 	/**

--- a/src/Internal/Abilities/AbilitiesRegistrar.php
+++ b/src/Internal/Abilities/AbilitiesRegistrar.php
@@ -70,6 +70,7 @@ class AbilitiesRegistrar {
 		\WCPay\Internal\Abilities\Domain\RefundCharge::class,
 		\WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence::class,
 		\WCPay\Internal\Abilities\Domain\AcceptDispute::class,
+		\WCPay\Internal\Abilities\Domain\GetBalance::class,
 	];
 
 	/**

--- a/src/Internal/Abilities/AbilitiesRegistrar.php
+++ b/src/Internal/Abilities/AbilitiesRegistrar.php
@@ -71,6 +71,7 @@ class AbilitiesRegistrar {
 		\WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence::class,
 		\WCPay\Internal\Abilities\Domain\AcceptDispute::class,
 		\WCPay\Internal\Abilities\Domain\GetBalance::class,
+		\WCPay\Internal\Abilities\Domain\GetFraudOutcomes::class,
 	];
 
 	/**

--- a/src/Internal/Abilities/AbilitiesRegistrar.php
+++ b/src/Internal/Abilities/AbilitiesRegistrar.php
@@ -69,6 +69,7 @@ class AbilitiesRegistrar {
 		\WCPay\Internal\Abilities\Domain\GetDeposits::class,
 		\WCPay\Internal\Abilities\Domain\RefundCharge::class,
 		\WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence::class,
+		\WCPay\Internal\Abilities\Domain\AcceptDispute::class,
 	];
 
 	/**

--- a/src/Internal/Abilities/Domain/AcceptDispute.php
+++ b/src/Internal/Abilities/Domain/AcceptDispute.php
@@ -17,9 +17,9 @@ defined( 'ABSPATH' ) || exit;
  * Registers the `woocommerce-payments/accept-dispute` ability.
  *
  * Accepting a dispute concedes it: the funds are refunded to the cardholder
- * and forfeited permanently. Irreversible (reversibility 0.0) and
- * destructive. mcp.public is false — never auto-invocable; the caller's policy
- * layer must gate this behind explicit operator approval.
+ * and forfeited permanently. Irreversible and destructive. mcp.public is
+ * false — never auto-invocable; the caller's policy layer must gate this
+ * behind explicit operator approval.
  *
  * @internal Only loaded when WooCommerce 10.9+ is active.
  *
@@ -61,10 +61,9 @@ class AcceptDispute extends AbstractWCPayAbility implements AbilityDefinition {
 			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
 			'meta'                => [
 				'annotations'  => [
-					'readonly'      => false,
-					'destructive'   => true,
-					'idempotent'    => false,
-					'reversibility' => 0.0,
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => false,
 				],
 				'show_in_rest' => true,
 				'mcp'          => [

--- a/src/Internal/Abilities/Domain/AcceptDispute.php
+++ b/src/Internal/Abilities/Domain/AcceptDispute.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments
  */
 
-// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
-
 namespace WCPay\Internal\Abilities\Domain;
 
 use Automattic\WooCommerce\Abilities\AbilityDefinition;

--- a/src/Internal/Abilities/Domain/AcceptDispute.php
+++ b/src/Internal/Abilities/Domain/AcceptDispute.php
@@ -88,11 +88,15 @@ class AcceptDispute extends AbstractWCPayAbility implements AbilityDefinition {
 			);
 		}
 
-		$container = \wcpay_get_container();
-		if ( ! $container->has( DisputeService::class ) ) {
-			return new \WP_Error( 'wcpay_not_initialized', __( 'WooPayments is not initialized.', 'woocommerce-payments' ) );
-		}
+		return self::get_dispute_service()->accept( $input['dispute_id'] );
+	}
 
-		return $container->get( DisputeService::class )->accept( $input['dispute_id'] );
+	/**
+	 * Resolve the shared dispute service from the container.
+	 *
+	 * @return DisputeService
+	 */
+	private static function get_dispute_service(): DisputeService {
+		return \wcpay_get_container()->get( DisputeService::class );
 	}
 }

--- a/src/Internal/Abilities/Domain/AcceptDispute.php
+++ b/src/Internal/Abilities/Domain/AcceptDispute.php
@@ -52,8 +52,7 @@ class AcceptDispute extends AbstractWCPayAbility implements AbilityDefinition {
 				'properties'           => [
 					'dispute_id' => [
 						'type'        => 'string',
-						'pattern'     => '^dp_',
-						'description' => __( 'Dispute ID (dp_…) to accept.', 'woocommerce-payments' ),
+						'description' => __( 'Stripe dispute ID (typically `du_…` or legacy `dp_…`). Stripe ID prefixes are not contractually stable, so this field is not pattern-validated.', 'woocommerce-payments' ),
 					],
 				],
 				'additionalProperties' => false,

--- a/src/Internal/Abilities/Domain/AcceptDispute.php
+++ b/src/Internal/Abilities/Domain/AcceptDispute.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Accept Dispute ability definition.
+ *
+ * @package WooCommerce\Payments
+ */
+
+// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
+
+namespace WCPay\Internal\Abilities\Domain;
+
+use Automattic\WooCommerce\Abilities\AbilityDefinition;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Service\DisputeService;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `woocommerce-payments/accept-dispute` ability.
+ *
+ * Accepting a dispute concedes it: the funds are refunded to the cardholder
+ * and forfeited permanently. Irreversible (reversibility 0.0) and
+ * destructive. mcp.public is false — never auto-invocable; the caller's policy
+ * layer must gate this behind explicit operator approval.
+ *
+ * @internal Only loaded when WooCommerce 10.9+ is active.
+ *
+ * @see \WCPay\Internal\Service\DisputeService::accept()
+ */
+class AcceptDispute extends AbstractWCPayAbility implements AbilityDefinition {
+
+	/**
+	 * Return the ability name.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'woocommerce-payments/accept-dispute';
+	}
+
+	/**
+	 * Return registration args for this ability.
+	 *
+	 * @return array
+	 */
+	public static function get_registration_args(): array {
+		return [
+			'label'               => __( 'Accept a dispute', 'woocommerce-payments' ),
+			'description'         => __( 'Accept (concede) a dispute. The disputed funds are forfeited to the cardholder permanently. This cannot be undone.', 'woocommerce-payments' ),
+			'category'            => AbilitiesRegistrar::CATEGORY_SLUG,
+			'input_schema'        => [
+				'type'                 => 'object',
+				'required'             => [ 'dispute_id' ],
+				'properties'           => [
+					'dispute_id' => [
+						'type'        => 'string',
+						'pattern'     => '^dp_',
+						'description' => __( 'Dispute ID (dp_…) to accept.', 'woocommerce-payments' ),
+					],
+				],
+				'additionalProperties' => false,
+			],
+			'execute_callback'    => [ self::class, 'execute' ],
+			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
+			'meta'                => [
+				'annotations'  => [
+					'readonly'      => false,
+					'destructive'   => true,
+					'idempotent'    => false,
+					'reversibility' => 0.0,
+				],
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => false,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the accept-dispute ability.
+	 *
+	 * @param array<string,mixed> $input Must contain `dispute_id`.
+	 * @return array|\WP_Error
+	 */
+	public static function execute( $input = null ) {
+		if ( ! is_array( $input ) || ! isset( $input['dispute_id'] ) || ! is_string( $input['dispute_id'] ) || '' === $input['dispute_id'] ) {
+			return new \WP_Error(
+				'wcpay_missing_dispute_id',
+				__( 'A dispute_id is required to accept a dispute.', 'woocommerce-payments' )
+			);
+		}
+
+		$container = \wcpay_get_container();
+		if ( ! $container->has( DisputeService::class ) ) {
+			return new \WP_Error( 'wcpay_not_initialized', __( 'WooPayments is not initialized.', 'woocommerce-payments' ) );
+		}
+
+		return $container->get( DisputeService::class )->accept( $input['dispute_id'] );
+	}
+}

--- a/src/Internal/Abilities/Domain/GetBalance.php
+++ b/src/Internal/Abilities/Domain/GetBalance.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Get Balance ability definition.
+ *
+ * @package WooCommerce\Payments
+ */
+
+// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
+
+namespace WCPay\Internal\Abilities\Domain;
+
+use Automattic\WooCommerce\Abilities\AbilityDefinition;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `woocommerce-payments/get-balance` ability.
+ *
+ * Returns the balance summary (available, pending, and on-hold movements) for
+ * a currency over a date range. Backed by the balance report endpoint.
+ *
+ * @internal Only loaded when WooCommerce 10.9+ is active.
+ *
+ * @see \WC_REST_Payments_Reports_Balance_Controller::get_balance_summary()
+ */
+class GetBalance extends AbstractWCPayAbility implements AbilityDefinition {
+
+	private const REQUIRED_FIELDS = [ 'date_start', 'date_end', 'currency' ];
+
+	/**
+	 * Return the ability name.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'woocommerce-payments/get-balance';
+	}
+
+	/**
+	 * Return registration args for this ability.
+	 *
+	 * @return array
+	 */
+	public static function get_registration_args(): array {
+		return [
+			'label'               => __( 'Get balance summary', 'woocommerce-payments' ),
+			'description'         => __( 'Return the balance summary (charges, refunds, disputes, fees, payouts, ending balance) for a currency over a date range.', 'woocommerce-payments' ),
+			'category'            => AbilitiesRegistrar::CATEGORY_SLUG,
+			'input_schema'        => [
+				'type'                 => 'object',
+				'required'             => [ 'date_start', 'date_end', 'currency' ],
+				'properties'           => [
+					'date_start' => [
+						'type'        => 'string',
+						'description' => __( 'Start of the period (ISO-8601 date-time).', 'woocommerce-payments' ),
+					],
+					'date_end'   => [
+						'type'        => 'string',
+						'description' => __( 'End of the period (ISO-8601 date-time).', 'woocommerce-payments' ),
+					],
+					'currency'   => [
+						'type'        => 'string',
+						'description' => __( 'Three-letter ISO-4217 currency code.', 'woocommerce-payments' ),
+					],
+				],
+				'additionalProperties' => false,
+			],
+			'execute_callback'    => [ self::class, 'execute' ],
+			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
+			'meta'                => [
+				'annotations'  => [
+					'readonly'      => true,
+					'destructive'   => false,
+					'idempotent'    => true,
+					'reversibility' => 1.0,
+				],
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the get-balance ability.
+	 *
+	 * @see \WC_REST_Payments_Reports_Balance_Controller::get_balance_summary()
+	 *
+	 * @param array<string, mixed> $input Required: date_start, date_end, currency.
+	 * @return array|\WP_Error
+	 */
+	public static function execute( $input = null ) {
+		$input = is_array( $input ) ? $input : [];
+
+		foreach ( self::REQUIRED_FIELDS as $field ) {
+			if ( ! isset( $input[ $field ] ) || ! is_string( $input[ $field ] ) || '' === $input[ $field ] ) {
+				return new \WP_Error(
+					'wcpay_missing_' . $field,
+					sprintf(
+						/* translators: %s: required field name. */
+						__( 'A %s is required to read the balance summary.', 'woocommerce-payments' ),
+						$field
+					)
+				);
+			}
+		}
+
+		return AbilitiesRegistrar::delegate_to_rest_controller(
+			'GET',
+			'/wc/v3/payments/reports/balance',
+			[
+				'date_start' => $input['date_start'],
+				'date_end'   => $input['date_end'],
+				'currency'   => $input['currency'],
+			]
+		);
+	}
+}

--- a/src/Internal/Abilities/Domain/GetBalance.php
+++ b/src/Internal/Abilities/Domain/GetBalance.php
@@ -68,10 +68,9 @@ class GetBalance extends AbstractWCPayAbility implements AbilityDefinition {
 			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
 			'meta'                => [
 				'annotations'  => [
-					'readonly'      => true,
-					'destructive'   => false,
-					'idempotent'    => true,
-					'reversibility' => 1.0,
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
 				],
 				'show_in_rest' => true,
 				'mcp'          => [

--- a/src/Internal/Abilities/Domain/GetBalance.php
+++ b/src/Internal/Abilities/Domain/GetBalance.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments
  */
 
-// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
-
 namespace WCPay\Internal\Abilities\Domain;
 
 use Automattic\WooCommerce\Abilities\AbilityDefinition;

--- a/src/Internal/Abilities/Domain/GetFeesSummary.php
+++ b/src/Internal/Abilities/Domain/GetFeesSummary.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Get Fees Summary ability definition.
+ *
+ * @package WooCommerce\Payments
+ */
+
+// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
+
+namespace WCPay\Internal\Abilities\Domain;
+
+use Automattic\WooCommerce\Abilities\AbilityDefinition;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `woocommerce-payments/get-fees-summary` ability.
+ *
+ * Returns aggregate processing-fee totals over a date range (and optional
+ * filters). Backed by the fees report summary endpoint.
+ *
+ * @internal Only loaded when WooCommerce 10.9+ is active.
+ *
+ * @see \WC_REST_Payments_Reports_Fees_Controller::get_fees_summary()
+ */
+class GetFeesSummary extends AbstractWCPayAbility implements AbilityDefinition {
+
+	/**
+	 * Return the ability name.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'woocommerce-payments/get-fees-summary';
+	}
+
+	/**
+	 * Return registration args for this ability.
+	 *
+	 * @return array
+	 */
+	public static function get_registration_args(): array {
+		return [
+			'label'               => __( 'Get processing-fee summary', 'woocommerce-payments' ),
+			'description'         => __( 'Return aggregate processing-fee totals (count, fees, net) over a date range. Answers \'how much did I pay in fees this period?\'.', 'woocommerce-payments' ),
+			'category'            => AbilitiesRegistrar::CATEGORY_SLUG,
+			'input_schema'        => [
+				'type'                 => 'object',
+				'default'              => (object) [],
+				'properties'           => [
+					'date_before'         => [ 'type' => 'string' ],
+					'date_after'          => [ 'type' => 'string' ],
+					'date_between'        => [
+						'type'  => 'array',
+						'items' => [ 'type' => 'string' ],
+					],
+					'match'               => [ 'type' => 'string' ],
+					'deposit_id'          => [ 'type' => 'string' ],
+					'payment_method_type' => [ 'type' => 'string' ],
+				],
+				'additionalProperties' => false,
+			],
+			'execute_callback'    => [ self::class, 'execute' ],
+			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
+			'meta'                => [
+				'annotations'  => [
+					'readonly'      => true,
+					'destructive'   => false,
+					'idempotent'    => true,
+					'reversibility' => 1.0,
+				],
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the get-fees-summary ability.
+	 *
+	 * @see \WC_REST_Payments_Reports_Fees_Controller::get_fees_summary()
+	 *
+	 * @param array<string, mixed> $input Optional date/filter parameters.
+	 * @return array|\WP_Error
+	 */
+	public static function execute( $input = null ) {
+		$input = is_array( $input ) ? $input : [];
+
+		return AbilitiesRegistrar::delegate_to_rest_controller(
+			'GET',
+			'/wc/v3/payments/reports/fees/summary',
+			$input
+		);
+	}
+}

--- a/src/Internal/Abilities/Domain/GetFeesSummary.php
+++ b/src/Internal/Abilities/Domain/GetFeesSummary.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments
  */
 
-// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
-
 namespace WCPay\Internal\Abilities\Domain;
 
 use Automattic\WooCommerce\Abilities\AbilityDefinition;

--- a/src/Internal/Abilities/Domain/GetFeesSummary.php
+++ b/src/Internal/Abilities/Domain/GetFeesSummary.php
@@ -63,10 +63,9 @@ class GetFeesSummary extends AbstractWCPayAbility implements AbilityDefinition {
 			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
 			'meta'                => [
 				'annotations'  => [
-					'readonly'      => true,
-					'destructive'   => false,
-					'idempotent'    => true,
-					'reversibility' => 1.0,
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
 				],
 				'show_in_rest' => true,
 				'mcp'          => [

--- a/src/Internal/Abilities/Domain/GetFraudOutcomes.php
+++ b/src/Internal/Abilities/Domain/GetFraudOutcomes.php
@@ -80,10 +80,9 @@ class GetFraudOutcomes extends AbstractWCPayAbility implements AbilityDefinition
 			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
 			'meta'                => [
 				'annotations'  => [
-					'readonly'      => true,
-					'destructive'   => false,
-					'idempotent'    => true,
-					'reversibility' => 1.0,
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
 				],
 				'show_in_rest' => true,
 				'mcp'          => [

--- a/src/Internal/Abilities/Domain/GetFraudOutcomes.php
+++ b/src/Internal/Abilities/Domain/GetFraudOutcomes.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Get Fraud Outcomes ability definition.
+ *
+ * @package WooCommerce\Payments
+ */
+
+// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
+
+namespace WCPay\Internal\Abilities\Domain;
+
+use Automattic\WooCommerce\Abilities\AbilityDefinition;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `woocommerce-payments/get-fraud-outcomes` ability.
+ *
+ * Lists transactions flagged by fraud protection for a given outcome status
+ * (e.g. block, review). Paginated.
+ *
+ * @internal Only loaded when WooCommerce 10.9+ is active.
+ *
+ * @see \WC_REST_Payments_Transactions_Controller::get_fraud_outcome_transactions()
+ */
+class GetFraudOutcomes extends AbstractWCPayAbility implements AbilityDefinition {
+
+	private const DEFAULT_PER_PAGE = 25;
+	private const MAX_PER_PAGE     = 100;
+
+	/**
+	 * Return the ability name.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'woocommerce-payments/get-fraud-outcomes';
+	}
+
+	/**
+	 * Return registration args for this ability.
+	 *
+	 * @return array
+	 */
+	public static function get_registration_args(): array {
+		$filter_properties = [
+			'status'      => [
+				'type'        => 'string',
+				'description' => __( 'Fraud outcome status to filter by (e.g. block, review).', 'woocommerce-payments' ),
+			],
+			'search'      => [
+				'type'  => 'array',
+				'items' => [ 'type' => 'string' ],
+			],
+			'search_term' => [ 'type' => 'string' ],
+			'orderby'     => [ 'type' => 'string' ],
+			'order'       => [
+				'type' => 'string',
+				'enum' => [ 'asc', 'desc' ],
+			],
+		];
+
+		return [
+			'label'               => __( 'List flagged (fraud outcome) transactions', 'woocommerce-payments' ),
+			'description'         => __( 'List transactions flagged by fraud protection for a given outcome status (e.g. block, review).', 'woocommerce-payments' ),
+			'category'            => AbilitiesRegistrar::CATEGORY_SLUG,
+			'input_schema'        => [
+				'type'                 => 'object',
+				'required'             => [ 'status' ],
+				'properties'           => array_merge(
+					self::get_pagination_input_properties( self::DEFAULT_PER_PAGE, self::MAX_PER_PAGE ),
+					$filter_properties
+				),
+				'additionalProperties' => false,
+			],
+			'output_schema'       => self::get_collection_output_schema(
+				'fraud_outcomes',
+				[ 'type' => 'object' ]
+			),
+			'execute_callback'    => [ self::class, 'execute' ],
+			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
+			'meta'                => [
+				'annotations'  => [
+					'readonly'      => true,
+					'destructive'   => false,
+					'idempotent'    => true,
+					'reversibility' => 1.0,
+				],
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the get-fraud-outcomes ability.
+	 *
+	 * @see \WC_REST_Payments_Transactions_Controller::get_fraud_outcome_transactions()
+	 *
+	 * @param array<string, mixed> $input Required `status`; optional pagination/search.
+	 * @return array|\WP_Error
+	 */
+	public static function execute( $input = null ) {
+		$input = is_array( $input ) ? $input : [];
+
+		if ( ! isset( $input['status'] ) || ! is_string( $input['status'] ) || '' === $input['status'] ) {
+			return new \WP_Error(
+				'wcpay_missing_status',
+				__( 'A status is required to list fraud outcomes.', 'woocommerce-payments' )
+			);
+		}
+
+		$input['page']     = isset( $input['page'] ) ? (int) $input['page'] : 1;
+		$input['per_page'] = isset( $input['per_page'] ) ? (int) $input['per_page'] : self::DEFAULT_PER_PAGE;
+
+		$response = AbilitiesRegistrar::delegate_to_rest_controller(
+			'GET',
+			'/wc/v3/payments/transactions/fraud-outcomes',
+			$input
+		);
+
+		return self::wrap_paginated_response( $response, 'fraud_outcomes', $input['page'], $input['per_page'] );
+	}
+}

--- a/src/Internal/Abilities/Domain/GetFraudOutcomes.php
+++ b/src/Internal/Abilities/Domain/GetFraudOutcomes.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments
  */
 
-// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
-
 namespace WCPay\Internal\Abilities\Domain;
 
 use Automattic\WooCommerce\Abilities\AbilityDefinition;

--- a/src/Internal/Abilities/Domain/RefundCharge.php
+++ b/src/Internal/Abilities/Domain/RefundCharge.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments
  */
 
-// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
-
 namespace WCPay\Internal\Abilities\Domain;
 
 use Automattic\WooCommerce\Abilities\AbilityDefinition;

--- a/src/Internal/Abilities/Domain/RefundCharge.php
+++ b/src/Internal/Abilities/Domain/RefundCharge.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Refund Charge ability definition.
+ *
+ * @package WooCommerce\Payments
+ */
+
+// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
+
+namespace WCPay\Internal\Abilities\Domain;
+
+use Automattic\WooCommerce\Abilities\AbilityDefinition;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Service\RefundService;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `woocommerce-payments/refund-charge` ability.
+ *
+ * Creates a full or partial refund on a Stripe charge. Destructive (moves
+ * money back to the cardholder). Idempotent ONLY when the caller supplies a
+ * stable `idempotency_key`; without one the platform generates a fresh key and
+ * a duplicate call creates a second refund.
+ *
+ * @internal Only loaded when WooCommerce 10.9+ is active.
+ *
+ * @see \WCPay\Internal\Service\RefundService::refund_charge()
+ */
+class RefundCharge extends AbstractWCPayAbility implements AbilityDefinition {
+
+	/**
+	 * Return the ability name.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'woocommerce-payments/refund-charge';
+	}
+
+	/**
+	 * Return registration args for this ability.
+	 *
+	 * @return array
+	 */
+	public static function get_registration_args(): array {
+		return [
+			'label'               => __( 'Refund a charge', 'woocommerce-payments' ),
+			'description'         => __( 'Create a full or partial refund on a Stripe charge. Supply a stable idempotency_key to make retries safe — identical keys return the original refund. Amount is in minor units (e.g. cents).', 'woocommerce-payments' ),
+			'category'            => AbilitiesRegistrar::CATEGORY_SLUG,
+			'input_schema'        => [
+				'type'                 => 'object',
+				'required'             => [ 'charge_id' ],
+				'properties'           => [
+					'charge_id'       => [
+						'type'        => 'string',
+						'pattern'     => '^(ch_|py_)',
+						'description' => __( 'Stripe charge ID to refund (ch_… or py_…).', 'woocommerce-payments' ),
+					],
+					'amount'          => [
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Amount to refund in minor units (e.g. cents). Omit for a full refund.', 'woocommerce-payments' ),
+					],
+					'reason'          => [
+						'type'        => 'string',
+						'enum'        => [ 'duplicate', 'fraudulent', 'requested_by_customer' ],
+						'description' => __( 'Optional refund reason.', 'woocommerce-payments' ),
+					],
+					'idempotency_key' => [
+						'type'        => 'string',
+						'description' => __( 'Caller-supplied key so duplicate retries dedupe to the original refund.', 'woocommerce-payments' ),
+					],
+				],
+				'additionalProperties' => false,
+			],
+			'execute_callback'    => [ self::class, 'execute' ],
+			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
+			'meta'                => [
+				'annotations'  => [
+					'readonly'      => false,
+					'destructive'   => true,
+					'idempotent'    => true,
+					'reversibility' => 0.2,
+				],
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => false,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the refund-charge ability.
+	 *
+	 * @param array<string,mixed> $input Refund parameters.
+	 * @return array|\WP_Error
+	 */
+	public static function execute( $input = null ) {
+		if ( ! is_array( $input ) || ! isset( $input['charge_id'] ) || ! is_string( $input['charge_id'] ) || '' === $input['charge_id'] ) {
+			return new \WP_Error(
+				'wcpay_missing_charge_id',
+				__( 'A charge_id is required to create a refund.', 'woocommerce-payments' )
+			);
+		}
+
+		$charge_id       = $input['charge_id'];
+		$amount          = isset( $input['amount'] ) ? (int) $input['amount'] : null;
+		$reason          = isset( $input['reason'] ) && is_string( $input['reason'] ) ? $input['reason'] : null;
+		$idempotency_key = isset( $input['idempotency_key'] ) && is_string( $input['idempotency_key'] ) ? $input['idempotency_key'] : null;
+
+		$container = \wcpay_get_container();
+		if ( ! $container->has( RefundService::class ) ) {
+			return new \WP_Error( 'wcpay_not_initialized', __( 'WooPayments is not initialized.', 'woocommerce-payments' ) );
+		}
+
+		return $container->get( RefundService::class )->refund_charge( $charge_id, $amount, $reason, $idempotency_key );
+	}
+}

--- a/src/Internal/Abilities/Domain/RefundCharge.php
+++ b/src/Internal/Abilities/Domain/RefundCharge.php
@@ -116,11 +116,15 @@ class RefundCharge extends AbstractWCPayAbility implements AbilityDefinition {
 		$reason          = isset( $input['reason'] ) && is_string( $input['reason'] ) ? $input['reason'] : null;
 		$idempotency_key = isset( $input['idempotency_key'] ) && is_string( $input['idempotency_key'] ) ? $input['idempotency_key'] : null;
 
-		$container = \wcpay_get_container();
-		if ( ! $container->has( RefundService::class ) ) {
-			return new \WP_Error( 'wcpay_not_initialized', __( 'WooPayments is not initialized.', 'woocommerce-payments' ) );
-		}
+		return self::get_refund_service()->refund_charge( $charge_id, $amount, $reason, $idempotency_key );
+	}
 
-		return $container->get( RefundService::class )->refund_charge( $charge_id, $amount, $reason, $idempotency_key );
+	/**
+	 * Resolve the shared refund service from the container.
+	 *
+	 * @return RefundService
+	 */
+	private static function get_refund_service(): RefundService {
+		return \wcpay_get_container()->get( RefundService::class );
 	}
 }

--- a/src/Internal/Abilities/Domain/RefundCharge.php
+++ b/src/Internal/Abilities/Domain/RefundCharge.php
@@ -77,10 +77,9 @@ class RefundCharge extends AbstractWCPayAbility implements AbilityDefinition {
 			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
 			'meta'                => [
 				'annotations'  => [
-					'readonly'      => false,
-					'destructive'   => true,
-					'idempotent'    => true,
-					'reversibility' => 0.2,
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
 				],
 				'show_in_rest' => true,
 				'mcp'          => [

--- a/src/Internal/Abilities/Domain/RefundCharge.php
+++ b/src/Internal/Abilities/Domain/RefundCharge.php
@@ -17,9 +17,10 @@ defined( 'ABSPATH' ) || exit;
  * Registers the `woocommerce-payments/refund-charge` ability.
  *
  * Creates a full or partial refund on a Stripe charge. Destructive (moves
- * money back to the cardholder). Idempotent ONLY when the caller supplies a
- * stable `idempotency_key`; without one the platform generates a fresh key and
- * a duplicate call creates a second refund.
+ * money back to the cardholder). Idempotent because `idempotency_key` is
+ * REQUIRED: an identical key returns the original refund, so a blind retry
+ * cannot create a second refund. (Without a key the platform would generate a
+ * fresh one and a duplicate call would double-refund — hence the requirement.)
  *
  * @internal Only loaded when WooCommerce 10.9+ is active.
  *
@@ -48,7 +49,7 @@ class RefundCharge extends AbstractWCPayAbility implements AbilityDefinition {
 			'category'            => AbilitiesRegistrar::CATEGORY_SLUG,
 			'input_schema'        => [
 				'type'                 => 'object',
-				'required'             => [ 'charge_id' ],
+				'required'             => [ 'charge_id', 'idempotency_key' ],
 				'properties'           => [
 					'charge_id'       => [
 						'type'        => 'string',
@@ -67,7 +68,7 @@ class RefundCharge extends AbstractWCPayAbility implements AbilityDefinition {
 					],
 					'idempotency_key' => [
 						'type'        => 'string',
-						'description' => __( 'Caller-supplied key so duplicate retries dedupe to the original refund.', 'woocommerce-payments' ),
+						'description' => __( 'Required. A stable, caller-unique key so duplicate retries dedupe to the original refund instead of creating a second one. Reuse the exact same key when retrying the same logical refund.', 'woocommerce-payments' ),
 					],
 				],
 				'additionalProperties' => false,
@@ -100,6 +101,13 @@ class RefundCharge extends AbstractWCPayAbility implements AbilityDefinition {
 			return new \WP_Error(
 				'wcpay_missing_charge_id',
 				__( 'A charge_id is required to create a refund.', 'woocommerce-payments' )
+			);
+		}
+
+		if ( ! isset( $input['idempotency_key'] ) || ! is_string( $input['idempotency_key'] ) || '' === $input['idempotency_key'] ) {
+			return new \WP_Error(
+				'wcpay_missing_idempotency_key',
+				__( 'An idempotency_key is required so refund retries are safe.', 'woocommerce-payments' )
 			);
 		}
 

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -142,11 +142,15 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 		$submit     = ! empty( $input['submit'] );
 		$metadata   = ( isset( $input['metadata'] ) && is_array( $input['metadata'] ) ) ? $input['metadata'] : [];
 
-		$container = \wcpay_get_container();
-		if ( ! $container->has( DisputeService::class ) ) {
-			return new \WP_Error( 'wcpay_not_initialized', __( 'WooPayments is not initialized.', 'woocommerce-payments' ) );
-		}
+		return self::get_dispute_service()->submit_evidence( $dispute_id, $evidence, $submit, $metadata );
+	}
 
-		return $container->get( DisputeService::class )->submit_evidence( $dispute_id, $evidence, $submit, $metadata );
+	/**
+	 * Resolve the shared dispute service from the container.
+	 *
+	 * @return DisputeService
+	 */
+	private static function get_dispute_service(): DisputeService {
+		return \wcpay_get_container()->get( DisputeService::class );
 	}
 }

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -19,7 +19,9 @@ defined( 'ABSPATH' ) || exit;
  * Two-phase: with `submit=false` (the default) evidence is staged as a draft
  * and can be revised; with `submit=true` the evidence is sent to the card
  * network and CANNOT be changed afterward. Not idempotent — each submit is a
- * fresh submission.
+ * fresh submission. Annotated `destructive=true`: a policy layer must reason
+ * about the most-dangerous mode, and the `submit=true` path is irreversible
+ * (matching accept-dispute).
  *
  * @internal Only loaded when WooCommerce 10.9+ is active.
  *
@@ -109,7 +111,7 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 			'meta'                => [
 				'annotations'  => [
 					'readonly'      => false,
-					'destructive'   => false,
+					'destructive'   => true,
 					'idempotent'    => false,
 					'reversibility' => 0.2,
 				],

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -110,10 +110,9 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
 			'meta'                => [
 				'annotations'  => [
-					'readonly'      => false,
-					'destructive'   => true,
-					'idempotent'    => false,
-					'reversibility' => 0.2,
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => false,
 				],
 				'show_in_rest' => true,
 				'mcp'          => [

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -5,8 +5,6 @@
  * @package WooCommerce\Payments
  */
 
-// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
-
 namespace WCPay\Internal\Abilities\Domain;
 
 use Automattic\WooCommerce\Abilities\AbilityDefinition;

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -84,8 +84,7 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 				'properties'           => [
 					'dispute_id' => [
 						'type'        => 'string',
-						'pattern'     => '^dp_',
-						'description' => __( 'Dispute ID (dp_…).', 'woocommerce-payments' ),
+						'description' => __( 'Stripe dispute ID (typically `du_…` or legacy `dp_…`). Stripe ID prefixes are not contractually stable, so this field is not pattern-validated.', 'woocommerce-payments' ),
 					],
 					'evidence'   => [
 						'type'                 => 'object',

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -139,7 +139,7 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 
 		$dispute_id = $input['dispute_id'];
 		$evidence   = ( isset( $input['evidence'] ) && is_array( $input['evidence'] ) ) ? $input['evidence'] : [];
-		$submit     = ! empty( $input['submit'] );
+		$submit     = true === ( $input['submit'] ?? false );
 		$metadata   = ( isset( $input['metadata'] ) && is_array( $input['metadata'] ) ) ? $input['metadata'] : [];
 
 		return self::get_dispute_service()->submit_evidence( $dispute_id, $evidence, $submit, $metadata );

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -30,33 +30,6 @@ defined( 'ABSPATH' ) || exit;
 class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefinition {
 
 	/**
-	 * Canonical Stripe dispute-evidence fields (all string-valued; document
-	 * fields carry an uploaded file ID).
-	 *
-	 * @var string[]
-	 */
-	private const EVIDENCE_FIELDS = [
-		'product_description',
-		'customer_communication',
-		'customer_signature',
-		'customer_purchase_ip',
-		'receipt',
-		'refund_policy',
-		'duplicate_charge_documentation',
-		'shipping_documentation',
-		'service_documentation',
-		'cancellation_policy',
-		'cancellation_rebuttal',
-		'access_activity_log',
-		'uncategorized_file',
-		'uncategorized_text',
-		'shipping_carrier',
-		'shipping_date',
-		'shipping_tracking_number',
-		'shipping_address',
-	];
-
-	/**
 	 * Return the ability name.
 	 *
 	 * @return string
@@ -71,9 +44,49 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 	 * @return array
 	 */
 	public static function get_registration_args(): array {
+		// Free-text evidence fields: an agent can fill these directly.
+		$evidence_text_fields = [
+			'product_description'      => __( 'Description of the product or service and how it was presented to the customer.', 'woocommerce-payments' ),
+			'customer_purchase_ip'     => __( 'IP address the customer used for the purchase.', 'woocommerce-payments' ),
+			'cancellation_rebuttal'    => __( 'Explanation of why the customer was not entitled to cancel.', 'woocommerce-payments' ),
+			'access_activity_log'      => __( 'Activity log showing the customer accessed or downloaded a digital product.', 'woocommerce-payments' ),
+			'uncategorized_text'       => __( 'Any additional explanation that does not fit another field.', 'woocommerce-payments' ),
+			'shipping_carrier'         => __( 'Delivery service that shipped the product (e.g. USPS, FedEx, UPS, DHL).', 'woocommerce-payments' ),
+			'shipping_date'            => __( 'Date the product was shipped.', 'woocommerce-payments' ),
+			'shipping_tracking_number' => __( 'Tracking number for a shipped physical product.', 'woocommerce-payments' ),
+			'shipping_address'         => __( 'Address the product was shipped to.', 'woocommerce-payments' ),
+		];
+
+		// Document evidence fields: each takes the ID of a file already uploaded
+		// (e.g. via woocommerce-payments/upload-dispute-evidence-file), not raw bytes.
+		$evidence_document_fields = [
+			'customer_communication'         => __( 'Correspondence with the customer relevant to the dispute (e.g. emails).', 'woocommerce-payments' ),
+			'customer_signature'             => __( 'Proof the customer signed for the product or agreed to terms.', 'woocommerce-payments' ),
+			'receipt'                        => __( 'Receipt or message sent to the customer for the charge.', 'woocommerce-payments' ),
+			'refund_policy'                  => __( 'Your refund policy as shown to the customer.', 'woocommerce-payments' ),
+			'duplicate_charge_documentation' => __( 'Documentation for the prior charge a duplicate dispute refers to.', 'woocommerce-payments' ),
+			'shipping_documentation'         => __( 'Proof the product was delivered (e.g. signed delivery confirmation).', 'woocommerce-payments' ),
+			'service_documentation'          => __( 'Proof the service was provided to the customer.', 'woocommerce-payments' ),
+			'cancellation_policy'            => __( 'Your cancellation policy as shown to the customer.', 'woocommerce-payments' ),
+			'uncategorized_file'             => __( 'Any additional supporting document.', 'woocommerce-payments' ),
+		];
+
 		$evidence_properties = [];
-		foreach ( self::EVIDENCE_FIELDS as $field ) {
-			$evidence_properties[ $field ] = [ 'type' => 'string' ];
+		foreach ( $evidence_text_fields as $field => $field_description ) {
+			$evidence_properties[ $field ] = [
+				'type'        => 'string',
+				'description' => $field_description,
+			];
+		}
+		foreach ( $evidence_document_fields as $field => $field_description ) {
+			$evidence_properties[ $field ] = [
+				'type'        => 'string',
+				'description' => sprintf(
+					/* translators: %s: description of what the document should show. */
+					__( '%s Provide the ID of a file uploaded via woocommerce-payments/upload-dispute-evidence-file, not raw file contents.', 'woocommerce-payments' ),
+					$field_description
+				),
+			];
 		}
 
 		return [
@@ -90,7 +103,7 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 					],
 					'evidence'   => [
 						'type'                 => 'object',
-						'description'          => __( 'Evidence fields. Document fields take an uploaded file ID.', 'woocommerce-payments' ),
+						'description'          => __( 'Evidence fields. Text fields take free text; document fields take the ID of a file uploaded via woocommerce-payments/upload-dispute-evidence-file (not raw file contents).', 'woocommerce-payments' ),
 						'properties'           => $evidence_properties,
 						'additionalProperties' => false,
 					],

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Submit Dispute Evidence ability definition.
+ *
+ * @package WooCommerce\Payments
+ */
+
+// @phan-file-suppress PhanUndeclaredClassMethod, PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API + AbilityDefinition added in WC 10.9; suppression covers older-WC compat runs where this class never loads.
+
+namespace WCPay\Internal\Abilities\Domain;
+
+use Automattic\WooCommerce\Abilities\AbilityDefinition;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Service\DisputeService;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `woocommerce-payments/submit-dispute-evidence` ability.
+ *
+ * Two-phase: with `submit=false` (the default) evidence is staged as a draft
+ * and can be revised; with `submit=true` the evidence is sent to the card
+ * network and CANNOT be changed afterward. Not idempotent — each submit is a
+ * fresh submission.
+ *
+ * @internal Only loaded when WooCommerce 10.9+ is active.
+ *
+ * @see \WCPay\Internal\Service\DisputeService::submit_evidence()
+ */
+class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefinition {
+
+	/**
+	 * Canonical Stripe dispute-evidence fields (all string-valued; document
+	 * fields carry an uploaded file ID).
+	 *
+	 * @var string[]
+	 */
+	private const EVIDENCE_FIELDS = [
+		'product_description',
+		'customer_communication',
+		'customer_signature',
+		'customer_purchase_ip',
+		'receipt',
+		'refund_policy',
+		'duplicate_charge_documentation',
+		'shipping_documentation',
+		'service_documentation',
+		'cancellation_policy',
+		'cancellation_rebuttal',
+		'access_activity_log',
+		'uncategorized_file',
+		'uncategorized_text',
+		'shipping_carrier',
+		'shipping_date',
+		'shipping_tracking_number',
+		'shipping_address',
+	];
+
+	/**
+	 * Return the ability name.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'woocommerce-payments/submit-dispute-evidence';
+	}
+
+	/**
+	 * Return registration args for this ability.
+	 *
+	 * @return array
+	 */
+	public static function get_registration_args(): array {
+		$evidence_properties = [];
+		foreach ( self::EVIDENCE_FIELDS as $field ) {
+			$evidence_properties[ $field ] = [ 'type' => 'string' ];
+		}
+
+		return [
+			'label'               => __( 'Submit dispute evidence', 'woocommerce-payments' ),
+			'description'         => __( 'Stage or submit evidence for a dispute. With submit=false (default) the evidence is saved as a draft you can revise; with submit=true it is sent to the card network and cannot be changed.', 'woocommerce-payments' ),
+			'category'            => AbilitiesRegistrar::CATEGORY_SLUG,
+			'input_schema'        => [
+				'type'                 => 'object',
+				'required'             => [ 'dispute_id' ],
+				'properties'           => [
+					'dispute_id' => [
+						'type'        => 'string',
+						'pattern'     => '^dp_',
+						'description' => __( 'Dispute ID (dp_…).', 'woocommerce-payments' ),
+					],
+					'evidence'   => [
+						'type'                 => 'object',
+						'description'          => __( 'Evidence fields. Document fields take an uploaded file ID.', 'woocommerce-payments' ),
+						'properties'           => $evidence_properties,
+						'additionalProperties' => false,
+					],
+					'submit'     => [
+						'type'        => 'boolean',
+						'default'     => false,
+						'description' => __( 'Whether to submit to the card network (irreversible). Default false stages a draft.', 'woocommerce-payments' ),
+					],
+					'metadata'   => [
+						'type'        => 'object',
+						'description' => __( 'Optional metadata to attach to the dispute.', 'woocommerce-payments' ),
+					],
+				],
+				'additionalProperties' => false,
+			],
+			'execute_callback'    => [ self::class, 'execute' ],
+			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
+			'meta'                => [
+				'annotations'  => [
+					'readonly'      => false,
+					'destructive'   => false,
+					'idempotent'    => false,
+					'reversibility' => 0.2,
+				],
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => false,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the submit-dispute-evidence ability.
+	 *
+	 * @param array<string,mixed> $input Evidence parameters.
+	 * @return array|\WP_Error
+	 */
+	public static function execute( $input = null ) {
+		if ( ! is_array( $input ) || ! isset( $input['dispute_id'] ) || ! is_string( $input['dispute_id'] ) || '' === $input['dispute_id'] ) {
+			return new \WP_Error(
+				'wcpay_missing_dispute_id',
+				__( 'A dispute_id is required to submit evidence.', 'woocommerce-payments' )
+			);
+		}
+
+		$dispute_id = $input['dispute_id'];
+		$evidence   = ( isset( $input['evidence'] ) && is_array( $input['evidence'] ) ) ? $input['evidence'] : [];
+		$submit     = ! empty( $input['submit'] );
+		$metadata   = ( isset( $input['metadata'] ) && is_array( $input['metadata'] ) ) ? $input['metadata'] : [];
+
+		$container = \wcpay_get_container();
+		if ( ! $container->has( DisputeService::class ) ) {
+			return new \WP_Error( 'wcpay_not_initialized', __( 'WooPayments is not initialized.', 'woocommerce-payments' ) );
+		}
+
+		return $container->get( DisputeService::class )->submit_evidence( $dispute_id, $evidence, $submit, $metadata );
+	}
+}

--- a/src/Internal/Abilities/Domain/UploadDisputeEvidenceFile.php
+++ b/src/Internal/Abilities/Domain/UploadDisputeEvidenceFile.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Upload Dispute Evidence File ability definition.
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Internal\Abilities\Domain;
+
+use Automattic\WooCommerce\Abilities\AbilityDefinition;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Service\FileService;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `woocommerce-payments/upload-dispute-evidence-file` ability.
+ *
+ * Uploads a document (PDF/PNG/JPEG) to the Files API for use as dispute
+ * evidence and returns the created file object. The file `id` it returns is
+ * what `submit-dispute-evidence` expects in its document fields (receipt,
+ * customer_communication, *_documentation, etc.). Not destructive (creates a
+ * file, moves no money, changes no dispute) and not idempotent (each call
+ * creates a new file). mcp.public is false: the whole evidence flow is
+ * operator-gated, so this is not auto-invocable.
+ *
+ * @internal Only loaded when WooCommerce 10.9+ is active.
+ *
+ * @see \WCPay\Internal\Service\FileService::upload_evidence_file()
+ */
+class UploadDisputeEvidenceFile extends AbstractWCPayAbility implements AbilityDefinition {
+
+	/**
+	 * MIME types accepted as dispute evidence — mirrors the merchant UI's
+	 * accept list (`client/disputes/new-evidence/file-upload-control.tsx`).
+	 *
+	 * @var string[]
+	 */
+	private const ACCEPTED_FILE_TYPES = [
+		'application/pdf',
+		'image/jpeg',
+		'image/png',
+	];
+
+	/**
+	 * Maximum decoded file size in bytes. Mirrors the dispute-evidence total
+	 * size limit the merchant UI enforces (`client/disputes/new-evidence/index.tsx`).
+	 *
+	 * @var int
+	 */
+	private const MAX_FILE_SIZE_BYTES = 4500000;
+
+	/**
+	 * Return the ability name.
+	 *
+	 * @return string
+	 */
+	public static function get_name(): string {
+		return 'woocommerce-payments/upload-dispute-evidence-file';
+	}
+
+	/**
+	 * Return registration args for this ability.
+	 *
+	 * @return array
+	 */
+	public static function get_registration_args(): array {
+		return [
+			'label'               => __( 'Upload dispute evidence file', 'woocommerce-payments' ),
+			'description'         => __( 'Upload a document (PDF, PNG, or JPEG) to use as dispute evidence. Returns a file object whose id can be passed to the document fields of woocommerce-payments/submit-dispute-evidence.', 'woocommerce-payments' ),
+			'category'            => AbilitiesRegistrar::CATEGORY_SLUG,
+			'input_schema'        => [
+				'type'                 => 'object',
+				'required'             => [ 'file_name', 'file_type', 'file_contents' ],
+				'properties'           => [
+					'file_name'     => [
+						'type'        => 'string',
+						'description' => __( 'File name including extension (e.g. receipt.pdf).', 'woocommerce-payments' ),
+					],
+					'file_type'     => [
+						'type'        => 'string',
+						'enum'        => self::ACCEPTED_FILE_TYPES,
+						'description' => __( 'File MIME type. One of application/pdf, image/jpeg, or image/png.', 'woocommerce-payments' ),
+					],
+					'file_contents' => [
+						'type'        => 'string',
+						'description' => __( 'Base64-encoded file contents. The decoded size must not exceed the dispute-evidence size limit.', 'woocommerce-payments' ),
+					],
+				],
+				'additionalProperties' => false,
+			],
+			'execute_callback'    => [ self::class, 'execute' ],
+			'permission_callback' => [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ],
+			'meta'                => [
+				'annotations'  => [
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				],
+				'show_in_rest' => true,
+				'mcp'          => [
+					'public' => false,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Execute the upload-dispute-evidence-file ability.
+	 *
+	 * @param array<string,mixed> $input File parameters.
+	 * @return array|\WP_Error File object on success, WP_Error on failure.
+	 */
+	public static function execute( $input = null ) {
+		if ( ! is_array( $input ) ) {
+			$input = [];
+		}
+
+		$file_name     = ( isset( $input['file_name'] ) && is_string( $input['file_name'] ) ) ? $input['file_name'] : '';
+		$file_type     = ( isset( $input['file_type'] ) && is_string( $input['file_type'] ) ) ? $input['file_type'] : '';
+		$file_contents = ( isset( $input['file_contents'] ) && is_string( $input['file_contents'] ) ) ? $input['file_contents'] : '';
+
+		if ( '' === $file_name || '' === $file_type || '' === $file_contents ) {
+			return new \WP_Error(
+				'wcpay_missing_file_input',
+				__( 'file_name, file_type, and file_contents are all required to upload a file.', 'woocommerce-payments' )
+			);
+		}
+
+		if ( ! in_array( $file_type, self::ACCEPTED_FILE_TYPES, true ) ) {
+			return new \WP_Error(
+				'wcpay_unsupported_file_type',
+				__( 'file_type must be one of application/pdf, image/jpeg, or image/png.', 'woocommerce-payments' )
+			);
+		}
+
+		// Validate the payload is real base64 and enforce the size cap on the
+		// decoded bytes before sending anything upstream.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- benign: validating caller-supplied base64.
+		$decoded = base64_decode( $file_contents, true );
+		if ( false === $decoded ) {
+			return new \WP_Error(
+				'wcpay_invalid_file_contents',
+				__( 'file_contents must be base64-encoded.', 'woocommerce-payments' )
+			);
+		}
+
+		if ( strlen( $decoded ) > self::MAX_FILE_SIZE_BYTES ) {
+			return new \WP_Error(
+				'wcpay_file_too_large',
+				sprintf(
+					/* translators: %d: maximum file size in bytes. */
+					__( 'The file exceeds the %d-byte dispute-evidence size limit.', 'woocommerce-payments' ),
+					self::MAX_FILE_SIZE_BYTES
+				)
+			);
+		}
+
+		return self::get_file_service()->upload_evidence_file( $file_contents, $file_name, $file_type, 'dispute_evidence' );
+	}
+
+	/**
+	 * Resolve the shared file service from the container.
+	 *
+	 * @return FileService
+	 */
+	private static function get_file_service(): FileService {
+		return \wcpay_get_container()->get( FileService::class );
+	}
+}

--- a/src/Internal/DependencyManagement/ServiceProvider/PaymentsServiceProvider.php
+++ b/src/Internal/DependencyManagement/ServiceProvider/PaymentsServiceProvider.php
@@ -8,10 +8,12 @@
 namespace WCPay\Internal\DependencyManagement\ServiceProvider;
 
 use Automattic\WooCommerce\Utilities\PluginUtil;
+use WC_Payments_API_Client;
 use WCPay\Core\Mode;
 use WCPay\Internal\DependencyManagement\AbstractServiceProvider;
 use WCPay\Internal\Proxy\HooksProxy;
 use WCPay\Internal\Proxy\LegacyProxy;
+use WCPay\Internal\Service\DisputeService;
 use WCPay\Internal\Service\DuplicatePaymentPreventionService;
 use WCPay\Internal\Service\ExampleService;
 use WCPay\Internal\Service\ExampleServiceWithDependencies;
@@ -31,6 +33,7 @@ class PaymentsServiceProvider extends AbstractServiceProvider {
 		ExampleService::class,
 		ExampleServiceWithDependencies::class,
 		DuplicatePaymentPreventionService::class,
+		DisputeService::class,
 		RefundService::class,
 	];
 
@@ -52,5 +55,8 @@ class PaymentsServiceProvider extends AbstractServiceProvider {
 			->addArgument( PluginUtil::class );
 
 		$container->addShared( RefundService::class );
+
+		$container->addShared( DisputeService::class )
+			->addArgument( WC_Payments_API_Client::class );
 	}
 }

--- a/src/Internal/DependencyManagement/ServiceProvider/PaymentsServiceProvider.php
+++ b/src/Internal/DependencyManagement/ServiceProvider/PaymentsServiceProvider.php
@@ -17,6 +17,7 @@ use WCPay\Internal\Service\DisputeService;
 use WCPay\Internal\Service\DuplicatePaymentPreventionService;
 use WCPay\Internal\Service\ExampleService;
 use WCPay\Internal\Service\ExampleServiceWithDependencies;
+use WCPay\Internal\Service\FileService;
 use WCPay\Internal\Service\RefundService;
 use WCPay\Internal\Service\SessionService;
 
@@ -35,6 +36,7 @@ class PaymentsServiceProvider extends AbstractServiceProvider {
 		DuplicatePaymentPreventionService::class,
 		DisputeService::class,
 		RefundService::class,
+		FileService::class,
 	];
 
 	/**
@@ -57,6 +59,9 @@ class PaymentsServiceProvider extends AbstractServiceProvider {
 		$container->addShared( RefundService::class );
 
 		$container->addShared( DisputeService::class )
+			->addArgument( WC_Payments_API_Client::class );
+
+		$container->addShared( FileService::class )
 			->addArgument( WC_Payments_API_Client::class );
 	}
 }

--- a/src/Internal/DependencyManagement/ServiceProvider/PaymentsServiceProvider.php
+++ b/src/Internal/DependencyManagement/ServiceProvider/PaymentsServiceProvider.php
@@ -15,6 +15,7 @@ use WCPay\Internal\Proxy\LegacyProxy;
 use WCPay\Internal\Service\DuplicatePaymentPreventionService;
 use WCPay\Internal\Service\ExampleService;
 use WCPay\Internal\Service\ExampleServiceWithDependencies;
+use WCPay\Internal\Service\RefundService;
 use WCPay\Internal\Service\SessionService;
 
 /**
@@ -30,6 +31,7 @@ class PaymentsServiceProvider extends AbstractServiceProvider {
 		ExampleService::class,
 		ExampleServiceWithDependencies::class,
 		DuplicatePaymentPreventionService::class,
+		RefundService::class,
 	];
 
 	/**
@@ -48,5 +50,7 @@ class PaymentsServiceProvider extends AbstractServiceProvider {
 			->addArgument( ExampleService::class )
 			->addArgument( Mode::class )
 			->addArgument( PluginUtil::class );
+
+		$container->addShared( RefundService::class );
 	}
 }

--- a/src/Internal/Service/DisputeService.php
+++ b/src/Internal/Service/DisputeService.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Class DisputeService
+ *
+ * @package WooCommerce\Payments
+ */
+
+declare( strict_types=1 );
+
+namespace WCPay\Internal\Service;
+
+use WC_Payments_API_Client;
+
+/**
+ * Dispute write service shared by the dispute abilities. Thin typed wrapper
+ * over the same WC_Payments_API_Client methods the REST controller calls, so
+ * there is no logic drift between the agent path and the UI path.
+ *
+ * Note on error handling: each method returns a WP_Error when the api client
+ * throws (caught below). But the api client may ALSO return a WP_Error without
+ * throwing (e.g. an internal prefetch failure), which we pass straight through.
+ * Callers must therefore handle both the thrown-and-caught path and a
+ * passed-through WP_Error.
+ */
+class DisputeService {
+
+	/**
+	 * WooPayments API client.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $api_client;
+
+	/**
+	 * DisputeService constructor.
+	 *
+	 * @param WC_Payments_API_Client $api_client WooPayments API client.
+	 */
+	public function __construct( WC_Payments_API_Client $api_client ) {
+		$this->api_client = $api_client;
+	}
+
+	/**
+	 * Submit (or stage as draft) dispute evidence.
+	 *
+	 * @param string $dispute_id Dispute ID (`dp_…`).
+	 * @param array  $evidence   Evidence field map.
+	 * @param bool   $submit     True submits to the card network (irreversible); false stages a draft.
+	 * @param array  $metadata   Optional metadata.
+	 * @return array|\WP_Error
+	 */
+	public function submit_evidence( string $dispute_id, array $evidence, bool $submit, array $metadata = [] ) {
+		try {
+			// May return a WP_Error without throwing (e.g. internal prefetch failure) — passed through to the caller.
+			return $this->api_client->update_dispute( $dispute_id, $evidence, $submit, $metadata );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'wcpay_dispute_evidence_failed', $e->getMessage(), [ 'exception' => $e ] );
+		}
+	}
+
+	/**
+	 * Accept (close) a dispute — concedes the dispute and forfeits the funds.
+	 *
+	 * @param string $dispute_id Dispute ID (`dp_…`).
+	 * @return array|\WP_Error
+	 */
+	public function accept( string $dispute_id ) {
+		try {
+			// May return a WP_Error without throwing (e.g. internal prefetch failure) — passed through to the caller.
+			return $this->api_client->close_dispute( $dispute_id );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'wcpay_dispute_close_failed', $e->getMessage(), [ 'exception' => $e ] );
+		}
+	}
+}

--- a/src/Internal/Service/DisputeService.php
+++ b/src/Internal/Service/DisputeService.php
@@ -43,6 +43,8 @@ class DisputeService {
 	/**
 	 * Submit (or stage as draft) dispute evidence.
 	 *
+	 * @see \WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence
+	 *
 	 * @param string $dispute_id Dispute ID (`dp_…`).
 	 * @param array  $evidence   Evidence field map.
 	 * @param bool   $submit     True submits to the card network (irreversible); false stages a draft.
@@ -60,6 +62,8 @@ class DisputeService {
 
 	/**
 	 * Accept (close) a dispute — concedes the dispute and forfeits the funds.
+	 *
+	 * @see \WCPay\Internal\Abilities\Domain\AcceptDispute
 	 *
 	 * @param string $dispute_id Dispute ID (`dp_…`).
 	 * @return array|\WP_Error

--- a/src/Internal/Service/DisputeService.php
+++ b/src/Internal/Service/DisputeService.php
@@ -54,8 +54,19 @@ class DisputeService {
 	public function submit_evidence( string $dispute_id, array $evidence, bool $submit, array $metadata = [] ) {
 		try {
 			// May return a WP_Error without throwing (e.g. internal prefetch failure) — passed through to the caller.
-			return $this->api_client->update_dispute( $dispute_id, $evidence, $submit, $metadata );
+			$result = $this->api_client->update_dispute( $dispute_id, $evidence, $submit, $metadata );
+			if ( is_wp_error( $result ) ) {
+				wc_get_logger()->error(
+					sprintf( 'Dispute evidence submission returned an error for %s: %s', $dispute_id, $result->get_error_message() ),
+					[ 'source' => 'woopayments-abilities' ]
+				);
+			}
+			return $result;
 		} catch ( \Throwable $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Dispute evidence submission failed for %s: %s', $dispute_id, $e->getMessage() ),
+				[ 'source' => 'woopayments-abilities' ]
+			);
 			return new \WP_Error( 'wcpay_dispute_evidence_failed', $e->getMessage(), [ 'exception' => $e ] );
 		}
 	}
@@ -71,8 +82,19 @@ class DisputeService {
 	public function accept( string $dispute_id ) {
 		try {
 			// May return a WP_Error without throwing (e.g. internal prefetch failure) — passed through to the caller.
-			return $this->api_client->close_dispute( $dispute_id );
+			$result = $this->api_client->close_dispute( $dispute_id );
+			if ( is_wp_error( $result ) ) {
+				wc_get_logger()->error(
+					sprintf( 'Dispute close returned an error for %s: %s', $dispute_id, $result->get_error_message() ),
+					[ 'source' => 'woopayments-abilities' ]
+				);
+			}
+			return $result;
 		} catch ( \Throwable $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Dispute close failed for %s: %s', $dispute_id, $e->getMessage() ),
+				[ 'source' => 'woopayments-abilities' ]
+			);
 			return new \WP_Error( 'wcpay_dispute_close_failed', $e->getMessage(), [ 'exception' => $e ] );
 		}
 	}

--- a/src/Internal/Service/FileService.php
+++ b/src/Internal/Service/FileService.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Class FileService
+ *
+ * @package WooCommerce\Payments
+ */
+
+declare( strict_types=1 );
+
+namespace WCPay\Internal\Service;
+
+use WC_Payments_API_Client;
+
+/**
+ * File-upload service shared by the file-upload ability. Thin typed wrapper
+ * over the same `WC_Payments_API_Client` Files API call the dispute-evidence
+ * UI uses, so the agent upload path and the UI upload path do not drift.
+ */
+class FileService {
+
+	/**
+	 * WooPayments API client.
+	 *
+	 * @var WC_Payments_API_Client
+	 */
+	private $api_client;
+
+	/**
+	 * FileService constructor.
+	 *
+	 * @param WC_Payments_API_Client $api_client WooPayments API client.
+	 */
+	public function __construct( WC_Payments_API_Client $api_client ) {
+		$this->api_client = $api_client;
+	}
+
+	/**
+	 * Upload a dispute-evidence file from base64 contents and return the file object.
+	 *
+	 * @see \WCPay\Internal\Abilities\Domain\UploadDisputeEvidenceFile
+	 *
+	 * @param string $file_content_base64 Base64-encoded file contents.
+	 * @param string $file_name           File name including extension.
+	 * @param string $file_type           File MIME type (e.g. `image/png`).
+	 * @param string $purpose             Stripe file purpose. Defaults to `dispute_evidence`.
+	 * @return array|\WP_Error File object (includes the file `id`) on success, WP_Error on failure.
+	 */
+	public function upload_evidence_file( string $file_content_base64, string $file_name, string $file_type, string $purpose = 'dispute_evidence' ) {
+		try {
+			return $this->api_client->upload_evidence_file_contents( $file_content_base64, $file_name, $file_type, $purpose, false );
+		} catch ( \Throwable $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Dispute evidence file upload failed (%s): %s', $file_name, $e->getMessage() ),
+				[ 'source' => 'woopayments-abilities' ]
+			);
+			return new \WP_Error( 'wcpay_file_upload_failed', $e->getMessage(), [ 'exception' => $e ] );
+		}
+	}
+}

--- a/src/Internal/Service/RefundService.php
+++ b/src/Internal/Service/RefundService.php
@@ -22,6 +22,8 @@ class RefundService {
 	/**
 	 * Refund a charge by its Stripe charge/payout ID.
 	 *
+	 * @see \WCPay\Internal\Abilities\Domain\RefundCharge
+	 *
 	 * @param string      $charge_id       Stripe charge (`ch_…`/`py_…`) ID.
 	 * @param int|null    $amount          Amount in minor units; null for a full refund.
 	 * @param string|null $reason          Refund reason (duplicate|fraudulent|requested_by_customer).

--- a/src/Internal/Service/RefundService.php
+++ b/src/Internal/Service/RefundService.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class RefundService
+ *
+ * @package WooCommerce\Payments
+ */
+
+declare( strict_types=1 );
+
+namespace WCPay\Internal\Service;
+
+use WCPay\Core\Server\Request\Refund_Charge;
+
+/**
+ * Charge-bound refund service shared by the refund ability (and available to
+ * other charge-bound refund callers). Wraps the typed `Refund_Charge` request
+ * so callers never re-implement refund plumbing and agent-driven refunds avoid
+ * the order-bound note/notification fan-out in the gateway's process_refund().
+ */
+class RefundService {
+
+	/**
+	 * Refund a charge by its Stripe charge/payout ID.
+	 *
+	 * @param string      $charge_id       Stripe charge (`ch_…`/`py_…`) ID.
+	 * @param int|null    $amount          Amount in minor units; null for a full refund.
+	 * @param string|null $reason          Refund reason (duplicate|fraudulent|requested_by_customer).
+	 * @param string|null $idempotency_key Optional caller key so retries dedupe to the original refund.
+	 * @return array|\WP_Error Refund object on success, WP_Error on failure.
+	 */
+	public function refund_charge( string $charge_id, ?int $amount = null, ?string $reason = null, ?string $idempotency_key = null ) {
+		try {
+			$request = Refund_Charge::create();
+			$request->set_charge( $charge_id );
+			if ( null !== $amount ) {
+				$request->set_amount( $amount );
+			}
+			if ( null !== $reason ) {
+				$request->set_reason( $reason );
+			}
+			if ( null !== $idempotency_key && '' !== $idempotency_key ) {
+				$request->set_idempotency_key( $idempotency_key );
+			}
+			$request->set_source( 'woopayments_ability' );
+
+			return $request->send();
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'wcpay_refund_failed', $e->getMessage(), [ 'exception' => $e ] );
+		}
+	}
+}

--- a/src/Internal/Service/RefundService.php
+++ b/src/Internal/Service/RefundService.php
@@ -47,6 +47,10 @@ class RefundService {
 
 			return $request->send();
 		} catch ( \Throwable $e ) {
+			wc_get_logger()->error(
+				sprintf( 'Refund failed for charge %s: %s', $charge_id, $e->getMessage() ),
+				[ 'source' => 'woopayments-abilities' ]
+			);
 			return new \WP_Error( 'wcpay_refund_failed', $e->getMessage(), [ 'exception' => $e ] );
 		}
 	}

--- a/tests/unit/core/server/request/test-class-core-refund-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-refund-charge-request.php
@@ -118,4 +118,12 @@ class Refund_Charge_Test extends WCPAY_UnitTestCase {
 		$this->assertNull( $params['reason'] );
 		$this->assertArrayNotHasKey( 'metadata', $params );
 	}
+
+	public function test_set_idempotency_key_sets_the_param(): void {
+		$request = new Refund_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_charge( 'ch_test' );
+		$request->set_idempotency_key( 'ik_test_42' );
+
+		$this->assertSame( 'ik_test_42', $request->get_params()['idempotency_key'] );
+	}
 }

--- a/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
+++ b/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
@@ -212,7 +212,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$reflection = new \ReflectionClass( AbilitiesRegistrar::class );
 		$expected   = $reflection->getReflectionConstant( 'ABILITY_CLASSES' )->getValue();
 
-		$this->assertCount( 18, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
+		$this->assertCount( 19, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
 
 		// Empty input → returns just the WCPay classes.
 		$result = AbilitiesRegistrar::append_classes( [] );
@@ -222,7 +222,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$caller = [ '\\Some\\Other\\Class' ];
 		$result = AbilitiesRegistrar::append_classes( $caller );
 		$this->assertSame( '\\Some\\Other\\Class', $result[0] );
-		$this->assertCount( 19, $result );
+		$this->assertCount( 20, $result );
 	}
 
 	public function test_every_ability_class_implements_ability_definition(): void {

--- a/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
+++ b/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
@@ -212,7 +212,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$reflection = new \ReflectionClass( AbilitiesRegistrar::class );
 		$expected   = $reflection->getReflectionConstant( 'ABILITY_CLASSES' )->getValue();
 
-		$this->assertCount( 21, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
+		$this->assertCount( 22, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
 
 		// Empty input → returns just the WCPay classes.
 		$result = AbilitiesRegistrar::append_classes( [] );
@@ -222,7 +222,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$caller = [ '\\Some\\Other\\Class' ];
 		$result = AbilitiesRegistrar::append_classes( $caller );
 		$this->assertSame( '\\Some\\Other\\Class', $result[0] );
-		$this->assertCount( 22, $result );
+		$this->assertCount( 23, $result );
 	}
 
 	public function test_every_ability_class_implements_ability_definition(): void {

--- a/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
+++ b/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
@@ -212,7 +212,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$reflection = new \ReflectionClass( AbilitiesRegistrar::class );
 		$expected   = $reflection->getReflectionConstant( 'ABILITY_CLASSES' )->getValue();
 
-		$this->assertCount( 19, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
+		$this->assertCount( 20, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
 
 		// Empty input → returns just the WCPay classes.
 		$result = AbilitiesRegistrar::append_classes( [] );
@@ -222,7 +222,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$caller = [ '\\Some\\Other\\Class' ];
 		$result = AbilitiesRegistrar::append_classes( $caller );
 		$this->assertSame( '\\Some\\Other\\Class', $result[0] );
-		$this->assertCount( 20, $result );
+		$this->assertCount( 21, $result );
 	}
 
 	public function test_every_ability_class_implements_ability_definition(): void {

--- a/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
+++ b/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
@@ -212,7 +212,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$reflection = new \ReflectionClass( AbilitiesRegistrar::class );
 		$expected   = $reflection->getReflectionConstant( 'ABILITY_CLASSES' )->getValue();
 
-		$this->assertCount( 15, $expected, 'ABILITY_CLASSES should contain all 15 migrated abilities.' );
+		$this->assertCount( 16, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
 
 		// Empty input → returns just the WCPay classes.
 		$result = AbilitiesRegistrar::append_classes( [] );
@@ -222,7 +222,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$caller = [ '\\Some\\Other\\Class' ];
 		$result = AbilitiesRegistrar::append_classes( $caller );
 		$this->assertSame( '\\Some\\Other\\Class', $result[0] );
-		$this->assertCount( 16, $result );
+		$this->assertCount( 17, $result );
 	}
 
 	public function test_every_ability_class_implements_ability_definition(): void {

--- a/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
+++ b/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
@@ -212,7 +212,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$reflection = new \ReflectionClass( AbilitiesRegistrar::class );
 		$expected   = $reflection->getReflectionConstant( 'ABILITY_CLASSES' )->getValue();
 
-		$this->assertCount( 20, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
+		$this->assertCount( 21, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
 
 		// Empty input → returns just the WCPay classes.
 		$result = AbilitiesRegistrar::append_classes( [] );
@@ -222,7 +222,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$caller = [ '\\Some\\Other\\Class' ];
 		$result = AbilitiesRegistrar::append_classes( $caller );
 		$this->assertSame( '\\Some\\Other\\Class', $result[0] );
-		$this->assertCount( 21, $result );
+		$this->assertCount( 22, $result );
 	}
 
 	public function test_every_ability_class_implements_ability_definition(): void {

--- a/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
+++ b/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
@@ -212,7 +212,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$reflection = new \ReflectionClass( AbilitiesRegistrar::class );
 		$expected   = $reflection->getReflectionConstant( 'ABILITY_CLASSES' )->getValue();
 
-		$this->assertCount( 17, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
+		$this->assertCount( 18, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
 
 		// Empty input → returns just the WCPay classes.
 		$result = AbilitiesRegistrar::append_classes( [] );
@@ -222,7 +222,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$caller = [ '\\Some\\Other\\Class' ];
 		$result = AbilitiesRegistrar::append_classes( $caller );
 		$this->assertSame( '\\Some\\Other\\Class', $result[0] );
-		$this->assertCount( 18, $result );
+		$this->assertCount( 19, $result );
 	}
 
 	public function test_every_ability_class_implements_ability_definition(): void {

--- a/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
+++ b/tests/unit/src/Internal/Abilities/AbilitiesRegistrarTest.php
@@ -212,7 +212,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$reflection = new \ReflectionClass( AbilitiesRegistrar::class );
 		$expected   = $reflection->getReflectionConstant( 'ABILITY_CLASSES' )->getValue();
 
-		$this->assertCount( 16, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
+		$this->assertCount( 17, $expected, 'ABILITY_CLASSES should contain all registered abilities.' );
 
 		// Empty input → returns just the WCPay classes.
 		$result = AbilitiesRegistrar::append_classes( [] );
@@ -222,7 +222,7 @@ class AbilitiesRegistrarTest extends WCPAY_UnitTestCase {
 		$caller = [ '\\Some\\Other\\Class' ];
 		$result = AbilitiesRegistrar::append_classes( $caller );
 		$this->assertSame( '\\Some\\Other\\Class', $result[0] );
-		$this->assertCount( 17, $result );
+		$this->assertCount( 18, $result );
 	}
 
 	public function test_every_ability_class_implements_ability_definition(): void {

--- a/tests/unit/src/Internal/Abilities/Domain/AcceptDisputeTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/AcceptDisputeTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for WCPay\Internal\Abilities\Domain\AcceptDispute.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Abilities\Domain;
+
+use WCPAY_UnitTestCase;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Abilities\Domain\AcceptDispute;
+
+/**
+ * @coversDefaultClass \WCPay\Internal\Abilities\Domain\AcceptDispute
+ */
+class AcceptDisputeTest extends WCPAY_UnitTestCase {
+
+	public function test_name(): void {
+		$this->assertSame( 'woocommerce-payments/accept-dispute', AcceptDispute::get_name() );
+	}
+
+	public function test_registration_args_has_destructive_irreversible_annotations(): void {
+		$args = AcceptDispute::get_registration_args();
+
+		$this->assertFalse( $args['meta']['annotations']['readonly'] );
+		$this->assertTrue( $args['meta']['annotations']['destructive'] );
+		$this->assertFalse( $args['meta']['annotations']['idempotent'] );
+		$this->assertSame( 0.0, $args['meta']['annotations']['reversibility'] );
+		$this->assertFalse( $args['meta']['mcp']['public'] );
+		$this->assertContains( 'dispute_id', $args['input_schema']['required'] );
+	}
+
+	public function test_execute_returns_error_when_dispute_id_missing(): void {
+		$result = AcceptDispute::execute( [] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_dispute_id', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_dispute_id_not_a_string(): void {
+		$result = AcceptDispute::execute( [ 'dispute_id' => 123 ] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_dispute_id', $result->get_error_code() );
+	}
+}

--- a/tests/unit/src/Internal/Abilities/Domain/AcceptDisputeTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/AcceptDisputeTest.php
@@ -42,4 +42,18 @@ class AcceptDisputeTest extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'wcpay_missing_dispute_id', $result->get_error_code() );
 	}
+
+	public function test_execute_delegates_to_dispute_service(): void {
+		$mock_service = $this->createMock( \WCPay\Internal\Service\DisputeService::class );
+		$mock_service->expects( $this->once() )->method( 'accept' )
+			->with( 'du_1' )
+			->willReturn( [ 'id' => 'du_1' ] );
+		wcpay_get_test_container()->replace( \WCPay\Internal\Service\DisputeService::class, $mock_service );
+		try {
+			$result = AcceptDispute::execute( [ 'dispute_id' => 'du_1' ] );
+		} finally {
+			wcpay_get_test_container()->reset_all_replacements();
+		}
+		$this->assertSame( [ 'id' => 'du_1' ], $result );
+	}
 }

--- a/tests/unit/src/Internal/Abilities/Domain/AcceptDisputeTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/AcceptDisputeTest.php
@@ -26,7 +26,6 @@ class AcceptDisputeTest extends WCPAY_UnitTestCase {
 		$this->assertFalse( $args['meta']['annotations']['readonly'] );
 		$this->assertTrue( $args['meta']['annotations']['destructive'] );
 		$this->assertFalse( $args['meta']['annotations']['idempotent'] );
-		$this->assertSame( 0.0, $args['meta']['annotations']['reversibility'] );
 		$this->assertFalse( $args['meta']['mcp']['public'] );
 		$this->assertContains( 'dispute_id', $args['input_schema']['required'] );
 	}

--- a/tests/unit/src/Internal/Abilities/Domain/GetBalanceTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/GetBalanceTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tests for WCPay\Internal\Abilities\Domain\GetBalance.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Abilities\Domain;
+
+use WCPAY_UnitTestCase;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Abilities\Domain\GetBalance;
+
+/**
+ * @coversDefaultClass \WCPay\Internal\Abilities\Domain\GetBalance
+ */
+class GetBalanceTest extends WCPAY_UnitTestCase {
+
+	public function test_name(): void {
+		$this->assertSame( 'woocommerce-payments/get-balance', GetBalance::get_name() );
+	}
+
+	public function test_registration_args_read_annotations_and_required_fields(): void {
+		$args = GetBalance::get_registration_args();
+
+		$this->assertTrue( $args['meta']['annotations']['readonly'] );
+		$this->assertFalse( $args['meta']['annotations']['destructive'] );
+		$this->assertTrue( $args['meta']['annotations']['idempotent'] );
+		$this->assertSame( 1.0, $args['meta']['annotations']['reversibility'] );
+		$this->assertTrue( $args['meta']['mcp']['public'] );
+		$this->assertSame( [ 'date_start', 'date_end', 'currency' ], $args['input_schema']['required'] );
+	}
+
+	public function test_execute_returns_error_when_required_field_missing(): void {
+		$result = GetBalance::execute(
+			[
+				'date_start' => '2026-01-01',
+				'date_end'   => '2026-02-01',
+			]
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_currency', $result->get_error_code() );
+	}
+
+	public function test_execute_delegates_and_returns_summary(): void {
+		$fixture = [
+			'currency'       => 'usd',
+			'ending_balance' => [ 'amount' => 0 ],
+		];
+		$filter  = function ( $result, $server, $request ) use ( $fixture ) {
+			if ( $request->get_route() === '/wc/v3/payments/reports/balance' ) {
+				return new \WP_REST_Response( $fixture, 200 );
+			}
+			return $result;
+		};
+		add_filter( 'rest_pre_dispatch', $filter, 10, 3 );
+		try {
+			$result = GetBalance::execute(
+				[
+					'date_start' => '2026-01-01',
+					'date_end'   => '2026-02-01',
+					'currency'   => 'usd',
+				]
+			);
+		} finally {
+			remove_filter( 'rest_pre_dispatch', $filter, 10 );
+		}
+
+		$this->assertSame( $fixture, $result );
+	}
+}

--- a/tests/unit/src/Internal/Abilities/Domain/GetBalanceTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/GetBalanceTest.php
@@ -26,7 +26,6 @@ class GetBalanceTest extends WCPAY_UnitTestCase {
 		$this->assertTrue( $args['meta']['annotations']['readonly'] );
 		$this->assertFalse( $args['meta']['annotations']['destructive'] );
 		$this->assertTrue( $args['meta']['annotations']['idempotent'] );
-		$this->assertSame( 1.0, $args['meta']['annotations']['reversibility'] );
 		$this->assertTrue( $args['meta']['mcp']['public'] );
 		$this->assertSame( [ 'date_start', 'date_end', 'currency' ], $args['input_schema']['required'] );
 	}

--- a/tests/unit/src/Internal/Abilities/Domain/GetFeesSummaryTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/GetFeesSummaryTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for WCPay\Internal\Abilities\Domain\GetFeesSummary.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Abilities\Domain;
+
+use WCPAY_UnitTestCase;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Abilities\Domain\GetFeesSummary;
+
+/**
+ * @coversDefaultClass \WCPay\Internal\Abilities\Domain\GetFeesSummary
+ */
+class GetFeesSummaryTest extends WCPAY_UnitTestCase {
+
+	public function test_name(): void {
+		$this->assertSame( 'woocommerce-payments/get-fees-summary', GetFeesSummary::get_name() );
+	}
+
+	public function test_registration_args_read_annotations(): void {
+		$args = GetFeesSummary::get_registration_args();
+
+		$this->assertTrue( $args['meta']['annotations']['readonly'] );
+		$this->assertSame( 1.0, $args['meta']['annotations']['reversibility'] );
+		$this->assertTrue( $args['meta']['mcp']['public'] );
+		$this->assertFalse( $args['input_schema']['additionalProperties'] );
+	}
+
+	public function test_execute_delegates_and_returns_summary(): void {
+		$fixture = [
+			'count'    => 15,
+			'fees'     => 12500,
+			'net'      => 87500,
+			'currency' => 'usd',
+		];
+		$filter  = function ( $result, $server, $request ) use ( $fixture ) {
+			if ( $request->get_route() === '/wc/v3/payments/reports/fees/summary' ) {
+				return new \WP_REST_Response( $fixture, 200 );
+			}
+			return $result;
+		};
+		add_filter( 'rest_pre_dispatch', $filter, 10, 3 );
+		try {
+			$result = GetFeesSummary::execute( [ 'date_after' => '2026-01-01' ] );
+		} finally {
+			remove_filter( 'rest_pre_dispatch', $filter, 10 );
+		}
+
+		$this->assertSame( $fixture, $result );
+	}
+}

--- a/tests/unit/src/Internal/Abilities/Domain/GetFeesSummaryTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/GetFeesSummaryTest.php
@@ -24,7 +24,6 @@ class GetFeesSummaryTest extends WCPAY_UnitTestCase {
 		$args = GetFeesSummary::get_registration_args();
 
 		$this->assertTrue( $args['meta']['annotations']['readonly'] );
-		$this->assertSame( 1.0, $args['meta']['annotations']['reversibility'] );
 		$this->assertTrue( $args['meta']['mcp']['public'] );
 		$this->assertFalse( $args['input_schema']['additionalProperties'] );
 	}

--- a/tests/unit/src/Internal/Abilities/Domain/GetFraudOutcomesTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/GetFraudOutcomesTest.php
@@ -24,7 +24,6 @@ class GetFraudOutcomesTest extends WCPAY_UnitTestCase {
 		$args = GetFraudOutcomes::get_registration_args();
 
 		$this->assertTrue( $args['meta']['annotations']['readonly'] );
-		$this->assertSame( 1.0, $args['meta']['annotations']['reversibility'] );
 		$this->assertTrue( $args['meta']['mcp']['public'] );
 		$this->assertContains( 'status', $args['input_schema']['required'] );
 		$this->assertArrayHasKey( 'page', $args['input_schema']['properties'] );

--- a/tests/unit/src/Internal/Abilities/Domain/GetFraudOutcomesTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/GetFraudOutcomesTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for WCPay\Internal\Abilities\Domain\GetFraudOutcomes.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Abilities\Domain;
+
+use WCPAY_UnitTestCase;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Abilities\Domain\GetFraudOutcomes;
+
+/**
+ * @coversDefaultClass \WCPay\Internal\Abilities\Domain\GetFraudOutcomes
+ */
+class GetFraudOutcomesTest extends WCPAY_UnitTestCase {
+
+	public function test_name(): void {
+		$this->assertSame( 'woocommerce-payments/get-fraud-outcomes', GetFraudOutcomes::get_name() );
+	}
+
+	public function test_registration_args_paginated_and_requires_status(): void {
+		$args = GetFraudOutcomes::get_registration_args();
+
+		$this->assertTrue( $args['meta']['annotations']['readonly'] );
+		$this->assertSame( 1.0, $args['meta']['annotations']['reversibility'] );
+		$this->assertTrue( $args['meta']['mcp']['public'] );
+		$this->assertContains( 'status', $args['input_schema']['required'] );
+		$this->assertArrayHasKey( 'page', $args['input_schema']['properties'] );
+		$this->assertArrayHasKey( 'per_page', $args['input_schema']['properties'] );
+		$this->assertArrayHasKey( 'fraud_outcomes', $args['output_schema']['properties'] );
+	}
+
+	public function test_execute_returns_error_when_status_missing(): void {
+		$result = GetFraudOutcomes::execute( [] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_status', $result->get_error_code() );
+	}
+
+	public function test_execute_delegates_and_wraps_envelope(): void {
+		$fixture = [
+			'data'        => [ [ 'order_id' => 1 ], [ 'order_id' => 2 ] ],
+			'total_count' => 2,
+		];
+		$filter  = function ( $result, $server, $request ) use ( $fixture ) {
+			if ( $request->get_route() === '/wc/v3/payments/transactions/fraud-outcomes' ) {
+				return new \WP_REST_Response( $fixture, 200 );
+			}
+			return $result;
+		};
+		add_filter( 'rest_pre_dispatch', $filter, 10, 3 );
+		try {
+			$result = GetFraudOutcomes::execute( [ 'status' => 'review' ] );
+		} finally {
+			remove_filter( 'rest_pre_dispatch', $filter, 10 );
+		}
+
+		$this->assertArrayHasKey( 'fraud_outcomes', $result );
+		$this->assertSame( [ [ 'order_id' => 1 ], [ 'order_id' => 2 ] ], $result['fraud_outcomes'] );
+		$this->assertSame( 1, $result['page'] );
+		$this->assertSame( 25, $result['per_page'] );
+	}
+}

--- a/tests/unit/src/Internal/Abilities/Domain/RefundChargeTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/RefundChargeTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for WCPay\Internal\Abilities\Domain\RefundCharge.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Abilities\Domain;
+
+use WCPAY_UnitTestCase;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Abilities\Domain\RefundCharge;
+
+/**
+ * @coversDefaultClass \WCPay\Internal\Abilities\Domain\RefundCharge
+ */
+class RefundChargeTest extends WCPAY_UnitTestCase {
+
+	public function test_name(): void {
+		$this->assertSame( 'woocommerce-payments/refund-charge', RefundCharge::get_name() );
+	}
+
+	public function test_registration_args_has_write_annotations(): void {
+		$args = RefundCharge::get_registration_args();
+
+		$this->assertSame( AbilitiesRegistrar::CATEGORY_SLUG, $args['category'] );
+		$this->assertSame( [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ], $args['permission_callback'] );
+		$this->assertFalse( $args['meta']['annotations']['readonly'] );
+		$this->assertTrue( $args['meta']['annotations']['destructive'] );
+		$this->assertTrue( $args['meta']['annotations']['idempotent'] );
+		$this->assertSame( 0.2, $args['meta']['annotations']['reversibility'] );
+		$this->assertFalse( $args['meta']['mcp']['public'] );
+		$this->assertContains( 'charge_id', $args['input_schema']['required'] );
+		$this->assertFalse( $args['input_schema']['additionalProperties'] );
+	}
+
+	public function test_execute_returns_error_when_charge_id_missing(): void {
+		$result = RefundCharge::execute( [] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_charge_id', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_charge_id_not_a_string(): void {
+		$result = RefundCharge::execute( [ 'charge_id' => 123 ] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_charge_id', $result->get_error_code() );
+	}
+}

--- a/tests/unit/src/Internal/Abilities/Domain/RefundChargeTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/RefundChargeTest.php
@@ -52,4 +52,25 @@ class RefundChargeTest extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'wcpay_missing_idempotency_key', $result->get_error_code() );
 	}
+
+	public function test_execute_delegates_to_refund_service(): void {
+		$mock_service = $this->createMock( \WCPay\Internal\Service\RefundService::class );
+		$mock_service->expects( $this->once() )->method( 'refund_charge' )
+			->with( 'ch_1', 500, 'requested_by_customer', 'ik_1' )
+			->willReturn( [ 'id' => 're_1' ] );
+		wcpay_get_test_container()->replace( \WCPay\Internal\Service\RefundService::class, $mock_service );
+		try {
+			$result = RefundCharge::execute(
+				[
+					'charge_id'       => 'ch_1',
+					'amount'          => 500,
+					'reason'          => 'requested_by_customer',
+					'idempotency_key' => 'ik_1',
+				]
+			);
+		} finally {
+			wcpay_get_test_container()->reset_all_replacements();
+		}
+		$this->assertSame( [ 'id' => 're_1' ], $result );
+	}
 }

--- a/tests/unit/src/Internal/Abilities/Domain/RefundChargeTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/RefundChargeTest.php
@@ -28,7 +28,6 @@ class RefundChargeTest extends WCPAY_UnitTestCase {
 		$this->assertFalse( $args['meta']['annotations']['readonly'] );
 		$this->assertTrue( $args['meta']['annotations']['destructive'] );
 		$this->assertTrue( $args['meta']['annotations']['idempotent'] );
-		$this->assertSame( 0.2, $args['meta']['annotations']['reversibility'] );
 		$this->assertFalse( $args['meta']['mcp']['public'] );
 		$this->assertContains( 'charge_id', $args['input_schema']['required'] );
 		$this->assertContains( 'idempotency_key', $args['input_schema']['required'] );

--- a/tests/unit/src/Internal/Abilities/Domain/RefundChargeTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/RefundChargeTest.php
@@ -31,6 +31,7 @@ class RefundChargeTest extends WCPAY_UnitTestCase {
 		$this->assertSame( 0.2, $args['meta']['annotations']['reversibility'] );
 		$this->assertFalse( $args['meta']['mcp']['public'] );
 		$this->assertContains( 'charge_id', $args['input_schema']['required'] );
+		$this->assertContains( 'idempotency_key', $args['input_schema']['required'] );
 		$this->assertFalse( $args['input_schema']['additionalProperties'] );
 	}
 
@@ -44,5 +45,11 @@ class RefundChargeTest extends WCPAY_UnitTestCase {
 		$result = RefundCharge::execute( [ 'charge_id' => 123 ] );
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'wcpay_missing_charge_id', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_idempotency_key_missing(): void {
+		$result = RefundCharge::execute( [ 'charge_id' => 'ch_1' ] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_idempotency_key', $result->get_error_code() );
 	}
 }

--- a/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Abilities\Domain;
+
+use WCPAY_UnitTestCase;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence;
+
+/**
+ * @coversDefaultClass \WCPay\Internal\Abilities\Domain\SubmitDisputeEvidence
+ */
+class SubmitDisputeEvidenceTest extends WCPAY_UnitTestCase {
+
+	public function test_name(): void {
+		$this->assertSame( 'woocommerce-payments/submit-dispute-evidence', SubmitDisputeEvidence::get_name() );
+	}
+
+	public function test_registration_args_has_additive_write_annotations(): void {
+		$args = SubmitDisputeEvidence::get_registration_args();
+
+		$this->assertFalse( $args['meta']['annotations']['readonly'] );
+		$this->assertFalse( $args['meta']['annotations']['destructive'] );
+		$this->assertFalse( $args['meta']['annotations']['idempotent'] );
+		$this->assertSame( 0.2, $args['meta']['annotations']['reversibility'] );
+		$this->assertFalse( $args['meta']['mcp']['public'] );
+		$this->assertContains( 'dispute_id', $args['input_schema']['required'] );
+		$this->assertFalse( $args['input_schema']['properties']['submit']['default'] );
+	}
+
+	public function test_execute_returns_error_when_dispute_id_missing(): void {
+		$result = SubmitDisputeEvidence::execute( [] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_dispute_id', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_dispute_id_not_a_string(): void {
+		$result = SubmitDisputeEvidence::execute( [ 'dispute_id' => 123 ] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_dispute_id', $result->get_error_code() );
+	}
+}

--- a/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
@@ -43,4 +43,27 @@ class SubmitDisputeEvidenceTest extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'wcpay_missing_dispute_id', $result->get_error_code() );
 	}
+
+	public function test_execute_delegates_to_dispute_service(): void {
+		$evidence     = [ 'customer_communication' => 'file_1' ];
+		$metadata     = [ 'k' => 'v' ];
+		$mock_service = $this->createMock( \WCPay\Internal\Service\DisputeService::class );
+		$mock_service->expects( $this->once() )->method( 'submit_evidence' )
+			->with( 'du_1', $evidence, true, $metadata )
+			->willReturn( [ 'id' => 'du_1' ] );
+		wcpay_get_test_container()->replace( \WCPay\Internal\Service\DisputeService::class, $mock_service );
+		try {
+			$result = SubmitDisputeEvidence::execute(
+				[
+					'dispute_id' => 'du_1',
+					'evidence'   => $evidence,
+					'submit'     => true,
+					'metadata'   => $metadata,
+				]
+			);
+		} finally {
+			wcpay_get_test_container()->reset_all_replacements();
+		}
+		$this->assertSame( [ 'id' => 'du_1' ], $result );
+	}
 }

--- a/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
@@ -26,7 +26,6 @@ class SubmitDisputeEvidenceTest extends WCPAY_UnitTestCase {
 		$this->assertFalse( $args['meta']['annotations']['readonly'] );
 		$this->assertTrue( $args['meta']['annotations']['destructive'] );
 		$this->assertFalse( $args['meta']['annotations']['idempotent'] );
-		$this->assertSame( 0.2, $args['meta']['annotations']['reversibility'] );
 		$this->assertFalse( $args['meta']['mcp']['public'] );
 		$this->assertContains( 'dispute_id', $args['input_schema']['required'] );
 		$this->assertFalse( $args['input_schema']['properties']['submit']['default'] );

--- a/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
@@ -20,11 +20,11 @@ class SubmitDisputeEvidenceTest extends WCPAY_UnitTestCase {
 		$this->assertSame( 'woocommerce-payments/submit-dispute-evidence', SubmitDisputeEvidence::get_name() );
 	}
 
-	public function test_registration_args_has_additive_write_annotations(): void {
+	public function test_registration_args_has_destructive_write_annotations(): void {
 		$args = SubmitDisputeEvidence::get_registration_args();
 
 		$this->assertFalse( $args['meta']['annotations']['readonly'] );
-		$this->assertFalse( $args['meta']['annotations']['destructive'] );
+		$this->assertTrue( $args['meta']['annotations']['destructive'] );
 		$this->assertFalse( $args['meta']['annotations']['idempotent'] );
 		$this->assertSame( 0.2, $args['meta']['annotations']['reversibility'] );
 		$this->assertFalse( $args['meta']['mcp']['public'] );

--- a/tests/unit/src/Internal/Abilities/Domain/UploadDisputeEvidenceFileTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/UploadDisputeEvidenceFileTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests for WCPay\Internal\Abilities\Domain\UploadDisputeEvidenceFile.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Abilities\Domain;
+
+use WCPAY_UnitTestCase;
+use WCPay\Internal\Abilities\AbilitiesRegistrar;
+use WCPay\Internal\Abilities\Domain\UploadDisputeEvidenceFile;
+use WCPay\Internal\Service\FileService;
+
+/**
+ * @coversDefaultClass \WCPay\Internal\Abilities\Domain\UploadDisputeEvidenceFile
+ */
+class UploadDisputeEvidenceFileTest extends WCPAY_UnitTestCase {
+
+	public function test_name(): void {
+		$this->assertSame( 'woocommerce-payments/upload-dispute-evidence-file', UploadDisputeEvidenceFile::get_name() );
+	}
+
+	public function test_registration_args_has_non_destructive_write_annotations(): void {
+		$args = UploadDisputeEvidenceFile::get_registration_args();
+
+		$this->assertSame( AbilitiesRegistrar::CATEGORY_SLUG, $args['category'] );
+		$this->assertSame( [ AbilitiesRegistrar::class, 'current_user_can_manage_woocommerce' ], $args['permission_callback'] );
+		$this->assertFalse( $args['meta']['annotations']['readonly'] );
+		$this->assertFalse( $args['meta']['annotations']['destructive'] );
+		$this->assertFalse( $args['meta']['annotations']['idempotent'] );
+		$this->assertFalse( $args['meta']['mcp']['public'] );
+		$this->assertSame( [ 'file_name', 'file_type', 'file_contents' ], $args['input_schema']['required'] );
+		$this->assertFalse( $args['input_schema']['additionalProperties'] );
+		$this->assertContains( 'application/pdf', $args['input_schema']['properties']['file_type']['enum'] );
+	}
+
+	public function test_execute_returns_error_when_input_missing(): void {
+		$result = UploadDisputeEvidenceFile::execute( [] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_file_input', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_file_type_unsupported(): void {
+		$result = UploadDisputeEvidenceFile::execute(
+			[
+				'file_name'     => 'evil.exe',
+				'file_type'     => 'application/x-msdownload',
+				'file_contents' => base64_encode( 'data' ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			]
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_unsupported_file_type', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_contents_not_base64(): void {
+		$result = UploadDisputeEvidenceFile::execute(
+			[
+				'file_name'     => 'receipt.pdf',
+				'file_type'     => 'application/pdf',
+				'file_contents' => '@@@not-base64@@@',
+			]
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_invalid_file_contents', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_file_too_large(): void {
+		$reflection = new \ReflectionClass( UploadDisputeEvidenceFile::class );
+		$max        = $reflection->getReflectionConstant( 'MAX_FILE_SIZE_BYTES' )->getValue();
+
+		$result = UploadDisputeEvidenceFile::execute(
+			[
+				'file_name'     => 'receipt.pdf',
+				'file_type'     => 'application/pdf',
+				'file_contents' => base64_encode( str_repeat( 'A', $max + 1 ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			]
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_file_too_large', $result->get_error_code() );
+	}
+
+	public function test_execute_delegates_to_file_service(): void {
+		$contents     = base64_encode( 'file-bytes' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$mock_service = $this->createMock( FileService::class );
+		$mock_service->expects( $this->once() )->method( 'upload_evidence_file' )
+			->with( $contents, 'receipt.pdf', 'application/pdf', 'dispute_evidence' )
+			->willReturn( [ 'id' => 'file_1' ] );
+		wcpay_get_test_container()->replace( FileService::class, $mock_service );
+		try {
+			$result = UploadDisputeEvidenceFile::execute(
+				[
+					'file_name'     => 'receipt.pdf',
+					'file_type'     => 'application/pdf',
+					'file_contents' => $contents,
+				]
+			);
+		} finally {
+			wcpay_get_test_container()->reset_all_replacements();
+		}
+		$this->assertSame( [ 'id' => 'file_1' ], $result );
+	}
+}

--- a/tests/unit/src/Internal/Service/DisputeServiceTest.php
+++ b/tests/unit/src/Internal/Service/DisputeServiceTest.php
@@ -106,4 +106,30 @@ class DisputeServiceTest extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'wcpay_dispute_close_failed', $result->get_error_code() );
 	}
+
+	public function test_submit_evidence_passes_through_wp_error_from_api_client(): void {
+		$wp_error = new \WP_Error( 'wcpay_prefetch_failed', 'prefetch failed' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'update_dispute' )
+			->willReturn( $wp_error );
+
+		$result = $this->sut->submit_evidence( 'dp_1', [ 'customer_communication' => 'file_1' ], true );
+
+		$this->assertSame( $wp_error, $result );
+	}
+
+	public function test_accept_passes_through_wp_error_from_api_client(): void {
+		$wp_error = new \WP_Error( 'wcpay_prefetch_failed', 'prefetch failed' );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'close_dispute' )
+			->willReturn( $wp_error );
+
+		$result = $this->sut->accept( 'dp_2' );
+
+		$this->assertSame( $wp_error, $result );
+	}
 }

--- a/tests/unit/src/Internal/Service/DisputeServiceTest.php
+++ b/tests/unit/src/Internal/Service/DisputeServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Class DisputeServiceTest
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Service;
+
+use WC_Payments_API_Client;
+use WCPay\Exceptions\API_Exception;
+use WCPay\Internal\Service\DisputeService;
+use WCPAY_UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @covers \WCPay\Internal\Service\DisputeService
+ */
+class DisputeServiceTest extends WCPAY_UnitTestCase {
+
+	/**
+	 * @var DisputeService
+	 */
+	private $sut;
+
+	/**
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$this->sut             = new DisputeService( $this->mock_api_client );
+	}
+
+	public function test_submit_evidence_forwards_to_api_client(): void {
+		$evidence = [ 'customer_communication' => 'file_1' ];
+		$metadata = [ 'k' => 'v' ];
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'update_dispute' )
+			->with( 'dp_1', $evidence, true, $metadata )
+			->willReturn(
+				[
+					'id'     => 'dp_1',
+					'status' => 'under_review',
+				]
+			);
+
+		$result = $this->sut->submit_evidence( 'dp_1', $evidence, true, $metadata );
+
+		$this->assertSame(
+			[
+				'id'     => 'dp_1',
+				'status' => 'under_review',
+			],
+			$result
+		);
+	}
+
+	public function test_accept_forwards_to_api_client(): void {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'close_dispute' )
+			->with( 'dp_2' )
+			->willReturn(
+				[
+					'id'     => 'dp_2',
+					'status' => 'lost',
+				]
+			);
+
+		$result = $this->sut->accept( 'dp_2' );
+
+		$this->assertSame(
+			[
+				'id'     => 'dp_2',
+				'status' => 'lost',
+			],
+			$result
+		);
+	}
+
+	public function test_submit_evidence_returns_wp_error_when_api_client_throws(): void {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'update_dispute' )
+			->willThrowException( new API_Exception( 'boom', 'test_err', 500 ) );
+
+		$result = $this->sut->submit_evidence( 'dp_1', [ 'customer_communication' => 'file_1' ], true );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_dispute_evidence_failed', $result->get_error_code() );
+	}
+
+	public function test_accept_returns_wp_error_when_api_client_throws(): void {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'close_dispute' )
+			->willThrowException( new API_Exception( 'boom', 'test_err', 500 ) );
+
+		$result = $this->sut->accept( 'dp_2' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_dispute_close_failed', $result->get_error_code() );
+	}
+}

--- a/tests/unit/src/Internal/Service/FileServiceTest.php
+++ b/tests/unit/src/Internal/Service/FileServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class FileServiceTest
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Service;
+
+use WC_Payments_API_Client;
+use WCPay\Exceptions\API_Exception;
+use WCPay\Internal\Service\FileService;
+use WCPAY_UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * @covers \WCPay\Internal\Service\FileService
+ */
+class FileServiceTest extends WCPAY_UnitTestCase {
+
+	/**
+	 * @var FileService
+	 */
+	private $sut;
+
+	/**
+	 * @var WC_Payments_API_Client|MockObject
+	 */
+	private $mock_api_client;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->mock_api_client = $this->createMock( WC_Payments_API_Client::class );
+		$this->sut             = new FileService( $this->mock_api_client );
+	}
+
+	public function test_upload_evidence_file_forwards_to_api_client(): void {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'upload_evidence_file_contents' )
+			->with( 'YmFzZTY0', 'receipt.pdf', 'application/pdf', 'dispute_evidence', false )
+			->willReturn( [ 'id' => 'file_1' ] );
+
+		$result = $this->sut->upload_evidence_file( 'YmFzZTY0', 'receipt.pdf', 'application/pdf' );
+
+		$this->assertSame( [ 'id' => 'file_1' ], $result );
+	}
+
+	public function test_upload_evidence_file_returns_wp_error_when_api_client_throws(): void {
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'upload_evidence_file_contents' )
+			->willThrowException( new API_Exception( 'boom', 'test_err', 500 ) );
+
+		$result = $this->sut->upload_evidence_file( 'YmFzZTY0', 'receipt.pdf', 'application/pdf' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_file_upload_failed', $result->get_error_code() );
+	}
+}

--- a/tests/unit/src/Internal/Service/RefundServiceTest.php
+++ b/tests/unit/src/Internal/Service/RefundServiceTest.php
@@ -53,4 +53,29 @@ class RefundServiceTest extends WCPAY_UnitTestCase {
 
 		$this->assertSame( [ 'id' => 're_2' ], $result );
 	}
+
+	public function test_refund_charge_skips_idempotency_key_when_empty_string(): void {
+		$request = $this->mock_wcpay_request( Refund_Charge::class );
+		$request->expects( $this->once() )->method( 'set_charge' )->with( 'ch_3' );
+		$request->expects( $this->never() )->method( 'set_idempotency_key' );
+		$request->expects( $this->once() )->method( 'set_source' )->with( 'woopayments_ability' );
+		$request->expects( $this->once() )->method( 'format_response' )->willReturn( [ 'id' => 're_3' ] );
+
+		$result = $this->sut->refund_charge( 'ch_3', null, null, '' );
+
+		$this->assertSame( [ 'id' => 're_3' ], $result );
+	}
+
+	public function test_refund_charge_returns_wp_error_when_request_throws(): void {
+		$request = $this->mock_wcpay_request( Refund_Charge::class );
+		$request->expects( $this->once() )->method( 'set_charge' )->with( 'ch_4' );
+		$request->expects( $this->once() )->method( 'set_source' )->with( 'woopayments_ability' );
+		$request->expects( $this->once() )->method( 'format_response' )
+			->willThrowException( new \WCPay\Exceptions\API_Exception( 'boom', 'test_err', 500 ) );
+
+		$result = $this->sut->refund_charge( 'ch_4', null, null, 'ik_4' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_refund_failed', $result->get_error_code() );
+	}
 }

--- a/tests/unit/src/Internal/Service/RefundServiceTest.php
+++ b/tests/unit/src/Internal/Service/RefundServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Class RefundServiceTest
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Tests\Internal\Service;
+
+use WCPay\Core\Server\Request\Refund_Charge;
+use WCPay\Internal\Service\RefundService;
+use WCPAY_UnitTestCase;
+
+/**
+ * @covers \WCPay\Internal\Service\RefundService
+ */
+class RefundServiceTest extends WCPAY_UnitTestCase {
+
+	/**
+	 * @var RefundService
+	 */
+	private $sut;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->sut = new RefundService();
+	}
+
+	public function test_refund_charge_builds_request_with_all_params(): void {
+		$request = $this->mock_wcpay_request( Refund_Charge::class );
+		$request->expects( $this->once() )->method( 'set_charge' )->with( 'ch_1' );
+		$request->expects( $this->once() )->method( 'set_amount' )->with( 500 );
+		$request->expects( $this->once() )->method( 'set_reason' )->with( 'requested_by_customer' );
+		$request->expects( $this->once() )->method( 'set_idempotency_key' )->with( 'ik_1' );
+		$request->expects( $this->once() )->method( 'set_source' )->with( 'woopayments_ability' );
+		$request->expects( $this->once() )->method( 'format_response' )->willReturn( [ 'id' => 're_1' ] );
+
+		$result = $this->sut->refund_charge( 'ch_1', 500, 'requested_by_customer', 'ik_1' );
+
+		$this->assertSame( [ 'id' => 're_1' ], $result );
+	}
+
+	public function test_refund_charge_omits_optional_params_when_null(): void {
+		$request = $this->mock_wcpay_request( Refund_Charge::class );
+		$request->expects( $this->once() )->method( 'set_charge' )->with( 'ch_2' );
+		$request->expects( $this->never() )->method( 'set_amount' );
+		$request->expects( $this->never() )->method( 'set_reason' );
+		$request->expects( $this->never() )->method( 'set_idempotency_key' );
+		$request->expects( $this->once() )->method( 'set_source' )->with( 'woopayments_ability' );
+		$request->expects( $this->once() )->method( 'format_response' )->willReturn( [ 'id' => 're_2' ] );
+
+		$result = $this->sut->refund_charge( 'ch_2' );
+
+		$this->assertSame( [ 'id' => 're_2' ], $result );
+	}
+}

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1775,4 +1775,50 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 		$this->assertIsString( $captured_headers['Idempotency-Key'] );
 		$this->assertNotEmpty( $captured_headers['Idempotency-Key'] );
 	}
+
+	public function test_upload_evidence_file_contents_posts_base64_payload_to_files_api(): void {
+		$captured_url  = '';
+		$captured_body = null;
+
+		$this->mock_http_client
+			->expects( $this->once() )
+			->method( 'remote_request' )
+			->with(
+				$this->callback(
+					function ( $data ) use ( &$captured_url ): bool {
+						$captured_url = $data['url'];
+						return true;
+					}
+				),
+				$this->callback(
+					function ( $body ) use ( &$captured_body ): bool {
+						$captured_body = $body;
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				[
+					'body'     => wp_json_encode( [ 'id' => 'file_1' ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				]
+			);
+
+		$result = $this->payments_api_client->upload_evidence_file_contents(
+			'YmFzZTY0ZGF0YQ==',
+			'receipt.pdf',
+			'application/pdf',
+			'dispute_evidence',
+			false
+		);
+
+		$this->assertSame( [ 'id' => 'file_1' ], $result );
+		$this->assertStringContainsString( '/wcpay/files', $captured_url );
+		$this->assertStringContainsString( 'YmFzZTY0ZGF0YQ==', (string) $captured_body );
+		$this->assertStringContainsString( 'receipt.pdf', (string) $captured_body );
+		$this->assertStringContainsString( 'dispute_evidence', (string) $captured_body );
+	}
 }

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1683,4 +1683,96 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 		// Act: Call the method.
 		$this->payments_api_client->get_dispute_summary( $dispute_id );
 	}
+
+	public function test_request_uses_caller_supplied_idempotency_key_and_strips_it_from_body(): void {
+		$captured_headers = [];
+		$captured_body    = null;
+
+		$this->mock_http_client
+			->expects( $this->once() )
+			->method( 'remote_request' )
+			->with(
+				$this->callback(
+					function ( $args ) use ( &$captured_headers ) {
+						$captured_headers = $args['headers'];
+						return true;
+					}
+				),
+				$this->callback(
+					function ( $body ) use ( &$captured_body ) {
+						$captured_body = $body;
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				[
+					'body'     => wp_json_encode( [ 'id' => 're_1' ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				]
+			);
+
+		PHPUnit_Utils::call_method(
+			$this->payments_api_client,
+			'request',
+			[
+				[
+					'charge'          => 'ch_1',
+					'idempotency_key' => 'ik_agent_123',
+				],
+				'refunds',
+				'POST',
+			]
+		);
+
+		$this->assertSame( 'ik_agent_123', $captured_headers['Idempotency-Key'] );
+		$this->assertStringNotContainsString( 'idempotency_key', (string) $captured_body );
+	}
+
+	public function test_request_auto_generates_idempotency_key_when_caller_omits_it(): void {
+		$captured_headers = [];
+
+		$this->mock_http_client
+			->expects( $this->once() )
+			->method( 'remote_request' )
+			->with(
+				$this->callback(
+					function ( $args ) use ( &$captured_headers ) {
+						$captured_headers = $args['headers'];
+						return true;
+					}
+				),
+				$this->callback(
+					function () {
+						return true;
+					}
+				)
+			)
+			->willReturn(
+				[
+					'body'     => wp_json_encode( [ 'id' => 're_1' ] ),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				]
+			);
+
+		PHPUnit_Utils::call_method(
+			$this->payments_api_client,
+			'request',
+			[
+				[ 'charge' => 'ch_1' ],
+				'refunds',
+				'POST',
+			]
+		);
+
+		$this->assertArrayHasKey( 'Idempotency-Key', $captured_headers );
+		$this->assertIsString( $captured_headers['Idempotency-Key'] );
+		$this->assertNotEmpty( $captured_headers['Idempotency-Key'] );
+	}
 }


### PR DESCRIPTION
Refs RSM-108

#### Changes proposed in this Pull Request

Extends the WooPayments Abilities API surface (shipped in #11705) with the first **write** abilities plus three high-value reads, scoped from the WooAgent OS partner proposal. Everything is gated behind the existing `woocommerce_payments_abilities_enabled` filter (default **off**) and the WC 10.9 `AbilitiesLoader` gate, so there is no behavior change on existing installs.

**Write abilities** — Shape 3 (backed by shared services, never `delegate_to_rest_controller`); `mcp.public: false` (not agent-discoverable):

| Ability | Annotations | Backed by |
|---|---|---|
| `woocommerce-payments/refund-charge` | `destructive`, `idempotent`* | `RefundService` → `Refund_Charge` |
| `woocommerce-payments/submit-dispute-evidence` | `destructive`, non-idempotent | `DisputeService::submit_evidence()` → `update_dispute()` |
| `woocommerce-payments/accept-dispute` | `destructive`, non-idempotent | `DisputeService::accept()` → `close_dispute()` |
| `woocommerce-payments/upload-dispute-evidence-file` | non-destructive, non-idempotent | `FileService` → `WC_Payments_API_Client::upload_evidence_file_contents()` |

\* `refund-charge` is idempotent only when the caller supplies a stable `idempotency_key` (see below).

**Read abilities** — `mcp.public: true`, consistent with the shipped reads:

| Ability | Backed by |
|---|---|
| `woocommerce-payments/get-balance` | `GET /reports/balance` |
| `woocommerce-payments/get-fraud-outcomes` | `GET /transactions/fraud-outcomes` (paginated) |
| `woocommerce-payments/get-fees-summary` | `GET /reports/fees/summary` |

**Supporting changes:**
- New `RefundService`, `DisputeService`, and `FileService` (`src/Internal/Service/`), registered in `PaymentsServiceProvider`. Writes call these so agent refunds run the charge-bound path (no order-note/notification fan-out) and dispute writes share the exact api-client methods the REST controllers use (no drift).
- Caller-supplied **idempotency key**: `Refund_Charge::set_idempotency_key()` + `WC_Payments_API_Client::request()` now lifts a caller `idempotency_key` into the `Idempotency-Key` header and strips it from the request body. Backward compatible — absent key auto-generates a UUID as before, and retry behavior is unchanged.
- New **file-upload path**: `WC_Payments_API_Client::upload_evidence_file_contents()` is extracted from the multipart `upload_file()` (which now delegates to it), so the agent upload path and the dispute-evidence UI share one Files API call. The `upload-dispute-evidence-file` ability takes base64 contents, restricts MIME types to pdf/png/jpeg (matching the UI's accept list), and caps decoded size at the UI's 4.5 MB dispute-evidence limit.
- The `submit-dispute-evidence` `evidence` schema now carries a per-field description and is split into free-text vs document (file-ID) fields.

#### How can this code break? What prevents it?
- These writes move money / concede disputes. Mitigations: every ability gates on `manage_woocommerce` (framework-enforced before `execute()`); writes are `mcp.public: false`; required-ID validation runs at the schema layer **and** in `execute()`; `accept-dispute` is irreversible, so a consumer's policy layer should require explicit operator approval. An independent security review of the original write/read surface found no exploitable issues (permission gating, MCP exposure, input validation, idempotency blast radius, data exposure, Shape-3 all verified).
- The new file-upload ability is non-destructive (creates a Stripe file, moves no money), `mcp.public: false`, MIME-restricted (pdf/png/jpeg), and size-capped (4.5 MB); base64 input is validated before anything is sent upstream.
- The idempotency change touches the shared `request()` method — covered by a new test (caller key used + stripped from body) and a backward-compat test (UUID still generated when the key is absent).

#### Testing instructions
- `npm run test:php -- --filter 'Abilities|RefundService|DisputeService|FileService|Refund_Charge|WC_Payments_API_Client_Test'` → all green (213 tests, 840 assertions).
- To exercise at runtime, enable the flag (`add_filter('woocommerce_payments_abilities_enabled', '__return_true')`) on a WC ≥ 10.9 site with a connected account.
- An integration harness (annotation audit, **readonly-but-writes gate: PASS**, write input-validation smoke — writes reject empty input) was captured during development of the original surface. The new `upload-dispute-evidence-file` ability adds unit coverage for its input validation (missing fields, non-base64, oversize, unsupported MIME type).

*

#### Notes for reviewers
- **Namespace**: kept `woocommerce-payments/*` (consistent with #11705; `woocommerce/*` is Core-reserved). The partner aliases their `woopayments/*` names at their own registry layer.
- **`refund-charge` `idempotent: true`** holds only when the caller passes a stable `idempotency_key`; this is documented in the ability description. Without one, the platform auto-generates a key and a duplicate call creates a second refund.
- **`DisputeService` calls the API client directly** (no typed Request class exists for dispute writes) — a deliberate, documented exception to the "use typed Request classes" guidance; it shares the same `update_dispute()`/`close_dispute()` methods the REST controller already calls, so there is no logic drift.
- **File-upload input**: the ability accepts base64 contents because the agent/JSON surface has no multipart upload; it shares the Files API call with the dispute-evidence UI via `upload_evidence_file_contents()`, so there is no drift. Document evidence fields take the resulting file `id`.
- **Deliberately deferred (unchanged)**: other audit writes (capture/cancel authorization, manual deposit, settings, ToS, terminal, etc.) stay out of scope; `refunds-list`/`refunds-get`, `risk-rules-list`, and a `customer-get`-with-stats have no REST backing and are not included.

-------------------

- [x] Run `npm run changelog` to add a changelog file — 4 entries added (3 minor, 1 patch).
- [x] Covered with tests (per-ability shape + error-path tests, service tests, idempotency tests).
- [x] Tested on mobile (or does not apply) — N/A (backend / agent surface, no UI).

**Post merge**

- [ ] QA Testing Not Applicable — feature is behind a default-off flag and is an agent/REST surface with no UI.


