### PR TITLE
Record full card details on 3D Secure renewal payments

### DIFF
--- a/changelog/fix-woopmnt-2882-3ds-renewal-card-details
+++ b/changelog/fix-woopmnt-2882-3ds-renewal-card-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the actual card brand and last four digits (instead of a generic "Card") on subscription renewal and saved-card payments confirmed with 3D Secure.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3932,6 +3932,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$charge    = $intent->get_charge();
 				$charge_id = ! empty( $charge ) ? $charge->get_id() : null;
 
+				// Capture the actual card details from the charge so the order's payment method title (and,
+				// via sync, the subscription's) reflects the card used — brand and funding — instead of a
+				// generic "Card". The 3DS/SCA pay-for-renewal flow lands here after frontend authentication;
+				// the synchronous non-3DS path already does this in process_payment_for_order(). See WOOPMNT-2882.
+				if ( ! empty( $charge ) ) {
+					$payment_method_details = $charge->get_payment_method_details();
+				}
+
 				$this->attach_exchange_info_to_order( $order, $charge_id );
 				$this->order_service->attach_intent_info_to_order( $order, $intent );
 				$this->order_service->attach_transaction_fee_to_order( $order, $charge );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2037,22 +2037,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$payment_method_type = Payment_Method::LINK;
 			}
 
-			if ( 'card' === $payment_method_type && isset( $payment_method_details['card']['last4'] ) ) {
-				$order->add_meta_data( 'last4', $payment_method_details['card']['last4'], true );
-				if ( isset( $payment_method_details['card']['brand'] ) ) {
-					$order->add_meta_data( '_card_brand', $payment_method_details['card']['brand'], true );
-				}
-				$order->save_meta_data();
-			}
-			if ( 'amazon_pay' === $payment_method_type
-				&& isset( $payment_method_details['amazon_pay']['funding']['card']['last4'] ) ) {
-				$funding_card = $payment_method_details['amazon_pay']['funding']['card'];
-				$order->add_meta_data( 'last4', $funding_card['last4'], true );
-				if ( isset( $funding_card['brand'] ) ) {
-					$order->add_meta_data( '_card_brand', strtolower( $funding_card['brand'] ), true );
-				}
-				$order->save_meta_data();
-			}
+			$this->store_card_details_meta_for_order( $order, $payment_method_type, $payment_method_details );
 		} else {
 			$payment_method_details = false;
 			$token                  = $payment_information->is_using_saved_payment_method() ? $payment_information->get_payment_token() : null;
@@ -4673,6 +4658,39 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		return 'card' === $payment_method_type
 			&& is_array( $payment_method_details )
 			&& 'link' === ( $payment_method_details['card']['wallet']['type'] ?? null );
+	}
+
+	/**
+	 * Stores the card brand and last 4 digits on the order from the charge's payment method details,
+	 * so order/email displays and reporting reflect the actual card used. No-op when the details are
+	 * unavailable or the payment method does not carry card information (e.g. redirect methods, Link).
+	 *
+	 * @param WC_Order    $order                  The order to store the meta on.
+	 * @param string|null $payment_method_type    The Stripe payment method type (e.g. 'card', 'amazon_pay').
+	 * @param array|false $payment_method_details The charge's payment method details, or false when unavailable.
+	 */
+	private function store_card_details_meta_for_order( $order, $payment_method_type, $payment_method_details ) {
+		if ( ! is_array( $payment_method_details ) ) {
+			return;
+		}
+
+		if ( 'card' === $payment_method_type && isset( $payment_method_details['card']['last4'] ) ) {
+			$order->add_meta_data( 'last4', $payment_method_details['card']['last4'], true );
+			if ( isset( $payment_method_details['card']['brand'] ) ) {
+				$order->add_meta_data( '_card_brand', $payment_method_details['card']['brand'], true );
+			}
+			$order->save_meta_data();
+		}
+
+		if ( 'amazon_pay' === $payment_method_type
+			&& isset( $payment_method_details['amazon_pay']['funding']['card']['last4'] ) ) {
+			$funding_card = $payment_method_details['amazon_pay']['funding']['card'];
+			$order->add_meta_data( 'last4', $funding_card['last4'], true );
+			if ( isset( $funding_card['brand'] ) ) {
+				$order->add_meta_data( '_card_brand', strtolower( $funding_card['brand'] ), true );
+			}
+			$order->save_meta_data();
+		}
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4019,10 +4019,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				}
 
 				// The token was saved and attached above (before the status update). Set the order's
-				// payment method title from it here.
+				// payment method title and card meta (brand + last4) from the charge details here, mirroring
+				// the synchronous non-3DS path so 3DS/SCA confirmations record the same data.
 				if ( ! empty( $token ) ) {
 					$payment_method_type = $this->get_payment_method_type_for_setup_intent( $intent, $token );
 					$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
+					$this->store_card_details_meta_for_order( $order, $payment_method_type, $payment_method_details );
 				}
 
 				$return_url = $this->get_return_url( $order );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5337,6 +5337,70 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'Visa credit card', wc_get_order( $order->get_id() )->get_payment_method_title() );
 	}
 
+	public function test_update_order_status_stores_card_last4_and_brand_meta_from_charge_details() {
+		// The asynchronous (3DS/SCA) confirmation path must record the same last4/brand order meta as the
+		// synchronous path, so order/email displays and reporting reflect the actual card. WOOPMNT-2882.
+		$order = WC_Helper_Order::create_order();
+
+		$token = WC_Helper_Token::create_token( 'pm_mock' );
+		$this->mock_token_service
+			->method( 'add_payment_method_to_user' )
+			->willReturn( $token );
+
+		$intent_id = 'pi_mock_3ds_renewal_meta';
+		$this->order_service->set_intent_id_for_order( $order, $intent_id );
+
+		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$_POST                = [
+			'action'                     => 'update_order_status',
+			'order_id'                   => $order->get_id(),
+			'intent_id'                  => $intent_id,
+			'should_save_payment_method' => 'true',
+			'_wpnonce'                   => $nonce,
+		];
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'id'                     => $intent_id,
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [] ],
+						'charge'                 => [
+							'payment_method_details' => [
+								'type' => 'card',
+								'card' => [
+									'network' => 'visa',
+									'brand'   => 'visa',
+									'last4'   => '4242',
+									'funding' => 'credit',
+								],
+							],
+						],
+					]
+				)
+			);
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+
+		try {
+			ob_start();
+			$this->card_gateway->update_order_status();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+		}
+
+		$saved = wc_get_order( $order->get_id() );
+		$this->assertSame( '4242', $saved->get_meta( 'last4' ) );
+		$this->assertSame( 'visa', $saved->get_meta( '_card_brand' ) );
+	}
+
 	public function return_ajax_wp_die_handler() {
 		return [ $this, 'ajax_wp_die_handler' ];
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5318,6 +5318,17 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 						'id'                     => $intent_id,
 						'status'                 => Intent_Status::SUCCEEDED,
 						'payment_method_options' => [ 'card' => [] ],
+						// Declare the charge explicitly so the asserted title is traceable to its inputs
+						// (network + funding) rather than relying on WC_Helper_Intention::create_charge() defaults.
+						'charge'                 => [
+							'payment_method_details' => [
+								'type' => 'card',
+								'card' => [
+									'network' => 'visa',
+									'funding' => 'credit',
+								],
+							],
+						],
 					]
 				)
 			);

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5285,6 +5285,58 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertEmpty( wc_get_order( $order->get_id() )->get_meta( '_order_stock_reduced', true ) );
 	}
 
+	public function test_update_order_status_sets_branded_payment_method_title_from_charge_details() {
+		// A payment confirmed asynchronously (e.g. 3DS/SCA) that saves the payment method lands here.
+		// The order's payment method title must reflect the actual card from the charge, not a generic
+		// "Card" label. This also propagates to the subscription. Regression guard for WOOPMNT-2882.
+		$order = WC_Helper_Order::create_order();
+
+		$token = WC_Helper_Token::create_token( 'pm_mock' );
+		$this->mock_token_service
+			->method( 'add_payment_method_to_user' )
+			->willReturn( $token );
+
+		$intent_id = 'pi_mock_3ds_renewal';
+		$this->order_service->set_intent_id_for_order( $order, $intent_id );
+
+		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$_POST                = [
+			'action'                     => 'update_order_status',
+			'order_id'                   => $order->get_id(),
+			'intent_id'                  => $intent_id,
+			'should_save_payment_method' => 'true',
+			'_wpnonce'                   => $nonce,
+		];
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'id'                     => $intent_id,
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [] ],
+					]
+				)
+			);
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+
+		try {
+			ob_start();
+			$this->card_gateway->update_order_status();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+		}
+
+		$this->assertSame( 'Visa credit card', wc_get_order( $order->get_id() )->get_payment_method_title() );
+	}
+
 	public function return_ajax_wp_die_handler() {
 		return [ $this, 'ajax_wp_die_handler' ];
 	}


### PR DESCRIPTION
Follow-up to #11756 (merged) · Part of WOOPMNT-2882

#### Changes proposed in this Pull Request

When a subscription renewal (or any saved-card payment) is confirmed asynchronously after 3D Secure / SCA, `update_order_status()` recorded incomplete card data: the order — and the subscription it syncs to — showed a generic "Card" payment method title and never stored the `last4` / `_card_brand` meta. The synchronous (non-3DS) path in `process_payment_for_order()` records both, so 3DS renewals (and 3DS first-time sign-ups) were inconsistent with non-3DS ones.

This brings the 3DS path to parity:

- Populate `$payment_method_details` from the intent's charge (it was hardcoded to `false`), so `set_payment_method_title_for_order()` renders the real card — e.g. "Visa credit card" instead of "Card" — which also propagates to the subscription via `sync_payment_method_to_subscriptions()`. (`6ec88f5`)
- Extract the inline `last4` / `_card_brand` meta logic into a shared `store_card_details_meta_for_order()` helper, behaviour-preserving for the existing path. (`5762309`)
- Call that helper from the 3DS path so the order records the same card meta. (`cf831e1`)

**How can this code break?** The new behaviour only runs where a token was saved/attached (subscriptions, renewals, save-card 3DS). One-time 3DS payments without saving and $0 setup-intent confirmations are unaffected (no charge → title stays generic, matching the non-3DS path).

**What keeps it from breaking?** Two new unit tests assert the title and the `last4`/`_card_brand` meta through the full `update_order_status()` flow; the gateway, process-payment, and subscriptions unit suites (297 tests) still pass, covering the refactored shared helper. PHPCS and PHPStan clean.

#### Testing instructions

**Prerequisites:** A store with WooPayments + WooCommerce Subscriptions in test mode, this branch built and active.

- Create a subscription and pay with a 3DS card that requires authentication (e.g. `4000 0027 6000 3184`), or set up a failed renewal and pay it from My Account with a new 3DS card; complete the authentication.
- [ ] Verify the renewal order's payment method shows the real card (e.g. "Visa credit card"), not "Card".
- [ ] Verify the subscription's payment method reflects the same card.
- [ ] Verify the order's `last4` and `_card_brand` meta are populated.
- Repeat with a non-3DS card and confirm no regression in the title/meta.

*

-------------------

- [x] Run `npm run changelog` (added `fix-woopmnt-2882-3ds-renewal-card-details`)
- [x] Covered with tests
- [ ] Tested on mobile (does not apply — backend change)

**Post merge**

- [ ] Link to testing instructions: _QA Testing Not Applicable_

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

