### PR TITLE
fix(e2e): stop the Save changes button click from hanging when disabled

### DIFF
--- a/changelog/fix-e2e-save-settings-button-enabled
+++ b/changelog/fix-e2e-save-settings-button-enabled
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: E2E test tooling only, not end client facing.

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -74,12 +74,19 @@ const expectSnackbarWithText = async (
 
 export const saveWooPaymentsSettings = async ( page: Page ) => {
 	await ensureSupportPhoneIsFilled( page );
-	await page.getByRole( 'button', { name: 'Save changes' } ).click();
+	// The Save button is disabled until settings finish loading and a change is
+	// pending; clicking it while disabled blocks until the test timeout, so wait
+	// for it to be enabled first.
+	const saveButton = page.getByRole( 'button', { name: 'Save changes' } );
+	await expect( saveButton ).toBeEnabled();
+	await saveButton.click();
 	await expectSnackbarWithText( page, 'Settings saved.' );
 };
 
 export const saveMultiCurrencySettings = async ( page: Page ) => {
-	await page.getByRole( 'button', { name: 'Save changes' } ).click();
+	const saveButton = page.getByRole( 'button', { name: 'Save changes' } );
+	await expect( saveButton ).toBeEnabled();
+	await saveButton.click();
 	await expectSnackbarWithText( page, 'Currency settings updated.' );
 };
 
@@ -105,8 +112,15 @@ export const activateMulticurrency = async ( page: Page ) => {
 
 export const deactivateMulticurrency = async ( page: Page ) => {
 	await navigation.goToWooPaymentsSettings( page );
-	await page.getByTestId( 'multi-currency-toggle' ).uncheck();
-	await saveWooPaymentsSettings( page );
+
+	// Only toggle + save when it is actually enabled; unchecking an already-off
+	// toggle is a no-op that leaves nothing to save (the Save button stays
+	// disabled). Mirrors the activate* guards.
+	const multiCurrencyToggle = page.getByTestId( 'multi-currency-toggle' );
+	if ( await multiCurrencyToggle.isChecked() ) {
+		await multiCurrencyToggle.uncheck();
+		await saveWooPaymentsSettings( page );
+	}
 };
 
 export const addMulticurrencyWidget = async (
@@ -421,8 +435,12 @@ export const activateWooPay = async ( page: Page ) => {
 
 export const deactivateWooPay = async ( page: Page ) => {
 	await navigation.goToWooPaymentsSettings( page );
-	await page.getByTestId( 'woopay-toggle' ).uncheck();
-	await saveWooPaymentsSettings( page );
+
+	const woopayToggle = page.getByTestId( 'woopay-toggle' );
+	if ( await woopayToggle.isChecked() ) {
+		await woopayToggle.uncheck();
+		await saveWooPaymentsSettings( page );
+	}
 };
 
 export const ensureBlockSettingsPanelIsOpen = async ( page: Page ) => {
@@ -465,6 +483,10 @@ export const activateCaptureLater = async ( page: Page ) => {
 
 export const deactivateCaptureLater = async ( page: Page ) => {
 	await navigation.goToWooPaymentsSettings( page );
-	await page.getByTestId( 'capture-later-checkbox' ).uncheck();
-	await saveWooPaymentsSettings( page );
+
+	const captureLaterCheckbox = page.getByTestId( 'capture-later-checkbox' );
+	if ( await captureLaterCheckbox.isChecked() ) {
+		await captureLaterCheckbox.uncheck();
+		await saveWooPaymentsSettings( page );
+	}
 };


### PR DESCRIPTION
Part of the `#wcpay-e2e-tests` flaky-test triage (sibling follow-up to #11763).

#### Changes proposed in this Pull Request

The WooPayments settings "Save changes" button is disabled until settings finish loading and a change is pending (`disabled={ isSaving || isLoading || disabled || ! isDirty }` in `client/settings/save-settings-section/index.js`). Two E2E helper patterns clicked it without that precondition, so under CI timing Playwright's click auto-wait blocked on a disabled button for the full 120s test timeout. This is the live flaky failure on the wcpay-shopper cell (the `Save changes` hang at `merchant.ts:77`, currently recovering on retry).

- **Wait for the button to be enabled** before clicking, in `saveWooPaymentsSettings` and `saveMultiCurrencySettings`. A not-yet-dirty or still-loading button now fails fast with a clear `expected enabled` error instead of hanging.
- **Guard the deactivate helpers** (`deactivateMulticurrency`, `deactivateWooPay`, `deactivateCaptureLater`) so they only toggle + save when the feature is actually enabled. Unchecking an already-off toggle was a no-op that left nothing to save, so the Save button stayed disabled forever (a guaranteed 120s hang). This mirrors the existing `activate*` guards.

This is **E2E test tooling only** — no product code change. The disabled-until-dirty button is correct product behavior.

How can this break? It touches shared settings-save helpers used across many specs (payment methods, multi-currency, WooPay, capture-later). The wait-for-enabled is a strict improvement over an unbounded click; the deactivate guards mirror the proven `activate*` pattern.

#### Testing instructions

- The wcpay-shopper and subscriptions E2E cells exercise these helpers via payment-method, multi-currency, WooPay, and capture-later setup/teardown. CI E2E coverage applies.
- No new test: the existing specs exercise the helpers; the fix is a timing/precondition hardening (and we are avoiding test-induced helper API surface).

*

-------------------

- [x] Run `npm run changelog` to add a changelog file (dev/comment entry included)
- [x] Covered with tests (existing specs exercise these helpers)
- [x] Tested on mobile (or does not apply) - E2E tooling, does not apply

**Post merge**

- [ ] QA Testing Not Applicable
