### PR TITLE
fix(e2e): bound WCB Stripe Payment Element wait to avoid 120s hangs

### DIFF
--- a/changelog/fix-e2e-wcb-checkout-payment-element-timeout
+++ b/changelog/fix-e2e-wcb-checkout-payment-element-timeout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: E2E test reliability only (WCB checkout helper bound), not end client facing.
+
+

--- a/tests/e2e/utils/shopper.ts
+++ b/tests/e2e/utils/shopper.ts
@@ -242,6 +242,13 @@ export const fillCardDetails = async (
 	}
 };
 
+// The WCB Stripe Payment Element only renders when the blocks (Store API)
+// checkout actually offers WCPay as a payment method. On a fresh environment the
+// Store API checkout intermittently reports no available payment methods, so the
+// element never appears; without a bound, the wait below burns the full 120s
+// test timeout. Bound it and fail with a clear diagnostic instead.
+const wcbPaymentElementTimeoutMs = 30 * 1000;
+
 export const fillCardDetailsWCB = async (
 	page: Page,
 	card: typeof config.cards.basic
@@ -252,9 +259,32 @@ export const fillCardDetailsWCB = async (
 	if ( await newPaymentMethodRadioButton.isVisible() ) {
 		await newPaymentMethodRadioButton.click();
 	}
-	await page.waitForSelector( '.__PrivateStripeElement' );
+
+	const paymentElementRendered = await page
+		.locator( '.__PrivateStripeElement' )
+		.first()
+		.waitFor( { state: 'visible', timeout: wcbPaymentElementTimeoutMs } )
+		.then( () => true )
+		.catch( () => false );
+
+	if ( ! paymentElementRendered ) {
+		const noPaymentMethods = await page
+			.getByText( 'There are no payment methods available' )
+			.isVisible()
+			.catch( () => false );
+		throw new Error(
+			`WCB checkout did not render the Stripe Payment Element within ${
+				wcbPaymentElementTimeoutMs / 1000
+			}s. ` +
+				( noPaymentMethods
+					? 'The blocks checkout reported "There are no payment methods available" — WCPay was not offered (no payable cart or WCPay unavailable on the Store API checkout).'
+					: 'The payment section never appeared (likely no payable cart or WCPay unavailable on the blocks checkout).' )
+		);
+	}
+
 	const frameHandle = await page.waitForSelector(
-		'#payment-method .wcpay-payment-element iframe[name^="__privateStripeFrame"]'
+		'#payment-method .wcpay-payment-element iframe[name^="__privateStripeFrame"]',
+		{ timeout: wcbPaymentElementTimeoutMs }
 	);
 	const stripeFrame = await frameHandle.contentFrame();
 	if ( ! stripeFrame ) return;


### PR DESCRIPTION
### Changes proposed in this Pull Request

The WooCommerce Blocks shopper E2E suite (`shopper-wc-blocks-checkout-*`) has been silently burning **~45 min of CI on every develop/trunk run for at least 2+ days**: every WCB checkout test hung the full 120s test timeout in phase 1, and only stayed green because the phase-2 re-run recovers it.

Root-caused from a captured trace (the two-phase `run-log-tests` action wipes the trace on normal runs, so this needed a one-off trace-capture harness): the universal hung action is `fillCardDetailsWCB` → `page.waitForSelector('.__PrivateStripeElement')`, which had **no effective timeout** and waited for a Stripe Payment Element that never rendered, because on a fresh environment the WC Blocks (Store API) checkout reports **no available payment methods** (WCPay's blocks payment method isn't registered while the account cache is cold — it warms later in the run, which is why phase-2 recovers).

This PR addresses the **test-resilience half**: it bounds the wait to 30s and throws a clear, accurate diagnostic instead of hanging:

```
WCB checkout did not render the Stripe Payment Element within 30s.
The blocks checkout reported "There are no payment methods available" — WCPay was not offered ...
```

Effect (verified on a trace-capture harness run): the blocks-shopper round dropped from **~58 min to ~13 min**, and the failure is now fast and legible. The happy path is unchanged (when the element renders in <30s it proceeds normally).

### Follow-ups

- The underlying cause (WCPay's blocks payment method unavailable on a fresh run due to a cold account cache, while classic checkout works) is a separate fix: warm the WCPay account cache before the blocks tests so phase-1 passes outright. Tracked separately.

### Testing instructions

- This is E2E test tooling only; no product/runtime code changes.
- CI E2E (blocks-shopper) exercises the changed helper. In a healthy (warm) run the element renders and tests pass as before; in the cold-cache condition the test now fails fast at 30s with the diagnostic above instead of hanging 120s.

- [ ] Covered with tests (N/A — test helper)
- [x] Changelog added (`dev`)
