### PR TITLE
[RSM] Emphasize the no-evidence catch-all in the Outcome View card

### DIFF
--- a/changelog/feat-no-evidence-catch-all
+++ b/changelog/feat-no-evidence-catch-all
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Dispute Outcome View: bump the no-evidence catch-all recommendation to the top of "What could help next time" and give it a "Critical" badge.

--- a/client/components/dispute-step-item/index.tsx
+++ b/client/components/dispute-step-item/index.tsx
@@ -33,6 +33,8 @@ interface Props {
 	titleAs?: 'div' | 'h3' | 'h4' | 'h5' | 'h6';
 	/** SR-only severity prefix; the icon is aria-hidden. */
 	titleSrPrefix?: string;
+	/** Inline node rendered after the title within the heading (e.g. a badge). */
+	titleBadge?: React.ReactNode;
 }
 
 /**
@@ -49,6 +51,7 @@ const DisputeStepItem: React.FC< Props > = ( {
 	as: Tag = 'div',
 	titleAs: TitleTag = 'div',
 	titleSrPrefix,
+	titleBadge,
 } ) => {
 	return (
 		<Tag className={ clsx( 'dispute-step-item', className ) }>
@@ -61,6 +64,7 @@ const DisputeStepItem: React.FC< Props > = ( {
 						<VisuallyHidden>{ titleSrPrefix + ' ' }</VisuallyHidden>
 					) }
 					{ title }
+					{ titleBadge }
 				</TitleTag>
 				<div className="dispute-step-item__description">
 					{ description }

--- a/client/payment-details/dispute-recommendations/__tests__/index.test.tsx
+++ b/client/payment-details/dispute-recommendations/__tests__/index.test.tsx
@@ -464,6 +464,78 @@ describe( 'DisputeRecommendationsCard', () => {
 		} );
 	} );
 
+	describe( 'no-evidence catch-all emphasis', () => {
+		// Lucy's design (Figma 3879:36436): when no evidence was submitted, the
+		// catch-all critical is bumped to the top of the coaching section and
+		// carries a "Critical" badge, while the surviving tips stay below it.
+		// Fixture mirrors the reviewed screenshot (lost + fraudulent + physical,
+		// no evidence): c15 fires plus the c8b shipping-date tip.
+		const noEvidenceFraudPhysical = () =>
+			buildDispute( {
+				status: 'lost',
+				reason: 'fraudulent',
+				metadata: { __product_type: 'physical_product' },
+				evidence: {},
+			} );
+
+		it( 'bumps the catch-all critical above the surviving tips', async () => {
+			render(
+				<DisputeRecommendationsCard
+					dispute={ noEvidenceFraudPhysical() }
+				/>
+			);
+
+			await expandSection( /what could help next time/i );
+
+			// DOM order across inline + show-more articles reflects the sort.
+			const headings = screen
+				.getAllByRole( 'article' )
+				.map(
+					( item ) =>
+						within( item ).getByRole( 'heading' ).textContent ?? ''
+				);
+			const catchAllIndex = headings.findIndex( ( h ) =>
+				/submit evidence with your dispute response/i.test( h )
+			);
+			const shippingTipIndex = headings.findIndex( ( h ) =>
+				/document the shipping date/i.test( h )
+			);
+
+			// c15 has no lift and is the last catalog cluster, so it sorts to
+			// the bottom without the bump; the tip is what it must clear.
+			expect( catchAllIndex ).toBe( 0 );
+			expect( shippingTipIndex ).toBeGreaterThan( catchAllIndex );
+		} );
+
+		it( 'badges the catch-all critical and leaves tips unbadged', async () => {
+			render(
+				<DisputeRecommendationsCard
+					dispute={ noEvidenceFraudPhysical() }
+				/>
+			);
+
+			await expandSection( /what could help next time/i );
+
+			const catchAll = screen
+				.getByRole( 'heading', {
+					name: /submit evidence with your dispute response/i,
+				} )
+				.closest( 'article' ) as HTMLElement;
+			const badge = within( catchAll ).getByText( 'Critical' );
+			expect( badge ).toBeInTheDocument();
+			expect( badge ).toHaveClass( 'chip', 'chip-warning' );
+
+			const tip = screen
+				.getByRole( 'heading', {
+					name: /document the shipping date/i,
+				} )
+				.closest( 'article' ) as HTMLElement;
+			expect(
+				within( tip ).queryByText( 'Critical' )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'link rendering', () => {
 		// Per RiskOps review: per-rec action links were removed in favor of a
 		// single "Learn more" link next to the "What could help next time"

--- a/client/payment-details/dispute-recommendations/index.tsx
+++ b/client/payment-details/dispute-recommendations/index.tsx
@@ -12,6 +12,7 @@ import { Icon, caution, published } from '@wordpress/icons';
  * Internal dependencies
  */
 import { Accordion, AccordionBody } from 'wcpay/components/accordion';
+import Chip from 'wcpay/components/chip';
 import DisputeStepItem from 'wcpay/components/dispute-step-item';
 import type { ChargeDispute } from 'wcpay/types/charges';
 import type {
@@ -60,6 +61,19 @@ const sortByLift = ( a: Recommendation, b: Recommendation ): number => {
 	return b.lift - a.lift;
 };
 
+// The no-evidence catch-all (the `suppressOtherCriticals` entry) is the
+// dominant message, so pin it above lift-ranked entries; it carries no lift
+// of its own and would otherwise sink to the bottom (Lucy design 2026-06-03).
+const sortRecommendations = (
+	a: Recommendation,
+	b: Recommendation
+): number => {
+	const pinned =
+		Number( !! b.suppressOtherCriticals ) -
+		Number( !! a.suppressOtherCriticals );
+	return pinned !== 0 ? pinned : sortByLift( a, b );
+};
+
 // SR-only severity qualifier; the icon is aria-hidden, so sighted-only cues
 // need a textual equivalent.
 const urgencyLabel = ( urgency: RecommendationUrgency ): string => {
@@ -77,27 +91,42 @@ const urgencyLabel = ( urgency: RecommendationUrgency ): string => {
 	}
 };
 
-const renderItem = ( rec: Recommendation ): JSX.Element => (
-	// Reuses the shared row from "Steps you can take". Urgency BEM hooks on
-	// the root drive the icon tint via style.scss; the shared component
-	// stays urgency-agnostic.
-	<DisputeStepItem
-		key={ rec.id }
-		as="article"
-		// h3 keeps the outline monotonic under the card's h2 title.
-		titleAs="h3"
-		className={ `dispute-recommendations__item dispute-recommendations__item--${ rec.urgency }` }
-		icon={
-			<Icon
-				icon={ rec.urgency === 'positive' ? published : caution }
-				size={ 24 }
-			/>
-		}
-		titleSrPrefix={ urgencyLabel( rec.urgency ) }
-		title={ rec.title }
-		description={ rec.body }
-	/>
-);
+const renderItem = ( rec: Recommendation ): JSX.Element => {
+	// The no-evidence catch-all gets a visible "Critical" badge that doubles as
+	// its severity cue, so drop the SR-only prefix to avoid announcing it twice.
+	const isCatchAll = !! rec.suppressOtherCriticals;
+	return (
+		// Reuses the shared row from "Steps you can take". Urgency BEM hooks on
+		// the root drive the icon tint via style.scss; the shared component
+		// stays urgency-agnostic.
+		<DisputeStepItem
+			key={ rec.id }
+			as="article"
+			// h3 keeps the outline monotonic under the card's h2 title.
+			titleAs="h3"
+			className={ `dispute-recommendations__item dispute-recommendations__item--${ rec.urgency }` }
+			icon={
+				<Icon
+					icon={ rec.urgency === 'positive' ? published : caution }
+					size={ 24 }
+				/>
+			}
+			titleSrPrefix={
+				isCatchAll ? undefined : urgencyLabel( rec.urgency )
+			}
+			title={ rec.title }
+			titleBadge={
+				isCatchAll ? (
+					<Chip
+						message={ __( 'Critical', 'woocommerce-payments' ) }
+						type="warning"
+					/>
+				) : undefined
+			}
+			description={ rec.body }
+		/>
+	);
+};
 
 // Both cards route their description through `subtitleNode` so the closed
 // state stays consistent: using `subtitle` for one and `subtitleNode` for
@@ -112,7 +141,7 @@ const renderCard = (
 		return null;
 	}
 
-	const sorted = [ ...items ].sort( sortByLift );
+	const sorted = [ ...items ].sort( sortRecommendations );
 	const visible = sorted.slice( 0, VISIBLE_PER_SECTION );
 	const hidden = sorted.slice( VISIBLE_PER_SECTION );
 

--- a/client/payment-details/dispute-recommendations/style.scss
+++ b/client/payment-details/dispute-recommendations/style.scss
@@ -71,6 +71,17 @@
 		border: none;
 	}
 
+	// The no-evidence catch-all renders a "Critical" badge after its title.
+	// Lay the heading out inline so the badge sits beside the text and wraps
+	// gracefully on narrow widths. Scoped here so the shared "Steps you can
+	// take" rows keep their plain block heading.
+	.dispute-step-item__name {
+		display: inline-flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: $grid-unit-10;
+	}
+
 	&--positive .dispute-step-item__icon svg {
 		color: $alert-green;
 	}


### PR DESCRIPTION
Follow-up enhancement to #11703 (the Outcome View recommendations card, now merged into `develop`).

#### Changes proposed in this Pull Request

Implements Lucy's design call (2026-06-03, [Figma 3879:36436](https://www.figma.com/design/MFTBqaIP0YmS1luyVWmZfW/Disputes-on-Woo-25-?node-id=3879-36436)) for the no-evidence case in the Dispute Outcome View "What could help next time" card:

- Bumps the no-evidence catch-all ("Submit evidence with your dispute response") to the top of the card. It carries no win-rate lift, so it previously sorted to the bottom, below softer tips.
- Adds an amber "Critical" badge beside its title.
- Drops the redundant screen-reader "Important:" prefix for that one item, since the visible badge now carries the severity cue (announced once instead of twice).

Surviving tips still render below the catch-all (Lucy's design keeps them: no tip suppression).

Scoped narrowly to the catch-all via the existing `suppressOtherCriticals` matcher flag (only c15 today), so the other eight critical recommendations and the evidence-submitted flows are untouched.

Why the existing `Chip` and not a `Badge` component:
- `@wordpress/ui` (the package referenced in the design thread) is not a current dependency.
- The `Badge` in our shipped `@wordpress/components@29.5.4` is locked behind `privateApis`, so it is not importable without `unlock()`.
- The existing `Chip` (`type="warning"`) renders the same amber pill with no new dependency, consistent with reusing existing components.

Questions for PR author:
- How can this break? The badge and bump key off the existing `suppressOtherCriticals` flag plus a new optional `titleBadge` slot on the shared `DisputeStepItem`.
- What keeps it from breaking? New unit tests cover ordering (catch-all first) and badge presence (on the catch-all) and absence (on tips). `titleBadge` is optional, so existing "Steps you can take" rows are unchanged (snapshots unchanged).

#### Testing instructions

The card is behind the `isDisputeOutcomeViewEnabled` feature flag.

1. Enable `isDisputeOutcomeViewEnabled`.
2. Open a lost dispute where the merchant submitted no evidence (force a lost status via dev-tools and leave evidence empty).
3. Expand "What could help next time".
4. Confirm "Submit evidence with your dispute response" is the first item and shows a "Critical" badge; any tips below it have no badge.
5. Narrow the viewport and confirm the badge wraps cleanly under the title.

*

-------------------

- [x] Run `npm run changelog` to add a changelog file (added: `changelog/feat-no-evidence-catch-all`).
- [x] Covered with tests (ordering + badge presence/absence).
- [ ] Tested on mobile (badge uses `flex-wrap`; please verify on narrow widths).
