### PR TITLE
Remove unsupported Fees report filters

### DIFF
--- a/changelog/fix-WOOPMNT-6189-remove-fees-report-filters
+++ b/changelog/fix-WOOPMNT-6189-remove-fees-report-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removed Gross amount, Fees total, and Settlement date filters from the Fees report.

--- a/client/reports/fees/__tests__/fields.test.tsx
+++ b/client/reports/fees/__tests__/fields.test.tsx
@@ -244,4 +244,14 @@ describe( 'getFeesFields field configuration', () => {
 			} )
 		);
 	} );
+
+	it( 'opts gross amount, fees total, and settlement date out of DataViews filtering', () => {
+		const fields = getTestFeesFields();
+
+		[ 'amount', 'fees', 'deposit_date' ].forEach( ( id ) => {
+			expect( fields.find( ( f ) => f.id === id )?.filterBy ).toBe(
+				false
+			);
+		} );
+	} );
 } );

--- a/client/reports/fees/fields.tsx
+++ b/client/reports/fees/fields.tsx
@@ -137,6 +137,7 @@ export const getFeesFields = ( {
 			label: __( 'Gross amount', 'woocommerce-payments' ),
 			type: 'integer',
 			enableSorting: true,
+			filterBy: false,
 			getValue: ( { item }: { item: ReportsFee } ) => item.amount,
 			render: ( { item }: { item: ReportsFee } ) => (
 				<>
@@ -152,6 +153,7 @@ export const getFeesFields = ( {
 			label: __( 'Fees total', 'woocommerce-payments' ),
 			type: 'integer',
 			enableSorting: true,
+			filterBy: false,
 			getValue: ( { item }: { item: ReportsFee } ) => item.fees,
 			render: ( { item }: { item: ReportsFee } ) => (
 				<>
@@ -166,6 +168,7 @@ export const getFeesFields = ( {
 			id: 'deposit_date',
 			label: __( 'Settlement date', 'woocommerce-payments' ),
 			type: 'datetime',
+			filterBy: false,
 			getValue: ( { item }: { item: ReportsFee } ) =>
 				item.deposit_date ?? '',
 			render: ( { item }: { item: ReportsFee } ) => (


### PR DESCRIPTION
Fixes WOOPMNT-6189

#### Changes proposed in this Pull Request

This removes the unsupported `Gross amount`, `Fees total`, and `Settlement date` filter options from the Fees report.

DataViews makes typed fields filterable by default. The Fees report still needs these fields as table columns, but the report query and API only support Date, Method, Type, and search filters. This PR opts those three fields out of DataViews filtering while keeping their column rendering and sorting behavior intact.

This also adds regression coverage for the field configuration and includes a patch changelog entry.

#### Merge dependency

This should be merged after https://github.com/Automattic/woocommerce-payments/pull/11779. That PR fixes the direct Reports route rendering error:

`There was an error rendering this view. Please contact support for assistance if the problem persists. TypeError: Cannot destructure property 'invalidateResolution' of '(0 , u.useDispatch)(...)' as it is null.`

#### Testing instructions

* Run `npm run test:js -- client/reports/fees/__tests__`
* Run `npx eslint client/reports/fees/fields.tsx client/reports/fees/__tests__/fields.test.tsx`
* Run `npm run build:client`
* Open the local Fees report at `http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Freports&tab=fees`
* Open the `Add filter` menu.
* Confirm `Method` and `Type` are still available as addable filters.
* Confirm `Gross amount`, `Fees total`, and `Settlement date` are not available as addable filters.
* Confirm the Date filter remains available in the toolbar.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) - Not applicable; this changes DataViews field filter configuration.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
