### PR TITLE
feat: show refund reason in timeline view

### DIFF
--- a/changelog/feat-add-refund-reason-to-timeline-view
+++ b/changelog/feat-add-refund-reason-to-timeline-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+feat: show refund reason in timeline view.

--- a/client/payment-details/timeline/__tests__/__snapshots__/index.test.js.snap
+++ b/client/payment-details/timeline/__tests__/__snapshots__/index.test.js.snap
@@ -472,6 +472,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                   >
                     <span />
                     <span />
+                    <span />
                   </div>
                 </li>
               </ul>
@@ -606,6 +607,7 @@ exports[`PaymentDetailsTimeline renders correctly (with a mocked Timeline compon
                   <div
                     class="woocommerce-timeline-item__body"
                   >
+                    <span />
                     <span />
                     <span />
                   </div>

--- a/client/payment-details/timeline/__tests__/__snapshots__/map-events.test.js.snap
+++ b/client/payment-details/timeline/__tests__/__snapshots__/map-events.test.js.snap
@@ -366,6 +366,7 @@ exports[`mapTimelineEvents Multi-Currency events formats full_refund events 1`] 
     "body": [
       "1,00 EUR → 1,20222 USD: 21,64 $ USD",
       "",
+      "",
     ],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "A payment of 18,00 € EUR was successfully refunded.",
@@ -400,6 +401,7 @@ exports[`mapTimelineEvents Multi-Currency events formats partial_refund events 1
     "body": [
       "1,00 EUR → 1,2 USD: 6,00 $ USD",
       "Acquirer Reference Number (ARN) 4785767637658864",
+      "",
     ],
     "date": 2020-04-03T18:58:01.000Z,
     "headline": "A payment of 5,00 € EUR was successfully refunded.",
@@ -1187,6 +1189,7 @@ exports[`mapTimelineEvents single currency events formats full_refund events 1`]
     "body": [
       undefined,
       "Acquirer Reference Number (ARN) 4785767637658864",
+      "",
     ],
     "date": 2020-04-04T13:51:06.000Z,
     "headline": "A payment of $100.00 USD was successfully refunded.",
@@ -1220,6 +1223,7 @@ exports[`mapTimelineEvents single currency events formats partial_refund events 
   {
     "body": [
       undefined,
+      "",
       "",
     ],
     "date": 2020-04-03T18:58:01.000Z,

--- a/client/payment-details/timeline/__tests__/map-events.test.js
+++ b/client/payment-details/timeline/__tests__/map-events.test.js
@@ -392,6 +392,59 @@ describe( 'mapTimelineEvents', () => {
 			).toMatchSnapshot();
 		} );
 
+		test( 'renders a free-text refund reason when present', () => {
+			const [ , , mainItem ] = mapTimelineEvents( [
+				{
+					amount_refunded: 5000,
+					currency: 'USD',
+					datetime: 1585940281,
+					deposit: null,
+					type: 'partial_refund',
+					reason: 'Customer changed their mind',
+				},
+			] );
+
+			expect( mainItem.body ).toContain(
+				'Reason: Customer changed their mind'
+			);
+		} );
+
+		test( 'humanizes Stripe refund reason enums', () => {
+			const [ , , mainItem ] = mapTimelineEvents( [
+				{
+					amount_refunded: 5000,
+					currency: 'USD',
+					datetime: 1585940281,
+					deposit: null,
+					type: 'partial_refund',
+					reason: 'requested_by_customer',
+				},
+			] );
+
+			expect( mainItem.body ).toContain(
+				'Reason: Requested by customer'
+			);
+		} );
+
+		test( 'omits the refund reason line when none was captured', () => {
+			const [ , , mainItem ] = mapTimelineEvents( [
+				{
+					amount_refunded: 5000,
+					currency: 'USD',
+					datetime: 1585940281,
+					deposit: null,
+					type: 'partial_refund',
+				},
+			] );
+
+			expect(
+				mainItem.body.some(
+					( line ) =>
+						typeof line === 'string' && line.includes( 'Reason:' )
+				)
+			).toBe( false );
+		} );
+
 		test( 'formats dispute_won events', () => {
 			expect(
 				mapTimelineEvents( [

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -464,7 +464,6 @@ const refundReasonLabels = {
 	),
 };
 
-// Conditionally adds the refund reason to the timeline when one was captured.
 const getRefundReason = ( event ) => {
 	if ( ! event.reason ) {
 		return '';

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -453,6 +453,30 @@ export const composeFXString = ( event ) => {
 	);
 };
 
+// Human-readable labels for Stripe's fixed refund reason enum. Free-text
+// merchant reasons fall through and are shown as entered.
+const refundReasonLabels = {
+	duplicate: __( 'Duplicate', 'woocommerce-payments' ),
+	fraudulent: __( 'Fraudulent', 'woocommerce-payments' ),
+	requested_by_customer: __(
+		'Requested by customer',
+		'woocommerce-payments'
+	),
+};
+
+// Conditionally adds the refund reason to the timeline when one was captured.
+const getRefundReason = ( event ) => {
+	if ( ! event.reason ) {
+		return '';
+	}
+	const reason = refundReasonLabels[ event.reason ] ?? event.reason;
+	return sprintf(
+		/* translators: %s is the reason the refund was issued */
+		__( 'Reason: %s', 'woocommerce-payments' ),
+		reason
+	);
+};
+
 // Conditionally adds the ARN details to the timeline in case they're available.
 const getRefundTrackingDetails = ( event ) => {
 	return event.acquirer_reference_number_status === 'available'
@@ -903,6 +927,7 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 					[
 						composeFXString( event ),
 						getRefundTrackingDetails( event ),
+						getRefundReason( event ),
 					]
 				),
 			];

--- a/includes/admin/class-wc-rest-payments-refunds-controller.php
+++ b/includes/admin/class-wc-rest-payments-refunds-controller.php
@@ -108,14 +108,7 @@ class WC_REST_Payments_Refunds_Controller extends WC_Payments_REST_Controller {
 		$refund_request = Refund_Charge::create( $charge_id );
 		$refund_request->set_charge( $charge_id );
 		$refund_request->set_amount( $amount );
-		// These are reasons supported by Stripe https://stripe.com/docs/api/refunds/create#create_refund-reason.
-		if ( in_array( $reason, [ 'duplicate', 'fraudulent', 'requested_by_customer' ], true ) ) {
-			$refund_request->set_reason( $reason );
-		}
-		// Capture the reason as metadata too, so it surfaces in the payment timeline (matches process_refund()).
-		if ( ! empty( $reason ) ) {
-			$refund_request->set_merchant_reason( $reason );
-		}
+		$refund_request->set_full_reason( $reason );
 		$refund_request->set_source( 'transaction_details_no_order' );
 		return $refund_request->send();
 	}

--- a/includes/admin/class-wc-rest-payments-refunds-controller.php
+++ b/includes/admin/class-wc-rest-payments-refunds-controller.php
@@ -108,7 +108,14 @@ class WC_REST_Payments_Refunds_Controller extends WC_Payments_REST_Controller {
 		$refund_request = Refund_Charge::create( $charge_id );
 		$refund_request->set_charge( $charge_id );
 		$refund_request->set_amount( $amount );
-		$refund_request->set_reason( $reason );
+		// These are reasons supported by Stripe https://stripe.com/docs/api/refunds/create#create_refund-reason.
+		if ( in_array( $reason, [ 'duplicate', 'fraudulent', 'requested_by_customer' ], true ) ) {
+			$refund_request->set_reason( $reason );
+		}
+		// Capture the reason as metadata too, so it surfaces in the payment timeline (matches process_refund()).
+		if ( ! empty( $reason ) ) {
+			$refund_request->set_merchant_reason( $reason );
+		}
 		$refund_request->set_source( 'transaction_details_no_order' );
 		return $refund_request->send();
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2686,6 +2686,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				if ( in_array( $reason, [ 'duplicate', 'fraudulent', 'requested_by_customer' ], true ) ) {
 					$refund_request->set_reason( $reason );
 				}
+				// Stripe's `reason` only accepts the enum above, so the merchant's free-text reason rides along as
+				// metadata. That way it survives to the payment timeline instead of living only in the order note.
+				if ( ! empty( $reason ) ) {
+					$refund_request->set_merchant_reason( $reason );
+				}
 				$refund = $refund_request->send();
 			}
 			$currency = strtoupper( $refund['currency'] );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2682,15 +2682,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				if ( null !== $amount ) {
 					$refund_request->set_amount( WC_Payments_Utils::prepare_amount( $amount, $order->get_currency() ) );
 				}
-				// These are reasons supported by Stripe https://stripe.com/docs/api/refunds/create#create_refund-reason.
-				if ( in_array( $reason, [ 'duplicate', 'fraudulent', 'requested_by_customer' ], true ) ) {
-					$refund_request->set_reason( $reason );
-				}
-				// Stripe's `reason` only accepts the enum above, so the merchant's free-text reason rides along as
-				// metadata. That way it survives to the payment timeline instead of living only in the order note.
-				if ( ! empty( $reason ) ) {
-					$refund_request->set_merchant_reason( $reason );
-				}
+				$refund_request->set_full_reason( $reason );
 				$refund = $refund_request->send();
 			}
 			$currency = strtoupper( $refund['currency'] );

--- a/includes/core/server/request/class-refund-charge.php
+++ b/includes/core/server/request/class-refund-charge.php
@@ -87,6 +87,26 @@ class Refund_Charge extends Request {
 	}
 
 	/**
+	 * Stores the merchant-provided refund reason as metadata.
+	 *
+	 * Stripe's `reason` field only accepts a fixed enum, so any free-text reason
+	 * the merchant typed has to travel as metadata to survive the round trip and
+	 * show up in the payment timeline.
+	 *
+	 * @param string $reason The free-text reason the merchant entered.
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_merchant_reason( string $reason ) {
+		$this->set_param(
+			'metadata',
+			array_merge(
+				$this->get_params()['metadata'] ?? [],
+				[ 'merchant_refund_reason' => $reason ]
+			)
+		);
+	}
+
+	/**
 	 * Returns the request's API.
 	 *
 	 * @return string

--- a/includes/core/server/request/class-refund-charge.php
+++ b/includes/core/server/request/class-refund-charge.php
@@ -87,31 +87,11 @@ class Refund_Charge extends Request {
 	}
 
 	/**
-	 * Stores the merchant-provided refund reason as metadata.
-	 *
-	 * Stripe's `reason` field only accepts a fixed enum, so any free-text reason
-	 * the merchant typed has to travel as metadata to survive the round trip and
-	 * show up in the payment timeline.
-	 *
-	 * @param string $reason The free-text reason the merchant entered.
-	 * @throws Invalid_Request_Parameter_Exception
-	 */
-	public function set_merchant_reason( string $reason ) {
-		$this->set_param(
-			'metadata',
-			array_merge(
-				$this->get_params()['metadata'] ?? [],
-				[ 'merchant_refund_reason' => $reason ]
-			)
-		);
-	}
-
-	/**
 	 * Captures a refund reason coming from the merchant.
 	 *
 	 * Stripe's `reason` only accepts a fixed enum, so a matching value is forwarded
-	 * there, while any reason (including free text) is also stored as metadata so it
-	 * survives to the payment timeline.
+	 * there. Any reason (including free text) is also stored as `merchant_refund_reason`
+	 * metadata so it survives the round trip and shows up in the payment timeline.
 	 *
 	 * @param string|null $reason The reason the merchant provided, enum or free text.
 	 * @throws Invalid_Request_Parameter_Exception
@@ -122,7 +102,13 @@ class Refund_Charge extends Request {
 			$this->set_reason( $reason );
 		}
 		if ( null !== $reason && '' !== $reason ) {
-			$this->set_merchant_reason( $reason );
+			$this->set_param(
+				'metadata',
+				array_merge(
+					$this->get_params()['metadata'] ?? [],
+					[ 'merchant_refund_reason' => $reason ]
+				)
+			);
 		}
 	}
 

--- a/includes/core/server/request/class-refund-charge.php
+++ b/includes/core/server/request/class-refund-charge.php
@@ -107,6 +107,26 @@ class Refund_Charge extends Request {
 	}
 
 	/**
+	 * Captures a refund reason coming from the merchant.
+	 *
+	 * Stripe's `reason` only accepts a fixed enum, so a matching value is forwarded
+	 * there, while any reason (including free text) is also stored as metadata so it
+	 * survives to the payment timeline.
+	 *
+	 * @param string|null $reason The reason the merchant provided, enum or free text.
+	 * @throws Invalid_Request_Parameter_Exception
+	 */
+	public function set_full_reason( ?string $reason ) {
+		// These are reasons supported by Stripe https://stripe.com/docs/api/refunds/create#create_refund-reason.
+		if ( in_array( $reason, [ 'duplicate', 'fraudulent', 'requested_by_customer' ], true ) ) {
+			$this->set_reason( $reason );
+		}
+		if ( null !== $reason && '' !== $reason ) {
+			$this->set_merchant_reason( $reason );
+		}
+	}
+
+	/**
 	 * Returns the request's API.
 	 *
 	 * @return string

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -110,6 +110,8 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		'company',
 		'customer_name',
 		'customer_email',
+		// Free-text refund reason can contain merchant-entered PII, so keep it out of logs.
+		'merchant_refund_reason',
 	];
 
 	const EVENT_AUTHORIZED            = 'authorized';

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.ts
@@ -125,6 +125,10 @@ test.describe( 'WooCommerce Payments - Full Refund', () => {
 			merchantPage.getByText( 'Payment status changed to Refunded.' )
 		).toBeVisible();
 
+		await expect(
+			merchantPage.getByText( 'Reason: No longer wanted' )
+		).toBeVisible();
+
 		// TODO: This visual regression test is not flaky, but we should revisit the approach.
 		// await expect( merchantPage ).toHaveScreenshot();
 	} );

--- a/tests/unit/admin/test-class-wc-rest-payments-refunds-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-refunds-controller.php
@@ -58,6 +58,48 @@ class WC_REST_Payments_Refunds_Controller_Test extends WCPAY_UnitTestCase {
 		$refund_request->expects( $this->once() )
 			->method( 'set_reason' )
 			->with( 'duplicate' );
+		$refund_request->expects( $this->once() )
+			->method( 'set_merchant_reason' )
+			->with( 'duplicate' );
+		$refund_response = [
+			'id' => 're_test',
+		];
+		$refund_request->expects( $this->once() )
+			->method( 'format_response' )
+			->with()
+			->willReturn( $refund_response );
+
+		$response = $this->controller->process_refund( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $refund_response, $response->get_data() );
+	}
+
+	public function test_process_refund_without_order_id_or_reason(): void {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params(
+			[
+				'order_id'  => null,
+				'charge_id' => 'ch_test',
+				'amount'    => 5000,
+				'reason'    => null,
+			]
+		);
+
+		$refund_request = $this->mock_wcpay_request( Refund_Charge::class );
+
+		$refund_request->expects( $this->once() )
+			->method( 'set_charge' )
+			->with( 'ch_test' );
+		$refund_request->expects( $this->once() )
+			->method( 'set_amount' )
+			->with( 5000 );
+
+		// With no reason there is nothing to send to Stripe or to store as metadata.
+		$refund_request->expects( $this->never() )
+			->method( 'set_reason' );
+		$refund_request->expects( $this->never() )
+			->method( 'set_merchant_reason' );
+
 		$refund_response = [
 			'id' => 're_test',
 		];

--- a/tests/unit/admin/test-class-wc-rest-payments-refunds-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-refunds-controller.php
@@ -56,10 +56,7 @@ class WC_REST_Payments_Refunds_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'set_amount' )
 			->with( 5000 );
 		$refund_request->expects( $this->once() )
-			->method( 'set_reason' )
-			->with( 'duplicate' );
-		$refund_request->expects( $this->once() )
-			->method( 'set_merchant_reason' )
+			->method( 'set_full_reason' )
 			->with( 'duplicate' );
 		$refund_response = [
 			'id' => 're_test',
@@ -94,11 +91,10 @@ class WC_REST_Payments_Refunds_Controller_Test extends WCPAY_UnitTestCase {
 			->method( 'set_amount' )
 			->with( 5000 );
 
-		// With no reason there is nothing to send to Stripe or to store as metadata.
-		$refund_request->expects( $this->never() )
-			->method( 'set_reason' );
-		$refund_request->expects( $this->never() )
-			->method( 'set_merchant_reason' );
+		// The gating lives in Refund_Charge::set_full_reason(); the controller just delegates.
+		$refund_request->expects( $this->once() )
+			->method( 'set_full_reason' )
+			->with( null );
 
 		$refund_response = [
 			'id' => 're_test',

--- a/tests/unit/core/server/request/test-class-core-refund-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-refund-charge-request.php
@@ -77,4 +77,24 @@ class Refund_Charge_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $amount, $params['amount'] );
 		$this->assertSame( $charge, $params['charge'] );
 	}
+
+	public function test_merchant_reason_is_stored_as_metadata() {
+		$request = new Refund_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_charge( 'ch_mock' );
+		$request->set_merchant_reason( 'Customer changed their mind' );
+
+		$params = $request->get_params();
+		$this->assertSame( 'Customer changed their mind', $params['metadata']['merchant_refund_reason'] );
+	}
+
+	public function test_merchant_reason_preserves_existing_metadata() {
+		$request = new Refund_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_charge( 'ch_mock' );
+		$request->set_source( 'edit_order' );
+		$request->set_merchant_reason( 'Customer changed their mind' );
+
+		$params = $request->get_params();
+		$this->assertSame( 'edit_order', $params['metadata']['refund_source'] );
+		$this->assertSame( 'Customer changed their mind', $params['metadata']['merchant_refund_reason'] );
+	}
 }

--- a/tests/unit/core/server/request/test-class-core-refund-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-refund-charge-request.php
@@ -97,4 +97,34 @@ class Refund_Charge_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'edit_order', $params['metadata']['refund_source'] );
 		$this->assertSame( 'Customer changed their mind', $params['metadata']['merchant_refund_reason'] );
 	}
+
+	public function test_full_reason_with_stripe_enum_sets_both_reason_and_metadata() {
+		$request = new Refund_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_charge( 'ch_mock' );
+		$request->set_full_reason( 'duplicate' );
+
+		$params = $request->get_params();
+		$this->assertSame( 'duplicate', $params['reason'] );
+		$this->assertSame( 'duplicate', $params['metadata']['merchant_refund_reason'] );
+	}
+
+	public function test_full_reason_with_free_text_only_sets_metadata() {
+		$request = new Refund_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_charge( 'ch_mock' );
+		$request->set_full_reason( 'Customer changed their mind' );
+
+		$params = $request->get_params();
+		$this->assertNull( $params['reason'] );
+		$this->assertSame( 'Customer changed their mind', $params['metadata']['merchant_refund_reason'] );
+	}
+
+	public function test_full_reason_with_empty_reason_sets_nothing() {
+		$request = new Refund_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$request->set_charge( 'ch_mock' );
+		$request->set_full_reason( null );
+
+		$params = $request->get_params();
+		$this->assertNull( $params['reason'] );
+		$this->assertArrayNotHasKey( 'metadata', $params );
+	}
 }

--- a/tests/unit/core/server/request/test-class-core-refund-charge-request.php
+++ b/tests/unit/core/server/request/test-class-core-refund-charge-request.php
@@ -78,20 +78,11 @@ class Refund_Charge_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $charge, $params['charge'] );
 	}
 
-	public function test_merchant_reason_is_stored_as_metadata() {
-		$request = new Refund_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
-		$request->set_charge( 'ch_mock' );
-		$request->set_merchant_reason( 'Customer changed their mind' );
-
-		$params = $request->get_params();
-		$this->assertSame( 'Customer changed their mind', $params['metadata']['merchant_refund_reason'] );
-	}
-
-	public function test_merchant_reason_preserves_existing_metadata() {
+	public function test_full_reason_preserves_existing_metadata() {
 		$request = new Refund_Charge( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$request->set_charge( 'ch_mock' );
 		$request->set_source( 'edit_order' );
-		$request->set_merchant_reason( 'Customer changed their mind' );
+		$request->set_full_reason( 'Customer changed their mind' );
 
 		$params = $request->get_params();
 		$this->assertSame( 'edit_order', $params['metadata']['refund_source'] );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -401,6 +401,14 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 			->method( 'set_charge' )
 			->with( $charge_id );
 
+		// Free-text reasons aren't valid Stripe enum values, so they travel as metadata.
+		$request->expects( $this->never() )
+			->method( 'set_reason' );
+
+		$request->expects( $this->once() )
+			->method( 'set_merchant_reason' )
+			->with( $reason );
+
 		$request->expects( $this->once() )
 			->method( 'format_response' )
 			->willReturn( $response );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -401,12 +401,8 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 			->method( 'set_charge' )
 			->with( $charge_id );
 
-		// Free-text reasons aren't valid Stripe enum values, so they travel as metadata.
-		$request->expects( $this->never() )
-			->method( 'set_reason' );
-
 		$request->expects( $this->once() )
-			->method( 'set_merchant_reason' )
+			->method( 'set_full_reason' )
 			->with( $reason );
 
 		$request->expects( $this->once() )


### PR DESCRIPTION
Fixes #753

#### Changes proposed in this Pull Request

Show the refund reason in the payment timeline. The reason a merchant enters when issuing a refund used to only land in an order note, so it never made it to the timeline.

Stripe's `reason` field only accepts a fixed enum (`duplicate`, `fraudulent`, `requested_by_customer`), so the free-text reason now rides along as refund metadata (`merchant_refund_reason`). The timeline prefers that metadata and falls back to the Stripe enum when that's the one that's set. Both refund entry points capture it: the order's Refund button and the order-less "Refund transaction" action.

Heads up for review: the order-less path used to pass the reason straight to Stripe's enum-only `reason` field. It now goes through the same enum guard as the gateway path, so a free-text reason only travels as metadata there too. Small but real behavior change for that path.

~This needs a companion change in the server to include the reason in the timeline payload~ change has been deployed.

#### Testing instructions

1. Open a WooPayments order and issue a refund (a partial one is fine), entering a reason in the refund form.
2. Go to Payments > Transactions and open that transaction's details.
3. In the Timeline, the refund event should show a `Reason: <your reason>` line.
<img width="489" height="129" alt="Screenshot 2026-06-04 at 10 19 01 PM" src="https://github.com/user-attachments/assets/4e9401ff-dfa1-4905-952e-cb920ab366d8" />

Worth a second pass on the order-less path too: from a transaction with no order, use the "Refund transaction" action and confirm the reason shows up in the timeline the same way.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
