### PR TITLE
fix: restore WooPay checkout appearance on classic themes (e.g. Storefront)

### DIFF
--- a/changelog/fix-woopay-classic-theme-appearance
+++ b/changelog/fix-woopay-classic-theme-appearance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay checkout appearance not applying on classic themes (e.g. Storefront)

--- a/includes/class-wc-payments-status.php
+++ b/includes/class-wc-payments-status.php
@@ -206,7 +206,7 @@ class WC_Payments_Status {
 			return __( 'You do not have permission to run this tool.', 'woocommerce-payments' );
 		}
 
-		WC_Payments_Styles_Cache::invalidate_styles_cache_version();
+		WC_Payments_Styles_Cache::bust_styles_cache();
 		return __( 'WooPayments styles cleared', 'woocommerce-payments' );
 	}
 

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -36,6 +36,17 @@ class WC_Payments_Styles_Cache {
 	];
 
 	/**
+	 * Option holding the manual-clear salt mixed into the styles cache version.
+	 * Regenerated only by bust_styles_cache() (the "Clear WooPayments calculated
+	 * styles" tool). Lets a merchant force a new version for style changes the
+	 * hash inputs can't detect (custom CSS, child themes, page builders) without
+	 * making routine recomputes non-deterministic.
+	 *
+	 * @var string
+	 */
+	const OPTION_STYLES_CACHE_SALT = 'wcpay_styles_cache_salt';
+
+	/**
 	 * Returns the styles cache version string used to invalidate localStorage
 	 * appearance caches. Reads from a stored WP option; if missing, computes
 	 * and stores it.
@@ -59,6 +70,26 @@ class WC_Payments_Styles_Cache {
 	 */
 	public static function invalidate_styles_cache_version(): void {
 		delete_option( 'wcpay_styles_cache_version' );
+	}
+
+	/**
+	 * Forces a brand-new styles cache version, even when the hash inputs are
+	 * unchanged. Backs the "Clear WooPayments calculated styles" admin tool.
+	 *
+	 * This is the escape hatch for "hash-invisible" style changes — custom CSS,
+	 * child-theme edits, page builders — that none of the version inputs capture,
+	 * so nothing auto-invalidates. Regenerating the salt changes the version,
+	 * which (a) busts shoppers' localStorage appearance caches so the front-end
+	 * re-extracts, and (b) makes the version-stamped WooPay appearance slot no
+	 * longer match, so get_woopay_appearance() stops serving the stale value.
+	 *
+	 * Deliberately separate from invalidate_styles_cache_version() (which runs on
+	 * every theme/style hook): routine invalidation must stay deterministic so the
+	 * WooPay slot survives recompute; only this deliberate clear changes the salt.
+	 */
+	public static function bust_styles_cache(): void {
+		update_option( self::OPTION_STYLES_CACHE_SALT, (string) time(), false );
+		self::invalidate_styles_cache_version();
 	}
 
 	/**
@@ -1203,6 +1234,13 @@ class WC_Payments_Styles_Cache {
 
 		// Theme mods capture Customizer changes (classic themes).
 		$parts .= wp_json_encode( get_theme_mods() );
+
+		// Manual-clear salt: covers "hash-invisible" style changes that none of
+		// the inputs above capture — custom CSS, child-theme CSS, page builders.
+		// Only bust_styles_cache() changes this value, so routine recomputes stay
+		// deterministic (the WooPay appearance slot is version-stamped and must
+		// survive recompute) while a deliberate clear forces a new version.
+		$parts .= get_option( self::OPTION_STYLES_CACHE_SALT, '' );
 
 		return md5( $parts );
 	}

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -88,7 +88,10 @@ class WC_Payments_Styles_Cache {
 	 * WooPay slot survives recompute; only this deliberate clear changes the salt.
 	 */
 	public static function bust_styles_cache(): void {
-		update_option( self::OPTION_STYLES_CACHE_SALT, (string) time(), false );
+		// wp_generate_uuid4() (not time()) so two clears within the same second
+		// still produce different salts — otherwise a sub-second double "Clear"
+		// would be a no-op, contradicting this method's guarantee.
+		update_option( self::OPTION_STYLES_CACHE_SALT, wp_generate_uuid4(), false );
 		self::invalidate_styles_cache_version();
 	}
 

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -1204,9 +1204,6 @@ class WC_Payments_Styles_Cache {
 		// Theme mods capture Customizer changes (classic themes).
 		$parts .= wp_json_encode( get_theme_mods() );
 
-		// just making sure that it gets updated each time this method is called.
-		$parts .= time();
-
 		return md5( $parts );
 	}
 }

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -130,15 +130,23 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * Test that clear_styles_cache deletes the option and returns expected message.
+	 * Test that clear_styles_cache busts the cache (deletes the version AND bumps
+	 * the salt) and returns the expected message. The salt bump is what forces a
+	 * new version for hash-invisible changes; asserting it guards against a revert
+	 * to plain invalidate_styles_cache_version() (which would not bust caches).
 	 */
-	public function test_clear_styles_cache_clears_option_and_returns_message() {
+	public function test_clear_styles_cache_busts_cache_and_returns_message() {
 		update_option( 'wcpay_styles_cache_version', 'test_version' );
+		delete_option( 'wcpay_styles_cache_salt' );
 
 		$result = $this->status->clear_styles_cache();
 
 		$this->assertEquals( 'WooPayments styles cleared', $result );
 		$this->assertFalse( get_option( 'wcpay_styles_cache_version' ) );
+		$this->assertNotEmpty(
+			get_option( 'wcpay_styles_cache_salt' ),
+			'clear_styles_cache() must bump the salt (call bust_styles_cache), not just delete the version.'
+		);
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -282,6 +282,35 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * The flip side of determinism: the version MUST change when a theme/style
+	 * input changes, otherwise a stale appearance would be served after a
+	 * Customizer edit. Guards against a future refactor dropping an input (e.g.
+	 * get_theme_mods()) from the hash, which the determinism test alone would
+	 * not catch.
+	 */
+	public function test_compute_styles_cache_version_changes_when_theme_mod_changes() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'compute_styles_cache_version' );
+		$method->setAccessible( true );
+
+		$before = $method->invoke( null );
+
+		// Simulate a Customizer change (classic themes store these as theme mods).
+		set_theme_mod( 'wcpay_test_mod', 'changed' );
+
+		try {
+			$after = $method->invoke( null );
+
+			$this->assertNotSame(
+				$before,
+				$after,
+				'compute_styles_cache_version() must change when a theme mod changes.'
+			);
+		} finally {
+			remove_theme_mod( 'wcpay_test_mod' );
+		}
+	}
+
+	/**
 	 * Mirrors the production failure: a stored (classic-theme) WooPay appearance
 	 * must survive the version recompute that happens on a later request when the
 	 * version option has been invalidated but nothing about the theme changed.

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -416,6 +416,29 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Two clears in quick succession (even within the same wall-clock second)
+	 * must each produce a new version. A time()-based salt would collide on a
+	 * sub-second double "Clear" and silently no-op the second one; the uuid-based
+	 * salt guarantees every clear changes the version.
+	 */
+	public function test_consecutive_busts_each_change_the_version() {
+		delete_option( 'wcpay_styles_cache_salt' );
+		delete_option( 'wcpay_styles_cache_version' );
+
+		WC_Payments_Styles_Cache::bust_styles_cache();
+		$after_first = WC_Payments_Styles_Cache::get_styles_cache_version();
+
+		WC_Payments_Styles_Cache::bust_styles_cache();
+		$after_second = WC_Payments_Styles_Cache::get_styles_cache_version();
+
+		$this->assertNotSame(
+			$after_first,
+			$after_second,
+			'Each clear must change the version, even two clears within the same second.'
+		);
+	}
+
+	/**
 	 * Routine auto-invalidation (theme/style hooks) must NOT bump the salt — only
 	 * the deliberate manual clear does. invalidate_styles_cache_version() is
 	 * called by handle_theme_change() on every theme/style save, so if it changed

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -254,6 +254,75 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		$this->assertMatchesRegularExpression( '/^[a-f0-9]{32}$/', $second_version );
 	}
 
+	/**
+	 * The cache version must be a pure content hash: recomputing it without any
+	 * theme/style change must yield the same value. A non-deterministic version
+	 * (e.g. one that mixes in time()) orphans the stored WooPay appearance — for
+	 * classic themes that have no server-side recompute fallback, this leaves
+	 * WooPay permanently unthemed. Regression test for the time() leftover.
+	 */
+	public function test_compute_styles_cache_version_is_deterministic() {
+		$method = new ReflectionMethod( WC_Payments_Styles_Cache::class, 'compute_styles_cache_version' );
+		$method->setAccessible( true );
+
+		$first = $method->invoke( null );
+
+		// Cross a wall-clock second boundary so a time()-dependent hash would
+		// change. The sleep makes the test deterministic (it always crosses the
+		// boundary) rather than flaky. A pure content hash is unaffected.
+		sleep( 1 );
+
+		$second = $method->invoke( null );
+
+		$this->assertSame(
+			$first,
+			$second,
+			'compute_styles_cache_version() must be deterministic when nothing changed (no time() component).'
+		);
+	}
+
+	/**
+	 * Mirrors the production failure: a stored (classic-theme) WooPay appearance
+	 * must survive the version recompute that happens on a later request when the
+	 * version option has been invalidated but nothing about the theme changed.
+	 */
+	public function test_stored_woopay_appearance_survives_version_recompute() {
+		// Force a non-block theme so get_woopay_appearance() does not auto-compute
+		// from theme.json — exercises the classic-theme persisted-slot path.
+		$stylesheet_filter = function () {
+			return 'default';
+		};
+		add_filter( 'stylesheet', $stylesheet_filter );
+
+		try {
+			delete_option( 'wcpay_woopay_checkout_appearance' );
+			delete_option( 'wcpay_styles_cache_version' );
+
+			$appearance = [
+				'theme' => 'stripe',
+				'rules' => [ '.Input' => [ 'color' => '#333' ] ],
+			];
+
+			// Shopper write stamps the appearance with the current version.
+			WC_Payments_Styles_Cache::set_woopay_appearance( $appearance );
+
+			// Simulate the next request: the version option is gone, so reading it
+			// forces a fresh recompute. Cross a second boundary so a time()-based
+			// version would change. With a deterministic version this still matches
+			// the stored stamp; with time() it would orphan the appearance.
+			delete_option( 'wcpay_styles_cache_version' );
+			sleep( 1 );
+
+			$this->assertEquals(
+				$appearance,
+				WC_Payments_Styles_Cache::get_woopay_appearance(),
+				'Stored WooPay appearance was orphaned by a non-deterministic cache version.'
+			);
+		} finally {
+			remove_filter( 'stylesheet', $stylesheet_filter );
+		}
+	}
+
 	public function test_set_woopay_appearance_stores_font_rules() {
 		delete_option( 'wcpay_woopay_checkout_appearance' );
 		delete_option( 'wcpay_styles_cache_version' );

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -352,6 +352,92 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Manual clear (bust) must force a NEW version even when the hash inputs are
+	 * byte-identical. This is the hash-invisible escape hatch: custom CSS /
+	 * child-theme / page-builder edits don't change theme.json, theme mods, or
+	 * the stylesheet, so nothing auto-invalidates. The clear tool regenerates a
+	 * salt so the version changes, busting the shopper localStorage caches and
+	 * forcing re-extraction.
+	 */
+	public function test_bust_styles_cache_changes_version_with_identical_inputs() {
+		delete_option( 'wcpay_styles_cache_salt' );
+		delete_option( 'wcpay_styles_cache_version' );
+
+		$before = WC_Payments_Styles_Cache::get_styles_cache_version();
+
+		WC_Payments_Styles_Cache::bust_styles_cache();
+
+		$after = WC_Payments_Styles_Cache::get_styles_cache_version();
+
+		$this->assertNotSame(
+			$before,
+			$after,
+			'bust_styles_cache() must change the version even when theme inputs are unchanged.'
+		);
+	}
+
+	/**
+	 * The manual clear must also invalidate WooPay's persisted appearance slot.
+	 * For classic themes a custom-CSS edit leaves the stored WooPay appearance
+	 * stale (the version still matches), and the slot is not deleted directly —
+	 * but bumping the version via the salt makes the stored stamp no longer
+	 * match, so get_woopay_appearance() stops serving the stale value.
+	 */
+	public function test_bust_styles_cache_invalidates_stored_woopay_appearance() {
+		// Force a non-block theme so get_woopay_appearance() does not auto-compute.
+		$stylesheet_filter = function () {
+			return 'default';
+		};
+		add_filter( 'stylesheet', $stylesheet_filter );
+
+		try {
+			delete_option( 'wcpay_styles_cache_salt' );
+			delete_option( 'wcpay_styles_cache_version' );
+			delete_option( 'wcpay_woopay_checkout_appearance' );
+
+			$appearance = [
+				'theme' => 'stripe',
+				'rules' => [ '.Input' => [ 'color' => '#333' ] ],
+			];
+			WC_Payments_Styles_Cache::set_woopay_appearance( $appearance );
+			$this->assertEquals( $appearance, WC_Payments_Styles_Cache::get_woopay_appearance() );
+
+			// Merchant edited custom CSS (hash-invisible) and clicked Clear.
+			WC_Payments_Styles_Cache::bust_styles_cache();
+
+			$this->assertNull(
+				WC_Payments_Styles_Cache::get_woopay_appearance(),
+				'A manual clear must invalidate the stored WooPay appearance via the version bump.'
+			);
+		} finally {
+			remove_filter( 'stylesheet', $stylesheet_filter );
+		}
+	}
+
+	/**
+	 * Routine auto-invalidation (theme/style hooks) must NOT bump the salt — only
+	 * the deliberate manual clear does. invalidate_styles_cache_version() is
+	 * called by handle_theme_change() on every theme/style save, so if it changed
+	 * the salt the version would be non-deterministic again and WooPay's slot
+	 * would be orphaned on routine recomputes.
+	 */
+	public function test_invalidate_styles_cache_version_does_not_change_salt() {
+		delete_option( 'wcpay_styles_cache_salt' );
+		delete_option( 'wcpay_styles_cache_version' );
+
+		$before = WC_Payments_Styles_Cache::get_styles_cache_version();
+
+		WC_Payments_Styles_Cache::invalidate_styles_cache_version();
+		$recomputed = WC_Payments_Styles_Cache::get_styles_cache_version();
+
+		$this->assertSame(
+			$before,
+			$recomputed,
+			'Routine invalidation must recompute the same version (salt unchanged).'
+		);
+	}
+
 	public function test_set_woopay_appearance_stores_font_rules() {
 		delete_option( 'wcpay_woopay_checkout_appearance' );
 		delete_option( 'wcpay_styles_cache_version' );


### PR DESCRIPTION
Fixes WOOPMNT-6204 — https://linear.app/a8c/issue/WOOPMNT-6204

#### Changes proposed in this Pull Request

WooPay's themed checkout appearance was not applying on **classic themes** (e.g. Storefront). It worked on block themes.

**Root cause.** `WC_Payments_Styles_Cache::compute_styles_cache_version()` appended `time()` to the version hash, making it non-deterministic. The WooPay appearance slot (`wcpay_woopay_checkout_appearance`) is version-stamped and only served when `$stored['version'] === get_styles_cache_version()`. A churning version orphaned that stored value on every routine invalidation; classic themes have no `theme.json` recompute fallback, so WooPay rendered unthemed. Block themes were unaffected (they recompute from `theme.json` on every miss).

**Attribution.** The `time()` line was added in #11440 to back the "Clear WooPayments calculated styles" admin tool — and was *correct* for the only consumer that existed then (the per-shopper localStorage cache). The regression was authored in #11427, which layered the determinism-dependent WooPay persistence on top of the already-present `time()` without reconciling it.

#### Why a plain `time()` removal wasn't enough (thanks @frosso)

`time()` was load-bearing for the manual Clear tool. The styles cache version feeds two consumers with opposite needs:

| Consumer | Storage | Needs the version to… |
| --- | --- | --- |
| Store-checkout (UPE) appearance | per-shopper localStorage | **change generously** — over-invalidation just re-extracts from the DOM (cheap) |
| WooPay appearance | server `wp_option` (version-stamped) | **change only on real change** — a spurious change orphans persisted state (classic = no fallback) |

The Clear tool exists for **hash-invisible** changes — custom CSS, child themes, page builders — that none of the hash inputs capture. Without `time()`, clicking "Clear" recomputes an identical hash, so shoppers' localStorage caches (keyed by `stylesCacheVersion`) never bust. So a plain removal fixes WooPay but regresses the Clear tool.

#### The fix — a clear-only salt

Move the non-determinism out of every recompute and into the deliberate clear action only:

- `compute_styles_cache_version()` mixes in `get_option('wcpay_styles_cache_salt')`. The salt is stable between clears → routine recomputes are **deterministic** → the WooPay slot survives (fixes WOOPMNT-6204).
- New `bust_styles_cache()` regenerates the salt (captures `time()` once) + invalidates the version. The Clear tool calls this instead of `invalidate_styles_cache_version()` → clicking "Clear" forces a new version → shopper localStorage busts and re-extracts (preserves @frosso's tool).
- Routine event-invalidation (the 6 theme/style hooks) does **not** touch the salt, so it stays deterministic.
- **Bonus:** the Clear tool previously only deleted the localStorage version, never WooPay's slot. Because that slot shares the version, the salt bump now invalidates it too — so a hash-invisible CSS edit + Clear correctly refreshes WooPay on classic themes.

#### Three invalidation mechanisms (the mental model)

| Mechanism | Type | Catches |
| --- | --- | --- |
| **Event invalidation** (6 `add_action` → `handle_theme_change()`) | event | theme switch, global-styles/template/template-part save *via editor*, Customizer, plugin update |
| **Version hash** (cache key on read) | hash | `theme.json` *file* edits (merged into global styles) |
| **Manual salt clear** (`bust_styles_cache()`) | deliberate | **hash-invisible** changes: classic custom CSS / page builders, and block template-part/pattern *files* edited outside the editor |

#### How can this code break?

A regression reintroducing per-call non-determinism, or the salt leaking into routine `invalidate_styles_cache_version()` (which would re-break WOOPMNT-6204). Guarded by tests: routine recompute is deterministic; version changes on a theme-mod change; the salt bump changes the version with identical inputs; the WooPay slot is invalidated by a clear; and **routine invalidation does NOT change the salt**.

#### Testing instructions

Requires a **classic theme** (e.g. Storefront), WooPay enabled, and "Global theme support" enabled.

> **How the WooPay slot fills on classic themes (read before testing).** `wcpay_woopay_checkout_appearance` is populated by client-side DOM extraction, which only runs when a WooPay session handoff occurs. The triggers are: (a) the admin **Customizer preview** (eager, on preview load — `maybePersistAdminWoopayAppearance`), or (b) a **shopper engaging WooPay** on a **shortcode** checkout — i.e. typing a valid email into the WooPay field (opens the OTP iframe → `resolveWoopayAppearance` → persist), or clicking the express button. **Simply landing on checkout does NOT fill the slot**, and a Blocks checkout never runs the shopper path at all (`isShortcodeCheckout` is false). So to observe the WooPay slot fill, use the Customizer preview, or type a valid email on a shortcode checkout. (The shopper fill being handoff-gated rather than page-load-eager is a pre-existing limitation tracked in RSM-4317, not changed by this PR.)

1. On a **shortcode** checkout, engage WooPay (type a valid email into the WooPay field). Confirm `wcpay_woopay_checkout_appearance` is written and WooPay reflects the store theme (previously it was orphaned/unthemed). On subsequent loads `wcpayConfig.woopayAppearance` is populated.
2. **Version stability:** compute `compute_styles_cache_version()` twice a second apart (via WP-CLI `eval` + Reflection) — values are identical (previously they differed every second).
3. **Manual clear still busts caches:** edit Customizer → Additional CSS (a hash-invisible change), then run **WooPayments → Status → "Clear WooPayments calculated styles"**. Confirm `wcpay_styles_cache_version` changes and the store-checkout appearance re-extracts (shopper localStorage `wcpay_appearance_*` no longer matches → recompute on next checkout view).
4. **Clear invalidates the WooPay slot too:** after the clear, confirm `wcpay_woopay_checkout_appearance` is gone / no longer served (its stamped version no longer matches). Note it only **re-fills** via the handoff triggers above (Customizer preview, or a shopper engaging WooPay on shortcode checkout), not on a plain checkout visit.
5. Regression: on a **block theme**, WooPay appearance still works (server `theme.json` recompute on read); theme switch / global-styles save still auto-invalidate.

Unit tests:
```
vendor/bin/phpunit --filter 'WC_Payments_Styles_Cache_Test'   # determinism, theme-mod sensitivity, salt bump, WooPay-slot invalidation
vendor/bin/phpunit --filter 'WC_Payments_Status'              # Clear tool
```

*

-------------------

- [x] Run `npm run changelog` to add a changelog file
- [x] Covered with tests
- [x] Tested on mobile (or does not apply) — backend cache-version logic, no UI surface of its own

**Post merge**

- [ ] Link to testing instructions from release testing doc
- [ ] Add or update critical flows and testing instructions, if applicable
- [ ] Add what's changed to the release announcement post, if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)



