### PR TITLE
refactor: admin routes code splitting

### DIFF
--- a/changelog/refactor-settings-route-code-splitting
+++ b/changelog/refactor-settings-route-code-splitting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+refactor: admin pages as separate chunks

--- a/client/index.js
+++ b/client/index.js
@@ -25,7 +25,13 @@ import { maybeAddReportsPage } from 'reports/page-config';
 const withSuspense = ( LazyComponent ) => ( props ) =>
 	(
 		<ErrorBoundary>
-			<Suspense fallback={ <Spinner /> }>
+			<Suspense
+				fallback={
+					<div className="wcpay-route-loading">
+						<Spinner />
+					</div>
+				}
+			>
 				<LazyComponent { ...props } />
 			</Suspense>
 		</ErrorBoundary>

--- a/client/index.js
+++ b/client/index.js
@@ -3,8 +3,10 @@
 /**
  * External dependencies
  */
+import { lazy, Suspense } from 'react';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { Spinner } from '@wordpress/components';
 // Create a dependency on wp-mediaelement. Necessary to prevent a type of JS error.
 // See discussion in WCPay PR #1263 in GitHub.
 // eslint-disable-next-line import/no-unresolved
@@ -14,25 +16,108 @@ import 'wp-mediaelement';
  * Internal dependencies
  */
 import './style.scss';
+// ConnectAccountPage is eagerly loaded — it's the first page shown to new merchants.
 import ConnectAccountPage from 'connect-account-page';
-import DepositsPage from 'deposits';
-import DepositDetailsPage from 'deposits/details';
-import TransactionsPage from 'transactions';
-import PaymentDetailsPage from 'payment-details';
-import DisputesPage from 'disputes';
-import RedirectToTransactionDetails from 'disputes/redirect-to-transaction-details';
-import DisputeNewEvidencePage from 'wcpay/disputes/new-evidence';
-import { MultiCurrencySetupPage } from 'multi-currency/interface/components';
-import CardReadersPage from 'card-readers';
-import CapitalPage from 'capital';
-import OverviewPage from 'overview';
-import DocumentsPage from 'documents';
-import ReportsPage from 'reports';
-import OnboardingPage from 'onboarding';
-import OnboardingKycPage from 'onboarding/kyc';
-import FraudProtectionAdvancedSettingsPage from './settings/fraud-protection/advanced-settings';
 import { getTasks } from 'overview/task-list/tasks';
 import { maybeAddReportsPage } from 'reports/page-config';
+
+const withSuspense = ( LazyComponent ) => ( props ) =>
+	(
+		<Suspense fallback={ <Spinner /> }>
+			<LazyComponent { ...props } />
+		</Suspense>
+	);
+
+// Payouts: list → details is a linear drill-down; load together.
+const DepositsPage = withSuspense(
+	lazy( () => import( /* webpackChunkName: "wcpay-payouts" */ 'deposits' ) )
+);
+const DepositDetailsPage = withSuspense(
+	lazy( () =>
+		import( /* webpackChunkName: "wcpay-payouts" */ 'deposits/details' )
+	)
+);
+
+// Money movement: transactions, payment details, and disputes form a tight
+// navigation triangle (list → details → challenge → back), so they share a chunk.
+const TransactionsPage = withSuspense(
+	lazy( () =>
+		import( /* webpackChunkName: "wcpay-money-movement" */ 'transactions' )
+	)
+);
+const PaymentDetailsPage = withSuspense(
+	lazy( () =>
+		import(
+			/* webpackChunkName: "wcpay-money-movement" */ 'payment-details'
+		)
+	)
+);
+const DisputesPage = withSuspense(
+	lazy( () =>
+		import( /* webpackChunkName: "wcpay-money-movement" */ 'disputes' )
+	)
+);
+const RedirectToTransactionDetails = withSuspense(
+	lazy( () =>
+		import(
+			/* webpackChunkName: "wcpay-money-movement" */ 'disputes/redirect-to-transaction-details'
+		)
+	)
+);
+const DisputeNewEvidencePage = withSuspense(
+	lazy( () =>
+		import(
+			/* webpackChunkName: "wcpay-money-movement" */ 'wcpay/disputes/new-evidence'
+		)
+	)
+);
+
+// Onboarding: the main flow and KYC step are always navigated sequentially.
+const OnboardingPage = withSuspense(
+	lazy( () =>
+		import( /* webpackChunkName: "wcpay-onboarding" */ 'onboarding' )
+	)
+);
+const OnboardingKycPage = withSuspense(
+	lazy( () =>
+		import( /* webpackChunkName: "wcpay-onboarding" */ 'onboarding/kyc' )
+	)
+);
+
+// Standalone pages — no meaningful cross-links to other admin pages.
+const OverviewPage = withSuspense(
+	lazy( () => import( /* webpackChunkName: "wcpay-overview" */ 'overview' ) )
+);
+const MultiCurrencySetupPage = withSuspense(
+	lazy( () =>
+		import(
+			/* webpackChunkName: "wcpay-multi-currency-setup" */ 'multi-currency/interface/components'
+		).then( ( { MultiCurrencySetupPage: Page } ) => ( { default: Page } ) )
+	)
+);
+const CardReadersPage = withSuspense(
+	lazy( () =>
+		import( /* webpackChunkName: "wcpay-card-readers" */ 'card-readers' )
+	)
+);
+const CapitalPage = withSuspense(
+	lazy( () => import( /* webpackChunkName: "wcpay-capital" */ 'capital' ) )
+);
+const DocumentsPage = withSuspense(
+	lazy( () =>
+		import( /* webpackChunkName: "wcpay-documents" */ 'documents' )
+	)
+);
+const ReportsPage = withSuspense(
+	lazy( () => import( /* webpackChunkName: "wcpay-reports" */ 'reports' ) )
+);
+const FraudProtectionAdvancedSettingsPage = withSuspense(
+	lazy( () =>
+		import(
+			/* webpackChunkName: "wcpay-fraud-protection" */ './settings/fraud-protection/advanced-settings'
+		)
+	)
+);
 
 addFilter(
 	'woocommerce_admin_pages_list',

--- a/client/index.js
+++ b/client/index.js
@@ -18,14 +18,17 @@ import 'wp-mediaelement';
 import './style.scss';
 // ConnectAccountPage is eagerly loaded — it's the first page shown to new merchants.
 import ConnectAccountPage from 'connect-account-page';
+import ErrorBoundary from 'components/error-boundary';
 import { getTasks } from 'overview/task-list/tasks';
 import { maybeAddReportsPage } from 'reports/page-config';
 
 const withSuspense = ( LazyComponent ) => ( props ) =>
 	(
-		<Suspense fallback={ <Spinner /> }>
-			<LazyComponent { ...props } />
-		</Suspense>
+		<ErrorBoundary>
+			<Suspense fallback={ <Spinner /> }>
+				<LazyComponent { ...props } />
+			</Suspense>
+		</ErrorBoundary>
 	);
 
 // Payouts: list → details is a linear drill-down; load together.

--- a/tests/e2e/specs/wcpay/merchant/multi-currency-on-boarding.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency-on-boarding.spec.ts
@@ -123,11 +123,11 @@ test.describe( 'Multi-currency on-boarding', { tag: '@critical' }, () => {
 		} );
 
 		test( 'should display suggested currencies at the beginning of the list', async () => {
+			// Use toBeVisible() (auto-waits) instead of .all() (snapshot,
+			// no wait) so lazy-loaded content has time to render.
 			await expect(
-				(
-					await page.getByTestId( 'recommended-currency' ).all()
-				 ).length
-			).toBeGreaterThan( 0 );
+				page.getByTestId( 'recommended-currency' ).first()
+			).toBeVisible();
 		} );
 
 		test( 'selected currencies are enabled after onboarding', async () => {

--- a/tests/e2e/specs/wcpay/merchant/multi-currency-on-boarding.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency-on-boarding.spec.ts
@@ -123,11 +123,17 @@ test.describe( 'Multi-currency on-boarding', { tag: '@critical' }, () => {
 		} );
 
 		test( 'should display suggested currencies at the beginning of the list', async () => {
-			// Use toBeVisible() (auto-waits) instead of .all() (snapshot,
-			// no wait) so lazy-loaded content has time to render.
+			// Wait for the first element to be visible before snapshotting
+			// the full list — .all() doesn't auto-wait so we need the
+			// content to be present first.
 			await expect(
 				page.getByTestId( 'recommended-currency' ).first()
 			).toBeVisible();
+			await expect(
+				(
+					await page.getByTestId( 'recommended-currency' ).all()
+				 ).length
+			).toBeGreaterThan( 0 );
 		} );
 
 		test( 'selected currencies are enabled after onboarding', async () => {

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -17,6 +17,8 @@ import RestAPI from './rest-api';
  */
 export const dataHasLoaded = async ( page: Page ) => {
 	await expect( page.locator( '.is-loadable-placeholder' ) ).toHaveCount( 0 );
+	// Wait for any lazy-loaded route chunk to finish mounting.
+	await expect( page.locator( '.wcpay-route-loading' ) ).toHaveCount( 0 );
 };
 
 export const tableDataHasLoaded = async ( page: Page ) => {

--- a/webpack/shared.js
+++ b/webpack/shared.js
@@ -169,6 +169,11 @@ module.exports = {
 		} ),
 		new MiniCssExtractPlugin( {
 			filename: '[name].css',
+			// Shared component stylesheets (chip, clickable-cell, etc.) are
+			// imported by multiple async route chunks in different orders.
+			// The styles themselves have no cross-component ordering dependency,
+			// so the warning is a false positive. Revisit if a genuine
+			// order-sensitive conflict is ever introduced.
 			ignoreOrder: true,
 		} ),
 		new WebpackRTLPlugin( {

--- a/webpack/shared.js
+++ b/webpack/shared.js
@@ -167,7 +167,10 @@ module.exports = {
 		new ProvidePlugin( {
 			process: 'process/browser.js',
 		} ),
-		new MiniCssExtractPlugin( { filename: '[name].css' } ),
+		new MiniCssExtractPlugin( {
+			filename: '[name].css',
+			ignoreOrder: true,
+		} ),
 		new WebpackRTLPlugin( {
 			filenameSuffix: '-rtl.css',
 		} ),


### PR DESCRIPTION
Fixes WOOPMNT-6197

Related to https://github.com/Automattic/woocommerce-payments/pull/11775.

#### Changes proposed in this Pull Request

All 16 admin page components in `client/index.js` were statically imported, so the full set loaded synchronously on every WooPayments admin page — regardless of which page the user actually visits. Converting them to `React.lazy()` + `import()` drops the synchronous bundle from ~714 KB to ~137 KB.

Pages are grouped by navigation pattern rather than one-per-chunk: transactions, payment-details, and disputes share a chunk because they form a navigation triangle (disputes list → payment details → challenge → back); deposits list+details and onboarding+KYC are paired for the same reason. `connect-account-page` stays eager since it's the first page shown to new merchants.

Also adds `ignoreOrder: true` to `MiniCssExtractPlugin` to suppress CSS ordering warnings that come up when shared component stylesheets are imported in different orders by different async chunks. The styles don't conflict.

#### Testing instructions

E2e tests should cover it — they exercise the navigation flows across all these pages.

I did a full run of the e2e tests: https://github.com/Automattic/woocommerce-payments/actions/runs/27056274413

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.