### PR TITLE
fix(e2e): refresh WCPay account cache on the live-server setup path

### DIFF
--- a/changelog/fix-e2e-wcpay-account-cache-live-setup
+++ b/changelog/fix-e2e-wcpay-account-cache-live-setup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: E2E environment setup only (warm WCPay account cache on the live-server path), not end client facing.
+
+

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -712,6 +712,12 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 else
 	info "Connecting to live server..."
 	cli wp wcpay_dev set_blog_id "$BLOG_ID" --blog_token="$E2E_JP_BLOG_TOKEN" --user_token="$E2E_JP_USER_TOKEN"
+	# Populate the account cache now that the blog token is set, mirroring the
+	# local-server path above. Without this the cache stays cold after setup, so
+	# WCPay's gateway is_available() (which reads the cached account country)
+	# returns false on the first run and the WC Blocks checkout reports no
+	# payment methods until a later refresh warms it.
+	cli wp wcpay_dev refresh_account_data
 	success "Connected to live server"
 fi
 

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -712,11 +712,8 @@ if [[ "$E2E_USE_LOCAL_SERVER" != false ]]; then
 else
 	info "Connecting to live server..."
 	cli wp wcpay_dev set_blog_id "$BLOG_ID" --blog_token="$E2E_JP_BLOG_TOKEN" --user_token="$E2E_JP_USER_TOKEN"
-	# Populate the account cache now that the blog token is set, mirroring the
-	# local-server path above. Without this the cache stays cold after setup, so
-	# WCPay's gateway is_available() (which reads the cached account country)
-	# returns false on the first run and the WC Blocks checkout reports no
-	# payment methods until a later refresh warms it.
+	# Mirror the local path: a cold account cache makes is_available() false on the
+	# first run, so the Blocks checkout offers no payment methods until a refresh.
 	cli wp wcpay_dev refresh_account_data
 	success "Connected to live server"
 fi


### PR DESCRIPTION
### Changes proposed in this Pull Request

The blocks-shopper E2E cell hung ~45 min on every develop/trunk run: every WC Blocks checkout test timed out at 120s in phase 1, recovered only by the phase-2 re-run.

`tests/e2e/env/setup.sh` warms the WCPay account cache (`refresh_account_data`) on the local-server path but not the live-server path CI uses. With a cold cache the gateway's `is_available()` is false on the first run, so the Blocks checkout offers no payment methods and the Stripe Payment Element never renders. This adds the same refresh to the live path.

### Testing instructions

E2E setup only, no product/runtime code. Validated on a silent full-suite copy of `e2e-test.yml`: 2 runs, 23/23 green, blocks-shopper passes first-try with no phase-2 recovery (suite ~24 min vs ~58).

