### PR TITLE
Split admin onboarding task imports

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -15,7 +15,7 @@ import 'wp-mediaelement';
  * Internal dependencies
  */
 import './style.scss';
-import { getTasks } from 'overview/task-list/tasks';
+import getAdminOnboardingTasks from 'overview/task-list/admin-tasks';
 import { maybeAddReportsPage } from 'reports/page-config';
 
 const lazyRoute = ( importer ) => {
@@ -316,7 +316,7 @@ addFilter(
 	( tasks ) => {
 		const { showUpdateDetailsTask, wpcomReconnectUrl } = wcpaySettings;
 
-		const wcPayTasks = getTasks( {
+		const wcPayTasks = getAdminOnboardingTasks( {
 			showUpdateDetailsTask: showUpdateDetailsTask,
 			wpcomReconnectUrl: wpcomReconnectUrl,
 			showGoLiveTask: true,

--- a/client/overview/task-list/admin-tasks.tsx
+++ b/client/overview/task-list/admin-tasks.tsx
@@ -1,0 +1,77 @@
+/** @format **/
+
+/**
+ * Internal dependencies.
+ */
+import getReconnectWpcomTask from './tasks/reconnect-task';
+import getUpdateBusinessDetailsTask from './tasks/update-business-details-task';
+import { TaskItemProps } from './types';
+import getGoLiveTask from './tasks/go-live-task';
+
+// Requirements we don't want to show to the user because they are too generic/not useful. These refer to Stripe error codes.
+const requirementBlacklist = [ 'invalid_value_other' ];
+
+interface AdminTaskListProps {
+	showUpdateDetailsTask: boolean;
+	wpcomReconnectUrl: string;
+	showGoLiveTask: boolean;
+}
+
+const getAdminOnboardingTasks = ( {
+	showUpdateDetailsTask,
+	wpcomReconnectUrl,
+	showGoLiveTask = false,
+}: AdminTaskListProps ): TaskItemProps[] => {
+	const {
+		status,
+		currentDeadline,
+		pastDue,
+		accountLink,
+		requirements,
+		detailsSubmitted,
+	} = wcpaySettings.accountStatus;
+
+	// Filter out requirements that we don't want to show to the user.
+	const requirementErrors = requirements?.errors?.filter(
+		( error ) => ! requirementBlacklist.includes( error.code )
+	);
+
+	const tasks: TaskItemProps[] = [];
+
+	if ( showUpdateDetailsTask ) {
+		const updateBusinessDetailsTask = getUpdateBusinessDetailsTask(
+			requirementErrors ?? [],
+			status ?? '',
+			accountLink ?? '',
+			Number( currentDeadline ) ?? null,
+			pastDue ?? false,
+			detailsSubmitted ?? true
+		);
+
+		if ( updateBusinessDetailsTask ) {
+			tasks.push( updateBusinessDetailsTask );
+		}
+	}
+
+	if ( wpcomReconnectUrl ) {
+		const reconnectTask = getReconnectWpcomTask( wpcomReconnectUrl );
+		if ( reconnectTask ) {
+			tasks.push( reconnectTask );
+		}
+	}
+
+	if (
+		showGoLiveTask &&
+		wcpaySettings.isAccountConnected &&
+		wcpaySettings?.testModeOnboarding
+	) {
+		const goLiveTask = getGoLiveTask();
+		if ( goLiveTask ) {
+			tasks.push( goLiveTask );
+		}
+	}
+
+	return tasks;
+};
+
+export default getAdminOnboardingTasks;

--- a/client/overview/task-list/tasks.tsx
+++ b/client/overview/task-list/tasks.tsx
@@ -7,17 +7,18 @@
 /**
  * Internal dependencies.
  */
-import strings from './strings';
 import {
 	getDisputeResolutionTask,
 	getDisputesDueWithinDays,
 } from './tasks/dispute-task';
-import { getReconnectWpcomTask } from './tasks/reconnect-task';
-import { getUpdateBusinessDetailsTask } from './tasks/update-business-details-task';
+import getReconnectWpcomTask from './tasks/reconnect-task';
+import getUpdateBusinessDetailsTask from './tasks/update-business-details-task';
 import { CachedDispute } from 'wcpay/types/disputes';
 import { TaskItemProps } from './types';
-import { getGoLiveTask } from './tasks/go-live-task';
-import { isInTestModeOnboarding } from 'wcpay/utils';
+import getGoLiveTask from './tasks/go-live-task';
+
+const isInTestModeOnboarding = ( fallback = false ): boolean =>
+	!! wcpaySettings?.testModeOnboarding || fallback;
 
 // Requirements we don't want to show to the user because they are too generic/not useful. These refer to Stripe error codes.
 const requirementBlacklist = [ 'invalid_value_other' ];
@@ -44,27 +45,10 @@ export const getTasks = ( {
 		detailsSubmitted,
 	} = wcpaySettings.accountStatus;
 
-	const getErrorMessagesFromRequirements = (): any => {
-		// strings.errors contains a mixture of strings and React elements built using createInterpolateElement.
-		const errors = strings.errors as {
-			[ key: string ]: string | React.ReactElement;
-		};
-
-		// Filter out requirements that we don't want to show to the user.
-		const filteredErrors = requirements?.errors?.filter(
-			( error ) => ! requirementBlacklist.includes( error.code )
-		);
-
-		// Map the error codes to the error messages.
-		const errorMessages = filteredErrors?.map(
-			( error ) => errors[ error.code ] || error.reason
-		);
-
-		// Remove duplicates.
-		return Array.from( new Set( errorMessages || [] ) );
-	};
-
-	const errorMessages = getErrorMessagesFromRequirements();
+	// Filter out requirements that we don't want to show to the user.
+	const requirementErrors = requirements?.errors?.filter(
+		( error ) => ! requirementBlacklist.includes( error.code )
+	);
 
 	const isUpdateDetailsTaskVisible = showUpdateDetailsTask;
 
@@ -81,7 +65,7 @@ export const getTasks = ( {
 	return [
 		isUpdateDetailsTaskVisible &&
 			getUpdateBusinessDetailsTask(
-				errorMessages,
+				requirementErrors ?? [],
 				status ?? '',
 				accountLink ?? '',
 				Number( currentDeadline ) ?? null,

--- a/client/overview/task-list/tasks/dispute-task.tsx
+++ b/client/overview/task-list/tasks/dispute-task.tsx
@@ -4,17 +4,136 @@
 import { __, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
 import { getHistory } from '@woocommerce/navigation';
+import { addQueryArgs } from '@wordpress/url';
+import Currency from '@woocommerce/currency';
 
 /**
  * Internal dependencies
  */
 import type { TaskItemProps } from '../types';
 import type { CachedDispute } from 'wcpay/types/disputes';
-import { formatCurrency } from 'multi-currency/interface/functions';
-import { getAdminUrl } from 'wcpay/utils';
-import { recordEvent } from 'tracks';
-import { isDueWithin } from 'wcpay/disputes/utils';
 import { formatDateTimeFromString } from 'wcpay/utils/date-time';
+import { recordTaskEvent } from './record-task-event';
+
+type CurrencySettings = typeof wcpaySettings & {
+	currencyData?: Record< string, any >;
+	zeroDecimalCurrencies?: string[];
+};
+
+const getAdminUrl = ( args: Record< string, string > ): string =>
+	addQueryArgs( 'admin.php', args );
+
+const htmlDecode = ( input: string ): string =>
+	new DOMParser().parseFromString( input, 'text/html' ).documentElement
+		.textContent ?? input;
+
+const getCurrencySettings = (): CurrencySettings =>
+	wcpaySettings as CurrencySettings;
+
+const getCurrency = ( currencyCode: string ) => {
+	const settings = getCurrencySettings();
+	const currencyData = settings.currencyData || {};
+	const country = settings.connect?.country || 'US';
+	const currency = Object.values( currencyData ).find(
+		( entry: any ) => entry?.code === currencyCode.toUpperCase()
+	);
+
+	if ( ! currency ) {
+		return null;
+	}
+
+	const baseCurrency = currencyData[ country ];
+
+	return Currency(
+		baseCurrency
+			? {
+					...( currency as Record< string, unknown > ),
+					decimalSeparator: baseCurrency.decimalSeparator,
+					thousandSeparator: baseCurrency.thousandSeparator,
+					symbolPosition: baseCurrency.symbolPosition,
+			  }
+			: currency
+	);
+};
+
+const composeFallbackCurrency = (
+	amount: number,
+	currencyCode: string,
+	isZeroDecimal: boolean
+): string => {
+	try {
+		return amount.toLocaleString( undefined, {
+			style: 'currency',
+			currency: currencyCode,
+			currencyDisplay: 'narrowSymbol',
+		} );
+	} catch ( error ) {
+		return isZeroDecimal
+			? `${ currencyCode.toUpperCase() } ${ Math.round( amount ) }`
+			: `${ currencyCode.toUpperCase() } ${ amount.toFixed( 2 ) }`;
+	}
+};
+
+const formatCurrency = ( amount: number, currencyCode = 'USD' ): string => {
+	const settings = getCurrencySettings();
+	const isZeroDecimal = !! settings.zeroDecimalCurrencies?.includes(
+		currencyCode.toLowerCase()
+	);
+	const normalizedAmount = isZeroDecimal ? amount : amount / 100;
+	const isNegative = normalizedAmount < 0;
+	const positiveAmount = Math.abs( normalizedAmount );
+	const prefix = isNegative ? '-' : '';
+	const currency = getCurrency( currencyCode );
+
+	if ( currency === null ) {
+		return (
+			prefix +
+			composeFallbackCurrency(
+				positiveAmount,
+				currencyCode,
+				isZeroDecimal
+			)
+		);
+	}
+
+	try {
+		return prefix + htmlDecode( currency.formatAmount( positiveAmount ) );
+	} catch ( error ) {
+		return (
+			prefix +
+			htmlDecode(
+				composeFallbackCurrency(
+					positiveAmount,
+					currencyCode,
+					isZeroDecimal
+				)
+			)
+		);
+	}
+};
+
+const isDueWithin = ( {
+	dueBy,
+	days,
+}: {
+	dueBy: CachedDispute[ 'due_by' ];
+	days: number;
+} ): boolean => {
+	if ( ! dueBy ) {
+		return false;
+	}
+
+	const dueByMoment = moment.utc( dueBy, true );
+
+	if ( ! dueByMoment.isValid() ) {
+		return false;
+	}
+
+	const now = moment().utc();
+	const isWithinDays = dueByMoment.diff( now, 'days', true ) <= days;
+	const isPastDue = now.isAfter( dueByMoment );
+	return isWithinDays && ! isPastDue;
+};
 
 /**
  * Returns an array of disputes that are due within the specified number of days.
@@ -50,7 +169,7 @@ export const getDisputeResolutionTask = (
 	}
 
 	const handleClick = () => {
-		recordEvent( 'wcpay_overview_task_click', {
+		recordTaskEvent( 'wcpay_overview_task_click', {
 			task: 'dispute-resolution-task',
 			active_dispute_count: activeDisputeCount,
 		} );

--- a/client/overview/task-list/tasks/go-live-modal-loader.js
+++ b/client/overview/task-list/tasks/go-live-modal-loader.js
@@ -1,0 +1,9 @@
+/** @format **/
+
+export const renderSetupLivePaymentsModal = async () => {
+	const { renderSetupLivePaymentsModal: renderModal } = await import(
+		'./go-live-modal-renderer'
+	);
+
+	renderModal();
+};

--- a/client/overview/task-list/tasks/go-live-modal-renderer.js
+++ b/client/overview/task-list/tasks/go-live-modal-renderer.js
@@ -1,0 +1,29 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+export const renderSetupLivePaymentsModal = async () => {
+	const { default: SetupLivePaymentsModal } = await import(
+		'wcpay/components/sandbox-mode-switch-to-live-notice/modal'
+	);
+	const container = document.createElement( 'div' );
+	container.id = 'wcpay-golivemodal-container';
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	const closeModal = () => {
+		root.unmount();
+		container.remove();
+	};
+
+	root.render(
+		React.createElement( SetupLivePaymentsModal, {
+			from: 'WCPAY_GO_LIVE_TASK',
+			source: 'wcpay-go-live-task',
+			onClose: closeModal,
+		} )
+	);
+};

--- a/client/overview/task-list/tasks/go-live-task-action-loader.js
+++ b/client/overview/task-list/tasks/go-live-task-action-loader.js
@@ -1,0 +1,5 @@
+/** @format **/
+
+export const runGoLiveTaskAction = async () => {
+	( await import( './go-live-task-action' ) ).default();
+};

--- a/client/overview/task-list/tasks/go-live-task-action.js
+++ b/client/overview/task-list/tasks/go-live-task-action.js
@@ -1,0 +1,18 @@
+/** @format **/
+
+/**
+ * Internal dependencies
+ */
+import { renderSetupLivePaymentsModal } from './go-live-modal-loader';
+import { recordTaskEvent } from './record-task-event';
+
+const runGoLiveTaskAction = () => {
+	recordTaskEvent( 'wcpay_overview_task_click', {
+		task: 'go-live',
+		source: 'wcpay-go-live-task',
+	} );
+
+	renderSetupLivePaymentsModal();
+};
+
+export default runGoLiveTaskAction;

--- a/client/overview/task-list/tasks/go-live-task.tsx
+++ b/client/overview/task-list/tasks/go-live-task.tsx
@@ -1,51 +1,25 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
-import { createRoot } from 'react-dom/client';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { TaskItemProps } from '../types';
-import strings from '../strings';
-import SetupLivePaymentsModal from 'wcpay/components/sandbox-mode-switch-to-live-notice/modal';
-import { recordEvent } from 'wcpay/tracks';
+import { runGoLiveTaskAction } from './go-live-task-action-loader';
 
-const SetupLivePaymentsModalWrapper: React.FC = () => {
-	const [ modalVisible, setModalVisible ] = useState( true );
-
-	return modalVisible ? (
-		<SetupLivePaymentsModal
-			from="WCPAY_GO_LIVE_TASK"
-			source="wcpay-go-live-task"
-			onClose={ () => setModalVisible( false ) }
-		/>
-	) : (
-		<></>
-	);
-};
-
-export const getGoLiveTask = (): TaskItemProps | null => {
+const getGoLiveTask = (): TaskItemProps | null => {
 	const handleClick = () => {
-		recordEvent( 'wcpay_overview_task_click', {
-			task: 'go-live',
-			source: 'wcpay-go-live-task',
-		} );
-
-		const container = document.createElement( 'div' );
-		container.id = 'wcpay-golivemodal-container';
-		document.body.appendChild( container );
-		const root = createRoot( container );
-		root.render( <SetupLivePaymentsModalWrapper /> );
+		runGoLiveTaskAction();
 	};
 
 	return {
 		key: 'go-live-payments',
 		level: 3,
 		content: '',
-		title: strings.tasks.go_live.title,
-		time: strings.tasks.go_live.time,
+		title: __( 'Activate payments', 'woocommerce-payments' ),
+		time: __( '10 minutes', 'woocommerce-payments' ),
 		completed: false,
 		onClick: handleClick,
 		action: handleClick,
@@ -53,3 +27,5 @@ export const getGoLiveTask = (): TaskItemProps | null => {
 		showActionButton: false,
 	};
 };
+
+export default getGoLiveTask;

--- a/client/overview/task-list/tasks/lazy-update-business-details-task-description.js
+++ b/client/overview/task-list/tasks/lazy-update-business-details-task-description.js
@@ -1,0 +1,21 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { createElement, lazy, Suspense } from '@wordpress/element';
+
+const UpdateBusinessDetailsTaskDescription = lazy( () =>
+	import( './update-business-details-task-description' )
+);
+
+export const LazyUpdateBusinessDetailsTaskDescription = ( props ) =>
+	createElement(
+		Suspense,
+		{
+			fallback: props.updateByDescription
+				? `${ props.error.reason } ${ props.updateByDescription }`
+				: props.error.reason,
+		},
+		createElement( UpdateBusinessDetailsTaskDescription, props )
+	);

--- a/client/overview/task-list/tasks/reconnect-task-action-loader.js
+++ b/client/overview/task-list/tasks/reconnect-task-action-loader.js
@@ -1,0 +1,5 @@
+/** @format **/
+
+export const runReconnectWpcomTaskAction = async ( wpcomReconnectUrl ) => {
+	( await import( './reconnect-task-action' ) ).default( wpcomReconnectUrl );
+};

--- a/client/overview/task-list/tasks/reconnect-task-action.js
+++ b/client/overview/task-list/tasks/reconnect-task-action.js
@@ -1,0 +1,25 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { recordTaskEvent } from './record-task-event';
+
+const runReconnectWpcomTaskAction = ( wpcomReconnectUrl ) => {
+	recordTaskEvent( 'wcpay_overview_task_click', {
+		task: 'reconnect-wpcom',
+		source: 'wcpay-reconnect-wpcom-task',
+	} );
+
+	window.location.href = addQueryArgs( wpcomReconnectUrl, {
+		from: 'WCPAY_OVERVIEW',
+		source: 'wcpay-reconnect-wpcom-user-task',
+	} );
+};
+
+export default runReconnectWpcomTaskAction;

--- a/client/overview/task-list/tasks/reconnect-task.tsx
+++ b/client/overview/task-list/tasks/reconnect-task.tsx
@@ -7,22 +7,13 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { TaskItemProps } from '../types';
-import { recordEvent } from 'wcpay/tracks';
-import { addQueryArgs } from '@wordpress/url';
+import { runReconnectWpcomTaskAction } from './reconnect-task-action-loader';
 
-export const getReconnectWpcomTask = (
+const getReconnectWpcomTask = (
 	wpcomReconnectUrl: string
 ): TaskItemProps | null => {
 	const handleClick = () => {
-		recordEvent( 'wcpay_overview_task_click', {
-			task: 'reconnect-wpcom',
-			source: 'wcpay-reconnect-wpcom-task',
-		} );
-
-		window.location.href = addQueryArgs( wpcomReconnectUrl, {
-			from: 'WCPAY_OVERVIEW',
-			source: 'wcpay-reconnect-wpcom-user-task',
-		} );
+		runReconnectWpcomTaskAction( wpcomReconnectUrl );
 	};
 
 	return {
@@ -51,3 +42,5 @@ export const getReconnectWpcomTask = (
 		showActionButton: true,
 	};
 };
+
+export default getReconnectWpcomTask;

--- a/client/overview/task-list/tasks/record-task-event.ts
+++ b/client/overview/task-list/tasks/record-task-event.ts
@@ -1,0 +1,25 @@
+/** @format **/
+
+export const recordTaskEvent = (
+	eventName: string,
+	eventProperties: Record< string, unknown > = {}
+): void => {
+	if ( window.wcpaySettings ) {
+		Object.assign( eventProperties, {
+			is_test_mode: wcpaySettings.testMode,
+			jetpack_connected: wcpaySettings.isJetpackConnected,
+			wcpay_version: wcpaySettings.version,
+			woo_country_code: wcpaySettings.connect.country,
+			hosting_provider: wcpaySettings.trackingInfo?.hosting_provider,
+		} );
+
+		for ( const key in eventProperties ) {
+			if ( eventProperties[ key ] === undefined ) {
+				delete eventProperties[ key ];
+			}
+		}
+	}
+
+	const recordFunction = wc?.tracks?.recordEvent ?? wcTracks.recordEvent;
+	recordFunction( eventName, eventProperties );
+};

--- a/client/overview/task-list/tasks/update-business-details-modal-loader.js
+++ b/client/overview/task-list/tasks/update-business-details-modal-loader.js
@@ -1,0 +1,9 @@
+/** @format **/
+
+export const renderUpdateBusinessDetailsModal = async ( props ) => {
+	const { renderUpdateBusinessDetailsModal: renderModal } = await import(
+		'./update-business-details-modal-renderer'
+	);
+
+	renderModal( props );
+};

--- a/client/overview/task-list/tasks/update-business-details-modal-renderer.js
+++ b/client/overview/task-list/tasks/update-business-details-modal-renderer.js
@@ -1,0 +1,42 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from '@wordpress/element';
+
+import { loadRequirementErrorMessages } from './update-business-details-task-description';
+
+export const renderUpdateBusinessDetailsModal = async ( {
+	requirementErrors,
+	status,
+	accountLink,
+	currentDeadline,
+} ) => {
+	const [ { default: UpdateBusinessDetailsModal }, errorMessages ] =
+		await Promise.all( [
+			import( 'wcpay/overview/modal/update-business-details' ),
+			loadRequirementErrorMessages( requirementErrors ),
+		] );
+	let container = document.querySelector(
+		'#wcpay-update-business-details-container'
+	);
+
+	if ( ! container ) {
+		container = document.createElement( 'div' );
+		container.id = 'wcpay-update-business-details-container';
+		document.body.appendChild( container );
+	}
+
+	render(
+		React.createElement( UpdateBusinessDetailsModal, {
+			key: Date.now(),
+			errorMessages,
+			accountStatus: status,
+			accountLink,
+			currentDeadline,
+		} ),
+		container
+	);
+};

--- a/client/overview/task-list/tasks/update-business-details-task-action-loader.js
+++ b/client/overview/task-list/tasks/update-business-details-task-action-loader.js
@@ -1,0 +1,7 @@
+/** @format **/
+
+export const runUpdateBusinessDetailsTaskAction = async ( props ) => {
+	( await import( './update-business-details-task-action' ) ).default(
+		props
+	);
+};

--- a/client/overview/task-list/tasks/update-business-details-task-action.js
+++ b/client/overview/task-list/tasks/update-business-details-task-action.js
@@ -1,0 +1,66 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { renderUpdateBusinessDetailsModal } from './update-business-details-modal-loader';
+import { recordTaskEvent } from './record-task-event';
+
+const getAdminUrl = ( args ) => addQueryArgs( 'admin.php', args );
+
+const runUpdateBusinessDetailsTaskAction = ( {
+	status,
+	hasMultipleErrors,
+	detailsSubmitted,
+	accountLink,
+	requirementErrors,
+	currentDeadline,
+} ) => {
+	if ( status === 'complete' || status === 'enabled' ) {
+		return;
+	}
+
+	if ( hasMultipleErrors ) {
+		renderUpdateBusinessDetailsModal( {
+			requirementErrors,
+			status,
+			accountLink,
+			currentDeadline,
+		} );
+		return;
+	}
+
+	let source = 'wcpay-update-business-details-task';
+	if ( ! detailsSubmitted ) {
+		source = 'wcpay-finish-setup-task';
+	}
+	recordTaskEvent( 'wcpay_account_details_link_clicked', {
+		source,
+	} );
+
+	// If the onboarding isn't complete redirect to the NOX onboarding page.
+	if ( ! detailsSubmitted ) {
+		window.location.href = getAdminUrl( {
+			page: 'wc-settings',
+			tab: 'checkout',
+			path: '/woopayments/onboarding',
+			source: 'wcpay-finish-setup-task',
+			from: 'WCPAY_OVERVIEW',
+		} );
+	} else {
+		window.open(
+			addQueryArgs( accountLink, {
+				from: 'WCPAY_OVERVIEW',
+				source: 'wcpay-update-business-details-task',
+			} ),
+			'_blank'
+		);
+	}
+};
+
+export default runUpdateBusinessDetailsTaskAction;

--- a/client/overview/task-list/tasks/update-business-details-task-description.js
+++ b/client/overview/task-list/tasks/update-business-details-task-description.js
@@ -1,0 +1,51 @@
+/** @format **/
+
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+
+const loadErrorMessage = async ( error ) => {
+	const { default: strings } = await import( '../strings' );
+
+	return strings.errors[ error.code ] || error.reason;
+};
+
+export const loadRequirementErrorMessages = async ( requirementErrors ) => {
+	const messages = await Promise.all(
+		requirementErrors.map( ( error ) => loadErrorMessage( error ) )
+	);
+
+	return Array.from( new Set( messages ) );
+};
+
+const UpdateBusinessDetailsTaskDescription = ( {
+	error,
+	updateByDescription,
+} ) => {
+	const [ message, setMessage ] = useState( error.reason );
+
+	useEffect( () => {
+		let isMounted = true;
+
+		loadErrorMessage( error ).then( ( loadedMessage ) => {
+			if ( isMounted ) {
+				setMessage( loadedMessage );
+			}
+		} );
+
+		return () => {
+			isMounted = false;
+		};
+	}, [ error ] );
+
+	return React.createElement(
+		React.Fragment,
+		null,
+		message,
+		updateByDescription ? ` ${ updateByDescription }` : null
+	);
+};
+
+export { UpdateBusinessDetailsTaskDescription };
+export default UpdateBusinessDetailsTaskDescription;

--- a/client/overview/task-list/tasks/update-business-details-task.tsx
+++ b/client/overview/task-list/tasks/update-business-details-task.tsx
@@ -1,22 +1,25 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import type { ReactElement } from 'react';
+import { createElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { render } from '@wordpress/element';
-import { addQueryArgs } from '@wordpress/url';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
 import type { TaskItemProps } from '../types';
-import UpdateBusinessDetailsModal from 'wcpay/overview/modal/update-business-details';
-import { recordEvent } from 'wcpay/tracks';
-import { formatDateTimeFromTimestamp } from 'wcpay/utils/date-time';
-import { getAdminUrl } from 'utils';
+import { LazyUpdateBusinessDetailsTaskDescription } from './lazy-update-business-details-task-description';
+import { runUpdateBusinessDetailsTaskAction } from './update-business-details-task-action-loader';
 
-export const getUpdateBusinessDetailsTask = (
-	errorMessages: string[],
+interface RequirementError {
+	code: string;
+	reason: string;
+}
+
+const getUpdateBusinessDetailsTask = (
+	requirementErrors: RequirementError[],
 	status: string,
 	accountLink: string,
 	currentDeadline: number | null,
@@ -25,17 +28,9 @@ export const getUpdateBusinessDetailsTask = (
 ): TaskItemProps | null => {
 	const accountRestrictedSoon = status === 'restricted_soon';
 	const accountDetailsPastDue = status === 'restricted' && pastDue;
-	const hasMultipleErrors = errorMessages.length > 1;
-	const hasSingleError = errorMessages.length === 1;
-	const accountLinkWithSource = accountLink
-		? addQueryArgs( accountLink, {
-				from: 'WCPAY_OVERVIEW',
-				source: 'wcpay-update-business-details-task',
-		  } )
-		: '';
-
-	let accountDetailsTaskDescription: React.ReactElement | string = '',
-		errorMessageDescription,
+	const hasMultipleErrors = requirementErrors.length > 1;
+	const hasSingleError = requirementErrors.length === 1;
+	let accountDetailsTaskDescription: ReactElement | string = '',
 		accountDetailsUpdateByDescription;
 
 	if ( accountRestrictedSoon && currentDeadline ) {
@@ -45,25 +40,31 @@ export const getUpdateBusinessDetailsTask = (
 				'Update by %s to avoid a disruption in payouts.',
 				'woocommerce-payments'
 			),
-			formatDateTimeFromTimestamp( currentDeadline, {
-				customFormat: 'ga M j, Y',
-			} )
+			dateI18n(
+				'ga M j, Y',
+				new Date( currentDeadline * 1000 ).toISOString()
+			)
 		);
 
 		if ( hasSingleError ) {
-			errorMessageDescription = errorMessages[ 0 ];
-			accountDetailsTaskDescription = (
-				<>
-					{ errorMessageDescription }{ ' ' }
-					{ accountDetailsUpdateByDescription }
-				</>
+			accountDetailsTaskDescription = createElement(
+				LazyUpdateBusinessDetailsTaskDescription,
+				{
+					error: requirementErrors[ 0 ],
+					updateByDescription: accountDetailsUpdateByDescription,
+				}
 			);
 		} else {
 			accountDetailsTaskDescription = accountDetailsUpdateByDescription;
 		}
 	} else if ( accountDetailsPastDue ) {
 		if ( hasSingleError ) {
-			accountDetailsTaskDescription = errorMessages[ 0 ];
+			accountDetailsTaskDescription = createElement(
+				LazyUpdateBusinessDetailsTaskDescription,
+				{
+					error: requirementErrors[ 0 ],
+				}
+			);
 		} else if ( ! detailsSubmitted ) {
 			accountDetailsTaskDescription =
 				/* translators: <a> - dashboard login URL */
@@ -81,58 +82,15 @@ export const getUpdateBusinessDetailsTask = (
 		}
 	}
 
-	const renderModal = () => {
-		let container = document.querySelector(
-			'#wcpay-update-business-details-container'
-		);
-
-		if ( ! container ) {
-			container = document.createElement( 'div' );
-			container.id = 'wcpay-update-business-details-container';
-			document.body.appendChild( container );
-		}
-
-		render(
-			<UpdateBusinessDetailsModal
-				key={ Date.now() }
-				errorMessages={ errorMessages }
-				accountStatus={ status }
-				accountLink={ accountLink }
-				currentDeadline={ currentDeadline }
-			/>,
-			container
-		);
-	};
-
 	const handleClick = () => {
-		if ( status === 'complete' || status === 'enabled' ) {
-			return;
-		}
-
-		if ( hasMultipleErrors ) {
-			renderModal();
-		} else {
-			let source = 'wcpay-update-business-details-task';
-			if ( ! detailsSubmitted ) {
-				source = 'wcpay-finish-setup-task';
-			}
-			recordEvent( 'wcpay_account_details_link_clicked', {
-				source,
-			} );
-
-			// If the onboarding isn't complete redirect to the NOX onboarding page.
-			if ( ! detailsSubmitted ) {
-				window.location.href = getAdminUrl( {
-					page: 'wc-settings',
-					tab: 'checkout',
-					path: '/woopayments/onboarding',
-					source: 'wcpay-finish-setup-task',
-					from: 'WCPAY_OVERVIEW',
-				} );
-			} else {
-				window.open( accountLinkWithSource, '_blank' );
-			}
-		}
+		runUpdateBusinessDetailsTaskAction( {
+			status,
+			hasMultipleErrors,
+			detailsSubmitted,
+			accountLink,
+			requirementErrors,
+			currentDeadline,
+		} );
 	};
 
 	let actionLabel;
@@ -169,3 +127,5 @@ export const getUpdateBusinessDetailsTask = (
 		showActionButton: true,
 	};
 };
+
+export default getUpdateBusinessDetailsTask;


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

This is a follow-up draft split out from the admin initial bundle autoresearch work for separate evaluation.

It focuses on the more maintainability-sensitive part of the optimization: reducing what the admin entrypoint imports for WooCommerce Admin onboarding task registration.

Summary:
- Adds a lightweight `overview/task-list/admin-tasks` adapter for the WooCommerce Admin task filter.
- Keeps the full overview task list/dispute task path in the lazy-loaded overview route.
- Defers task-only strings, modals, and click-action code behind async loaders.
- Narrows a few task helper imports that were pulling broader modules into the initial admin bundle.

Reason this is separate:
- This area has a larger maintainability/readability tradeoff than the route-lazy-loading work.
- It creates more files and async boundaries around task behavior.
- We should review whether the initial bundle win is worth the extra split before merging.

#### Testing instructions

* Apply on top of the admin initial bundle draft PR branch.
* Run `NODE_ENV=production npm run build:client`.
* Run `npm run lint:js`.
* Run `npm run test:js -- client/overview/task-list/__tests__/tasks.test.js --runInBand`.
* Recommended manual smoke: verify WooPayments overview onboarding tasks still render and that reconnect/go-live/update-business actions and modals work when visible.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (targeted task-list JS tests run during autoresearch)
- [x] Tested on mobile (does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
