### PR TITLE
[dev] Ignore .playwright-mcp browser-automation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ bin/jurassictube/
 
 # Git worktrees
 .worktrees/
+
+# Playwright MCP browser-automation artifacts
+.playwright-mcp/


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

The Playwright MCP browser tool writes session artifacts (snapshots, screenshots) to a `.playwright-mcp/` directory at the repo root. This adds that directory to `.gitignore` so it isn't accidentally committed.

Repo-hygiene only — no runtime, build, or test impact.

#### Testing instructions

- [ ] Confirm `.playwright-mcp/` no longer appears under untracked files in `git status` after the Playwright MCP tool has run.

*

-------------------

- [x] Covered with tests (or have a good reason not to test in description ☝️) — N/A, `.gitignore`-only change
- [x] Tested on mobile (or does not apply) — does not apply

**Post merge**

- [ ] Link to testing instructions: _QA Testing Not Applicable_

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
