### PR TITLE
fix: restore 100% src code coverage after write abilities

### DIFF
--- a/changelog/fix-coverage-svc
+++ b/changelog/fix-coverage-svc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+fix: restore 100% src code coverage after write abilities addition

--- a/tests/unit/src/Internal/Abilities/Domain/UploadDisputeEvidenceFileTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/UploadDisputeEvidenceFileTest.php
@@ -41,6 +41,12 @@ class UploadDisputeEvidenceFileTest extends WCPAY_UnitTestCase {
 		$this->assertSame( 'wcpay_missing_file_input', $result->get_error_code() );
 	}
 
+	public function test_execute_returns_error_when_input_not_array(): void {
+		$result = UploadDisputeEvidenceFile::execute( null );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_missing_file_input', $result->get_error_code() );
+	}
+
 	public function test_execute_returns_error_when_file_type_unsupported(): void {
 		$result = UploadDisputeEvidenceFile::execute(
 			[


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#11751 added the write abilities (refund, dispute evidence/accept) along with their services and Domain classes. It landed with one untested branch, which dropped the "Code coverage (src)" job to 99.90% and started failing the 100% gate.

The gap was a single statement: the `! is_array( $input )` guard at the top of `UploadDisputeEvidenceFile::execute()` (`$input = []`). Every existing test passed an array, so that line never ran.

This adds one test that calls `execute( null )` and asserts the same `wcpay_missing_file_input` error the empty-array case returns. No production code changes.

Verified locally against the full `phpunit-src.xml.dist` suite: `coverage-check` now reports `Total code coverage is 100.00 % – OK!`.

#### Testing instructions

* Re-run the "Code coverage (src)" CI job and confirm it passes at 100%.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
