### PR TITLE
Show card brand on free-trial subscription orders and emails

### DIFF
--- a/changelog/fix-woopmnt-2882-free-trial-card-title
+++ b/changelog/fix-woopmnt-2882-free-trial-card-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the actual card brand instead of a generic "Card" on free-trial ($0) subscription orders, the subscription, and their confirmation emails.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4712,8 +4712,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Stores the card brand and last 4 digits on the order from the charge's payment method details,
-	 * so order/email displays and reporting reflect the actual card used. No-op when the details are
-	 * unavailable or the payment method does not carry card information (e.g. redirect methods, Link).
+	 * so order/email displays and reporting reflect the actual card used. Also caches the full payment
+	 * method details for reuse (see below). No-op when the details are unavailable or the payment method
+	 * does not carry card information (e.g. redirect methods, Link).
 	 *
 	 * @param WC_Order    $order                  The order to store the meta on.
 	 * @param string|null $payment_method_type    The Stripe payment method type (e.g. 'card', 'amazon_pay').
@@ -4730,6 +4731,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// consistent — including the $0 SetupIntent paths, where the type stays 'card'. WOOPMNT-2882.
 		if ( self::is_link_card_wallet( $payment_method_type, $payment_method_details ) ) {
 			return;
+		}
+
+		// Cache the full payment method details so a later get_card_info() reuse (e.g. an order-details
+		// render) hits this cache instead of firing a second get_payment_method() lookup. The positive-charge
+		// paths already persist this via the charge in attach_intent_info_to_order(), which runs before this;
+		// only the no-charge $0 paths reach here with it unset. Guarded on absence so we never overwrite the
+		// charge's details, and placed after the Link guard above so a Link payment never caches the
+		// underlying card here. WOOPMNT-2882.
+		if ( null === $this->order_service->get_payment_method_details( $order ) ) {
+			$this->order_service->store_payment_method_details( $order, $payment_method_details );
 		}
 
 		if ( 'card' === $payment_method_type && isset( $payment_method_details['card']['last4'] ) ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4724,6 +4724,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
+		// Stripe reports Link as type='card' with card.wallet.type='link'. Link wraps a card but must not
+		// persist the underlying card's brand/last4 as the order's card meta. The positive-payment path
+		// normalizes the type to Payment_Method::LINK before calling; guarding here keeps every caller
+		// consistent — including the $0 SetupIntent paths, where the type stays 'card'. WOOPMNT-2882.
+		if ( self::is_link_card_wallet( $payment_method_type, $payment_method_details ) ) {
+			return;
+		}
+
 		if ( 'card' === $payment_method_type && isset( $payment_method_details['card']['last4'] ) ) {
 			$order->add_meta_data( 'last4', $payment_method_details['card']['last4'], true );
 			if ( isset( $payment_method_details['card']['brand'] ) ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1604,7 +1604,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$zero_amount_token      = $payment_information->is_using_saved_payment_method() ? $payment_information->get_payment_token() : null;
 			$zero_amount_pm_details = $zero_amount_token instanceof \WC_Payment_Token_WCPay_Link
 				? false
-				: $this->get_setup_intent_payment_method_details( $payment_information->get_payment_method() );
+				: $this->get_payment_method_details_for_zero_amount_order( $payment_information->get_payment_method() );
 			if ( $zero_amount_pm_details ) {
 				$this->set_payment_method_title_for_order( $order, $zero_amount_pm_details['type'], $zero_amount_pm_details );
 				$this->store_card_details_meta_for_order( $order, $zero_amount_pm_details['type'], $zero_amount_pm_details );
@@ -2050,7 +2050,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			// card instead of a generic "Card" — this is the common free-trial path. The Link token check
 			// is preserved for saved-Link payments. WOOPMNT-2882.
 			$token                  = $payment_information->is_using_saved_payment_method() ? $payment_information->get_payment_token() : null;
-			$payment_method_details = $this->get_setup_intent_payment_method_details( $intent ? $intent->get_payment_method_id() : null );
+			$payment_method_details = $this->get_payment_method_details_for_zero_amount_order( $intent ? $intent->get_payment_method_id() : null );
 			$payment_method_type    = $token
 				? $this->get_payment_method_type_for_setup_intent( $intent, $token )
 				: ( $payment_method_details ? $payment_method_details['type'] : null );
@@ -2231,7 +2231,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$payment_method_id = $intent->get_payment_method_id();
 				// SetupIntents carry no charge, so source the card details from the confirmed payment method
 				// to brand the order title (and card meta) instead of falling back to a generic "Card". WOOPMNT-2882.
-				$payment_method_details = $this->get_setup_intent_payment_method_details( $payment_method_id );
+				$payment_method_details = $this->get_payment_method_details_for_zero_amount_order( $payment_method_id );
 				$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : $intent->get_payment_method_type();
 				$error                  = $intent->get_last_setup_error();
 			}
@@ -3979,7 +3979,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					// re-applies the SAME branded title rather than overwriting it back to a generic "Card" with
 					// the still-false default — mirroring how the $amount > 0 branch feeds the charge details
 					// into $payment_method_details. WOOPMNT-2882.
-					$payment_method_details = $this->get_setup_intent_payment_method_details( $intent->get_payment_method_id() );
+					$payment_method_details = $this->get_payment_method_details_for_zero_amount_order( $intent->get_payment_method_id() );
 					if ( $payment_method_details ) {
 						$this->set_payment_method_title_for_order( $order, $payment_method_details['type'], $payment_method_details );
 						$this->store_card_details_meta_for_order( $order, $payment_method_details['type'], $payment_method_details );
@@ -4752,14 +4752,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Fetches the card-identifying details for a $0 SetupIntent confirmation from the confirmed payment
-	 * method. SetupIntents carry no charge, so without this the order/subscription/email would fall back
-	 * to a generic "Card". Returns false on any failure so callers keep the generic title. See WOOPMNT-2882.
+	 * Fetches the card-identifying details for a $0 order confirmation from the confirmed payment method.
+	 * These orders carry no charge to read the card from — whether they confirm a SetupIntent (new card)
+	 * or take the no-intent branch (already-saved card) — so without this the order/subscription/email
+	 * would fall back to a generic "Card". Returns false on any failure so callers keep the generic title.
+	 * See WOOPMNT-2882.
 	 *
 	 * @param string|null $payment_method_id The confirmed payment method ID.
 	 * @return array|false The payment method details (e.g. [ 'type' => 'card', 'card' => [...] ]), or false.
 	 */
-	private function get_setup_intent_payment_method_details( $payment_method_id ) {
+	private function get_payment_method_details_for_zero_amount_order( $payment_method_id ) {
 		if ( empty( $payment_method_id ) ) {
 			return false;
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -3974,11 +3974,15 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					// $0 orders (free trials) confirm a SetupIntent with no charge to read the card from.
 					// Source the card details from the confirmed payment method so the order, its synced
 					// subscription, and the completion email show the real card instead of a generic "Card".
-					// Set the title BEFORE payment_complete(), which fires the customer email. WOOPMNT-2882.
-					$pm_details = $this->get_setup_intent_payment_method_details( $intent->get_payment_method_id() );
-					if ( $pm_details ) {
-						$this->set_payment_method_title_for_order( $order, $pm_details['type'], $pm_details );
-						$this->store_card_details_meta_for_order( $order, $pm_details['type'], $pm_details );
+					// Set the title BEFORE payment_complete(), which fires the customer email. Assign into the
+					// method-scoped $payment_method_details (not a local) so the later ! empty( $token ) block
+					// re-applies the SAME branded title rather than overwriting it back to a generic "Card" with
+					// the still-false default — mirroring how the $amount > 0 branch feeds the charge details
+					// into $payment_method_details. WOOPMNT-2882.
+					$payment_method_details = $this->get_setup_intent_payment_method_details( $intent->get_payment_method_id() );
+					if ( $payment_method_details ) {
+						$this->set_payment_method_title_for_order( $order, $payment_method_details['type'], $payment_method_details );
+						$this->store_card_details_meta_for_order( $order, $payment_method_details['type'], $payment_method_details );
 					}
 
 					$order->payment_complete( $intent_id );

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -4764,10 +4764,13 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return false;
 		}
 
+		// Catch \Exception (not just API_Exception): branding is a display enhancement, so a lookup failure
+		// of any kind must degrade to the generic title rather than break the $0 checkout that calls this
+		// before payment_complete(). See WOOPMNT-2882.
 		try {
 			$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
 			return ( is_array( $payment_method_details ) && isset( $payment_method_details['type'] ) ) ? $payment_method_details : false;
-		} catch ( API_Exception $e ) {
+		} catch ( \Exception $e ) {
 			Logger::error( 'Could not fetch payment method to brand the $0 order title: ' . $e->getMessage() );
 			return false;
 		}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1597,6 +1597,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		// In case amount is 0 and we're not saving the payment method, we won't be using intents and can confirm the order payment.
 		if ( apply_filters( 'wcpay_confirm_without_payment_intent', ! $payment_needed && ! $save_payment_method_to_store ) ) {
+			// No intent/charge is created on this path (e.g. a $0 free trial paid with an already-saved card),
+			// so source the card details from the payment method to brand the order title + card meta instead
+			// of a generic "Card". Set BEFORE payment_complete(), which fires the order email. Link keeps its
+			// own title in the block below. WOOPMNT-2882.
+			$zero_amount_token      = $payment_information->is_using_saved_payment_method() ? $payment_information->get_payment_token() : null;
+			$zero_amount_pm_details = $zero_amount_token instanceof \WC_Payment_Token_WCPay_Link
+				? false
+				: $this->get_setup_intent_payment_method_details( $payment_information->get_payment_method() );
+			if ( $zero_amount_pm_details ) {
+				$this->set_payment_method_title_for_order( $order, $zero_amount_pm_details['type'], $zero_amount_pm_details );
+				$this->store_card_details_meta_for_order( $order, $zero_amount_pm_details['type'], $zero_amount_pm_details );
+			}
+
 			$order->payment_complete();
 
 			if ( $payment_information->is_using_saved_payment_method() ) {
@@ -1651,10 +1664,12 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$token_for_title = $payment_information->get_payment_token();
 				if ( $token_for_title instanceof \WC_Payment_Token_WCPay_Link ) {
 					$order->set_payment_method_title( __( 'Link', 'woocommerce-payments' ) );
-				} else {
+				} elseif ( ! $zero_amount_pm_details ) {
+					// Keep the branded title set above when we sourced the card from the payment method;
+					// otherwise fall back to a generic title. WOOPMNT-2882.
 					$order->set_payment_method_title( __( 'Credit / Debit Cards', 'woocommerce-payments' ) );
 				}
-			} else {
+			} elseif ( ! $zero_amount_pm_details ) {
 				$order->set_payment_method_title( __( 'Credit / Debit Cards', 'woocommerce-payments' ) );
 			}
 			$order->save();
@@ -2030,9 +2045,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			$this->store_card_details_meta_for_order( $order, $payment_method_type, $payment_method_details );
 		} else {
-			$payment_method_details = false;
+			// $0 SetupIntent confirmations (free trials, $0 PM changes) have no charge. Source the card
+			// details from the confirmed payment method so the order title + card meta reflect the real
+			// card instead of a generic "Card" — this is the common free-trial path. The Link token check
+			// is preserved for saved-Link payments. WOOPMNT-2882.
 			$token                  = $payment_information->is_using_saved_payment_method() ? $payment_information->get_payment_token() : null;
-			$payment_method_type    = $token ? $this->get_payment_method_type_for_setup_intent( $intent, $token ) : null;
+			$payment_method_details = $this->get_setup_intent_payment_method_details( $intent ? $intent->get_payment_method_id() : null );
+			$payment_method_type    = $token
+				? $this->get_payment_method_type_for_setup_intent( $intent, $token )
+				: ( $payment_method_details ? $payment_method_details['type'] : null );
+
+			if ( $payment_method_details ) {
+				$this->store_card_details_meta_for_order( $order, $payment_method_type, $payment_method_details );
+			}
 		}
 
 		$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
@@ -2197,15 +2222,17 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			} else {
 				$request = Get_Setup_Intention::create( $intent_id );
 				/** @var WC_Payments_API_Setup_Intention $intent */ // phpcs:ignore Generic.Commenting.DocComment.MissingShort
-				$intent                 = $request->send();
-				$client_secret          = $intent->get_client_secret();
-				$status                 = $intent->get_status();
-				$charge_id              = '';
-				$charge                 = null;
-				$currency               = $order->get_currency();
-				$payment_method_id      = $intent->get_payment_method_id();
-				$payment_method_details = false;
-				$payment_method_type    = $intent->get_payment_method_type();
+				$intent            = $request->send();
+				$client_secret     = $intent->get_client_secret();
+				$status            = $intent->get_status();
+				$charge_id         = '';
+				$charge            = null;
+				$currency          = $order->get_currency();
+				$payment_method_id = $intent->get_payment_method_id();
+				// SetupIntents carry no charge, so source the card details from the confirmed payment method
+				// to brand the order title (and card meta) instead of falling back to a generic "Card". WOOPMNT-2882.
+				$payment_method_details = $this->get_setup_intent_payment_method_details( $payment_method_id );
+				$payment_method_type    = $payment_method_details ? $payment_method_details['type'] : $intent->get_payment_method_type();
 				$error                  = $intent->get_last_setup_error();
 			}
 
@@ -2237,6 +2264,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					$this->duplicate_payment_prevention_service->remove_session_processing_order( $order->get_id() );
 				}
 				$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
+				$this->store_card_details_meta_for_order( $order, $payment_method_type, $payment_method_details );
 				$this->order_service->update_order_status_from_intent( $order, $intent );
 				$this->order_service->attach_transaction_fee_to_order( $order, $charge );
 
@@ -3943,6 +3971,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				// directly ensures the order transitions to the correct status and activates subscriptions.
 				// Otherwise, the order would be in a "Pending payment" state and the subscription would be "Pending".
 				if ( Intent_Status::SUCCEEDED === $status && ! $order->is_paid() && ! $is_subscription_payment_method_change ) {
+					// $0 orders (free trials) confirm a SetupIntent with no charge to read the card from.
+					// Source the card details from the confirmed payment method so the order, its synced
+					// subscription, and the completion email show the real card instead of a generic "Card".
+					// Set the title BEFORE payment_complete(), which fires the customer email. WOOPMNT-2882.
+					$pm_details = $this->get_setup_intent_payment_method_details( $intent->get_payment_method_id() );
+					if ( $pm_details ) {
+						$this->set_payment_method_title_for_order( $order, $pm_details['type'], $pm_details );
+						$this->store_card_details_meta_for_order( $order, $pm_details['type'], $pm_details );
+					}
+
 					$order->payment_complete( $intent_id );
 
 					// Add a success note similar to mark_payment_completed().
@@ -4698,6 +4736,28 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$order->add_meta_data( '_card_brand', strtolower( $funding_card['brand'] ), true );
 			}
 			$order->save_meta_data();
+		}
+	}
+
+	/**
+	 * Fetches the card-identifying details for a $0 SetupIntent confirmation from the confirmed payment
+	 * method. SetupIntents carry no charge, so without this the order/subscription/email would fall back
+	 * to a generic "Card". Returns false on any failure so callers keep the generic title. See WOOPMNT-2882.
+	 *
+	 * @param string|null $payment_method_id The confirmed payment method ID.
+	 * @return array|false The payment method details (e.g. [ 'type' => 'card', 'card' => [...] ]), or false.
+	 */
+	private function get_setup_intent_payment_method_details( $payment_method_id ) {
+		if ( empty( $payment_method_id ) ) {
+			return false;
+		}
+
+		try {
+			$payment_method_details = $this->payments_api_client->get_payment_method( $payment_method_id );
+			return ( is_array( $payment_method_details ) && isset( $payment_method_details['type'] ) ) ? $payment_method_details : false;
+		} catch ( API_Exception $e ) {
+			Logger::error( 'Could not fetch payment method to brand the $0 order title: ' . $e->getMessage() );
+			return false;
 		}
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -1307,12 +1307,148 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			}
 		);
 
+		// Capture the title set on the order. Asserting it alongside the meta guards against a regression
+		// that breaks title branding while leaving the card meta intact (the two are set independently).
+		$title = null;
+		$mock_order->method( 'set_payment_method_title' )->willReturnCallback(
+			function ( $value ) use ( &$title ) {
+				$title = $value;
+			}
+		);
+
 		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, null, null, null, 'card' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$payment_information->must_save_payment_method_to_store();
 
 		$this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
 
+		$this->assertSame( 'Visa credit card', $title, 'The order title must be branded from the payment method for a $0 setup intent.' );
 		$this->assertSame( '4242', $meta['last4'] ?? null, 'last4 must be sourced from the payment method for a $0 setup intent.' );
+		$this->assertSame( 'visa', $meta['_card_brand'] ?? null );
+	}
+
+	public function test_process_payment_for_order_completes_zero_amount_setup_intent_when_payment_method_lookup_fails() {
+		// Branding the $0 title is a display enhancement and runs BEFORE payment_complete(). A lookup failure
+		// of any kind must degrade to the generic title rather than break the free-trial checkout. Regression
+		// guard: get_payment_method() throwing must not bubble up; the order still completes with no card meta
+		// and the generic (unbranded) title. WOOPMNT-2882.
+		$order_id = 126;
+
+		$mock_order = $this->createMock( 'WC_Order' );
+		$mock_order->method( 'get_data_store' )->willReturn( new \WC_Mock_WC_Data_Store() );
+		$mock_order->method( 'get_id' )->willReturn( $order_id );
+		$mock_order->method( 'get_total' )->willReturn( 0 );
+		$mock_order->method( 'get_currency' )->willReturn( 'USD' );
+		$mock_order->method( 'get_user' )->willReturn( wp_get_current_user() );
+		$mock_order->method( 'get_payment_tokens' )->willReturn( [] );
+		$mock_order->method( 'get_meta' )->willReturn( '' );
+
+		$this->mock_customer_service->method( 'create_customer_for_user' )->willReturn( 'cus_mock' );
+		$this->mock_token_service->method( 'add_payment_method_to_user' )->willReturn( WC_Helper_Token::create_token( 'pm_mock' ) );
+
+		$mock_cart = $this->createMock( 'WC_Cart' );
+
+		$intent  = WC_Helper_Intention::create_setup_intention(
+			[
+				'id'             => 'seti_mock',
+				'status'         => Intent_Status::SUCCEEDED,
+				'client_secret'  => 'cs_mock',
+				'payment_method' => 'pm_mock',
+			]
+		);
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class );
+		$request->expects( $this->once() )->method( 'format_response' )->willReturn( $intent );
+
+		// The branding lookup fails — a generic exception (not just API_Exception) must be swallowed.
+		$this->mock_api_client->method( 'get_payment_method' )->with( 'pm_mock' )->willThrowException( new \Exception( 'lookup boom' ) );
+
+		// Capture any card meta / title that would be written — neither should be on the failure path.
+		$meta = [];
+		$mock_order->method( 'add_meta_data' )->willReturnCallback(
+			function ( $key, $value ) use ( &$meta ) {
+				$meta[ $key ] = $value;
+			}
+		);
+		$title = null;
+		$mock_order->method( 'set_payment_method_title' )->willReturnCallback(
+			function ( $value ) use ( &$title ) {
+				$title = $value;
+			}
+		);
+
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, null, null, null, 'card' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$payment_information->must_save_payment_method_to_store();
+
+		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
+
+		$this->assertSame( 'success', $result['result'], 'The $0 checkout must complete even when the branding lookup fails.' );
+		$this->assertArrayNotHasKey( 'last4', $meta, 'No card meta must be stored when the branding lookup fails.' );
+		$this->assertArrayNotHasKey( '_card_brand', $meta );
+		$this->assertNotSame( 'Visa credit card', $title, 'The title must degrade to the generic title, not the branded card, when the lookup fails.' );
+	}
+
+	public function test_process_payment_for_order_brands_zero_amount_saved_card_on_no_intent_path() {
+		// $0 free-trial paid with an already-saved card: no charge and no SetupIntent are created (the
+		// wcpay_confirm_without_payment_intent branch), so the card brand/last4 and the title must be sourced
+		// from the saved payment method instead of falling back to "Credit / Debit Cards". WOOPMNT-2882.
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		// A saved (non-Link) card token selected at checkout drives the no-intent path.
+		$token = WC_Helper_Token::create_token( 'pm_mock', $user_id );
+
+		$_POST['payment_method'] = WC_Payment_Gateway_WCPay::GATEWAY_ID;
+		$_POST[ 'wc-' . WC_Payment_Gateway_WCPay::GATEWAY_ID . '-payment-token' ] = (string) $token->get_id();
+
+		$mock_order = $this->createMock( 'WC_Order' );
+		$mock_order->method( 'get_data_store' )->willReturn( new \WC_Mock_WC_Data_Store() );
+		$mock_order->method( 'get_id' )->willReturn( 127 );
+		$mock_order->method( 'get_total' )->willReturn( 0 );
+		$mock_order->method( 'get_currency' )->willReturn( 'USD' );
+		$mock_order->method( 'get_user' )->willReturn( wp_get_current_user() );
+		$mock_order->method( 'get_user_id' )->willReturn( $user_id );
+		$mock_order->method( 'get_payment_tokens' )->willReturn( [] );
+		$mock_order->method( 'get_meta' )->willReturn( '' );
+
+		$this->mock_customer_service->method( 'get_customer_id_by_user_id' )->willReturn( 'cus_mock' );
+		$this->mock_customer_service->method( 'create_customer_for_user' )->willReturn( 'cus_mock' );
+
+		$mock_cart = $this->createMock( 'WC_Cart' );
+
+		// No charge and no SetupIntent on this path — the card is read from the saved payment method.
+		$this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class, 0 );
+		$this->mock_api_client->method( 'get_payment_method' )->with( 'pm_mock' )->willReturn(
+			[
+				'type' => 'card',
+				'card' => [
+					'network' => 'visa',
+					'funding' => 'credit',
+					'brand'   => 'visa',
+					'last4'   => '4242',
+				],
+			]
+		);
+
+		$meta = [];
+		$mock_order->method( 'add_meta_data' )->willReturnCallback(
+			function ( $key, $value ) use ( &$meta ) {
+				$meta[ $key ] = $value;
+			}
+		);
+		$title = null;
+		$mock_order->method( 'set_payment_method_title' )->willReturnCallback(
+			function ( $value ) use ( &$title ) {
+				$title = $value;
+			}
+		);
+
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, null, null, null, 'card' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$this->assertTrue( $payment_information->is_using_saved_payment_method(), 'Test setup: the payment must use the saved token to exercise the no-intent path.' );
+
+		$result = $this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
+
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertSame( 'Visa credit card', $title, 'The saved-card no-intent path must brand the title from the payment method.' );
+		$this->assertSame( '4242', $meta['last4'] ?? null );
 		$this->assertSame( 'visa', $meta['_card_brand'] ?? null );
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -1256,6 +1256,66 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
+	public function test_process_payment_for_order_brands_zero_amount_setup_intent_from_payment_method() {
+		// $0 free-trial confirmation (new card): the SetupIntent has no charge, so the card brand/last4
+		// must be sourced from the confirmed payment method and written to the order. WOOPMNT-2882.
+		$order_id = 125;
+
+		$mock_order = $this->createMock( 'WC_Order' );
+		$mock_order->method( 'get_data_store' )->willReturn( new \WC_Mock_WC_Data_Store() );
+		$mock_order->method( 'get_id' )->willReturn( $order_id );
+		$mock_order->method( 'get_total' )->willReturn( 0 );
+		$mock_order->method( 'get_currency' )->willReturn( 'USD' );
+		$mock_order->method( 'get_user' )->willReturn( wp_get_current_user() );
+		$mock_order->method( 'get_payment_tokens' )->willReturn( [] );
+		$mock_order->method( 'get_meta' )->willReturn( '' );
+
+		$this->mock_customer_service->method( 'create_customer_for_user' )->willReturn( 'cus_mock' );
+		$this->mock_token_service->method( 'add_payment_method_to_user' )->willReturn( WC_Helper_Token::create_token( 'pm_mock' ) );
+
+		$mock_cart = $this->createMock( 'WC_Cart' );
+
+		$intent  = WC_Helper_Intention::create_setup_intention(
+			[
+				'id'             => 'seti_mock',
+				'status'         => Intent_Status::SUCCEEDED,
+				'client_secret'  => 'cs_mock',
+				'payment_method' => 'pm_mock',
+			]
+		);
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class );
+		$request->expects( $this->once() )->method( 'format_response' )->willReturn( $intent );
+
+		// The payment-method lookup that supplies brand/last4 for the no-charge ($0) case.
+		$this->mock_api_client->method( 'get_payment_method' )->with( 'pm_mock' )->willReturn(
+			[
+				'type' => 'card',
+				'card' => [
+					'network' => 'visa',
+					'funding' => 'credit',
+					'brand'   => 'visa',
+					'last4'   => '4242',
+				],
+			]
+		);
+
+		// Capture the card meta written to the order.
+		$meta = [];
+		$mock_order->method( 'add_meta_data' )->willReturnCallback(
+			function ( $key, $value ) use ( &$meta ) {
+				$meta[ $key ] = $value;
+			}
+		);
+
+		$payment_information = WCPay\Payment_Information::from_payment_request( $_POST, $mock_order, null, null, null, 'card' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$payment_information->must_save_payment_method_to_store();
+
+		$this->mock_wcpay_gateway->process_payment_for_order( $mock_cart, $payment_information );
+
+		$this->assertSame( '4242', $meta['last4'] ?? null, 'last4 must be sourced from the payment method for a $0 setup intent.' );
+		$this->assertSame( 'visa', $meta['_card_brand'] ?? null );
+	}
+
 	public function test_saved_card_at_checkout() {
 		$order = WC_Helper_Order::create_order();
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5557,6 +5557,83 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertEmpty( $saved->get_meta( '_card_brand' ), 'Card brand meta must not be stored when the payment method is not saved.' );
 	}
 
+	public function test_update_order_status_keeps_branded_title_on_zero_amount_setup_intent_when_saving() {
+		// A $0 free-trial signup whose SetupIntent required frontend authentication lands in
+		// update_order_status()'s $0 (SetupIntent) branch. That branch has no charge, so it sources the card
+		// from the confirmed payment method and brands the title BEFORE the email fires. Because the order
+		// saves the payment method (recurring), the later `! empty( $token )` block re-applies the title from
+		// the method-scoped $payment_method_details. Regression guard: those details must carry the real card,
+		// or that re-apply overwrites the saved order / synced subscription title back to a generic "Card"
+		// after the email. WOOPMNT-2882.
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 0 ); // $0 free trial routes to the SetupIntent branch.
+		$order->save();
+
+		$token = WC_Helper_Token::create_token( 'pm_mock' );
+		$this->mock_token_service
+			->method( 'add_payment_method_to_user' )
+			->willReturn( $token );
+
+		// The $0 SetupIntent carries no charge; the card is sourced from the confirmed payment method.
+		$this->mock_api_client
+			->method( 'get_payment_method' )
+			->with( 'pm_mock' )
+			->willReturn(
+				[
+					'type' => 'card',
+					'card' => [
+						'network' => 'visa',
+						'brand'   => 'visa',
+						'last4'   => '4242',
+						'funding' => 'credit',
+					],
+				]
+			);
+
+		$intent_id = 'seti_mock_free_trial';
+		$this->order_service->set_intent_id_for_order( $order, $intent_id );
+
+		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$_POST                = [
+			'action'                     => 'update_order_status',
+			'order_id'                   => $order->get_id(),
+			'intent_id'                  => $intent_id,
+			'should_save_payment_method' => 'true',
+			'_wpnonce'                   => $nonce,
+		];
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		$request = $this->mock_wcpay_request( Get_Setup_Intention::class, 1, $intent_id );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn(
+				WC_Helper_Intention::create_setup_intention(
+					[
+						'id'                => $intent_id,
+						'status'            => Intent_Status::SUCCEEDED,
+						'payment_method_id' => 'pm_mock',
+					]
+				)
+			);
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+
+		try {
+			ob_start();
+			$this->card_gateway->update_order_status();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+		}
+
+		$saved = wc_get_order( $order->get_id() );
+		$this->assertSame( 'Visa credit card', $saved->get_payment_method_title(), 'The saved title must stay branded after the token-save block re-applies it.' );
+		$this->assertSame( '4242', $saved->get_meta( 'last4' ) );
+		$this->assertSame( 'visa', $saved->get_meta( '_card_brand' ) );
+	}
+
 	public function return_ajax_wp_die_handler() {
 		return [ $this, 'ajax_wp_die_handler' ];
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5634,6 +5634,82 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'visa', $saved->get_meta( '_card_brand' ) );
 	}
 
+	public function test_update_order_status_does_not_store_card_meta_for_link_on_zero_amount_setup_intent() {
+		// Stripe reports Link as type='card' with card.wallet.type='link'. On the $0 SetupIntent path the
+		// payment method type stays 'card' (it is not normalized to Link before storing meta), so without a
+		// guard the underlying card's brand/last4 would be persisted as the order's card meta. Regression
+		// guard: a $0 free trial paid with Link must not store last4/_card_brand. WOOPMNT-2882.
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 0 ); // $0 free trial routes to the SetupIntent branch.
+		$order->save();
+
+		$token = WC_Helper_Token::create_token( 'pm_mock' );
+		$this->mock_token_service
+			->method( 'add_payment_method_to_user' )
+			->willReturn( $token );
+
+		// Link-as-card shape: a card wrapped by Link. The card sub-details carry brand/last4, but the wallet
+		// type marks it as Link, so the card meta must not be persisted.
+		$this->mock_api_client
+			->method( 'get_payment_method' )
+			->with( 'pm_mock' )
+			->willReturn(
+				[
+					'type' => 'card',
+					'card' => [
+						'network' => 'visa',
+						'brand'   => 'visa',
+						'last4'   => '4242',
+						'funding' => 'credit',
+						'wallet'  => [ 'type' => 'link' ],
+					],
+				]
+			);
+
+		$intent_id = 'seti_mock_link_free_trial';
+		$this->order_service->set_intent_id_for_order( $order, $intent_id );
+
+		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$_POST                = [
+			'action'                     => 'update_order_status',
+			'order_id'                   => $order->get_id(),
+			'intent_id'                  => $intent_id,
+			'should_save_payment_method' => 'true',
+			'_wpnonce'                   => $nonce,
+		];
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		$request = $this->mock_wcpay_request( Get_Setup_Intention::class, 1, $intent_id );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn(
+				WC_Helper_Intention::create_setup_intention(
+					[
+						'id'                => $intent_id,
+						'status'            => Intent_Status::SUCCEEDED,
+						'payment_method_id' => 'pm_mock',
+					]
+				)
+			);
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+
+		try {
+			ob_start();
+			$this->card_gateway->update_order_status();
+			ob_end_clean();
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+		}
+
+		$saved = wc_get_order( $order->get_id() );
+		$this->assertEmpty( $saved->get_meta( 'last4' ), 'Link must not persist the underlying card last4.' );
+		$this->assertEmpty( $saved->get_meta( '_card_brand' ), 'Link must not persist the underlying card brand.' );
+		$this->assertNotSame( 'Visa credit card', $saved->get_payment_method_title(), 'A Link payment must not be titled as a branded card.' );
+	}
+
 	public function return_ajax_wp_die_handler() {
 		return [ $this, 'ajax_wp_die_handler' ];
 	}


### PR DESCRIPTION
Stacked on #11808 · Part of WOOPMNT-2882

### Description

Reviewing #11791, @frosso and @oaratovskyi noted that **free-trial ($0) subscriptions still show a generic "Card"** instead of the real card. A $0 signup confirms a SetupIntent — or no intent at all when the payment method is already saved — so there is no charge to read the card from, and the order, subscription, and (at renewal) the confirmation email fell back to "Card" / "Credit / Debit Cards".

**Tracing the real flows end-to-end** (a temporary mu-plugin logging the order-completion backtrace + title, against live local checkouts) showed the common free-trial paths run through `process_payment_for_order`, **not** the SetupIntent confirm handlers:

| Flow | Completion path | Before |
|------|-----------------|--------|
| New card ($0) | `process_payment_for_order` → SetupIntent `else` branch | "Card" |
| Saved card ($0) | `process_payment_for_order` → `wcpay_confirm_without_payment_intent` (no intent), title hardcoded | "Credit / Debit Cards" |
| 3DS / redirect ($0) | `update_order_status()` / `process_redirect_payment()` | "Card" |

**The fix** sources card brand/last4/funding from the confirmed payment method (mirroring `get_card_info()`'s `get_payment_method()` lookup) via one shared helper, set **before** the email-firing completion, at every $0 site. On the no-intent path the previous hardcoded generic title is suppressed when we have real details; Link keeps its own title; a lookup failure falls back to the generic title.

**Key commit:** Show the real card on $0 free-trial subscriptions (`776060367`)

**Verified end-to-end** (real local checkouts, emails captured via an email-log plugin):

| | Order + subscription | Email |
|---|---|---|
| **Before** | `Card` / `Credit / Debit Cards` | generic / blank |
| **After** | `Visa credit card` (last4 `4242`) | branded on the **first renewal** email (`Visa credit card`) via #11808 |

> **About the $0 signup email:** a pure $0 trial's *initial* order email does **not** render a "Payment method" row at all — WooCommerce core gates that row on `$order->get_total() > 0` (`WC_Order::add_order_item_totals_payment_method_row()`), so any $0-total order email omits it regardless of gateway. This PR's payoff is the branded **order page + synced subscription**, visible immediately; the **email** branding for these subscriptions rides on #11808 and lands on the first $10 renewal (total > 0). So a tester checking the $0 signup email for a card line won't find one — that's expected.

> **Stacking:** stacked on #11808 (which now targets `develop`, since #11791 merged). Retarget to `develop` once #11808 merges.

### Testing Steps

**Prerequisites:** WooPayments + WooCommerce Subscriptions in test mode, this branch active, an email logger to inspect sent mail.

1. Create a subscription product with a **free trial** (so the amount due today is $0).
2. Buy it as a logged-in customer with a **new** card (`4242 4242 4242 4242`).
- [ ] The order and the new subscription show the real card (e.g. `Visa credit card`), not "Card".
- [ ] Note: the $0 **signup** email won't show a "Payment method" row — WooCommerce core omits it for any $0-total order. Verify the branded card on the order page + subscription instead.
3. Buy the free-trial product again as a customer who **already has a saved card** (select the saved card).
- [ ] The order and subscription again show the real card (not "Credit / Debit Cards").
4. (Optional, depends on #11808) Trigger/await the **first renewal** (total > 0).
- [ ] The renewal email shows the real card under **Payment method** (e.g. `Visa credit card - 4242`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
