### PR TITLE
Fix Apple/Google Pay orders with custom checkout fields

### DIFF
--- a/changelog/fix-woopmnt-2363-ece-custom-checkout-fields
+++ b/changelog/fix-woopmnt-2363-ece-custom-checkout-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Pass classic checkout custom fields through express checkout Store API orders.

--- a/changelog/fix-woopmnt-2363-ece-custom-checkout-fields
+++ b/changelog/fix-woopmnt-2363-ece-custom-checkout-fields
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Pass classic checkout custom fields through express checkout Store API orders.
+Support registered classic checkout custom fields in Express Checkout Store API orders.

--- a/client/express-checkout/block-buttons/index.js
+++ b/client/express-checkout/block-buttons/index.js
@@ -12,6 +12,7 @@ import { getConfig } from 'wcpay/utils/checkout';
 import ExpressCheckoutContainer from './components/express-checkout-container';
 import { checkPaymentMethodIsAvailable } from '../utils/checkPaymentMethodIsAvailable';
 import { getExpressCheckoutData } from '../utils';
+import '../compatibility/classic-checkout-custom-fields';
 import '../compatibility/wc-order-attribution';
 import '../compatibility/wc-subscriptions';
 

--- a/client/express-checkout/compatibility/__tests__/classic-checkout-custom-fields.test.js
+++ b/client/express-checkout/compatibility/__tests__/classic-checkout-custom-fields.test.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import '../classic-checkout-custom-fields';
+
+const EXTENSION_NAMESPACE = 'woocommerce-payments/express-checkout';
+
+describe( 'Classic checkout custom fields compatibility', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		global.wcpayExpressCheckoutParams = {
+			button_context: 'checkout',
+			custom_checkout_fields: {
+				my_field_name: {
+					type: 'text',
+				},
+				gift_wrap: {
+					type: 'checkbox',
+				},
+				newsletter_signup: {
+					type: 'checkbox',
+				},
+				delivery_preference: {
+					type: 'radio',
+				},
+				order_note: {
+					type: 'textarea',
+				},
+			},
+		};
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		delete global.wcpayExpressCheckoutParams;
+	} );
+
+	it( 'adds checkout form custom field values to the Store API extensions payload', () => {
+		document.body.innerHTML = `
+			<form name="checkout">
+				<input name="my_field_name" value="A required value" />
+				<input type="checkbox" name="gift_wrap" value="yes" checked />
+				<input type="checkbox" name="newsletter_signup" value="yes" />
+				<input type="radio" name="delivery_preference" value="morning" />
+				<input type="radio" name="delivery_preference" value="evening" checked />
+				<textarea name="order_note">Please leave it at the door.</textarea>
+			</form>
+		`;
+
+		const extensionData = applyFilters(
+			'wcpay.express-checkout.cart-place-order-extension-data',
+			{
+				'example/existing-extension': {
+					foo: 'bar',
+				},
+			}
+		);
+
+		expect( extensionData ).toMatchObject( {
+			'example/existing-extension': {
+				foo: 'bar',
+			},
+			[ EXTENSION_NAMESPACE ]: {
+				custom_checkout_data: JSON.stringify( {
+					my_field_name: 'A required value',
+					gift_wrap: 'yes',
+					newsletter_signup: '',
+					delivery_preference: 'evening',
+					order_note: 'Please leave it at the door.',
+				} ),
+			},
+		} );
+	} );
+
+	it( 'does not add checkout form custom field values outside checkout context', () => {
+		global.wcpayExpressCheckoutParams.button_context = 'cart';
+		document.body.innerHTML = `
+			<form name="checkout">
+				<input name="my_field_name" value="A cart page value" />
+			</form>
+		`;
+
+		const existingExtensionData = {
+			'example/existing-extension': {
+				foo: 'bar',
+			},
+		};
+
+		const extensionData = applyFilters(
+			'wcpay.express-checkout.cart-place-order-extension-data',
+			existingExtensionData
+		);
+
+		expect( extensionData ).toBe( existingExtensionData );
+	} );
+} );

--- a/client/express-checkout/compatibility/__tests__/classic-checkout-custom-fields.test.js
+++ b/client/express-checkout/compatibility/__tests__/classic-checkout-custom-fields.test.js
@@ -77,6 +77,39 @@ describe( 'Classic checkout custom fields compatibility', () => {
 		} );
 	} );
 
+	it( 'adds action-rendered custom checkout field values to the Store API extensions payload', () => {
+		global.wcpayExpressCheckoutParams.custom_checkout_fields = {};
+		document.body.innerHTML = `
+			<form name="checkout">
+				<input name="billing_first_name" value="Jane" />
+				<input name="payment_method" value="woocommerce_payments" />
+				<input name="_wpnonce" value="nonce" />
+				<input name="wc_order_attribution_source_type" value="organic" />
+				<input name="my_field_name" value="A required value" />
+				<select name="delivery_window">
+					<option value="morning" selected>Morning</option>
+					<option value="evening">Evening</option>
+				</select>
+				<input type="checkbox" name="gift_message" value="yes" checked />
+			</form>
+		`;
+
+		const extensionData = applyFilters(
+			'wcpay.express-checkout.cart-place-order-extension-data',
+			{}
+		);
+
+		expect( extensionData ).toMatchObject( {
+			[ EXTENSION_NAMESPACE ]: {
+				custom_checkout_data: JSON.stringify( {
+					my_field_name: 'A required value',
+					delivery_window: 'morning',
+					gift_message: 'yes',
+				} ),
+			},
+		} );
+	} );
+
 	it( 'does not add checkout form custom field values outside checkout context', () => {
 		global.wcpayExpressCheckoutParams.button_context = 'cart';
 		document.body.innerHTML = `

--- a/client/express-checkout/compatibility/__tests__/classic-checkout-custom-fields.test.js
+++ b/client/express-checkout/compatibility/__tests__/classic-checkout-custom-fields.test.js
@@ -85,6 +85,9 @@ describe( 'Classic checkout custom fields compatibility', () => {
 				<input name="payment_method" value="woocommerce_payments" />
 				<input name="_wpnonce" value="nonce" />
 				<input name="wc_order_attribution_source_type" value="organic" />
+				<input name="save_user_in_woopay" value="1" />
+				<input name="woopay_source_url" value="https://example.test/checkout/" />
+				<input name="woopay_user_phone_field[no-country-code]" value="1234567890" />
 				<input name="my_field_name" value="A required value" />
 				<select name="delivery_window">
 					<option value="morning" selected>Morning</option>

--- a/client/express-checkout/compatibility/classic-checkout-custom-fields.js
+++ b/client/express-checkout/compatibility/classic-checkout-custom-fields.js
@@ -44,6 +44,7 @@ const INTERNAL_CHECKOUT_FIELDS = new Set( [
 	'account_username',
 	'account_password',
 	'account_password-2',
+	'save_user_in_woopay',
 	'woocommerce-process-checkout-nonce',
 ] );
 const INTERNAL_CHECKOUT_FIELD_PREFIXES = [
@@ -52,6 +53,7 @@ const INTERNAL_CHECKOUT_FIELD_PREFIXES = [
 	'wc_order_attribution_',
 	'woocommerce_',
 	'wcpay_',
+	'woopay_',
 ];
 const IGNORED_FORM_FIELD_TYPES = new Set( [ 'button', 'reset', 'submit' ] );
 

--- a/client/express-checkout/compatibility/classic-checkout-custom-fields.js
+++ b/client/express-checkout/compatibility/classic-checkout-custom-fields.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { getExpressCheckoutData } from '../utils';
+
+const EXTENSION_NAMESPACE = 'woocommerce-payments/express-checkout';
+const CUSTOM_CHECKOUT_DATA_KEY = 'custom_checkout_data';
+
+const normalizeFormDataValue = ( value ) => {
+	if ( typeof File !== 'undefined' && value instanceof File ) {
+		return value.name;
+	}
+
+	return value;
+};
+
+const getNamedFormElement = ( form, fieldName ) =>
+	form.elements.namedItem( fieldName ) ||
+	form.elements.namedItem( `${ fieldName }[]` );
+
+const getCustomCheckoutFieldValue = ( form, formData, fieldName ) => {
+	const values = formData.has( fieldName )
+		? formData.getAll( fieldName )
+		: formData.getAll( `${ fieldName }[]` );
+
+	if ( values.length > 1 ) {
+		return values.map( normalizeFormDataValue );
+	}
+
+	if ( values.length === 1 ) {
+		return normalizeFormDataValue( values[ 0 ] );
+	}
+
+	return getNamedFormElement( form, fieldName ) ? '' : undefined;
+};
+
+const getCustomCheckoutData = () => {
+	if ( getExpressCheckoutData( 'button_context' ) !== 'checkout' ) {
+		return {};
+	}
+
+	const customCheckoutFields =
+		getExpressCheckoutData( 'custom_checkout_fields' ) ?? {};
+	const fieldNames = Object.keys( customCheckoutFields );
+
+	if ( fieldNames.length === 0 ) {
+		return {};
+	}
+
+	const checkoutForm = document.querySelector( 'form[name="checkout"]' );
+	if ( ! checkoutForm || typeof FormData === 'undefined' ) {
+		return {};
+	}
+
+	const formData = new FormData( checkoutForm );
+	return fieldNames.reduce( ( customCheckoutData, fieldName ) => {
+		const fieldValue = getCustomCheckoutFieldValue(
+			checkoutForm,
+			formData,
+			fieldName
+		);
+
+		if ( fieldValue !== undefined ) {
+			customCheckoutData[ fieldName ] = fieldValue;
+		}
+
+		return customCheckoutData;
+	}, {} );
+};
+
+addFilter(
+	'wcpay.express-checkout.cart-place-order-extension-data',
+	'automattic/wcpay/express-checkout-custom-fields',
+	( extensionData ) => {
+		const customCheckoutData = getCustomCheckoutData();
+
+		if ( Object.keys( customCheckoutData ).length === 0 ) {
+			return extensionData;
+		}
+
+		return {
+			...extensionData,
+			[ EXTENSION_NAMESPACE ]: {
+				...( extensionData[ EXTENSION_NAMESPACE ] ?? {} ),
+				[ CUSTOM_CHECKOUT_DATA_KEY ]:
+					JSON.stringify( customCheckoutData ),
+			},
+		};
+	}
+);

--- a/client/express-checkout/compatibility/classic-checkout-custom-fields.js
+++ b/client/express-checkout/compatibility/classic-checkout-custom-fields.js
@@ -10,6 +10,52 @@ import { getExpressCheckoutData } from '../utils';
 
 const EXTENSION_NAMESPACE = 'woocommerce-payments/express-checkout';
 const CUSTOM_CHECKOUT_DATA_KEY = 'custom_checkout_data';
+const STANDARD_CHECKOUT_FIELDS = new Set( [
+	'billing_first_name',
+	'billing_last_name',
+	'billing_company',
+	'billing_country',
+	'billing_address_1',
+	'billing_address_2',
+	'billing_city',
+	'billing_state',
+	'billing_postcode',
+	'billing_phone',
+	'billing_email',
+	'shipping_first_name',
+	'shipping_last_name',
+	'shipping_company',
+	'shipping_country',
+	'shipping_address_1',
+	'shipping_address_2',
+	'shipping_city',
+	'shipping_state',
+	'shipping_postcode',
+	'shipping_phone',
+	'order_comments',
+] );
+const INTERNAL_CHECKOUT_FIELDS = new Set( [
+	'payment_method',
+	'terms',
+	'terms-field',
+	'privacy_policy',
+	'ship_to_different_address',
+	'createaccount',
+	'account_username',
+	'account_password',
+	'account_password-2',
+	'woocommerce-process-checkout-nonce',
+] );
+const INTERNAL_CHECKOUT_FIELD_PREFIXES = [
+	'_',
+	'wc-',
+	'wc_order_attribution_',
+	'woocommerce_',
+	'wcpay_',
+];
+const IGNORED_FORM_FIELD_TYPES = new Set( [ 'button', 'reset', 'submit' ] );
+
+const normalizeFieldName = ( fieldName ) => fieldName.replace( /\[\]$/, '' );
 
 const normalizeFormDataValue = ( value ) => {
 	if ( typeof File !== 'undefined' && value instanceof File ) {
@@ -27,6 +73,11 @@ const getCustomCheckoutFieldValue = ( form, formData, fieldName ) => {
 	const values = formData.has( fieldName )
 		? formData.getAll( fieldName )
 		: formData.getAll( `${ fieldName }[]` );
+	const namedElement = getNamedFormElement( form, fieldName );
+
+	if ( values.length > 1 && namedElement?.type === 'select-one' ) {
+		return normalizeFormDataValue( namedElement.value );
+	}
 
 	if ( values.length > 1 ) {
 		return values.map( normalizeFormDataValue );
@@ -36,7 +87,48 @@ const getCustomCheckoutFieldValue = ( form, formData, fieldName ) => {
 		return normalizeFormDataValue( values[ 0 ] );
 	}
 
-	return getNamedFormElement( form, fieldName ) ? '' : undefined;
+	return namedElement ? '' : undefined;
+};
+
+const isSupportedCheckoutFormElement = ( element ) => {
+	const tagName = element.tagName?.toLowerCase();
+
+	if ( ! [ 'input', 'select', 'textarea' ].includes( tagName ) ) {
+		return false;
+	}
+
+	if ( ! element.name || element.disabled ) {
+		return false;
+	}
+
+	return ! IGNORED_FORM_FIELD_TYPES.has(
+		( element.type ?? '' ).toLowerCase()
+	);
+};
+
+const isInternalCheckoutFieldName = ( fieldName, registeredFieldNames ) => {
+	if ( registeredFieldNames.has( fieldName ) ) {
+		return false;
+	}
+
+	return (
+		STANDARD_CHECKOUT_FIELDS.has( fieldName ) ||
+		INTERNAL_CHECKOUT_FIELDS.has( fieldName ) ||
+		INTERNAL_CHECKOUT_FIELD_PREFIXES.some( ( prefix ) =>
+			fieldName.startsWith( prefix )
+		)
+	);
+};
+
+const getCheckoutFormFieldNames = ( form, registeredFieldNames ) => {
+	return Array.from( form.elements )
+		.filter( isSupportedCheckoutFormElement )
+		.map( ( element ) => normalizeFieldName( element.name ) )
+		.filter(
+			( fieldName ) =>
+				fieldName &&
+				! isInternalCheckoutFieldName( fieldName, registeredFieldNames )
+		);
 };
 
 const getCustomCheckoutData = () => {
@@ -44,16 +136,22 @@ const getCustomCheckoutData = () => {
 		return {};
 	}
 
-	const customCheckoutFields =
-		getExpressCheckoutData( 'custom_checkout_fields' ) ?? {};
-	const fieldNames = Object.keys( customCheckoutFields );
-
-	if ( fieldNames.length === 0 ) {
+	const checkoutForm = document.querySelector( 'form[name="checkout"]' );
+	if ( ! checkoutForm || typeof FormData === 'undefined' ) {
 		return {};
 	}
 
-	const checkoutForm = document.querySelector( 'form[name="checkout"]' );
-	if ( ! checkoutForm || typeof FormData === 'undefined' ) {
+	const customCheckoutFields =
+		getExpressCheckoutData( 'custom_checkout_fields' ) ?? {};
+	const registeredFieldNames = new Set( Object.keys( customCheckoutFields ) );
+	const fieldNames = [
+		...new Set( [
+			...registeredFieldNames,
+			...getCheckoutFormFieldNames( checkoutForm, registeredFieldNames ),
+		] ),
+	];
+
+	if ( fieldNames.length === 0 ) {
 		return {};
 	}
 

--- a/client/express-checkout/compatibility/classic-checkout-custom-fields.js
+++ b/client/express-checkout/compatibility/classic-checkout-custom-fields.js
@@ -144,6 +144,8 @@ const getCustomCheckoutData = () => {
 	const customCheckoutFields =
 		getExpressCheckoutData( 'custom_checkout_fields' ) ?? {};
 	const registeredFieldNames = new Set( Object.keys( customCheckoutFields ) );
+	// Registered fields are validated and saved server-side. Additional form
+	// fields are exposed for extension hooks.
 	const fieldNames = [
 		...new Set( [
 			...registeredFieldNames,

--- a/client/express-checkout/shortcode-buttons-express/index.js
+++ b/client/express-checkout/shortcode-buttons-express/index.js
@@ -11,6 +11,7 @@ import { addAction, removeAction, applyFilters } from '@wordpress/hooks';
 import WCPayAPI from '../../checkout/api';
 import './express-checkout-buttons.scss';
 import './compatibility/wc-deposits';
+import '../compatibility/classic-checkout-custom-fields';
 import '../compatibility/wc-order-attribution';
 import './compatibility/wc-product-page';
 import './compatibility/wc-product-bundles';

--- a/client/express-checkout/utils/express-checkout-data.ts
+++ b/client/express-checkout/utils/express-checkout-data.ts
@@ -26,6 +26,15 @@ export interface WCPayExpressCheckoutParams {
 	 * Indicates in which context the button is being displayed.
 	 */
 	button_context: 'checkout' | 'cart' | 'product' | 'pay_for_order';
+	custom_checkout_fields?: Record<
+		string,
+		{
+			type?: string;
+			label?: string;
+			required?: boolean;
+			location?: string;
+		}
+	>;
 	checkout: {
 		country_code: string;
 		currency_code: string;

--- a/docs/express-checkout-custom-checkout-fields.md
+++ b/docs/express-checkout-custom-checkout-fields.md
@@ -4,6 +4,8 @@ WooPayments Express Checkout sends eligible classic checkout form fields through
 
 Fields registered through the `woocommerce_checkout_fields` filter are validated for `required` server-side and saved to order meta by default using their checkout field keys.
 
+Required validation assumes the registered field is present on the checkout form whenever it is required. If a required field is conditionally hidden, make sure the condition also updates the field's required state, or handle that field through the validation hook below.
+
 Fields rendered directly into the checkout form, for example with `woocommerce_after_order_notes`, are included in the WooPayments extension payload but are not automatically validated or saved. Use the WooPayments hooks below when those fields need Express Checkout support.
 
 ## Validate A Custom Field

--- a/docs/express-checkout-custom-checkout-fields.md
+++ b/docs/express-checkout-custom-checkout-fields.md
@@ -13,7 +13,7 @@ Fields rendered directly into the checkout form, for example with `woocommerce_a
 ```php
 add_action(
 	'wcpay_express_checkout_after_custom_fields_validation',
-	function ( array $custom_checkout_data, WP_Error $errors ) {
+	function ( array $custom_checkout_data, WP_Error $errors, WC_Order $order, WP_REST_Request $request ) {
 		if ( empty( $custom_checkout_data['my_custom_field'] ) ) {
 			$errors->add(
 				'my_custom_field_required',
@@ -22,7 +22,7 @@ add_action(
 		}
 	},
 	10,
-	2
+	4
 );
 ```
 
@@ -31,7 +31,7 @@ add_action(
 ```php
 add_action(
 	'wcpay_express_checkout_update_custom_fields_order_meta',
-	function ( int $order_id, array $custom_checkout_data ) {
+	function ( int $order_id, array $custom_checkout_data, WC_Order $order, WP_REST_Request $request ) {
 		if ( ! isset( $custom_checkout_data['my_custom_field'] ) ) {
 			return;
 		}
@@ -43,6 +43,6 @@ add_action(
 		);
 	},
 	10,
-	2
+	4
 );
 ```

--- a/docs/express-checkout-custom-checkout-fields.md
+++ b/docs/express-checkout-custom-checkout-fields.md
@@ -1,0 +1,46 @@
+# Express Checkout Custom Checkout Fields
+
+WooPayments Express Checkout sends eligible classic checkout form fields through the Store API extensions payload before placing an Apple Pay or Google Pay order.
+
+Fields registered through the `woocommerce_checkout_fields` filter are validated for `required` server-side and saved to order meta by default using their checkout field keys.
+
+Fields rendered directly into the checkout form, for example with `woocommerce_after_order_notes`, are included in the WooPayments extension payload but are not automatically validated or saved. Use the WooPayments hooks below when those fields need Express Checkout support.
+
+## Validate A Custom Field
+
+```php
+add_action(
+	'wcpay_express_checkout_after_custom_fields_validation',
+	function ( array $custom_checkout_data, WP_Error $errors ) {
+		if ( empty( $custom_checkout_data['my_custom_field'] ) ) {
+			$errors->add(
+				'my_custom_field_required',
+				__( 'My custom field is required.', 'my-text-domain' )
+			);
+		}
+	},
+	10,
+	2
+);
+```
+
+## Save A Custom Field
+
+```php
+add_action(
+	'wcpay_express_checkout_update_custom_fields_order_meta',
+	function ( int $order_id, array $custom_checkout_data ) {
+		if ( ! isset( $custom_checkout_data['my_custom_field'] ) ) {
+			return;
+		}
+
+		update_post_meta(
+			$order_id,
+			'my_custom_field',
+			sanitize_text_field( wp_unslash( $custom_checkout_data['my_custom_field'] ) )
+		);
+	},
+	10,
+	2
+);
+```

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -301,6 +301,13 @@ class WC_Payments {
 	private static $express_checkout_helper;
 
 	/**
+	 * Instance of WC_Payments_Express_Checkout_Custom_Fields_Handler, created in init function.
+	 *
+	 * @var WC_Payments_Express_Checkout_Custom_Fields_Handler
+	 */
+	private static $express_checkout_custom_fields_handler;
+
+	/**
 	 * Instance of Compatibility_Service, created in init function
 	 *
 	 * @var Compatibility_Service
@@ -467,6 +474,7 @@ class WC_Payments {
 		include_once __DIR__ . '/payment-methods/class-upe-payment-method.php';
 		include_once __DIR__ . '/inline-script-payloads/class-woo-payments-payment-methods-config.php';
 		include_once __DIR__ . '/express-checkout/class-wc-payments-express-checkout-button-helper.php';
+		include_once __DIR__ . '/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php';
 		include_once __DIR__ . '/class-wc-payment-token-wcpay-sepa.php';
 		include_once __DIR__ . '/class-wc-payments-status.php';
 		include_once __DIR__ . '/class-wc-payments-token-service.php';
@@ -666,6 +674,9 @@ class WC_Payments {
 
 		$express_checkout_helper = new WC_Payments_Express_Checkout_Button_Helper( self::get_gateway(), self::$account );
 		self::set_express_checkout_helper( $express_checkout_helper );
+
+		self::$express_checkout_custom_fields_handler = new WC_Payments_Express_Checkout_Custom_Fields_Handler();
+		self::$express_checkout_custom_fields_handler->init();
 
 		self::$payment_method_service = new WC_Payments_Payment_Method_Service( self::$api_client, self::$order_service );
 		self::$payment_method_service->init_hooks();

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -226,16 +226,16 @@ class WC_Payments_Express_Checkout_Button_Handler {
 			apply_filters(
 				'wcpay_express_checkout_js_params',
 				[
-					'ajax_url'               => admin_url( 'admin-ajax.php' ),
-					'wc_ajax_url'            => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-					'nonce'                  => [
+					'ajax_url'           => admin_url( 'admin-ajax.php' ),
+					'wc_ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+					'nonce'              => [
 						'platform_tracker'             => wp_create_nonce( 'platform_tracks_nonce' ),
 						// needed to communicate via the Store API.
 						'tokenized_cart_nonce'         => wp_create_nonce( 'woopayments_tokenized_cart_nonce' ),
 						'tokenized_cart_session_nonce' => wp_create_nonce( 'woopayments_tokenized_cart_session_nonce' ),
 						'store_api_nonce'              => wp_create_nonce( 'wc_store_api' ),
 					],
-					'checkout'               => [
+					'checkout'           => [
 						'currency_code'              => strtolower( get_woocommerce_currency() ),
 						'currency_decimals'          => WC_Payments::get_localization_service()->get_currency_format( get_woocommerce_currency() )['num_decimals'],
 						'stripe_minor_unit'          => WC_Payments_Utils::get_stripe_minor_unit_for_currency( get_woocommerce_currency() ),
@@ -246,20 +246,22 @@ class WC_Payments_Express_Checkout_Button_Handler {
 						'allowed_shipping_countries' => array_keys( WC()->countries->get_shipping_countries() ?? [] ),
 						'display_prices_with_tax'    => 'incl' === get_option( 'woocommerce_tax_display_cart' ),
 					],
-					'has_subscription'       => $this->express_checkout_helper->has_subscription_product(),
-					'is_manual_capture'      => 'yes' === $this->gateway->get_option( 'manual_capture' ),
-					'button'                 => $this->get_button_settings(),
-					'login_confirmation'     => $this->get_login_confirmation_settings(),
-					'button_context'         => $button_context,
-					'custom_checkout_fields' => 'checkout' === $button_context
-						? WC_Payments_Express_Checkout_Custom_Fields_Handler::get_custom_checkout_fields()
-						: [],
-					'has_block'              => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
-					'product'                => $this->express_checkout_helper->get_product_data(),
-					'store_name'             => get_bloginfo( 'name' ),
-					'enabled_methods'        => $this->express_checkout_helper->get_enabled_express_checkout_methods_for_context(),
+					'has_subscription'   => $this->express_checkout_helper->has_subscription_product(),
+					'is_manual_capture'  => 'yes' === $this->gateway->get_option( 'manual_capture' ),
+					'button'             => $this->get_button_settings(),
+					'login_confirmation' => $this->get_login_confirmation_settings(),
+					'button_context'     => $button_context,
+					'has_block'          => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
+					'product'            => $this->express_checkout_helper->get_product_data(),
+					'store_name'         => get_bloginfo( 'name' ),
+					'enabled_methods'    => $this->express_checkout_helper->get_enabled_express_checkout_methods_for_context(),
 				]
 			),
+			[
+				'custom_checkout_fields' => 'checkout' === $button_context
+					? WC_Payments_Express_Checkout_Custom_Fields_Handler::get_custom_checkout_fields()
+					: [],
+			],
 			[
 				// placing these outside of the filter to prevent modification of the values.
 				'stripe' => [

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -215,6 +215,8 @@ class WC_Payments_Express_Checkout_Button_Handler {
 	 * @return array Parameters for Express Checkout.
 	 */
 	public function get_express_checkout_params() {
+		$button_context = $this->express_checkout_helper->get_button_context();
+
 		/**
 		 * Allowing some specific configuration to be tweaked by 3pd.
 		 *
@@ -224,16 +226,16 @@ class WC_Payments_Express_Checkout_Button_Handler {
 			apply_filters(
 				'wcpay_express_checkout_js_params',
 				[
-					'ajax_url'           => admin_url( 'admin-ajax.php' ),
-					'wc_ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-					'nonce'              => [
+					'ajax_url'               => admin_url( 'admin-ajax.php' ),
+					'wc_ajax_url'            => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+					'nonce'                  => [
 						'platform_tracker'             => wp_create_nonce( 'platform_tracks_nonce' ),
 						// needed to communicate via the Store API.
 						'tokenized_cart_nonce'         => wp_create_nonce( 'woopayments_tokenized_cart_nonce' ),
 						'tokenized_cart_session_nonce' => wp_create_nonce( 'woopayments_tokenized_cart_session_nonce' ),
 						'store_api_nonce'              => wp_create_nonce( 'wc_store_api' ),
 					],
-					'checkout'           => [
+					'checkout'               => [
 						'currency_code'              => strtolower( get_woocommerce_currency() ),
 						'currency_decimals'          => WC_Payments::get_localization_service()->get_currency_format( get_woocommerce_currency() )['num_decimals'],
 						'stripe_minor_unit'          => WC_Payments_Utils::get_stripe_minor_unit_for_currency( get_woocommerce_currency() ),
@@ -244,15 +246,18 @@ class WC_Payments_Express_Checkout_Button_Handler {
 						'allowed_shipping_countries' => array_keys( WC()->countries->get_shipping_countries() ?? [] ),
 						'display_prices_with_tax'    => 'incl' === get_option( 'woocommerce_tax_display_cart' ),
 					],
-					'has_subscription'   => $this->express_checkout_helper->has_subscription_product(),
-					'is_manual_capture'  => 'yes' === $this->gateway->get_option( 'manual_capture' ),
-					'button'             => $this->get_button_settings(),
-					'login_confirmation' => $this->get_login_confirmation_settings(),
-					'button_context'     => $this->express_checkout_helper->get_button_context(),
-					'has_block'          => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
-					'product'            => $this->express_checkout_helper->get_product_data(),
-					'store_name'         => get_bloginfo( 'name' ),
-					'enabled_methods'    => $this->express_checkout_helper->get_enabled_express_checkout_methods_for_context(),
+					'has_subscription'       => $this->express_checkout_helper->has_subscription_product(),
+					'is_manual_capture'      => 'yes' === $this->gateway->get_option( 'manual_capture' ),
+					'button'                 => $this->get_button_settings(),
+					'login_confirmation'     => $this->get_login_confirmation_settings(),
+					'button_context'         => $button_context,
+					'custom_checkout_fields' => 'checkout' === $button_context
+						? WC_Payments_Express_Checkout_Custom_Fields_Handler::get_custom_checkout_fields()
+						: [],
+					'has_block'              => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
+					'product'                => $this->express_checkout_helper->get_product_data(),
+					'store_name'             => get_bloginfo( 'name' ),
+					'enabled_methods'        => $this->express_checkout_helper->get_enabled_express_checkout_methods_for_context(),
 				]
 			),
 			[

--- a/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
@@ -131,7 +131,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 		$custom_checkout_data = $this->get_custom_checkout_data_from_request( $request );
 
 		if ( [] === $custom_checkout_data ) {
-			// Normal Store API checkouts can include empty extension defaults without an Express Checkout custom-field payload.
+			// Required custom checkout field validation depends on Express Checkout sending its custom-field payload.
 			return;
 		}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
@@ -262,6 +262,11 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 
 		foreach ( $custom_checkout_data as $field_name => $field_value ) {
 			$field_name = wc_clean( wp_unslash( $field_name ) );
+
+			if ( '' === $field_name ) {
+				continue;
+			}
+
 			$field_type = $custom_checkout_fields[ $field_name ]['type'] ?? 'textarea';
 
 			$sanitized_data[ $field_name ] = $this->sanitize_custom_checkout_field_value( $field_value, $field_type );

--- a/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
@@ -135,10 +135,11 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 			return;
 		}
 
-		$custom_checkout_data = $this->sanitize_custom_checkout_data( $custom_checkout_data );
-		$errors               = new WP_Error();
+		$custom_checkout_fields = self::get_custom_checkout_fields();
+		$custom_checkout_data   = $this->sanitize_custom_checkout_data( $custom_checkout_data, $custom_checkout_fields );
+		$errors                 = new WP_Error();
 
-		$this->validate_required_custom_checkout_fields( $custom_checkout_data, $errors );
+		$this->validate_required_custom_checkout_fields( $custom_checkout_data, $errors, $custom_checkout_fields );
 
 		/**
 		 * Allows extensions to validate Express Checkout custom checkout fields.
@@ -160,7 +161,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 			);
 		}
 
-		$this->save_registered_custom_checkout_fields( $order, $custom_checkout_data );
+		$this->save_registered_custom_checkout_fields( $order, $custom_checkout_data, $custom_checkout_fields );
 
 		/**
 		 * Allows extensions to save Express Checkout custom checkout fields to the order.
@@ -253,15 +254,15 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 	 * Sanitizes custom checkout data according to the checkout field type.
 	 *
 	 * @param array $custom_checkout_data Custom checkout data.
+	 * @param array $custom_checkout_fields Custom checkout field definitions.
 	 * @return array
 	 */
-	private function sanitize_custom_checkout_data( array $custom_checkout_data ): array {
-		$custom_checkout_fields = self::get_custom_checkout_fields();
-		$sanitized_data         = [];
+	private function sanitize_custom_checkout_data( array $custom_checkout_data, array $custom_checkout_fields ): array {
+		$sanitized_data = [];
 
 		foreach ( $custom_checkout_data as $field_name => $field_value ) {
 			$field_name = wc_clean( wp_unslash( $field_name ) );
-			$field_type = $custom_checkout_fields[ $field_name ]['type'] ?? 'text';
+			$field_type = $custom_checkout_fields[ $field_name ]['type'] ?? 'textarea';
 
 			$sanitized_data[ $field_name ] = $this->sanitize_custom_checkout_field_value( $field_value, $field_type );
 		}
@@ -298,10 +299,11 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 	 *
 	 * @param array    $custom_checkout_data Custom checkout data.
 	 * @param WP_Error $errors Validation errors.
+	 * @param array    $custom_checkout_fields Custom checkout field definitions.
 	 * @return void
 	 */
-	private function validate_required_custom_checkout_fields( array $custom_checkout_data, WP_Error $errors ) {
-		foreach ( self::get_custom_checkout_fields() as $field_name => $field ) {
+	private function validate_required_custom_checkout_fields( array $custom_checkout_data, WP_Error $errors, array $custom_checkout_fields ) {
+		foreach ( $custom_checkout_fields as $field_name => $field ) {
 			if ( empty( $field['required'] ) ) {
 				continue;
 			}
@@ -324,12 +326,13 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 	 *
 	 * @param WC_Order $order Order object.
 	 * @param array    $custom_checkout_data Custom checkout data.
+	 * @param array    $custom_checkout_fields Custom checkout field definitions.
 	 * @return void
 	 */
-	private function save_registered_custom_checkout_fields( WC_Order $order, array $custom_checkout_data ) {
+	private function save_registered_custom_checkout_fields( WC_Order $order, array $custom_checkout_data, array $custom_checkout_fields ) {
 		$updated_order_meta = false;
 
-		foreach ( array_keys( self::get_custom_checkout_fields() ) as $field_name ) {
+		foreach ( array_keys( $custom_checkout_fields ) as $field_name ) {
 			if ( ! array_key_exists( $field_name, $custom_checkout_data ) ) {
 				continue;
 			}

--- a/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
@@ -131,31 +131,26 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 		$custom_checkout_data = $this->get_custom_checkout_data_from_request( $request );
 
 		if ( [] === $custom_checkout_data ) {
+			// Normal Store API checkouts can include empty extension defaults without an Express Checkout custom-field payload.
 			return;
 		}
 
 		$custom_checkout_data = $this->sanitize_custom_checkout_data( $custom_checkout_data );
 		$errors               = new WP_Error();
 
-		$this->with_custom_checkout_post_data(
-			$custom_checkout_data,
-			function () use ( $custom_checkout_data, $errors, $order, $request ) {
-				$this->validate_required_custom_checkout_fields( $custom_checkout_data, $errors );
-				$this->validate_custom_checkout_fields_using_classic_hooks( $errors );
+		$this->validate_required_custom_checkout_fields( $custom_checkout_data, $errors );
 
-				/**
-				 * Allows extensions to validate Express Checkout custom checkout fields.
-				 *
-				 * @since 10.9.0
-				 *
-				 * @param array           $custom_checkout_data Custom checkout data.
-				 * @param WP_Error        $errors Validation errors.
-				 * @param WC_Order        $order Order object.
-				 * @param WP_REST_Request $request Full request object.
-				 */
-				do_action( 'wcpay_express_checkout_after_custom_fields_validation', $custom_checkout_data, $errors, $order, $request );
-			}
-		);
+		/**
+		 * Allows extensions to validate Express Checkout custom checkout fields.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param array           $custom_checkout_data Custom checkout data.
+		 * @param WP_Error        $errors Validation errors.
+		 * @param WC_Order        $order Order object.
+		 * @param WP_REST_Request $request Full request object.
+		 */
+		do_action( 'wcpay_express_checkout_after_custom_fields_validation', $custom_checkout_data, $errors, $order, $request );
 
 		if ( $errors->has_errors() ) {
 			throw new RouteException(
@@ -167,24 +162,17 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 
 		$this->save_registered_custom_checkout_fields( $order, $custom_checkout_data );
 
-		$this->with_custom_checkout_post_data(
-			$custom_checkout_data,
-			function () use ( $custom_checkout_data, $order, $request ) {
-				do_action( 'woocommerce_checkout_update_order_meta', $order->get_id(), $custom_checkout_data );
-
-				/**
-				 * Allows extensions to save Express Checkout custom checkout fields to the order.
-				 *
-				 * @since 10.9.0
-				 *
-				 * @param int             $order_id Order ID.
-				 * @param array           $custom_checkout_data Custom checkout data.
-				 * @param WC_Order        $order Order object.
-				 * @param WP_REST_Request $request Full request object.
-				 */
-				do_action( 'wcpay_express_checkout_update_custom_fields_order_meta', $order->get_id(), $custom_checkout_data, $order, $request );
-			}
-		);
+		/**
+		 * Allows extensions to save Express Checkout custom checkout fields to the order.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param int             $order_id Order ID.
+		 * @param array           $custom_checkout_data Custom checkout data.
+		 * @param WC_Order        $order Order object.
+		 * @param WP_REST_Request $request Full request object.
+		 */
+		do_action( 'wcpay_express_checkout_update_custom_fields_order_meta', $order->get_id(), $custom_checkout_data, $order, $request );
 	}
 
 	/**
@@ -239,10 +227,6 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 		}
 
 		$custom_checkout_data = $extensions[ self::EXTENSION_NAMESPACE ][ self::CUSTOM_CHECKOUT_DATA ];
-
-		if ( is_array( $custom_checkout_data ) ) {
-			return $custom_checkout_data;
-		}
 
 		if ( ! is_string( $custom_checkout_data ) ) {
 			return [];
@@ -336,51 +320,6 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 	}
 
 	/**
-	 * Runs classic checkout validation hooks and copies newly-created error notices to the Store API error object.
-	 *
-	 * @param WP_Error $errors Validation errors.
-	 * @return void
-	 */
-	private function validate_custom_checkout_fields_using_classic_hooks( WP_Error $errors ) {
-		$previous_notices = wc_get_notices();
-		$previous_errors  = $previous_notices['error'] ?? [];
-
-		do_action( 'woocommerce_checkout_process' );
-
-		$current_notices = wc_get_notices();
-		$new_errors      = array_slice( $current_notices['error'] ?? [], count( $previous_errors ) );
-
-		foreach ( $new_errors as $index => $notice ) {
-			$message = $this->get_classic_checkout_error_notice_message( $notice );
-
-			if ( '' === $message ) {
-				continue;
-			}
-
-			$errors->add(
-				'wcpay_express_checkout_classic_checkout_validation_error_' . $index,
-				$message
-			);
-		}
-
-		wc_set_notices( $previous_notices );
-	}
-
-	/**
-	 * Gets the message from a WooCommerce checkout error notice.
-	 *
-	 * @param mixed $notice WooCommerce notice.
-	 * @return string
-	 */
-	private function get_classic_checkout_error_notice_message( $notice ): string {
-		if ( is_array( $notice ) ) {
-			$notice = $notice['notice'] ?? '';
-		}
-
-		return wp_strip_all_tags( (string) $notice );
-	}
-
-	/**
 	 * Saves WooCommerce-registered custom checkout fields to order meta.
 	 *
 	 * @param WC_Order $order Order object.
@@ -401,27 +340,6 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 
 		if ( $updated_order_meta ) {
 			$order->save_meta_data();
-		}
-	}
-
-	/**
-	 * Temporarily exposes custom checkout data through $_POST for classic checkout callbacks.
-	 *
-	 * @param array    $custom_checkout_data Custom checkout data.
-	 * @param callable $callback Callback to run with bridged $_POST data.
-	 * @return mixed
-	 */
-	private function with_custom_checkout_post_data( array $custom_checkout_data, callable $callback ) {
-		$previous_post = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-
-		foreach ( $custom_checkout_data as $field_name => $field_value ) {
-			$_POST[ $field_name ] = $field_value; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		}
-
-		try {
-			return $callback();
-		} finally {
-			$_POST = $previous_post; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		}
 	}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
@@ -248,6 +248,10 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 			return [];
 		}
 
+		if ( '' === trim( $custom_checkout_data ) ) {
+			return [];
+		}
+
 		$decoded_custom_checkout_data = json_decode( $custom_checkout_data, true );
 
 		if ( ! is_array( $decoded_custom_checkout_data ) ) {

--- a/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
@@ -137,19 +137,25 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 		$custom_checkout_data = $this->sanitize_custom_checkout_data( $custom_checkout_data );
 		$errors               = new WP_Error();
 
-		$this->validate_required_custom_checkout_fields( $custom_checkout_data, $errors );
+		$this->with_custom_checkout_post_data(
+			$custom_checkout_data,
+			function () use ( $custom_checkout_data, $errors, $order, $request ) {
+				$this->validate_required_custom_checkout_fields( $custom_checkout_data, $errors );
+				$this->validate_custom_checkout_fields_using_classic_hooks( $errors );
 
-		/**
-		 * Allows extensions to validate Express Checkout custom checkout fields.
-		 *
-		 * @since 10.9.0
-		 *
-		 * @param array           $custom_checkout_data Custom checkout data.
-		 * @param WP_Error        $errors Validation errors.
-		 * @param WC_Order        $order Order object.
-		 * @param WP_REST_Request $request Full request object.
-		 */
-		do_action( 'wcpay_express_checkout_after_checkout_validation', $custom_checkout_data, $errors, $order, $request );
+				/**
+				 * Allows extensions to validate Express Checkout custom checkout fields.
+				 *
+				 * @since 10.9.0
+				 *
+				 * @param array           $custom_checkout_data Custom checkout data.
+				 * @param WP_Error        $errors Validation errors.
+				 * @param WC_Order        $order Order object.
+				 * @param WP_REST_Request $request Full request object.
+				 */
+				do_action( 'wcpay_express_checkout_after_custom_fields_validation', $custom_checkout_data, $errors, $order, $request );
+			}
+		);
 
 		if ( $errors->has_errors() ) {
 			throw new RouteException(
@@ -159,17 +165,26 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 			);
 		}
 
-		/**
-		 * Allows extensions to save Express Checkout custom checkout fields to the order.
-		 *
-		 * @since 10.9.0
-		 *
-		 * @param int             $order_id Order ID.
-		 * @param array           $custom_checkout_data Custom checkout data.
-		 * @param WC_Order        $order Order object.
-		 * @param WP_REST_Request $request Full request object.
-		 */
-		do_action( 'wcpay_express_checkout_update_order_meta', $order->get_id(), $custom_checkout_data, $order, $request );
+		$this->save_registered_custom_checkout_fields( $order, $custom_checkout_data );
+
+		$this->with_custom_checkout_post_data(
+			$custom_checkout_data,
+			function () use ( $custom_checkout_data, $order, $request ) {
+				do_action( 'woocommerce_checkout_update_order_meta', $order->get_id(), $custom_checkout_data );
+
+				/**
+				 * Allows extensions to save Express Checkout custom checkout fields to the order.
+				 *
+				 * @since 10.9.0
+				 *
+				 * @param int             $order_id Order ID.
+				 * @param array           $custom_checkout_data Custom checkout data.
+				 * @param WC_Order        $order Order object.
+				 * @param WP_REST_Request $request Full request object.
+				 */
+				do_action( 'wcpay_express_checkout_update_custom_fields_order_meta', $order->get_id(), $custom_checkout_data, $order, $request );
+			}
+		);
 	}
 
 	/**
@@ -313,6 +328,96 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler {
 					)
 				);
 			}
+		}
+	}
+
+	/**
+	 * Runs classic checkout validation hooks and copies newly-created error notices to the Store API error object.
+	 *
+	 * @param WP_Error $errors Validation errors.
+	 * @return void
+	 */
+	private function validate_custom_checkout_fields_using_classic_hooks( WP_Error $errors ) {
+		$previous_notices = wc_get_notices();
+		$previous_errors  = $previous_notices['error'] ?? [];
+
+		do_action( 'woocommerce_checkout_process' );
+
+		$current_notices = wc_get_notices();
+		$new_errors      = array_slice( $current_notices['error'] ?? [], count( $previous_errors ) );
+
+		foreach ( $new_errors as $index => $notice ) {
+			$message = $this->get_classic_checkout_error_notice_message( $notice );
+
+			if ( '' === $message ) {
+				continue;
+			}
+
+			$errors->add(
+				'wcpay_express_checkout_classic_checkout_validation_error_' . $index,
+				$message
+			);
+		}
+
+		wc_set_notices( $previous_notices );
+	}
+
+	/**
+	 * Gets the message from a WooCommerce checkout error notice.
+	 *
+	 * @param mixed $notice WooCommerce notice.
+	 * @return string
+	 */
+	private function get_classic_checkout_error_notice_message( $notice ): string {
+		if ( is_array( $notice ) ) {
+			$notice = $notice['notice'] ?? '';
+		}
+
+		return wp_strip_all_tags( (string) $notice );
+	}
+
+	/**
+	 * Saves WooCommerce-registered custom checkout fields to order meta.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @param array    $custom_checkout_data Custom checkout data.
+	 * @return void
+	 */
+	private function save_registered_custom_checkout_fields( WC_Order $order, array $custom_checkout_data ) {
+		$updated_order_meta = false;
+
+		foreach ( array_keys( self::get_custom_checkout_fields() ) as $field_name ) {
+			if ( ! array_key_exists( $field_name, $custom_checkout_data ) ) {
+				continue;
+			}
+
+			$order->update_meta_data( $field_name, $custom_checkout_data[ $field_name ] );
+			$updated_order_meta = true;
+		}
+
+		if ( $updated_order_meta ) {
+			$order->save_meta_data();
+		}
+	}
+
+	/**
+	 * Temporarily exposes custom checkout data through $_POST for classic checkout callbacks.
+	 *
+	 * @param array    $custom_checkout_data Custom checkout data.
+	 * @param callable $callback Callback to run with bridged $_POST data.
+	 * @return mixed
+	 */
+	private function with_custom_checkout_post_data( array $custom_checkout_data, callable $callback ) {
+		$previous_post = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		foreach ( $custom_checkout_data as $field_name => $field_value ) {
+			$_POST[ $field_name ] = $field_value; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		}
+
+		try {
+			return $callback();
+		} finally {
+			$_POST = $previous_post; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		}
 	}
 

--- a/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-custom-fields-handler.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * Class WC_Payments_Express_Checkout_Custom_Fields_Handler
+ *
+ * @package WooCommerce\Payments
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * Adds classic checkout custom field support to Express Checkout Store API orders.
+ */
+class WC_Payments_Express_Checkout_Custom_Fields_Handler {
+	const EXTENSION_NAMESPACE   = 'woocommerce-payments/express-checkout';
+	const CUSTOM_CHECKOUT_DATA  = 'custom_checkout_data';
+	const CHECKOUT_ENDPOINT     = 'checkout';
+	const CHECKOUT_FIELD_GROUPS = [ 'billing', 'shipping', 'order' ];
+
+	const STANDARD_CHECKOUT_FIELDS = [
+		'billing_first_name',
+		'billing_last_name',
+		'billing_company',
+		'billing_country',
+		'billing_address_1',
+		'billing_address_2',
+		'billing_city',
+		'billing_state',
+		'billing_postcode',
+		'billing_phone',
+		'billing_email',
+		'shipping_first_name',
+		'shipping_last_name',
+		'shipping_company',
+		'shipping_country',
+		'shipping_address_1',
+		'shipping_address_2',
+		'shipping_city',
+		'shipping_state',
+		'shipping_postcode',
+		'shipping_phone',
+		'order_comments',
+	];
+
+	/**
+	 * Tracks whether the Store API extension schema was registered.
+	 *
+	 * @var bool
+	 */
+	private $store_api_extension_registered = false;
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'woocommerce_blocks_loaded', [ $this, 'register_store_api_extension' ] );
+		add_action( 'woocommerce_store_api_checkout_update_order_from_request', [ $this, 'process_store_api_checkout_request' ], 10, 2 );
+
+		if ( function_exists( 'woocommerce_store_api_register_endpoint_data' ) ) {
+			$this->register_store_api_extension();
+		}
+	}
+
+	/**
+	 * Register the Store API extension schema used by express checkout custom fields.
+	 *
+	 * @return void
+	 */
+	public function register_store_api_extension() {
+		if ( $this->store_api_extension_registered || ! function_exists( 'woocommerce_store_api_register_endpoint_data' ) ) {
+			return;
+		}
+
+		$result = woocommerce_store_api_register_endpoint_data(
+			[
+				'endpoint'        => self::CHECKOUT_ENDPOINT,
+				'namespace'       => self::EXTENSION_NAMESPACE,
+				'schema_callback' => [ $this, 'get_store_api_extension_schema' ],
+				'data_callback'   => [ $this, 'get_store_api_extension_data' ],
+				'schema_type'     => 'ARRAY_A',
+			]
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return;
+		}
+
+		$this->store_api_extension_registered = true;
+	}
+
+	/**
+	 * Returns the Store API extension schema.
+	 *
+	 * @return array
+	 */
+	public function get_store_api_extension_schema() {
+		return [
+			self::CUSTOM_CHECKOUT_DATA => [
+				'description' => __( 'Serialized custom checkout field data for WooPayments Express Checkout.', 'woocommerce-payments' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+			],
+		];
+	}
+
+	/**
+	 * Returns data for checkout responses.
+	 *
+	 * @return array
+	 */
+	public function get_store_api_extension_data() {
+		return [];
+	}
+
+	/**
+	 * Process custom checkout fields sent with an Express Checkout Store API checkout request.
+	 *
+	 * @param WC_Order        $order Order object.
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @throws RouteException When custom checkout field validation fails.
+	 *
+	 * @return void
+	 */
+	public function process_store_api_checkout_request( WC_Order $order, WP_REST_Request $request ) {
+		$custom_checkout_data = $this->get_custom_checkout_data_from_request( $request );
+
+		if ( [] === $custom_checkout_data ) {
+			return;
+		}
+
+		$custom_checkout_data = $this->sanitize_custom_checkout_data( $custom_checkout_data );
+		$errors               = new WP_Error();
+
+		$this->validate_required_custom_checkout_fields( $custom_checkout_data, $errors );
+
+		/**
+		 * Allows extensions to validate Express Checkout custom checkout fields.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param array           $custom_checkout_data Custom checkout data.
+		 * @param WP_Error        $errors Validation errors.
+		 * @param WC_Order        $order Order object.
+		 * @param WP_REST_Request $request Full request object.
+		 */
+		do_action( 'wcpay_express_checkout_after_checkout_validation', $custom_checkout_data, $errors, $order, $request );
+
+		if ( $errors->has_errors() ) {
+			throw new RouteException(
+				'woocommerce_payments_express_checkout_custom_fields_validation_error',
+				implode( ' ', $errors->get_error_messages() ),
+				400
+			);
+		}
+
+		/**
+		 * Allows extensions to save Express Checkout custom checkout fields to the order.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param int             $order_id Order ID.
+		 * @param array           $custom_checkout_data Custom checkout data.
+		 * @param WC_Order        $order Order object.
+		 * @param WP_REST_Request $request Full request object.
+		 */
+		do_action( 'wcpay_express_checkout_update_order_meta', $order->get_id(), $custom_checkout_data, $order, $request );
+	}
+
+	/**
+	 * Gets classic checkout custom field definitions.
+	 *
+	 * @return array
+	 */
+	public static function get_custom_checkout_fields(): array {
+		if ( ! function_exists( 'WC' ) || ! WC()->checkout() ) {
+			return [];
+		}
+
+		$checkout_fields = WC()->checkout()->get_checkout_fields();
+		$custom_fields   = [];
+
+		foreach ( self::CHECKOUT_FIELD_GROUPS as $field_group ) {
+			if ( empty( $checkout_fields[ $field_group ] ) || ! is_array( $checkout_fields[ $field_group ] ) ) {
+				continue;
+			}
+
+			foreach ( $checkout_fields[ $field_group ] as $field_name => $field ) {
+				if ( in_array( $field_name, self::STANDARD_CHECKOUT_FIELDS, true ) ) {
+					continue;
+				}
+
+				$custom_fields[ $field_name ] = [
+					'type'     => $field['type'] ?? 'text',
+					'label'    => $field['label'] ?? $field_name,
+					'required' => ! empty( $field['required'] ),
+					'location' => $field_group,
+				];
+			}
+		}
+
+		return $custom_fields;
+	}
+
+	/**
+	 * Gets custom checkout data from a Store API request.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @throws RouteException When custom checkout data is invalid.
+	 *
+	 * @return array
+	 */
+	private function get_custom_checkout_data_from_request( WP_REST_Request $request ): array {
+		$extensions = $request->get_param( 'extensions' );
+
+		if ( ! is_array( $extensions ) || ! isset( $extensions[ self::EXTENSION_NAMESPACE ][ self::CUSTOM_CHECKOUT_DATA ] ) ) {
+			return [];
+		}
+
+		$custom_checkout_data = $extensions[ self::EXTENSION_NAMESPACE ][ self::CUSTOM_CHECKOUT_DATA ];
+
+		if ( is_array( $custom_checkout_data ) ) {
+			return $custom_checkout_data;
+		}
+
+		if ( ! is_string( $custom_checkout_data ) ) {
+			return [];
+		}
+
+		$decoded_custom_checkout_data = json_decode( $custom_checkout_data, true );
+
+		if ( ! is_array( $decoded_custom_checkout_data ) ) {
+			throw new RouteException(
+				'woocommerce_payments_express_checkout_invalid_custom_checkout_data',
+				__( 'Invalid custom checkout field data.', 'woocommerce-payments' ),
+				400
+			);
+		}
+
+		return $decoded_custom_checkout_data;
+	}
+
+	/**
+	 * Sanitizes custom checkout data according to the checkout field type.
+	 *
+	 * @param array $custom_checkout_data Custom checkout data.
+	 * @return array
+	 */
+	private function sanitize_custom_checkout_data( array $custom_checkout_data ): array {
+		$custom_checkout_fields = self::get_custom_checkout_fields();
+		$sanitized_data         = [];
+
+		foreach ( $custom_checkout_data as $field_name => $field_value ) {
+			$field_name = wc_clean( wp_unslash( $field_name ) );
+			$field_type = $custom_checkout_fields[ $field_name ]['type'] ?? 'text';
+
+			$sanitized_data[ $field_name ] = $this->sanitize_custom_checkout_field_value( $field_value, $field_type );
+		}
+
+		return $sanitized_data;
+	}
+
+	/**
+	 * Sanitizes a single custom checkout field value.
+	 *
+	 * @param mixed  $field_value Field value.
+	 * @param string $field_type Field type.
+	 * @return mixed
+	 */
+	private function sanitize_custom_checkout_field_value( $field_value, string $field_type ) {
+		if ( is_array( $field_value ) ) {
+			return array_map(
+				function ( $value ) use ( $field_type ) {
+					return $this->sanitize_custom_checkout_field_value( $value, $field_type );
+				},
+				$field_value
+			);
+		}
+
+		if ( 'textarea' === $field_type ) {
+			return sanitize_textarea_field( wp_unslash( $field_value ) );
+		}
+
+		return sanitize_text_field( wp_unslash( $field_value ) );
+	}
+
+	/**
+	 * Validates required custom checkout fields.
+	 *
+	 * @param array    $custom_checkout_data Custom checkout data.
+	 * @param WP_Error $errors Validation errors.
+	 * @return void
+	 */
+	private function validate_required_custom_checkout_fields( array $custom_checkout_data, WP_Error $errors ) {
+		foreach ( self::get_custom_checkout_fields() as $field_name => $field ) {
+			if ( empty( $field['required'] ) ) {
+				continue;
+			}
+
+			if ( ! array_key_exists( $field_name, $custom_checkout_data ) || $this->is_empty_custom_checkout_field_value( $custom_checkout_data[ $field_name ] ) ) {
+				$errors->add(
+					'wcpay_express_checkout_required_custom_field_' . sanitize_key( $field_name ),
+					sprintf(
+						/* translators: %s: checkout field label. */
+						__( '%s is a required field.', 'woocommerce-payments' ),
+						wp_strip_all_tags( $field['label'] ?? $field_name )
+					)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Checks whether a custom checkout field value is empty.
+	 *
+	 * @param mixed $field_value Field value.
+	 * @return bool
+	 */
+	private function is_empty_custom_checkout_field_value( $field_value ): bool {
+		if ( is_array( $field_value ) ) {
+			foreach ( $field_value as $value ) {
+				if ( ! $this->is_empty_custom_checkout_field_value( $value ) ) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return '' === trim( (string) $field_value );
+	}
+}

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-handler.php
@@ -149,6 +149,71 @@ class WC_Payments_Express_Checkout_Button_Handler_Test extends WCPAY_UnitTestCas
 		$this->assertEquals( get_bloginfo( 'name' ), $params['store_name'] );
 	}
 
+	public function test_get_express_checkout_params_includes_custom_checkout_fields_on_checkout_page() {
+		$add_custom_checkout_field = function ( $fields ) {
+			$fields['billing']['woopmnt_2363_required_field'] = [
+				'label'    => 'WOOPMNT 2363 Required Field',
+				'required' => true,
+				'type'     => 'text',
+			];
+
+			return $fields;
+		};
+
+		add_filter( 'woocommerce_checkout_fields', $add_custom_checkout_field );
+		WC()->checkout()->checkout_fields = null;
+
+		$this->mock_ece_button_helper
+			->method( 'get_button_context' )
+			->willReturn( 'checkout' );
+
+		$this->mock_ece_button_helper
+			->method( 'get_common_button_settings' )
+			->willReturn( [] );
+
+		try {
+			$params = $this->system_under_test->get_express_checkout_params();
+		} finally {
+			remove_filter( 'woocommerce_checkout_fields', $add_custom_checkout_field );
+			WC()->checkout()->checkout_fields = null;
+		}
+
+		$this->assertArrayHasKey( 'woopmnt_2363_required_field', $params['custom_checkout_fields'] );
+		$this->assertTrue( $params['custom_checkout_fields']['woopmnt_2363_required_field']['required'] );
+	}
+
+	public function test_get_express_checkout_params_omits_custom_checkout_fields_outside_checkout_page() {
+		$add_custom_checkout_field = function ( $fields ) {
+			$fields['billing']['woopmnt_2363_required_field'] = [
+				'label'    => 'WOOPMNT 2363 Required Field',
+				'required' => true,
+				'type'     => 'text',
+			];
+
+			return $fields;
+		};
+
+		add_filter( 'woocommerce_checkout_fields', $add_custom_checkout_field );
+		WC()->checkout()->checkout_fields = null;
+
+		$this->mock_ece_button_helper
+			->method( 'get_button_context' )
+			->willReturn( 'cart' );
+
+		$this->mock_ece_button_helper
+			->method( 'get_common_button_settings' )
+			->willReturn( [] );
+
+		try {
+			$params = $this->system_under_test->get_express_checkout_params();
+		} finally {
+			remove_filter( 'woocommerce_checkout_fields', $add_custom_checkout_field );
+			WC()->checkout()->checkout_fields = null;
+		}
+
+		$this->assertSame( [], $params['custom_checkout_fields'] );
+	}
+
 	public function test_payment_fields_js_config_on_cart_page_with_cart_disabled() {
 		$this->mock_ece_button_helper
 			->method( 'get_button_context' )

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
@@ -172,6 +172,38 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$this->assertSame( 'A required value', $order->get_meta( 'my_field_name' ) );
 	}
 
+	public function test_process_store_api_checkout_request_exposes_unregistered_custom_checkout_fields_to_hooks_without_saving_by_default() {
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				'after_order_notes_field' => ' A hook-only value ',
+			]
+		);
+
+		$captured_data = null;
+
+		add_action(
+			'wcpay_express_checkout_update_custom_fields_order_meta',
+			function ( $order_id, $custom_checkout_data ) use ( &$captured_data ) {
+				$captured_data = $custom_checkout_data;
+			},
+			10,
+			2
+		);
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertSame(
+			[
+				'after_order_notes_field' => 'A hook-only value',
+			],
+			$captured_data
+		);
+		$this->assertSame( '', $order->get_meta( 'after_order_notes_field' ) );
+	}
+
 	public function test_process_store_api_checkout_request_does_not_run_classic_checkout_process_validation() {
 		$classic_checkout_process_ran = false;
 		$checkout_process_callback    = function () use ( &$classic_checkout_process_ran ) {

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
@@ -172,12 +172,11 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$this->assertSame( 'A required value', $order->get_meta( 'my_field_name' ) );
 	}
 
-	public function test_process_store_api_checkout_request_runs_classic_checkout_process_validation() {
-		$checkout_process_callback = function () {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			if ( empty( $_POST['my_field_name'] ) ) {
-				wc_add_notice( 'Please enter something into this new shiny field.', 'error' );
-			}
+	public function test_process_store_api_checkout_request_does_not_run_classic_checkout_process_validation() {
+		$classic_checkout_process_ran = false;
+		$checkout_process_callback    = function () use ( &$classic_checkout_process_ran ) {
+			$classic_checkout_process_ran = true;
+			wc_add_notice( 'Classic checkout validation should not run.', 'error' );
 		};
 
 		$this->classic_checkout_process_callbacks[] = $checkout_process_callback;
@@ -194,19 +193,17 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 			]
 		);
 
-		$this->expectException( RouteException::class );
-		$this->expectExceptionMessage( 'Please enter something into this new shiny field.' );
-
 		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+
+		$this->assertFalse( $classic_checkout_process_ran );
+		$this->assertSame( [], wc_get_notices( 'error' ) );
 	}
 
-	public function test_process_store_api_checkout_request_runs_classic_checkout_update_order_meta_callbacks() {
-		$checkout_update_order_meta_callback = function ( $order_id ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			if ( isset( $_POST['my_field_name'] ) ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing
-				update_post_meta( $order_id, 'My Field', sanitize_text_field( wp_unslash( $_POST['my_field_name'] ) ) );
-			}
+	public function test_process_store_api_checkout_request_does_not_run_classic_checkout_update_order_meta_callbacks() {
+		$classic_checkout_update_order_meta_ran = false;
+		$checkout_update_order_meta_callback    = function ( $order_id ) use ( &$classic_checkout_update_order_meta_ran ) {
+			$classic_checkout_update_order_meta_ran = true;
+			update_post_meta( $order_id, 'My Field', 'Classic checkout meta should not save.' );
 		};
 
 		$this->classic_checkout_update_order_meta_callbacks[] = $checkout_update_order_meta_callback;
@@ -225,7 +222,31 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 
 		$this->system_under_test->process_store_api_checkout_request( $order, $request );
 
-		$this->assertSame( 'A required value', get_post_meta( $order->get_id(), 'My Field', true ) );
+		$this->assertFalse( $classic_checkout_update_order_meta_ran );
+		$this->assertSame( '', get_post_meta( $order->get_id(), 'My Field', true ) );
+	}
+
+	public function test_process_store_api_checkout_request_throws_when_custom_field_validation_hook_adds_error() {
+		add_action(
+			'wcpay_express_checkout_after_custom_fields_validation',
+			function ( $custom_checkout_data, $errors ) {
+				$errors->add( 'my_custom_checkout_field_error', 'Custom checkout field error.' );
+			},
+			10,
+			2
+		);
+
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				'my_field_name' => 'A value',
+			]
+		);
+
+		$this->expectException( RouteException::class );
+		$this->expectExceptionMessage( 'Custom checkout field error.' );
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
 	}
 
 	public function test_process_store_api_checkout_request_ignores_empty_custom_checkout_data() {
@@ -235,6 +256,16 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$this->system_under_test->process_store_api_checkout_request( $order, $request );
 
 		$this->assertSame( '', $order->get_meta( 'my_field_name' ) );
+	}
+
+	public function test_process_store_api_checkout_request_throws_when_custom_checkout_data_is_invalid_json() {
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request_with_raw_custom_checkout_data( '{invalid-json' );
+
+		$this->expectException( RouteException::class );
+		$this->expectExceptionMessage( 'Invalid custom checkout field data.' );
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
 	}
 
 	public function test_process_store_api_checkout_request_throws_when_required_custom_field_is_empty() {

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
@@ -176,7 +176,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$order   = WC_Helper_Order::create_order();
 		$request = $this->create_request(
 			[
-				'after_order_notes_field' => ' A hook-only value ',
+				'after_order_notes_field' => " A hook-only value\nwith another line ",
 			]
 		);
 
@@ -197,11 +197,41 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 
 		$this->assertSame(
 			[
-				'after_order_notes_field' => 'A hook-only value',
+				'after_order_notes_field' => "A hook-only value\nwith another line",
 			],
 			$captured_data
 		);
 		$this->assertSame( '', $order->get_meta( 'after_order_notes_field' ) );
+	}
+
+	public function test_process_store_api_checkout_request_loads_custom_checkout_fields_once() {
+		$get_checkout_fields_count = 0;
+
+		add_filter(
+			'woocommerce_checkout_fields',
+			function ( $fields ) use ( &$get_checkout_fields_count ) {
+				++$get_checkout_fields_count;
+
+				$fields['order']['my_field_name'] = [
+					'type'     => 'text',
+					'label'    => 'My field name',
+					'required' => true,
+				];
+
+				return $fields;
+			}
+		);
+
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				'my_field_name' => ' A required value ',
+			]
+		);
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+
+		$this->assertSame( 1, $get_checkout_fields_count );
 	}
 
 	public function test_process_store_api_checkout_request_does_not_run_classic_checkout_process_validation() {

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * WC_Payments_Express_Checkout_Custom_Fields_Handler unit tests.
+ */
+class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_UnitTestCase {
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payments_Express_Checkout_Custom_Fields_Handler
+	 */
+	private $system_under_test;
+
+	/**
+	 * Test setup.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->system_under_test = new WC_Payments_Express_Checkout_Custom_Fields_Handler();
+	}
+
+	/**
+	 * Test teardown.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'woocommerce_checkout_fields' );
+		remove_all_actions( 'wcpay_express_checkout_update_order_meta' );
+		remove_all_actions( 'wcpay_express_checkout_after_checkout_validation' );
+		WC()->checkout()->checkout_fields = null;
+
+		parent::tear_down();
+	}
+
+	public function test_get_custom_checkout_fields_includes_only_non_standard_fields() {
+		add_filter(
+			'woocommerce_checkout_fields',
+			function ( $fields ) {
+				$fields['billing']['billing_vat_id'] = [
+					'type'     => 'text',
+					'label'    => 'VAT ID',
+					'required' => true,
+				];
+
+				$fields['order']['delivery_note'] = [
+					'type'     => 'textarea',
+					'label'    => 'Delivery note',
+					'required' => false,
+				];
+
+				return $fields;
+			}
+		);
+
+		$custom_fields = WC_Payments_Express_Checkout_Custom_Fields_Handler::get_custom_checkout_fields();
+
+		$this->assertArrayHasKey( 'billing_vat_id', $custom_fields );
+		$this->assertArrayHasKey( 'delivery_note', $custom_fields );
+		$this->assertArrayNotHasKey( 'billing_first_name', $custom_fields );
+		$this->assertSame( 'text', $custom_fields['billing_vat_id']['type'] );
+		$this->assertSame( 'billing', $custom_fields['billing_vat_id']['location'] );
+		$this->assertTrue( $custom_fields['billing_vat_id']['required'] );
+	}
+
+	public function test_process_store_api_checkout_request_passes_sanitized_custom_checkout_data_to_actions() {
+		add_filter(
+			'woocommerce_checkout_fields',
+			function ( $fields ) {
+				$fields['order']['my_field_name'] = [
+					'type'     => 'text',
+					'label'    => 'My field name',
+					'required' => false,
+				];
+				$fields['order']['order_note']    = [
+					'type'     => 'textarea',
+					'label'    => 'Order note',
+					'required' => false,
+				];
+
+				return $fields;
+			}
+		);
+
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				'my_field_name' => ' A required value ',
+				'order_note'    => "Line one\nLine two",
+			]
+		);
+
+		$captured_order_id = null;
+		$captured_data     = null;
+
+		add_action(
+			'wcpay_express_checkout_update_order_meta',
+			function ( $order_id, $custom_checkout_data ) use ( &$captured_order_id, &$captured_data ) {
+				$captured_order_id = $order_id;
+				$captured_data     = $custom_checkout_data;
+			},
+			10,
+			2
+		);
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+
+		$this->assertSame( $order->get_id(), $captured_order_id );
+		$this->assertSame(
+			[
+				'my_field_name' => 'A required value',
+				'order_note'    => "Line one\nLine two",
+			],
+			$captured_data
+		);
+	}
+
+	public function test_process_store_api_checkout_request_throws_when_required_custom_field_is_empty() {
+		add_filter(
+			'woocommerce_checkout_fields',
+			function ( $fields ) {
+				$fields['order']['my_field_name'] = [
+					'type'     => 'text',
+					'label'    => 'My field name',
+					'required' => true,
+				];
+
+				return $fields;
+			}
+		);
+
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				'my_field_name' => '',
+			]
+		);
+
+		$this->expectException( RouteException::class );
+		$this->expectExceptionMessage( 'My field name is a required field.' );
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+	}
+
+	/**
+	 * Creates a Store API checkout request containing custom checkout data.
+	 *
+	 * @param array $custom_checkout_data Custom checkout data.
+	 * @return WP_REST_Request
+	 */
+	private function create_request( array $custom_checkout_data ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_param(
+			'extensions',
+			[
+				'woocommerce-payments/express-checkout' => [
+					'custom_checkout_data' => wp_json_encode( $custom_checkout_data ),
+				],
+			]
+		);
+
+		return $request;
+	}
+}

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
@@ -19,6 +19,20 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	private $system_under_test;
 
 	/**
+	 * Classic checkout process callbacks added during a test.
+	 *
+	 * @var array
+	 */
+	private $classic_checkout_process_callbacks = [];
+
+	/**
+	 * Classic checkout update order meta callbacks added during a test.
+	 *
+	 * @var array
+	 */
+	private $classic_checkout_update_order_meta_callbacks = [];
+
+	/**
 	 * Test setup.
 	 */
 	public function set_up() {
@@ -32,8 +46,17 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	 */
 	public function tear_down() {
 		remove_all_filters( 'woocommerce_checkout_fields' );
-		remove_all_actions( 'wcpay_express_checkout_update_order_meta' );
-		remove_all_actions( 'wcpay_express_checkout_after_checkout_validation' );
+		remove_all_actions( 'wcpay_express_checkout_update_custom_fields_order_meta' );
+		remove_all_actions( 'wcpay_express_checkout_after_custom_fields_validation' );
+		foreach ( $this->classic_checkout_process_callbacks as $callback ) {
+			remove_action( 'woocommerce_checkout_process', $callback );
+		}
+		foreach ( $this->classic_checkout_update_order_meta_callbacks as $callback ) {
+			remove_action( 'woocommerce_checkout_update_order_meta', $callback );
+		}
+		$this->classic_checkout_process_callbacks           = [];
+		$this->classic_checkout_update_order_meta_callbacks = [];
+		wc_clear_notices();
 		WC()->checkout()->checkout_fields = null;
 
 		parent::tear_down();
@@ -69,7 +92,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$this->assertTrue( $custom_fields['billing_vat_id']['required'] );
 	}
 
-	public function test_process_store_api_checkout_request_passes_sanitized_custom_checkout_data_to_actions() {
+	public function test_process_store_api_checkout_request_passes_sanitized_custom_checkout_data_to_custom_field_actions() {
 		add_filter(
 			'woocommerce_checkout_fields',
 			function ( $fields ) {
@@ -100,7 +123,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$captured_data     = null;
 
 		add_action(
-			'wcpay_express_checkout_update_order_meta',
+			'wcpay_express_checkout_update_custom_fields_order_meta',
 			function ( $order_id, $custom_checkout_data ) use ( &$captured_order_id, &$captured_data ) {
 				$captured_order_id = $order_id;
 				$captured_data     = $custom_checkout_data;
@@ -119,6 +142,90 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 			],
 			$captured_data
 		);
+	}
+
+	public function test_process_store_api_checkout_request_saves_registered_custom_checkout_fields_to_order_meta() {
+		add_filter(
+			'woocommerce_checkout_fields',
+			function ( $fields ) {
+				$fields['order']['my_field_name'] = [
+					'type'     => 'text',
+					'label'    => 'My field name',
+					'required' => false,
+				];
+
+				return $fields;
+			}
+		);
+
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				'my_field_name' => ' A required value ',
+			]
+		);
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertSame( 'A required value', $order->get_meta( 'my_field_name' ) );
+	}
+
+	public function test_process_store_api_checkout_request_runs_classic_checkout_process_validation() {
+		$checkout_process_callback = function () {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( empty( $_POST['my_field_name'] ) ) {
+				wc_add_notice( 'Please enter something into this new shiny field.', 'error' );
+			}
+		};
+
+		$this->classic_checkout_process_callbacks[] = $checkout_process_callback;
+
+		add_action(
+			'woocommerce_checkout_process',
+			$checkout_process_callback
+		);
+
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				'my_field_name' => '',
+			]
+		);
+
+		$this->expectException( RouteException::class );
+		$this->expectExceptionMessage( 'Please enter something into this new shiny field.' );
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+	}
+
+	public function test_process_store_api_checkout_request_runs_classic_checkout_update_order_meta_callbacks() {
+		$checkout_update_order_meta_callback = function ( $order_id ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( isset( $_POST['my_field_name'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing
+				update_post_meta( $order_id, 'My Field', sanitize_text_field( wp_unslash( $_POST['my_field_name'] ) ) );
+			}
+		};
+
+		$this->classic_checkout_update_order_meta_callbacks[] = $checkout_update_order_meta_callback;
+
+		add_action(
+			'woocommerce_checkout_update_order_meta',
+			$checkout_update_order_meta_callback
+		);
+
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				'my_field_name' => ' A required value ',
+			]
+		);
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+
+		$this->assertSame( 'A required value', get_post_meta( $order->get_id(), 'My Field', true ) );
 	}
 
 	public function test_process_store_api_checkout_request_throws_when_required_custom_field_is_empty() {

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
@@ -33,6 +33,13 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	private $classic_checkout_update_order_meta_callbacks = [];
 
 	/**
+	 * Checkout fields callbacks added during a test.
+	 *
+	 * @var array
+	 */
+	private $checkout_fields_callbacks = [];
+
+	/**
 	 * Test setup.
 	 */
 	public function set_up() {
@@ -45,15 +52,18 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	 * Test teardown.
 	 */
 	public function tear_down() {
-		remove_all_filters( 'woocommerce_checkout_fields' );
 		remove_all_actions( 'wcpay_express_checkout_update_custom_fields_order_meta' );
 		remove_all_actions( 'wcpay_express_checkout_after_custom_fields_validation' );
+		foreach ( $this->checkout_fields_callbacks as $callback ) {
+			remove_filter( 'woocommerce_checkout_fields', $callback );
+		}
 		foreach ( $this->classic_checkout_process_callbacks as $callback ) {
 			remove_action( 'woocommerce_checkout_process', $callback );
 		}
 		foreach ( $this->classic_checkout_update_order_meta_callbacks as $callback ) {
 			remove_action( 'woocommerce_checkout_update_order_meta', $callback );
 		}
+		$this->checkout_fields_callbacks                    = [];
 		$this->classic_checkout_process_callbacks           = [];
 		$this->classic_checkout_update_order_meta_callbacks = [];
 		wc_clear_notices();
@@ -63,8 +73,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	}
 
 	public function test_get_custom_checkout_fields_includes_only_non_standard_fields() {
-		add_filter(
-			'woocommerce_checkout_fields',
+		$this->add_checkout_fields_filter(
 			function ( $fields ) {
 				$fields['billing']['billing_vat_id'] = [
 					'type'     => 'text',
@@ -93,8 +102,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	}
 
 	public function test_process_store_api_checkout_request_passes_sanitized_custom_checkout_data_to_custom_field_actions() {
-		add_filter(
-			'woocommerce_checkout_fields',
+		$this->add_checkout_fields_filter(
 			function ( $fields ) {
 				$fields['order']['my_field_name'] = [
 					'type'     => 'text',
@@ -145,8 +153,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	}
 
 	public function test_process_store_api_checkout_request_saves_registered_custom_checkout_fields_to_order_meta() {
-		add_filter(
-			'woocommerce_checkout_fields',
+		$this->add_checkout_fields_filter(
 			function ( $fields ) {
 				$fields['order']['my_field_name'] = [
 					'type'     => 'text',
@@ -204,11 +211,41 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$this->assertSame( '', $order->get_meta( 'after_order_notes_field' ) );
 	}
 
+	public function test_process_store_api_checkout_request_skips_empty_custom_checkout_field_names() {
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request(
+			[
+				' '                       => 'Skipped value',
+				'after_order_notes_field' => ' A hook-only value ',
+				"\n\t"                    => 'Also skipped',
+			]
+		);
+
+		$captured_data = null;
+
+		add_action(
+			'wcpay_express_checkout_update_custom_fields_order_meta',
+			function ( $order_id, $custom_checkout_data ) use ( &$captured_data ) {
+				$captured_data = $custom_checkout_data;
+			},
+			10,
+			2
+		);
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+
+		$this->assertSame(
+			[
+				'after_order_notes_field' => 'A hook-only value',
+			],
+			$captured_data
+		);
+	}
+
 	public function test_process_store_api_checkout_request_loads_custom_checkout_fields_once() {
 		$get_checkout_fields_count = 0;
 
-		add_filter(
-			'woocommerce_checkout_fields',
+		$this->add_checkout_fields_filter(
 			function ( $fields ) use ( &$get_checkout_fields_count ) {
 				++$get_checkout_fields_count;
 
@@ -331,8 +368,7 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	}
 
 	public function test_process_store_api_checkout_request_throws_when_required_custom_field_is_empty() {
-		add_filter(
-			'woocommerce_checkout_fields',
+		$this->add_checkout_fields_filter(
 			function ( $fields ) {
 				$fields['order']['my_field_name'] = [
 					'type'     => 'text',
@@ -355,6 +391,17 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$this->expectExceptionMessage( 'My field name is a required field.' );
 
 		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+	}
+
+	/**
+	 * Adds a checkout fields filter that will be removed after the test.
+	 *
+	 * @param callable $callback Filter callback.
+	 * @return void
+	 */
+	private function add_checkout_fields_filter( callable $callback ) {
+		$this->checkout_fields_callbacks[] = $callback;
+		add_filter( 'woocommerce_checkout_fields', $callback );
 	}
 
 	/**

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-custom-fields-handler.php
@@ -228,6 +228,15 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 		$this->assertSame( 'A required value', get_post_meta( $order->get_id(), 'My Field', true ) );
 	}
 
+	public function test_process_store_api_checkout_request_ignores_empty_custom_checkout_data() {
+		$order   = WC_Helper_Order::create_order();
+		$request = $this->create_request_with_raw_custom_checkout_data( '' );
+
+		$this->system_under_test->process_store_api_checkout_request( $order, $request );
+
+		$this->assertSame( '', $order->get_meta( 'my_field_name' ) );
+	}
+
 	public function test_process_store_api_checkout_request_throws_when_required_custom_field_is_empty() {
 		add_filter(
 			'woocommerce_checkout_fields',
@@ -262,12 +271,22 @@ class WC_Payments_Express_Checkout_Custom_Fields_Handler_Test extends WCPAY_Unit
 	 * @return WP_REST_Request
 	 */
 	private function create_request( array $custom_checkout_data ): WP_REST_Request {
+		return $this->create_request_with_raw_custom_checkout_data( wp_json_encode( $custom_checkout_data ) );
+	}
+
+	/**
+	 * Creates a Store API checkout request containing raw custom checkout data.
+	 *
+	 * @param mixed $custom_checkout_data Custom checkout data.
+	 * @return WP_REST_Request
+	 */
+	private function create_request_with_raw_custom_checkout_data( $custom_checkout_data ): WP_REST_Request {
 		$request = new WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
 		$request->set_param(
 			'extensions',
 			[
 				'woocommerce-payments/express-checkout' => [
-					'custom_checkout_data' => wp_json_encode( $custom_checkout_data ),
+					'custom_checkout_data' => $custom_checkout_data,
 				],
 			]
 		);


### PR DESCRIPTION
Fixes WOOPMNT-2363

#### Changes proposed in this Pull Request

Apple Pay / Google Pay express checkout places orders through the Store API without submitting the classic checkout form. If a store adds required custom fields to classic checkout, those values were not included in the express checkout Store API request, so the order could fail validation or miss the custom field data.

This PR follows the existing Store API extensions pattern used by order attribution: the checkout page collects the extra data, sends it through the Store API `extensions` payload, and WooPayments processes only its own extension namespace on the backend.

This PR:

- Collects eligible custom fields from the classic checkout form before the express checkout order is placed.
- Sends the collected values through `extensions['woocommerce-payments/express-checkout'].custom_checkout_data`.
- Validates required fields registered through `woocommerce_checkout_fields` server-side from WooCommerce checkout field definitions.
- Saves registered custom checkout fields to order meta using their checkout field keys, matching classic checkout custom-field behavior. These meta keys intentionally are not prefixed with `_`, so they remain visible like normal classic checkout custom field meta.
- Exposes `wcpay_express_checkout_after_custom_fields_validation` and `wcpay_express_checkout_update_custom_fields_order_meta` for custom validation/persistence.
- Keeps collection scoped to checkout-context express buttons, so product and cart page express buttons are not changed.
- Ignores empty Store API extension defaults so normal Blocks checkout requests that only include WooCommerce order-attribution data continue through checkout normally.

Registered vs unregistered checkout fields:

- Fields registered through `woocommerce_checkout_fields` are the turnkey path: they are collected, required-validated, and saved to order meta by default.
- Fields rendered directly into the checkout form, for example with `woocommerce_after_order_notes`, are intentionally collected and sent in the WooPayments extension payload, but are not automatically validated or saved. They can be handled with the new `wcpay_` hooks.
- Required validation assumes a registered required field is present on the checkout form whenever it is required. Conditionally hidden required fields should also update their required state, or be handled through the validation hook.
- This PR intentionally does not re-fire classic checkout hooks such as `woocommerce_checkout_process` or `woocommerce_checkout_update_order_meta` from the Store API request.

Product decision for review:

- This fully fixes the registered-field variant out of the box.
- The literal `woocommerce_after_order_notes` tutorial variant is supported through the extension payload and `wcpay_` hooks, not through automatic validation/persistence.
- Please confirm that “registered fields auto, action-rendered fields via hook” is the intended resolution for WOOPMNT-2363 / #5018 before moving this out of draft.

Developer note:

- Added [Express Checkout Custom Checkout Fields](https://github.com/Automattic/woocommerce-payments/blob/fix/woopmnt-2363-ece-custom-checkout-fields/docs/express-checkout-custom-checkout-fields.md) with hook examples for action-rendered fields.

#### Testing instructions

1. On a WooPayments test-mode store, add a required field through the `woocommerce_checkout_fields` filter.
2. Open a classic shortcode checkout page with an express checkout button.
3. Confirm the custom field appears in `wcpayConfig.custom_checkout_fields`.
4. Fill the custom field and trigger an express checkout order.
5. Confirm the Store API checkout request includes `extensions['woocommerce-payments/express-checkout'].custom_checkout_data`.
6. Confirm the order is created and the custom field value is saved to order meta.
7. Repeat with the custom field empty and confirm the Store API request returns the required-field validation error.
8. Add an action-rendered field to the checkout form, for example through `woocommerce_after_order_notes`.
9. Confirm the action-rendered field value is included in the WooPayments extension payload.
10. Hook `wcpay_express_checkout_update_custom_fields_order_meta` and confirm the action-rendered field value is available for custom persistence.
11. Place a normal Blocks checkout order without express checkout and confirm checkout is unaffected.
12. Verify the express checkout surface matrix:
    - Shortcode checkout: Apple Pay and Google Pay.
    - Blocks checkout: Apple Pay and Google Pay.
    - Cart page: Apple Pay and Google Pay still place orders without custom checkout field payloads.
    - Product page: Apple Pay and Google Pay still place orders without custom checkout field payloads.

Automated checks run locally:

- [x] `npm run lint:js`
- [x] `npm run lint:css`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npm run test:js -- --runInBand`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 npm run test:js -- client/express-checkout/compatibility/__tests__/classic-checkout-custom-fields.test.js --runInBand`
- [x] `npm run lint:php`
- [x] `php ../tools/composer.phar run phpstan -- --memory-limit=2G`
- [x] `npm run lint:php-compatibility`
- [x] `npm run test:php -- --filter WC_Payments_Express_Checkout_Custom_Fields_Handler_Test`
- [x] `npm run test:php`
- [x] `npm run build:client`
- [x] `git diff --check`

Known notes:

- `npm run test:js -- --runInBand` prints existing jsdom CSS parsing noise from `@wordpress/dataviews`; Jest exits successfully.
- `npm run build:client` completes with existing webpack asset-size warnings.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) - no mobile-specific UI changes.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
