### PR TITLE
test: reuse refund helper for Alipay, BNPL, card and QIT coverage

### DIFF
--- a/changelog/add-e2e-refund-all-methods
+++ b/changelog/add-e2e-refund-all-methods
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+test: reuse the refund helper for Alipay, BNPL, card and QIT order/refund coverage

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-full-refund.spec.ts
@@ -16,6 +16,7 @@ import {
 	goToOrder,
 	goToPaymentDetails,
 } from '../../../utils/merchant-navigation';
+import { submitFullRefund } from '../../../utils/merchant-orders';
 
 test.describe( 'WooCommerce Payments - Full Refund', () => {
 	let merchantPage: Page;
@@ -54,52 +55,7 @@ test.describe( 'WooCommerce Payments - Full Refund', () => {
 			// Open the order
 			await goToOrder( merchantPage, orderId );
 
-			// Click refund button
-			await merchantPage
-				.getByRole( 'button', {
-					name: 'Refund',
-				} )
-				.click();
-
-			// Fill refund details
-			await merchantPage
-				.getByLabel( 'Refund amount' )
-				.fill( orderAmount );
-			// await merchantPage.fill( '.refund_line_total', orderAmount );
-			await merchantPage
-				.getByLabel( 'Reason for refund' )
-				.fill( 'No longer wanted' );
-
-			const refundButton = await merchantPage.getByRole( 'button', {
-				name: `Refund ${ orderAmount } via WooPayments`,
-			} );
-
-			await expect( refundButton ).toBeVisible();
-
-			// TODO: This visual regression test is not flaky, but we should revisit the approach.
-			// await expect( merchantPage ).toHaveScreenshot();
-
-			// Click refund and handle confirmation dialog
-			merchantPage.on( 'dialog', ( dialog ) => dialog.accept() );
-			await refundButton.click();
-
-			// Wait for the refund to finish processing.
-			await merchantPage.waitForLoadState( 'load' );
-
-			// Verify refund details
-			await expect(
-				merchantPage.getByRole( 'cell', {
-					name: `-${ orderAmount }`,
-				} )
-			).toHaveCount( 2 );
-			await expect(
-				merchantPage.getByText(
-					`A refund of ${ orderAmount } was successfully processed using WooPayments. Reason: No longer wanted`
-				)
-			).toBeVisible();
-
-			// TODO: This visual regression test is not flaky, but we should revisit the approach.
-			// await expect( merchantPage ).toHaveScreenshot();
+			await submitFullRefund( merchantPage );
 		}
 	);
 

--- a/tests/e2e/specs/wcpay/shopper/alipay-checkout-purchase.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/alipay-checkout-purchase.spec.ts
@@ -12,6 +12,35 @@ import * as merchant from '../../../utils/merchant';
 import { config } from '../../../config/default';
 import { goToCheckoutWCB } from '../../../utils/shopper-navigation';
 import { shouldRunWCBlocksTests } from '../../../utils/constants';
+import { verifyOrderAndRefund } from '../../../utils/merchant-orders';
+
+const checkoutWithAlipay = async ( page: Page ): Promise< string > => {
+	await shopper.setupProductCheckout(
+		page,
+		[ [ config.products.belt, 1 ] ],
+		config.addresses.customer.billing
+	);
+
+	await page.locator( '.wc_payment_methods' ).getByText( 'alipay' ).click();
+
+	await shopper.placeOrder( page );
+
+	await expect( page.getByText( /Alipay test payment page/ ) ).toBeVisible();
+
+	await page.getByText( 'Authorize Test Payment' ).click();
+
+	await expect(
+		page.getByRole( 'heading', { name: 'Order received' } )
+	).toBeVisible();
+
+	const orderId = page.url().match( /\/order-received\/(\d+)\// )?.[ 1 ];
+	if ( ! orderId ) {
+		throw new Error(
+			`Expected an order-received URL with an order ID, got: ${ page.url() }`
+		);
+	}
+	return orderId;
+};
 
 test.describe( 'Alipay Checkout', () => {
 	let merchantPage: Page;
@@ -32,30 +61,8 @@ test.describe( 'Alipay Checkout', () => {
 		'checkout on shortcode checkout page',
 		{ tag: '@critical' },
 		async () => {
-			await shopper.setupProductCheckout(
-				shopperPage,
-				[ [ config.products.belt, 1 ] ],
-				config.addresses.customer.billing
-			);
+			await checkoutWithAlipay( shopperPage );
 
-			await shopperPage
-				.locator( '.wc_payment_methods' )
-				.getByText( 'alipay' )
-				.click();
-
-			await shopper.placeOrder( shopperPage );
-
-			await expect(
-				shopperPage.getByText( /Alipay test payment page/ )
-			).toBeVisible();
-
-			await shopperPage.getByText( 'Authorize Test Payment' ).click();
-
-			await expect(
-				shopperPage.getByRole( 'heading', {
-					name: 'Order received',
-				} )
-			).toBeVisible();
 			await expect(
 				shopperPage.getByRole( 'img', {
 					name: 'Alipay',
@@ -63,6 +70,12 @@ test.describe( 'Alipay Checkout', () => {
 			).toBeVisible();
 		}
 	);
+
+	test( 'merchant can see and refund an Alipay order', async () => {
+		const orderId = await checkoutWithAlipay( shopperPage );
+
+		await verifyOrderAndRefund( merchantPage, orderId );
+	} );
 
 	describeif( shouldRunWCBlocksTests )(
 		'checkout on block-based checkout page',

--- a/tests/e2e/specs/wcpay/shopper/klarna-checkout-purchase.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/klarna-checkout-purchase.spec.ts
@@ -50,6 +50,10 @@ test.describe( 'Klarna Checkout', () => {
 		).not.toBeEmpty();
 	} );
 
+	// Order-visibility and refund are intentionally NOT asserted for Klarna: the
+	// Klarna playground redirect cannot be driven to a completed order without
+	// flakiness (see the redirect-only assertion below), so there is no captured
+	// order or transaction to verify or refund. Tracked alongside #6763.
 	test(
 		'allows to use Klarna as a payment method',
 		{ tag: '@critical' },

--- a/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-bnpls-checkout.spec.ts
@@ -12,12 +12,47 @@ import * as merchant from '../../../utils/merchant';
 import * as shopper from '../../../utils/shopper';
 import * as devtools from '../../../utils/devtools';
 import * as navigation from '../../../utils/shopper-navigation';
+import { verifyOrderAndRefund } from '../../../utils/merchant-orders';
 
 const cardTestingProtectionStates = [ false, true ];
 const bnplProviders = [ 'Affirm', 'Cash App Afterpay' ];
 
 // using multiple products to prevent the "order duplication service" to be triggered.
 const products = [ 'belt', 'sunglasses' ];
+
+const checkoutWithBnpl = async (
+	page: Page,
+	provider: string,
+	productSlug: string,
+	ctpEnabled: boolean
+): Promise< string > => {
+	await navigation.goToProductPageBySlug( page, productSlug );
+
+	await page.locator( '.single_add_to_cart_button' ).click();
+	await page.waitForLoadState( 'domcontentloaded' );
+	await expect(
+		page.getByText( /has been added to your cart\./ )
+	).toBeVisible();
+
+	await shopper.setupCheckout( page );
+	await shopper.selectPaymentMethod( page, provider );
+	await shopper.expectFraudPreventionToken( page, ctpEnabled );
+	await shopper.placeOrder( page );
+	await expect( page.getByText( /test payment page/ ) ).toBeVisible();
+	// sometimes it's a button, other times it's a link.
+	await page.getByText( 'Authorize Test Payment' ).click();
+	await expect(
+		page.getByRole( 'heading', { name: 'Order received' } )
+	).toBeVisible();
+
+	const orderId = page.url().match( /\/order-received\/(\d+)\// )?.[ 1 ];
+	if ( ! orderId ) {
+		throw new Error(
+			`Expected an order-received URL with an order ID, got: ${ page.url() }`
+		);
+	}
+	return orderId;
+};
 test.describe( 'BNPL checkout', { tag: '@critical' }, () => {
 	let merchantPage: Page;
 	let shopperPage: Page;
@@ -61,40 +96,29 @@ test.describe( 'BNPL checkout', { tag: '@critical' }, () => {
 				const provider = bnplProviders[ i ];
 
 				test( `Checkout with ${ provider }`, async () => {
-					await navigation.goToProductPageBySlug(
+					await checkoutWithBnpl(
 						shopperPage,
-						products[ i % products.length ]
-					);
-
-					await shopperPage
-						.locator( '.single_add_to_cart_button' )
-						.click();
-					await shopperPage.waitForLoadState( 'domcontentloaded' );
-					await expect(
-						shopperPage.getByText( /has been added to your cart\./ )
-					).toBeVisible();
-
-					await shopper.setupCheckout( shopperPage );
-					await shopper.selectPaymentMethod( shopperPage, provider );
-					await shopper.expectFraudPreventionToken(
-						shopperPage,
+						provider,
+						products[ i % products.length ],
 						ctpEnabled
 					);
-					await shopper.placeOrder( shopperPage );
-					await expect(
-						shopperPage.getByText( /test payment page/ )
-					).toBeVisible();
-					// sometimes it's a button, other times it's a link.
-					await shopperPage
-						.getByText( 'Authorize Test Payment' )
-						.click();
-					await expect(
-						shopperPage.getByRole( 'heading', {
-							name: 'Order received',
-						} )
-					).toBeVisible();
 				} );
 			}
+		} );
+	}
+
+	for ( let i = 0; i < bnplProviders.length; i++ ) {
+		const provider = bnplProviders[ i ];
+
+		test( `merchant can see and refund a ${ provider } order`, async () => {
+			const orderId = await checkoutWithBnpl(
+				shopperPage,
+				provider,
+				products[ i % products.length ],
+				false
+			);
+
+			await verifyOrderAndRefund( merchantPage, orderId );
 		} );
 	}
 } );

--- a/tests/qit/test-package/tests/woopayments/merchant/merchant-orders-full-refund.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/merchant/merchant-orders-full-refund.spec.ts
@@ -3,6 +3,7 @@
  */
 import { test, expect } from '../../../fixtures/auth';
 import { goToOrder, goToPaymentDetails } from '../../../utils/merchant';
+import { submitFullRefund } from '../../../utils/merchant-orders';
 import { placeOrderWithCurrency } from '../../../utils/shopper';
 
 test.describe(
@@ -10,7 +11,6 @@ test.describe(
 	{ tag: '@merchant' },
 	() => {
 		let orderId: string;
-		let orderAmount: string;
 		let paymentIntentId: string;
 
 		test(
@@ -20,58 +20,10 @@ test.describe(
 				// Place an order to refund later and get the order ID so we can open it in the merchant view
 				orderId = await placeOrderWithCurrency( customerPage, 'USD' );
 
-				// Get the order total so we can verify the refund amount
-				orderAmount = await customerPage
-					.locator(
-						'.woocommerce-order-overview__total .woocommerce-Price-amount'
-					)
-					.textContent();
-
 				// Open the order
 				await goToOrder( adminPage, orderId );
 
-				// Click refund button
-				await adminPage
-					.getByRole( 'button', {
-						name: 'Refund',
-					} )
-					.click();
-
-				// Fill refund details
-				await adminPage
-					.getByLabel( 'Refund amount' )
-					.fill( orderAmount );
-				await adminPage
-					.getByLabel( 'Reason for refund' )
-					.fill( 'No longer wanted' );
-
-				const refundButton = await adminPage.getByRole( 'button', {
-					name: `Refund ${ orderAmount } via WooPayments`,
-				} );
-
-				await expect( refundButton ).toBeVisible();
-
-				// Click refund and handle confirmation dialog
-				adminPage.on( 'dialog', ( dialog ) => dialog.accept() );
-				await refundButton.click();
-
-				// Wait for refund to process
-				await adminPage.waitForLoadState( 'networkidle' );
-
-				// Verify refund details
-				await expect(
-					adminPage.getByRole( 'cell', {
-						name: `-${ orderAmount }`,
-					} )
-				).toHaveCount( 2 );
-				// Use regex to match the refund message, accounting for optional currency code suffix (e.g., "USD")
-				await expect(
-					adminPage.getByText(
-						new RegExp(
-							`A refund of \\$\\d+\\.\\d{2}(?: USD)? was successfully processed using WooPayments\\. Reason: No longer wanted`
-						)
-					)
-				).toBeVisible();
+				await submitFullRefund( adminPage );
 
 				// Get and store the payment intent ID for the next test
 				paymentIntentId = await adminPage

--- a/tests/qit/test-package/tests/woopayments/shopper/klarna-checkout-purchase.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/shopper/klarna-checkout-purchase.spec.ts
@@ -68,6 +68,10 @@ test.describe( 'Klarna Checkout', { tag: '@shopper' }, () => {
 		).not.toBeEmpty();
 	} );
 
+	// Order-visibility and refund are intentionally NOT asserted for Klarna: the
+	// Klarna playground redirect cannot be driven to a completed order without
+	// flakiness (see the redirect-only assertion below), so there is no captured
+	// order or transaction to verify or refund. Tracked alongside #6763.
 	test(
 		'allows to use Klarna as a payment method',
 		{ tag: '@critical' },

--- a/tests/qit/test-package/tests/woopayments/shopper/shopper-bnpls-checkout.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/shopper/shopper-bnpls-checkout.spec.ts
@@ -11,12 +11,48 @@ import * as navigation from '../../../utils/shopper-navigation';
 import * as shopper from '../../../utils/shopper';
 import * as merchant from '../../../utils/merchant';
 import * as devtools from '../../../utils/devtools';
+import { verifyOrderAndRefund } from '../../../utils/merchant-orders';
 
 const cardTestingProtectionStates = [ false, true ];
 const bnplProviders = [ 'Affirm', 'Cash App Afterpay' ];
 
 // Use different products per provider to avoid the order duplication protection.
 const products = [ 'belt', 'sunglasses' ];
+
+const checkoutWithBnpl = async (
+	page: Page,
+	provider: string,
+	productSlug: string,
+	ctpEnabled: boolean
+): Promise< string > => {
+	await navigation.goToProductPageBySlug( page, productSlug );
+
+	await page.locator( '.single_add_to_cart_button' ).click();
+	await page.waitForLoadState( 'domcontentloaded' );
+	await expect(
+		page.getByText( /has been added to your cart\./ )
+	).toBeVisible();
+
+	await shopper.setupCheckout( page );
+	await shopper.selectPaymentMethod( page, provider );
+	await shopper.expectFraudPreventionToken( page, ctpEnabled );
+	await shopper.placeOrder( page );
+	await expect( page.getByText( /test payment page/ ) ).toBeVisible();
+
+	await page.getByText( 'Authorize Test Payment' ).click();
+
+	await expect(
+		page.getByRole( 'heading', { name: 'Order received' } )
+	).toBeVisible();
+
+	const orderId = page.url().match( /\/order-received\/(\d+)\// )?.[ 1 ];
+	if ( ! orderId ) {
+		throw new Error(
+			`Expected an order-received URL with an order ID, got: ${ page.url() }`
+		);
+	}
+	return orderId;
+};
 
 test.describe( 'BNPL checkout', { tag: [ '@shopper', '@critical' ] }, () => {
 	let merchantContext: BrowserContext;
@@ -79,41 +115,27 @@ test.describe( 'BNPL checkout', { tag: [ '@shopper', '@critical' ] }, () => {
 
 			for ( const [ index, provider ] of bnplProviders.entries() ) {
 				test( `Checkout with ${ provider }`, async () => {
-					await navigation.goToProductPageBySlug(
+					await checkoutWithBnpl(
 						shopperPage,
-						products[ index % products.length ]
-					);
-
-					await shopperPage
-						.locator( '.single_add_to_cart_button' )
-						.click();
-					await shopperPage.waitForLoadState( 'domcontentloaded' );
-					await expect(
-						shopperPage.getByText( /has been added to your cart\./ )
-					).toBeVisible();
-
-					await shopper.setupCheckout( shopperPage );
-					await shopper.selectPaymentMethod( shopperPage, provider );
-					await shopper.expectFraudPreventionToken(
-						shopperPage,
+						provider,
+						products[ index % products.length ],
 						ctpEnabled
 					);
-					await shopper.placeOrder( shopperPage );
-					await expect(
-						shopperPage.getByText( /test payment page/ )
-					).toBeVisible();
-
-					await shopperPage
-						.getByText( 'Authorize Test Payment' )
-						.click();
-
-					await expect(
-						shopperPage.getByRole( 'heading', {
-							name: 'Order received',
-						} )
-					).toBeVisible();
 				} );
 			}
+		} );
+	}
+
+	for ( const [ index, provider ] of bnplProviders.entries() ) {
+		test( `merchant can see and refund a ${ provider } order`, async () => {
+			const orderId = await checkoutWithBnpl(
+				shopperPage,
+				provider,
+				products[ index % products.length ],
+				false
+			);
+
+			await verifyOrderAndRefund( merchantPage, orderId );
 		} );
 	}
 } );


### PR DESCRIPTION
Follow-up to #6763 

#### Changes proposed in this Pull Request

Reuses the `merchant-orders` helper from #11811 across the remaining specs:

- **Alipay** and **BNPL** (Affirm, Cash App Afterpay) — assert order visibility + refund.
- **Card** full-refund spec refactored onto the shared helper (one source of truth).
- Mirrored in the QIT suite (Alipay excluded there — already `describe.skip`'d, no Stripe test-account support).
- **Klarna** documented as excluded: its redirect can't be driven to a completed order without flakiness, so there's no captured order to verify or refund.

#### Testing instructions

1. CI runs the Playwright (`wcpay - shopper/merchant`) and QIT suites.
2. Confirm the `merchant can see and refund a <method> order` tests pass for Alipay, Affirm and Cash App Afterpay, and the card full-refund spec still passes.

-------------------

- [x] Run `npm run changelog` to add a changelog file.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
