### PR TITLE
Show card brand in subscription renewal and order emails

### DIFF
--- a/changelog/fix-woopmnt-2882-renewal-email-card-title
+++ b/changelog/fix-woopmnt-2882-renewal-email-card-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the actual card brand (e.g. "Visa credit card") instead of a generic "Card" in subscription renewal and order confirmation emails.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4002,6 +4002,18 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				}
 			}
 
+			// Set the branded payment method title + card meta from the charge details BEFORE the status
+			// update. update_order_status_from_intent() -> payment_complete() fires the customer order/renewal
+			// email synchronously, and that email renders get_payment_method_title(); the title must already
+			// reflect the real card or the email falls back to a generic "Card". $token is non-null only when
+			// the intent is authorized and the payment method was saved (see the token-attach guard above).
+			// See WOOPMNT-2882.
+			if ( ! empty( $token ) ) {
+				$payment_method_type = $this->get_payment_method_type_for_setup_intent( $intent, $token );
+				$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
+				$this->store_card_details_meta_for_order( $order, $payment_method_type, $payment_method_details );
+			}
+
 			if ( $is_subscription_payment_method_change ) {
 				$this->with_stock_reduction_disabled(
 					function () use ( $order, $intent ) {
@@ -4016,15 +4028,6 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// Stock reduction is left to WooCommerce core (see note in process_payment_for_order()).
 				if ( ! $is_subscription_payment_method_change ) {
 					WC()->cart->empty_cart();
-				}
-
-				// The token was saved and attached above (before the status update). Set the order's
-				// payment method title and card meta (brand + last4) from the charge details here, mirroring
-				// the synchronous non-3DS path so 3DS/SCA confirmations record the same data.
-				if ( ! empty( $token ) ) {
-					$payment_method_type = $this->get_payment_method_type_for_setup_intent( $intent, $token );
-					$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
-					$this->store_card_details_meta_for_order( $order, $payment_method_type, $payment_method_details );
 				}
 
 				$return_url = $this->get_return_url( $order );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2007,20 +2007,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( Intent_Status::SUCCEEDED === $status || ( Intent_Status::REQUIRES_ACTION === $status && $is_offline_payment_method ) ) {
 			$this->duplicate_payment_prevention_service->remove_session_processing_order( $order->get_id() );
 		}
-		if ( $is_changing_payment_method_for_subscription ) {
-			$this->with_stock_reduction_disabled(
-				function () use ( $order, $intent ) {
-					$this->order_service->update_order_status_from_intent( $order, $intent );
-				}
-			);
-		} else {
-			$this->order_service->update_order_status_from_intent( $order, $intent );
-		}
-		$this->order_service->attach_transaction_fee_to_order( $order, $charge );
-
-		$this->maybe_add_customer_notification_note( $order, $processing );
-
-		// Extract payment method details for setting the payment method title.
+		// Set the branded payment method title + card meta from the charge details BEFORE the status update.
+		// update_order_status_from_intent() -> payment_complete() fires the customer order/renewal email
+		// synchronously, and that email renders get_payment_method_title(); the title must already reflect the
+		// real card or the email falls back to a generic "Card". Re-deriving $charge here is a no-op (it already
+		// equals $intent->get_charge()), so attach_transaction_fee_to_order() below is unaffected. WOOPMNT-2882.
 		if ( $payment_needed ) {
 			$charge                 = $intent ? $intent->get_charge() : null;
 			$payment_method_details = $charge ? $charge->get_payment_method_details() : [];
@@ -2044,8 +2035,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$payment_method_type    = $token ? $this->get_payment_method_type_for_setup_intent( $intent, $token ) : null;
 		}
 
-		// ensuring the payment method title is set before any early return paths to avoid incomplete order data.
 		$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
+
+		if ( $is_changing_payment_method_for_subscription ) {
+			$this->with_stock_reduction_disabled(
+				function () use ( $order, $intent ) {
+					$this->order_service->update_order_status_from_intent( $order, $intent );
+				}
+			);
+		} else {
+			$this->order_service->update_order_status_from_intent( $order, $intent );
+		}
+		$this->order_service->attach_transaction_fee_to_order( $order, $charge );
+
+		$this->maybe_add_customer_notification_note( $order, $processing );
 
 		if ( isset( $status ) && ( Intent_Status::REQUIRES_ACTION === $status || Intent_Status::REQUIRES_CONFIRMATION === $status ) && $this->is_changing_payment_method_for_subscription() ) {
 			// Because we're filtering woocommerce_subscriptions_update_payment_via_pay_shortcode, we need to manually set this delayed update all flag here.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -334,6 +334,55 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * The branded payment method title must be set BEFORE update_order_status_from_intent(), because that
+	 * call transitions the order status, which synchronously fires the customer/renewal email. The email
+	 * renders get_payment_method_title(), so if the title is set afterwards the email shows a generic "Card".
+	 * Regression guard for WOOPMNT-2882 (card brand missing from order/renewal emails on the sync path).
+	 */
+	public function test_process_payment_for_order_sets_title_before_status_transition() {
+		$order_id = 124;
+
+		$mock_order = $this->createMock( 'WC_Order' );
+		$mock_order->method( 'get_data_store' )->willReturn( new \WC_Mock_WC_Data_Store() );
+		$mock_order->method( 'get_id' )->willReturn( $order_id );
+		$mock_order->method( 'get_total' )->willReturn( 12.23 );
+		$mock_order->method( 'get_user' )->willReturn( wp_get_current_user() );
+
+		$this->mock_customer_service->method( 'get_customer_id_by_user_id' )->willReturn( 'cus_mock' );
+
+		$mock_cart = $this->createMock( 'WC_Cart' );
+
+		$intent  = WC_Helper_Intention::create_intention();
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+		$request->expects( $this->once() )->method( 'format_response' )->willReturn( $intent );
+
+		$charge_request = $this->mock_wcpay_request( Get_Charge::class, 1, 'ch_mock' );
+		$charge_request->method( 'format_response' )->willReturn( [ 'balance_transaction' => [ 'exchange_rate' => 0.86 ] ] );
+
+		// Record the relative order of the title write (on the order) vs the status transition.
+		$calls = [];
+		$mock_order->method( 'set_payment_method_title' )->willReturnCallback(
+			function () use ( &$calls ) {
+				$calls[] = 'title';
+			}
+		);
+		$this->mock_order_service->method( 'update_order_status_from_intent' )->willReturnCallback(
+			function () use ( &$calls ) {
+				$calls[] = 'status';
+			}
+		);
+
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, null, null, null, 'card' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
+
+		$title_pos  = array_search( 'title', $calls, true );
+		$status_pos = array_search( 'status', $calls, true );
+		$this->assertNotFalse( $title_pos, 'set_payment_method_title should be called' );
+		$this->assertNotFalse( $status_pos, 'update_order_status_from_intent should be called' );
+		$this->assertLessThan( $status_pos, $title_pos, 'Payment method title must be set before the status transition that fires the email.' );
+	}
+
+	/**
 	 * Test processing payment with the status 'succeeded'.
 	 */
 	public function test_intent_status_success_logged_out_user() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5412,6 +5412,75 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'visa', $saved->get_meta( '_card_brand' ) );
 	}
 
+	public function test_update_order_status_sets_branded_title_before_status_transition() {
+		// The branded title must be on the order BEFORE the status transition, because that transition
+		// (payment_complete) synchronously fires the customer/renewal email, which renders the title.
+		// If the title is set afterwards, the email falls back to a generic "Card". WOOPMNT-2882.
+		$order = WC_Helper_Order::create_order();
+
+		$token = WC_Helper_Token::create_token( 'pm_mock' );
+		$this->mock_token_service
+			->method( 'add_payment_method_to_user' )
+			->willReturn( $token );
+
+		$intent_id = 'pi_mock_3ds_renewal_email';
+		$this->order_service->set_intent_id_for_order( $order, $intent_id );
+
+		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$_POST                = [
+			'action'                     => 'update_order_status',
+			'order_id'                   => $order->get_id(),
+			'intent_id'                  => $intent_id,
+			'should_save_payment_method' => 'true',
+			'_wpnonce'                   => $nonce,
+		];
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'id'                     => $intent_id,
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [] ],
+						'charge'                 => [
+							'payment_method_details' => [
+								'type' => 'card',
+								'card' => [
+									'network' => 'visa',
+									'funding' => 'credit',
+								],
+							],
+						],
+					]
+				)
+			);
+
+		// Capture the title at the order-status transition (the same moment WC fires the email).
+		$title_at_transition = 'NOT_CAPTURED';
+		$capture             = function ( $order_id ) use ( &$title_at_transition ) {
+			$title_at_transition = wc_get_order( $order_id )->get_payment_method_title();
+		};
+		add_action( 'woocommerce_order_status_changed', $capture, 1, 1 );
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+
+		try {
+			ob_start();
+			$this->card_gateway->update_order_status();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+			remove_action( 'woocommerce_order_status_changed', $capture, 1 );
+		}
+
+		$this->assertSame( 'Visa credit card', $title_at_transition, 'Title must be branded at the status transition that fires the email.' );
+	}
+
 	public function return_ajax_wp_die_handler() {
 		return [ $this, 'ajax_wp_die_handler' ];
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5289,6 +5289,8 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		// A payment confirmed asynchronously (e.g. 3DS/SCA) that saves the payment method lands here.
 		// The order's payment method title must reflect the actual card from the charge, not a generic
 		// "Card" label. This also propagates to the subscription. Regression guard for WOOPMNT-2882.
+		// Scope: this and the two 3DS tests below cover only the save (token-present) sub-path; the no-save
+		// boundary is pinned by test_update_order_status_does_not_brand_title_or_card_meta_when_not_saving_payment_method.
 		$order = WC_Helper_Order::create_order();
 
 		$token = WC_Helper_Token::create_token( 'pm_mock' );
@@ -5478,7 +5480,81 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			remove_action( 'woocommerce_order_status_changed', $capture, 1 );
 		}
 
-		$this->assertSame( 'Visa credit card', $title_at_transition, 'Title must be branded at the status transition that fires the email.' );
+		// This guards the ordering invariant, not the exact wording: the title must be present and
+		// branded (carry the card network) at the moment the email fires. The verbatim "Visa credit card"
+		// string is pinned once, by test_update_order_status_sets_branded_payment_method_title_from_charge_details,
+		// so a future wording change touches one test instead of weakening this ordering guard.
+		$this->assertNotSame( 'NOT_CAPTURED', $title_at_transition, 'The status transition that fires the email must have run.' );
+		$this->assertStringContainsString( 'Visa', $title_at_transition, 'Title must be branded at the status transition that fires the email.' );
+	}
+
+	public function test_update_order_status_does_not_brand_title_or_card_meta_when_not_saving_payment_method() {
+		// Companion to the three tests above, which all hard-code should_save_payment_method = 'true' and so
+		// exercise only the token-present sub-path. Branding (title + last4/_card_brand meta) lives entirely
+		// inside update_order_status()'s `! empty( $token )` branch, so the no-save path must leave the card
+		// details untouched. This pins that boundary: if branding ever leaks out of the save branch, this
+		// fails. We assert the meta is absent rather than a specific generic title to stay wording-agnostic.
+		// WOOPMNT-2882.
+		$order = WC_Helper_Order::create_order();
+
+		// No token is created on this path; assert it is never requested rather than relying on a stub.
+		$this->mock_token_service
+			->expects( $this->never() )
+			->method( 'add_payment_method_to_user' );
+
+		$intent_id = 'pi_mock_3ds_no_save';
+		$this->order_service->set_intent_id_for_order( $order, $intent_id );
+
+		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$_POST                = [
+			'action'                     => 'update_order_status',
+			'order_id'                   => $order->get_id(),
+			'intent_id'                  => $intent_id,
+			'should_save_payment_method' => 'false',
+			'_wpnonce'                   => $nonce,
+		];
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		$request = $this->mock_wcpay_request( Get_Intention::class, 1, $intent_id );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'id'                     => $intent_id,
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [] ],
+						'charge'                 => [
+							'payment_method_details' => [
+								'type' => 'card',
+								'card' => [
+									'network' => 'visa',
+									'brand'   => 'visa',
+									'last4'   => '4242',
+									'funding' => 'credit',
+								],
+							],
+						],
+					]
+				)
+			);
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+
+		try {
+			ob_start();
+			$this->card_gateway->update_order_status();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+		}
+
+		$saved = wc_get_order( $order->get_id() );
+		$this->assertNotSame( 'Visa credit card', $saved->get_payment_method_title(), 'Title must not be branded when the payment method is not saved.' );
+		$this->assertEmpty( $saved->get_meta( 'last4' ), 'Card last4 meta must not be stored when the payment method is not saved.' );
+		$this->assertEmpty( $saved->get_meta( '_card_brand' ), 'Card brand meta must not be stored when the payment method is not saved.' );
 	}
 
 	public function return_ajax_wp_die_handler() {


### PR DESCRIPTION
Follow-up to #11791 · Part of WOOPMNT-2882

### Description

#11791 brought the card-detail display on the **order** and **subscription** to parity for 3DS/SCA confirmations. While reviewing it, @frosso found the card brand still didn't appear in renewal **emails** (on that branch or `develop`), and @oaratovskyi confirmed.

**Root cause (verified end-to-end):** the branded payment-method title is written _after_ the order-status transition that synchronously fires the customer email. Order/renewal emails render `get_payment_method_title()`, so they went out with a generic/blank payment method while the order and synced subscription ended up branded ("Visa credit card"). This affects both charge paths:

- `process_payment_for_order()` — non-3DS checkouts **and automatic renewals**
- `update_order_status()` — 3DS/SCA async confirmations

This PR moves the title + card-meta write to run **before** the status transition in both paths, so the branded title is present when the email renders. `update_order_status_from_intent()` → `payment_complete()` never touches the title (so it isn't reset), and re-deriving `$charge` in the sync path is a no-op (so `attach_transaction_fee_to_order()` is unaffected).

**Key commits:**
- Brand the 3DS (async) order title before the status transition (`873090c6`)
- Brand the sync-path order title before the status transition (`d3c92b20`)

**Verified end-to-end** against a real automatic renewal (real charge via the local Transact Platform; emails captured with an email-log plugin):

| | Order page | Renewal email "Payment method" |
|---|---|---|
| **Before** | `Visa credit card` | _(blank)_ |
| **After** | `Visa credit card` | `Visa credit card - 4242` |

The order was always branded; only the fix gets the brand into the **email**.

> **Stacking:** #11791 has merged; this now targets `develop` directly. #11809 is stacked on top.

### Testing Steps

**Prerequisites:** WooPayments + WooCommerce Subscriptions in test mode, this branch built/active, and an email logger (e.g. an email-log plugin) to inspect sent mail.

1. Create a subscription product and buy it with a non-3DS test card (`4242 4242 4242 4242`).
- [ ] The order-confirmation email (and admin new-order email) show the real card under **Payment method** (e.g. `Visa credit card`), not a generic "Card".
2. Trigger an automatic renewal for that subscription (let it renew, or use WCS "Process renewal").
- [ ] The renewal emails (customer receipt + admin "new renewal order") show the real card under **Payment method**.
3. Repeat the purchase with a 3DS card (`4000 0027 6000 3184`) and complete authentication.
- [ ] The order/renewal emails still show the real card.
- [ ] Confirm no regression: the order page and the subscription continue to show the real card.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

