### PR TITLE
fix: suppress WC 10.9 EmailLogger notes in test base class

### DIFF
--- a/changelog/fix-wc-beta-notes
+++ b/changelog/fix-wc-beta-notes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: fix: suppress WC 10.9 EmailLogger notes in test base class for WC beta compatibility

--- a/changelog/fix-wc-beta-notes
+++ b/changelog/fix-wc-beta-notes
@@ -1,3 +1,4 @@
 Significance: patch
 Type: dev
-Comment: fix: suppress WC 10.9 EmailLogger notes in test base class for WC beta compatibility
+
+fix: suppress WC 10.9 EmailLogger notes in test base class for WC beta compatibility

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -25,14 +25,15 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 		add_filter( 'woocommerce_get_geolocation', [ $this, 'filter_mock_wc_geolocation' ], 9, 2 );
 
 		// WC 10.9+ EmailLogger adds order notes after every transactional email. Suppress in tests
-		// so note-count and note-index assertions remain stable across WC versions.
-		add_filter( 'woocommerce_email_log_add_order_note', '__return_false' );
+		// so note-count and note-index assertions remain stable across WC versions. Priority 9
+		// matches the other filters here, so a test that wants notes back can re-enable at 10.
+		add_filter( 'woocommerce_email_log_add_order_note', '__return_false', 9 );
 	}
 
 	public function tear_down() {
 		remove_filter( 'pre_http_request', [ $this, 'filter_intercept_external_requests' ], 9, 3 );
 		remove_filter( 'woocommerce_get_geolocation', [ $this, 'filter_mock_wc_geolocation' ], 9, 2 );
-		remove_filter( 'woocommerce_email_log_add_order_note', '__return_false' );
+		remove_filter( 'woocommerce_email_log_add_order_note', '__return_false', 9 );
 
 		parent::tear_down();
 	}

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -23,11 +23,16 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 		// But by default we will intercept all external requests.
 		add_filter( 'pre_http_request', [ $this, 'filter_intercept_external_requests' ], 9, 3 );
 		add_filter( 'woocommerce_get_geolocation', [ $this, 'filter_mock_wc_geolocation' ], 9, 2 );
+
+		// WC 10.9+ EmailLogger adds order notes after every transactional email. Suppress in tests
+		// so note-count and note-index assertions remain stable across WC versions.
+		add_filter( 'woocommerce_email_log_add_order_note', '__return_false' );
 	}
 
 	public function tear_down() {
 		remove_filter( 'pre_http_request', [ $this, 'filter_intercept_external_requests' ], 9, 3 );
 		remove_filter( 'woocommerce_get_geolocation', [ $this, 'filter_mock_wc_geolocation' ], 9, 2 );
+		remove_filter( 'woocommerce_email_log_add_order_note', '__return_false' );
 
 		parent::tear_down();
 	}


### PR DESCRIPTION
WC 10.9.0-beta.1 added an `EmailLogger` that calls `$order->add_order_note()` after every transactional email (e.g. `Email "Processing order" sent.`). Those extra notes shift note indices and bump note counts, which breaks 26 of our tests that assert on order note counts/indices. The `WC compatibility (beta, latest, latest, 7.4)` CI job fails on every open PR as a result.

#### Changes proposed in this Pull Request

The test base class now suppresses the `woocommerce_email_log_add_order_note` filter in `set_up()` (and removes it in `tear_down()`), so EmailLogger does not write notes during tests. The filter is a no-op on WC < 10.9 — WordPress silently ignores `add_filter` on a hook that never fires — so no version guard is needed.

#### Testing instructions

1. Check out this branch.
2. Check the `WC compatibility (beta, latest, latest, 7.4)` job from the "Compatibility - WC, WP and PHP" workflow (or push to a PR and let CI run it).
3. Confirm the previously failing order-note assertions pass.
4. Confirm the rest of the PHP suite on stable WC still passes — the filter is inert there.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — this is a test-infra change; existing affected tests are the coverage.
- [x] Tested on mobile (or does not apply) — does not apply.
