### PR TITLE
fix: Dependabot github-actions entry doesn't cover .github/actions/*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,12 +48,12 @@ updates:
         - 'Automattic/moltres'
 
     # Enable version updates for GitHub Actions (SHA pins in .github/workflows/ and .github/actions/).
-    # directory '/' only scans .github/workflows + a root action.yml; the glob
-    # entry is what actually covers the composite actions in .github/actions/*.
+    # Scan composite actions too — their SHA-pinned `uses:` refs need update PRs
+    # just like the workflow files do ('**' so nested ones like e2e/env-setup are covered).
     - package-ecosystem: 'github-actions'
       directories:
         - '/'
-        - '/.github/actions/*'
+        - '/.github/actions/**'
       # Check for updates once a week
       schedule:
         interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,9 +47,13 @@ updates:
         - 'Automattic/gamma'
         - 'Automattic/moltres'
 
-    # Enable version updates for GitHub Actions (SHA pins in .github/workflows/ and .github/actions/)
+    # Enable version updates for GitHub Actions (SHA pins in .github/workflows/ and .github/actions/).
+    # directory '/' only scans .github/workflows + a root action.yml; the glob
+    # entry is what actually covers the composite actions in .github/actions/*.
     - package-ecosystem: 'github-actions'
-      directory: '/'
+      directories:
+        - '/'
+        - '/.github/actions/*'
       # Check for updates once a week
       schedule:
         interval: 'weekly'


### PR DESCRIPTION
Follow-up to #11760 (DEVPROD-1072 SHA-pinning).

The existing comment says the `github-actions` entry covers *"SHA pins in .github/workflows/ and .github/actions/"* — but `directory: '/'` only scans `.github/workflows/` plus a root `action.yml` ([Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)). The pinned ref in `.github/actions/setup-php/action.yml` would never get update PRs.

This switches to the `directories` key with a glob (`/` + `/.github/actions/*`), which the docs confirm supports globbing — covering current and future composite actions.

Config-only change; no workflow behaviour change.