### PR TITLE
test(e2e): scope Action Scheduler Run locator to first match

### DIFF
--- a/changelog/qit-subscriptions-state-reset
+++ b/changelog/qit-subscriptions-state-reset
@@ -1,4 +1,5 @@
 Significance: patch
 Type: dev
+Comment: Test-only change to the QIT E2E subscriptions suite (Playwright locator scoping); no production code is affected.
 
-Scope the Action Scheduler "Run" locator to the first match in the QIT subscriptions renew test to avoid a strict-mode failure when more than one scheduled payment is pending
+

--- a/changelog/qit-subscriptions-state-reset
+++ b/changelog/qit-subscriptions-state-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Scope the Action Scheduler "Run" locator to the first match in the QIT subscriptions renew test to avoid a strict-mode failure when more than one scheduled payment is pending

--- a/tests/qit/test-package/tests/woopayments/subscriptions/merchant-subscriptions-renew-action-scheduler.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/subscriptions/merchant-subscriptions-renew-action-scheduler.spec.ts
@@ -58,8 +58,11 @@ test.describe(
 			// The pending-actions list can contain more than one "Run" link; scope to
 			// the first so the click is deterministic instead of throwing a strict-mode
 			// violation when an extra scheduled payment is queued.
-			await adminPage.getByRole( 'link', { name: 'Run' } ).first().focus();
-			await adminPage.getByRole( 'link', { name: 'Run' } ).first().click();
+			const runAction = adminPage
+				.getByRole( 'link', { name: 'Run' } )
+				.first();
+			await runAction.focus();
+			await runAction.click();
 
 			await expect(
 				adminPage.getByText( actionSchedulerHook, { exact: true } )

--- a/tests/qit/test-package/tests/woopayments/subscriptions/merchant-subscriptions-renew-action-scheduler.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/subscriptions/merchant-subscriptions-renew-action-scheduler.spec.ts
@@ -55,8 +55,11 @@ test.describe(
 				} )
 				.click();
 
-			await adminPage.getByRole( 'link', { name: 'Run' } ).focus();
-			await adminPage.getByRole( 'link', { name: 'Run' } ).click();
+			// The pending-actions list can contain more than one "Run" link; scope to
+			// the first so the click is deterministic instead of throwing a strict-mode
+			// violation when an extra scheduled payment is queued.
+			await adminPage.getByRole( 'link', { name: 'Run' } ).first().focus();
+			await adminPage.getByRole( 'link', { name: 'Run' } ).first().click();
 
 			await expect(
 				adminPage.getByText( actionSchedulerHook, { exact: true } )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The QIT subscriptions renew test clicked the Action Scheduler "Run" link with `getByRole('link', { name: 'Run' })`, which throws a Playwright strict-mode violation when more than one `woocommerce_scheduled_subscription_payment` action is pending (the failure on `subscriptions | WC 10.8.0-beta.2`). Scope the locator to `.first()` so the click is deterministic. Test-only, no state manipulation.

#### Testing instructions

Confirm the QIT E2E `subscriptions` slots pass. Validated with a develop-vs-branch A/B: subscriptions clean 3/3 on the branch.

* Test-only change (QIT E2E).
