### PR TITLE
refactor: extract ExpressPaymentSession and payment-result sinks

### DIFF
--- a/changelog/refactor-express-payment-session-and-sinks
+++ b/changelog/refactor-express-payment-session-and-sinks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Refactor dynamic place order buttons onto a shared ExpressPaymentSession and payment-result sinks.
+Refactor express checkout paths onto a shared ExpressPaymentSession and payment-result sinks (blocks/classic dynamic place order buttons and the standalone Store API flow).

--- a/changelog/refactor-express-payment-session-and-sinks
+++ b/changelog/refactor-express-payment-session-and-sinks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Refactor dynamic place order buttons onto a shared ExpressPaymentSession and payment-result sinks.

--- a/client/express-checkout/block-buttons/components/__tests__/dynamic-button-container.test.js
+++ b/client/express-checkout/block-buttons/components/__tests__/dynamic-button-container.test.js
@@ -234,7 +234,7 @@ describe( 'DynamicButtonContainer', () => {
 			);
 		} );
 
-		it( 'returns an error marker when credential creation fails', async () => {
+		it( 'returns an error response when credential creation fails', async () => {
 			createPaymentCredential.mockRejectedValue(
 				new Error( 'declined' )
 			);
@@ -244,13 +244,8 @@ describe( 'DynamicButtonContainer', () => {
 			const result = await getRegisteredPaymentSetupCallback( props )();
 
 			expect( result ).toEqual( {
-				type: 'success',
-				meta: {
-					paymentMethodData: {
-						payment_method: 'woocommerce_payments_google_pay',
-						'wcpay-payment-method': 'error',
-					},
-				},
+				type: 'error',
+				message: 'declined',
 			} );
 		} );
 

--- a/client/express-checkout/block-buttons/components/dynamic-button-container.tsx
+++ b/client/express-checkout/block-buttons/components/dynamic-button-container.tsx
@@ -8,7 +8,7 @@ import {
 	useStripe,
 	useElements,
 } from '@stripe/react-stripe-js';
-import { select, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
@@ -18,24 +18,13 @@ import {
 	getExpressCheckoutData,
 	getPaymentMethodsOverride,
 	shouldUseConfirmationTokens,
-	createPaymentCredential,
-	buildStripeElementsOptions,
 } from '../../utils';
 import type { AvailablePaymentMethods } from '@stripe/stripe-js';
-import {
-	transformCartDataForDisplayItems,
-	transformPrice,
-} from '../../transformers/wc-to-stripe';
-import { getSetupFutureUsageForCart } from '../../utils/subscriptions';
-import { validateElements } from 'wcpay/checkout/utils/validate-elements';
+import { transformPrice } from '../../transformers/wc-to-stripe';
 import { WC_STORE_CART } from 'wcpay/checkout/constants';
+import { ExpressPaymentSession } from 'wcpay/express-checkout/session/express-payment-session';
+import { createBlocksMetaSink } from 'wcpay/express-checkout/session/sinks';
 import type WCPayAPI from 'wcpay/checkout/api';
-
-declare global {
-	interface Window {
-		wcpayFraudPreventionToken?: string;
-	}
-}
 
 interface CartTotalItem {
 	key: string;
@@ -68,47 +57,43 @@ interface DynamicButtonContainerProps {
 	isEditor?: boolean;
 }
 
+interface DynamicButtonProps {
+	session: ExpressPaymentSession;
+	expressPaymentMethod: keyof AvailablePaymentMethods;
+	gatewayId: string;
+	validate: () => Promise< { hasError: boolean } >;
+	onSubmit: () => void;
+	eventRegistration: DynamicButtonContainerProps[ 'eventRegistration' ];
+	emitResponse: DynamicButtonContainerProps[ 'emitResponse' ];
+}
+
 /**
  * Inner component that has access to Stripe and Elements via hooks.
  * Renders the ExpressCheckoutElement and handles payment setup.
  */
 const DynamicButton = ( {
+	session,
 	expressPaymentMethod,
-	expressPaymentType,
-	stripePaymentMethodType,
 	gatewayId,
 	validate,
 	onSubmit,
 	eventRegistration: { onPaymentSetup },
 	emitResponse: { responseTypes },
-}: Omit< DynamicButtonContainerProps, 'api' | 'isEditor' > ) => {
+}: DynamicButtonProps ) => {
 	const stripe = useStripe();
 	const elements = useElements();
 
-	const useConfirmationTokens = shouldUseConfirmationTokens();
-
 	const handleClick = useCallback(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		async ( event: any ) => {
 			const { hasError } = await validate();
 			if ( hasError ) {
 				return;
 			}
 
-			const cartData = ( select( WC_STORE_CART ) as any )?.getCartData();
-			const lineItems = transformCartDataForDisplayItems( cartData );
-
-			event.resolve( {
-				business: {
-					name: ( getExpressCheckoutData as any )( 'store_name' ),
-				},
-				lineItems,
-				emailRequired: true,
-				phoneNumberRequired:
-					getExpressCheckoutData( 'checkout' )?.needs_payer_phone ??
-					false,
-			} );
+			event.resolve( session.buildClickResolution() );
 		},
-		[ validate ]
+		[ validate, session ]
 	);
 
 	const handleConfirm = useCallback( () => {
@@ -116,67 +101,25 @@ const DynamicButton = ( {
 	}, [ onSubmit ] );
 
 	useEffect( () => {
+		const sink = createBlocksMetaSink( { gatewayId, responseTypes } );
+
 		const unsubscribe = onPaymentSetup( async () => {
 			try {
-				await validateElements( elements! );
+				const result = await session.confirm( stripe!, elements! );
+				return sink.success( result );
 			} catch ( e ) {
-				return {
-					type: responseTypes.ERROR,
-					message: ( e as Error ).message,
-				};
+				return sink.error( ( e as Error ).message );
 			}
-
-			let credential;
-			try {
-				credential = await createPaymentCredential(
-					stripe!,
-					elements!,
-					useConfirmationTokens
-				);
-			} catch {
-				return {
-					type: responseTypes.SUCCESS,
-					meta: {
-						paymentMethodData: {
-							payment_method: gatewayId,
-							'wcpay-payment-method': 'error',
-						},
-					},
-				};
-			}
-
-			const credentialKey =
-				credential.type === 'confirmation_token'
-					? 'wcpay-confirmation-token'
-					: 'wcpay-payment-method';
-
-			return {
-				type: responseTypes.SUCCESS,
-				meta: {
-					paymentMethodData: {
-						payment_method: gatewayId,
-						[ credentialKey ]: credential.id,
-						express_payment_type: expressPaymentType,
-						'wcpay-express-payment-method-types': JSON.stringify( [
-							stripePaymentMethodType,
-						] ),
-						'wcpay-fraud-prevention-token':
-							window.wcpayFraudPreventionToken ?? '',
-					},
-				},
-			};
 		} );
 
 		return unsubscribe;
 	}, [
+		session,
 		stripe,
 		elements,
 		onPaymentSetup,
-		useConfirmationTokens,
 		responseTypes,
 		gatewayId,
-		expressPaymentType,
-		stripePaymentMethodType,
 	] );
 
 	const expressCheckoutOptions = useMemo(
@@ -200,20 +143,19 @@ const DynamicButton = ( {
  * and renders the DynamicButton inside it.
  */
 const DynamicButtonContainer = ( props: DynamicButtonContainerProps ) => {
-	const { api, billing, stripePaymentMethodType, isEditor } = props;
-
-	const useConfirmationTokens = shouldUseConfirmationTokens();
-	const isManualCaptureEnabled =
-		getExpressCheckoutData( 'is_manual_capture' ) ?? false;
+	const {
+		api,
+		billing,
+		expressPaymentMethod,
+		expressPaymentType,
+		stripePaymentMethodType,
+		gatewayId,
+		isEditor,
+	} = props;
 
 	const stripePromise = useMemo( () => {
 		return api.loadStripeForExpressCheckout();
 	}, [ api ] );
-
-	const paymentMethodTypes = useMemo(
-		() => [ stripePaymentMethodType ],
-		[ stripePaymentMethodType ]
-	);
 
 	const cartData = useSelect(
 		( selectCart ) => ( selectCart( WC_STORE_CART ) as any )?.getCartData(),
@@ -229,24 +171,38 @@ const DynamicButtonContainer = ( props: DynamicButtonContainerProps ) => {
 		cartData
 	) as number;
 
-	const elementsOptions = useMemo(
+	const session = useMemo(
 		() =>
-			buildStripeElementsOptions( {
+			new ExpressPaymentSession( {
+				method: expressPaymentMethod,
+				expressPaymentType,
+				stripePaymentMethodType,
 				amount,
 				currency: billing.currency.code,
-				useConfirmationTokens,
-				paymentMethodTypes,
-				captureMethod: isManualCaptureEnabled ? 'manual' : undefined,
-				setupFutureUsage: getSetupFutureUsageForCart( cartData ),
+				useConfirmationTokens: shouldUseConfirmationTokens(),
+				isManualCapture:
+					getExpressCheckoutData( 'is_manual_capture' ) ?? false,
+				cartData,
+				storeName: getExpressCheckoutData( 'store_name' ) as
+					| string
+					| null,
+				needsPayerPhone:
+					getExpressCheckoutData( 'checkout' )?.needs_payer_phone ??
+					false,
 			} ),
 		[
+			expressPaymentMethod,
+			expressPaymentType,
+			stripePaymentMethodType,
 			amount,
 			billing.currency.code,
-			useConfirmationTokens,
-			paymentMethodTypes,
-			isManualCaptureEnabled,
 			cartData,
 		]
+	);
+
+	const elementsOptions = useMemo(
+		() => session.getElementsOptions(),
+		[ session ]
 	);
 
 	if ( isEditor ) {
@@ -255,7 +211,15 @@ const DynamicButtonContainer = ( props: DynamicButtonContainerProps ) => {
 
 	return (
 		<Elements stripe={ stripePromise } options={ elementsOptions }>
-			<DynamicButton { ...props } />
+			<DynamicButton
+				session={ session }
+				expressPaymentMethod={ expressPaymentMethod }
+				gatewayId={ gatewayId }
+				validate={ props.validate }
+				onSubmit={ props.onSubmit }
+				eventRegistration={ props.eventRegistration }
+				emitResponse={ props.emitResponse }
+			/>
 		</Elements>
 	);
 };

--- a/client/express-checkout/event-handlers.js
+++ b/client/express-checkout/event-handlers.js
@@ -2,17 +2,14 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
 import {
-	getErrorMessageFromNotice,
 	getExpressCheckoutData,
 	updateShippingAddressUI,
-	createPaymentCredential,
 	shouldUseConfirmationTokens,
 } from './utils';
 import {
@@ -20,16 +17,15 @@ import {
 	trackExpressCheckoutButtonLoad,
 } from './tracking';
 import ExpressCheckoutCartApi from './cart-api';
-import {
-	transformStripePaymentMethodForStoreApi,
-	transformStripeShippingAddressForStoreApi,
-} from './transformers/stripe-to-wc';
+import { transformStripeShippingAddressForStoreApi } from './transformers/stripe-to-wc';
 import {
 	transformCartDataForDisplayItems,
 	transformCartDataForShippingRates,
 	transformPrice,
 } from './transformers/wc-to-stripe';
 import { getSetupFutureUsageForCart } from './utils/subscriptions';
+import { confirmExpressCredential } from './session/express-payment-session';
+import { createStoreApiSink } from './session/sinks';
 
 let lastSelectedAddress = null;
 let lastCartData = null;
@@ -133,92 +129,30 @@ export const onConfirmHandler = async (
 	event,
 	paymentMethodTypes = []
 ) => {
-	const { error: submitError } = await elements.submit();
-	if ( submitError ) {
-		return abortPayment( submitError.message );
-	}
-
-	const useConfirmationTokens = shouldUseConfirmationTokens();
+	// The standalone buttons own the address and place the order via the Store
+	// API, so they deliver the credential through the Store API sink rather than
+	// the checkout form. `cartApi` is read live so test overrides apply.
+	const sink = createStoreApiSink( {
+		api,
+		cartApi,
+		event,
+		paymentMethodTypes,
+		completePayment,
+		abortPayment,
+	} );
 
 	let credential;
 	try {
-		credential = await createPaymentCredential(
+		credential = await confirmExpressCredential(
 			stripe,
 			elements,
-			useConfirmationTokens
+			shouldUseConfirmationTokens()
 		);
-	} catch ( credentialError ) {
-		return abortPayment( credentialError.message );
-	}
-
-	try {
-		// Kick off checkout processing step.
-		const orderResponse = await cartApi.placeOrder( {
-			// adding extension data as a separate action,
-			// so that we make it harder for external plugins to modify or intercept checkout data.
-			...transformStripePaymentMethodForStoreApi(
-				event,
-				credential.id,
-				useConfirmationTokens,
-				paymentMethodTypes
-			),
-			extensions: applyFilters(
-				'wcpay.express-checkout.cart-place-order-extension-data',
-				{}
-			),
-		} );
-
-		if ( orderResponse.payment_result.payment_status !== 'success' ) {
-			return abortPayment(
-				getErrorMessageFromNotice(
-					orderResponse.message ??
-						orderResponse.payment_result?.payment_details.find(
-							( detail ) => detail.key === 'errorMessage'
-						)?.value ??
-						''
-				)
-			);
-		}
-
-		// Extract redirect URL from payment_details if redirect_url is empty
-		let redirectUrl = orderResponse.payment_result.redirect_url;
-		if ( ! redirectUrl ) {
-			const redirectDetail =
-				orderResponse.payment_result.payment_details?.find(
-					( detail ) => detail.key === 'redirect'
-				);
-			redirectUrl = redirectDetail?.value || '';
-		}
-
-		const confirmationRequest = api.confirmIntent( redirectUrl );
-
-		// `true` means there is no intent to confirm.
-		if ( confirmationRequest === true ) {
-			completePayment( redirectUrl );
-		} else {
-			const authenticatedRedirectUrl = await confirmationRequest;
-
-			completePayment( authenticatedRedirectUrl );
-		}
 	} catch ( e ) {
-		// API errors are not parsed, so we need to do it ourselves.
-		if ( e.json ) {
-			e = await Promise.resolve( e.json() );
-		}
-
-		return abortPayment(
-			getErrorMessageFromNotice(
-				e.message ||
-					e.payment_result?.payment_details.find(
-						( detail ) => detail.key === 'errorMessage'
-					)?.value ||
-					__(
-						'There was a problem processing the order.',
-						'woocommerce-payments'
-					)
-			)
-		);
+		return sink.error( e.message );
 	}
+
+	return sink.success( credential );
 };
 
 export const onReadyHandler = async function ( { availablePaymentMethods } ) {

--- a/client/express-checkout/session/__tests__/express-payment-session.test.js
+++ b/client/express-checkout/session/__tests__/express-payment-session.test.js
@@ -1,0 +1,213 @@
+/**
+ * Internal dependencies
+ */
+import { ExpressPaymentSession } from '../express-payment-session';
+import {
+	buildStripeElementsOptions,
+	createPaymentCredential,
+} from 'wcpay/express-checkout/utils';
+import { getSetupFutureUsageForCart } from 'wcpay/express-checkout/utils/subscriptions';
+import { transformCartDataForDisplayItems } from 'wcpay/express-checkout/transformers/wc-to-stripe';
+import { validateElements } from 'wcpay/checkout/utils/validate-elements';
+
+jest.mock( 'wcpay/express-checkout/utils', () => ( {
+	// Passthrough so assertions can inspect the options the session assembles.
+	buildStripeElementsOptions: jest.fn( ( options ) => options ),
+	createPaymentCredential: jest.fn(),
+} ) );
+
+jest.mock( 'wcpay/express-checkout/utils/subscriptions', () => ( {
+	getSetupFutureUsageForCart: jest.fn( () => null ),
+} ) );
+
+jest.mock( 'wcpay/express-checkout/transformers/wc-to-stripe', () => ( {
+	transformCartDataForDisplayItems: jest.fn(),
+} ) );
+
+jest.mock( 'wcpay/checkout/utils/validate-elements', () => ( {
+	validateElements: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
+const baseConfig = ( overrides = {} ) => ( {
+	method: 'googlePay',
+	expressPaymentType: 'google_pay',
+	stripePaymentMethodType: 'card',
+	amount: 2399,
+	currency: 'usd',
+	useConfirmationTokens: true,
+	isManualCapture: false,
+	cartData: { totals: {}, items: [] },
+	storeName: 'Test Store',
+	needsPayerPhone: false,
+	...overrides,
+} );
+
+describe( 'ExpressPaymentSession', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		getSetupFutureUsageForCart.mockReturnValue( null );
+	} );
+
+	describe( 'getElementsOptions', () => {
+		it( 'assembles the Stripe Elements options for the single method type', () => {
+			const session = new ExpressPaymentSession( baseConfig() );
+
+			const options = session.getElementsOptions();
+
+			expect( buildStripeElementsOptions ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					amount: 2399,
+					currency: 'usd',
+					useConfirmationTokens: true,
+					paymentMethodTypes: [ 'card' ],
+					captureMethod: undefined,
+					setupFutureUsage: null,
+				} )
+			);
+			expect( options.paymentMethodTypes ).toEqual( [ 'card' ] );
+		} );
+
+		it( 'requests manual capture when enabled', () => {
+			const session = new ExpressPaymentSession(
+				baseConfig( { isManualCapture: true } )
+			);
+
+			session.getElementsOptions();
+
+			expect( buildStripeElementsOptions ).toHaveBeenCalledWith(
+				expect.objectContaining( { captureMethod: 'manual' } )
+			);
+		} );
+
+		it( 'carries the cart-derived setupFutureUsage', () => {
+			getSetupFutureUsageForCart.mockReturnValue( 'off_session' );
+			const session = new ExpressPaymentSession( baseConfig() );
+
+			session.getElementsOptions();
+
+			expect( buildStripeElementsOptions ).toHaveBeenCalledWith(
+				expect.objectContaining( { setupFutureUsage: 'off_session' } )
+			);
+		} );
+
+		it( 'omits the method type when none is configured', () => {
+			const session = new ExpressPaymentSession(
+				baseConfig( { stripePaymentMethodType: '' } )
+			);
+
+			session.getElementsOptions();
+
+			expect( buildStripeElementsOptions ).toHaveBeenCalledWith(
+				expect.objectContaining( { paymentMethodTypes: [] } )
+			);
+		} );
+	} );
+
+	describe( 'buildClickResolution', () => {
+		it( 'never collects shipping and requires email', () => {
+			transformCartDataForDisplayItems.mockReturnValue( [
+				{ name: 'A product', amount: 2399 },
+			] );
+			const session = new ExpressPaymentSession( baseConfig() );
+
+			const resolution = session.buildClickResolution();
+
+			expect( resolution ).toEqual( {
+				emailRequired: true,
+				phoneNumberRequired: false,
+				shippingAddressRequired: false,
+				lineItems: [ { name: 'A product', amount: 2399 } ],
+				business: { name: 'Test Store' },
+			} );
+		} );
+
+		it( 'omits the business name when the store name is empty', () => {
+			const session = new ExpressPaymentSession(
+				baseConfig( { storeName: null } )
+			);
+
+			expect( session.buildClickResolution() ).not.toHaveProperty(
+				'business'
+			);
+		} );
+
+		it( 'requests the payer phone when configured', () => {
+			const session = new ExpressPaymentSession(
+				baseConfig( { needsPayerPhone: true } )
+			);
+
+			expect( session.buildClickResolution().phoneNumberRequired ).toBe(
+				true
+			);
+		} );
+
+		it( 'falls back to no line items when the cart is unavailable', () => {
+			const session = new ExpressPaymentSession(
+				baseConfig( { cartData: null } )
+			);
+
+			expect( session.buildClickResolution().lineItems ).toBeUndefined();
+			expect( transformCartDataForDisplayItems ).not.toHaveBeenCalled();
+		} );
+
+		it( 'tolerates a transformer failure', () => {
+			transformCartDataForDisplayItems.mockImplementation( () => {
+				throw new Error( 'bad cart' );
+			} );
+			const session = new ExpressPaymentSession( baseConfig() );
+
+			expect( session.buildClickResolution().lineItems ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'confirm', () => {
+		const stripe = {};
+		const elements = { submit: jest.fn() };
+
+		it( 'validates, creates the credential, and normalizes the result', async () => {
+			createPaymentCredential.mockResolvedValue( {
+				id: 'ct_123',
+				type: 'confirmation_token',
+			} );
+			const session = new ExpressPaymentSession( baseConfig() );
+
+			const result = await session.confirm( stripe, elements );
+
+			expect( validateElements ).toHaveBeenCalledWith( elements );
+			expect( createPaymentCredential ).toHaveBeenCalledWith(
+				stripe,
+				elements,
+				true
+			);
+			expect( result ).toEqual( {
+				credentialId: 'ct_123',
+				credentialType: 'confirmation_token',
+				expressPaymentType: 'google_pay',
+				stripePaymentMethodTypes: [ 'card' ],
+			} );
+		} );
+
+		it( 'propagates a validation failure without creating a credential', async () => {
+			validateElements.mockRejectedValueOnce(
+				new Error( 'incomplete fields' )
+			);
+			const session = new ExpressPaymentSession( baseConfig() );
+
+			await expect( session.confirm( stripe, elements ) ).rejects.toThrow(
+				'incomplete fields'
+			);
+			expect( createPaymentCredential ).not.toHaveBeenCalled();
+		} );
+
+		it( 'propagates a credential failure', async () => {
+			createPaymentCredential.mockRejectedValueOnce(
+				new Error( 'declined' )
+			);
+			const session = new ExpressPaymentSession( baseConfig() );
+
+			await expect( session.confirm( stripe, elements ) ).rejects.toThrow(
+				'declined'
+			);
+		} );
+	} );
+} );

--- a/client/express-checkout/session/__tests__/sinks.test.js
+++ b/client/express-checkout/session/__tests__/sinks.test.js
@@ -1,0 +1,164 @@
+/**
+ * Internal dependencies
+ */
+import { createBlocksMetaSink, createClassicFormSink } from '../sinks';
+import {
+	appendPaymentMethodIdToForm,
+	appendConfirmationTokenToForm,
+	appendExpressPaymentTypeToForm,
+	appendFraudPreventionTokenInputToForm,
+} from 'wcpay/checkout/classic/upe-utils';
+import { appendFingerprintInputToForm } from 'wcpay/checkout/utils/fingerprint';
+
+jest.mock( 'wcpay/checkout/classic/upe-utils', () => ( {
+	appendPaymentMethodIdToForm: jest.fn(),
+	appendConfirmationTokenToForm: jest.fn(),
+	appendExpressPaymentTypeToForm: jest.fn(),
+	appendFraudPreventionTokenInputToForm: jest.fn(),
+} ) );
+
+jest.mock( 'wcpay/checkout/utils/fingerprint', () => ( {
+	appendFingerprintInputToForm: jest.fn(),
+} ) );
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const responseTypes = { SUCCESS: 'success', ERROR: 'error', FAIL: 'fail' };
+
+const confirmationTokenResult = {
+	credentialId: 'ct_123',
+	credentialType: 'confirmation_token',
+	expressPaymentType: 'google_pay',
+	stripePaymentMethodTypes: [ 'card' ],
+};
+
+const paymentMethodResult = {
+	...confirmationTokenResult,
+	credentialId: 'pm_123',
+	credentialType: 'payment_method',
+};
+
+describe( 'createBlocksMetaSink', () => {
+	beforeEach( () => {
+		window.wcpayFraudPreventionToken = 'fraud-token';
+	} );
+
+	it( 'maps a confirmation token result to the WC Blocks payment data', () => {
+		const sink = createBlocksMetaSink( {
+			gatewayId: 'woocommerce_payments_google_pay',
+			responseTypes,
+		} );
+
+		expect( sink.success( confirmationTokenResult ) ).toEqual( {
+			type: 'success',
+			meta: {
+				paymentMethodData: {
+					payment_method: 'woocommerce_payments_google_pay',
+					'wcpay-confirmation-token': 'ct_123',
+					express_payment_type: 'google_pay',
+					'wcpay-express-payment-method-types': JSON.stringify( [
+						'card',
+					] ),
+					'wcpay-fraud-prevention-token': 'fraud-token',
+				},
+			},
+		} );
+	} );
+
+	it( 'uses the payment method key when not tokenizing', () => {
+		const sink = createBlocksMetaSink( {
+			gatewayId: 'woocommerce_payments_google_pay',
+			responseTypes,
+		} );
+
+		expect(
+			sink.success( paymentMethodResult ).meta.paymentMethodData
+		).toEqual(
+			expect.objectContaining( { 'wcpay-payment-method': 'pm_123' } )
+		);
+	} );
+
+	it( 'returns a proper error response instead of a success sentinel', () => {
+		const sink = createBlocksMetaSink( {
+			gatewayId: 'woocommerce_payments_google_pay',
+			responseTypes,
+		} );
+
+		expect( sink.error( 'declined' ) ).toEqual( {
+			type: 'error',
+			message: 'declined',
+		} );
+	} );
+} );
+
+describe( 'createClassicFormSink', () => {
+	let onSubmit;
+	let onError;
+	let $form;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		onSubmit = jest.fn();
+		onError = jest.fn();
+		$form = { append: jest.fn() };
+	} );
+
+	it( 'appends a confirmation token, the express type, fraud signals, then submits', () => {
+		const sink = createClassicFormSink( {
+			$form,
+			fingerprint: 'fp_123',
+			onSubmit,
+			onError,
+		} );
+
+		sink.success( confirmationTokenResult );
+
+		expect( appendConfirmationTokenToForm ).toHaveBeenCalledWith(
+			$form,
+			'ct_123'
+		);
+		expect( appendPaymentMethodIdToForm ).not.toHaveBeenCalled();
+		expect( appendExpressPaymentTypeToForm ).toHaveBeenCalledWith(
+			$form,
+			'google_pay'
+		);
+		expect( appendFingerprintInputToForm ).toHaveBeenCalledWith(
+			$form,
+			'fp_123'
+		);
+		expect( appendFraudPreventionTokenInputToForm ).toHaveBeenCalledWith(
+			$form
+		);
+		expect( onSubmit ).toHaveBeenCalled();
+	} );
+
+	it( 'appends the payment method id when not tokenizing', () => {
+		const sink = createClassicFormSink( {
+			$form,
+			fingerprint: 'fp_123',
+			onSubmit,
+			onError,
+		} );
+
+		sink.success( paymentMethodResult );
+
+		expect( appendPaymentMethodIdToForm ).toHaveBeenCalledWith(
+			$form,
+			'pm_123'
+		);
+		expect( appendConfirmationTokenToForm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'delegates errors to the injected handler without submitting', () => {
+		const sink = createClassicFormSink( {
+			$form,
+			fingerprint: 'fp_123',
+			onSubmit,
+			onError,
+		} );
+
+		sink.error( 'declined' );
+
+		expect( onError ).toHaveBeenCalledWith( 'declined' );
+		expect( onSubmit ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/express-checkout/session/__tests__/sinks.test.js
+++ b/client/express-checkout/session/__tests__/sinks.test.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { createBlocksMetaSink, createClassicFormSink } from '../sinks';
+import {
+	createBlocksMetaSink,
+	createClassicFormSink,
+	createStoreApiSink,
+} from '../sinks';
 import {
 	appendPaymentMethodIdToForm,
 	appendConfirmationTokenToForm,
@@ -160,5 +164,104 @@ describe( 'createClassicFormSink', () => {
 
 		expect( onError ).toHaveBeenCalledWith( 'declined' );
 		expect( onSubmit ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'createStoreApiSink', () => {
+	let api;
+	let cartApi;
+	let completePayment;
+	let abortPayment;
+
+	const event = {
+		billingDetails: {
+			name: 'Card Holder',
+			email: 'card.holder@example.com',
+			address: { country: 'US' },
+		},
+		expressPaymentType: 'google_pay',
+	};
+
+	const makeSink = () =>
+		createStoreApiSink( {
+			api,
+			cartApi,
+			event,
+			paymentMethodTypes: [ 'card' ],
+			completePayment,
+			abortPayment,
+		} );
+
+	beforeEach( () => {
+		window.wcpayFraudPreventionToken = 'fraud-token';
+		completePayment = jest.fn();
+		abortPayment = jest.fn();
+		api = { confirmIntent: jest.fn().mockReturnValue( true ) };
+		cartApi = { placeOrder: jest.fn() };
+	} );
+
+	it( 'places the order from the credential and completes payment on success', async () => {
+		cartApi.placeOrder.mockResolvedValue( {
+			payment_result: {
+				payment_status: 'success',
+				redirect_url: 'https://example.com/ok',
+			},
+		} );
+
+		await makeSink().success( {
+			credentialId: 'ct_123',
+			credentialType: 'confirmation_token',
+		} );
+
+		expect( cartApi.placeOrder ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				payment_data: expect.arrayContaining( [
+					expect.objectContaining( {
+						key: 'wcpay-confirmation-token',
+						value: 'ct_123',
+					} ),
+					expect.objectContaining( {
+						key: 'express_payment_type',
+						value: 'google_pay',
+					} ),
+					expect.objectContaining( {
+						key: 'wcpay-express-payment-method-types',
+						value: JSON.stringify( [ 'card' ] ),
+					} ),
+				] ),
+			} )
+		);
+		expect( api.confirmIntent ).toHaveBeenCalledWith(
+			'https://example.com/ok'
+		);
+		expect( completePayment ).toHaveBeenCalledWith(
+			'https://example.com/ok'
+		);
+		expect( abortPayment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'aborts when the order does not succeed', async () => {
+		cartApi.placeOrder.mockResolvedValue( {
+			payment_result: {
+				payment_status: 'failure',
+				payment_details: [
+					{ key: 'errorMessage', value: 'Card declined.' },
+				],
+			},
+		} );
+
+		await makeSink().success( {
+			credentialId: 'pm_1',
+			credentialType: 'payment_method',
+		} );
+
+		expect( abortPayment ).toHaveBeenCalledWith( 'Card declined.' );
+		expect( completePayment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'maps an authorization error to abortPayment', () => {
+		makeSink().error( 'Submit error' );
+
+		expect( abortPayment ).toHaveBeenCalledWith( 'Submit error' );
 	} );
 } );

--- a/client/express-checkout/session/express-payment-session.ts
+++ b/client/express-checkout/session/express-payment-session.ts
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+import type { Stripe, StripeElements } from '@stripe/stripe-js';
+
+/**
+ * Internal dependencies
+ */
+import {
+	buildStripeElementsOptions,
+	createPaymentCredential,
+} from 'wcpay/express-checkout/utils';
+import { getSetupFutureUsageForCart } from 'wcpay/express-checkout/utils/subscriptions';
+import { transformCartDataForDisplayItems } from 'wcpay/express-checkout/transformers/wc-to-stripe';
+import { validateElements } from 'wcpay/checkout/utils/validate-elements';
+import type { ExpressPaymentResult } from './payment-result';
+
+// The Store API cart shape, kept loose - only the fields the transformers and
+// subscription helpers read are relevant here.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CartData = any;
+
+export interface ExpressPaymentSessionConfig {
+	/** camelCase method key: 'applePay' | 'googlePay' | 'amazonPay'. */
+	method: string;
+	/** snake_cased method key, sent to the server: 'apple_pay' | ... */
+	expressPaymentType: string;
+	/** Stripe PaymentMethod type for the PaymentIntent ('card', 'amazon_pay'). */
+	stripePaymentMethodType: string;
+	/** Cart total in the smallest currency unit, already filtered/transformed by the caller. */
+	amount: number;
+	currency: string;
+	useConfirmationTokens: boolean;
+	isManualCapture: boolean;
+	/** Store API cart data, for line items and subscription detection. */
+	cartData?: CartData | null;
+	storeName?: string | null;
+	needsPayerPhone?: boolean;
+}
+
+interface ClickResolution {
+	emailRequired: true;
+	phoneNumberRequired: boolean;
+	// The checkout form owns address, shipping, and totals when the method is a
+	// row in the payment methods list, so the wallet sheet never collects shipping.
+	shippingAddressRequired: false;
+	lineItems?: ReturnType< typeof transformCartDataForDisplayItems >;
+	business?: { name: string };
+}
+
+/**
+ * Owns the Stripe Express Checkout Element lifecycle that the two "dynamic place
+ * order button" paths share: the Elements options, the payment-sheet resolution
+ * on click, and turning a confirm into a normalized {@link ExpressPaymentResult}.
+ *
+ * It is deliberately environment-agnostic - it neither mounts the element (React
+ * vs. imperative) nor delivers the result to WooCommerce (that is the sink's job).
+ * The caller resolves the amount/cart up front and the session is a pure function
+ * of its config from there.
+ */
+export class ExpressPaymentSession {
+	private readonly config: ExpressPaymentSessionConfig;
+
+	public constructor( config: ExpressPaymentSessionConfig ) {
+		this.config = config;
+	}
+
+	/**
+	 * Options for `stripe.elements()` / the React `<Elements>` provider.
+	 */
+	public getElementsOptions(): ReturnType<
+		typeof buildStripeElementsOptions
+	> {
+		const { amount, currency, useConfirmationTokens, isManualCapture } =
+			this.config;
+
+		return buildStripeElementsOptions( {
+			amount,
+			currency,
+			useConfirmationTokens,
+			paymentMethodTypes: this.getPaymentMethodTypes(),
+			captureMethod: isManualCapture ? 'manual' : undefined,
+			setupFutureUsage: getSetupFutureUsageForCart(
+				this.config.cartData ?? undefined
+			),
+		} );
+	}
+
+	/**
+	 * The payment-sheet configuration passed to the Express Checkout Element's
+	 * `click` event `resolve()`.
+	 */
+	public buildClickResolution(): ClickResolution {
+		const resolution: ClickResolution = {
+			emailRequired: true,
+			phoneNumberRequired: this.config.needsPayerPhone ?? false,
+			shippingAddressRequired: false,
+			lineItems: this.getLineItems(),
+		};
+
+		if ( this.config.storeName ) {
+			resolution.business = { name: this.config.storeName };
+		}
+
+		return resolution;
+	}
+
+	/**
+	 * Submits the elements and creates the payment credential.
+	 *
+	 * @throws The Stripe error if element validation or credential creation fails.
+	 *         Callers map this to their environment's error contract via the sink.
+	 */
+	public async confirm(
+		stripe: Stripe,
+		elements: StripeElements
+	): Promise< ExpressPaymentResult > {
+		await validateElements( elements );
+
+		const credential = await createPaymentCredential(
+			stripe,
+			elements,
+			this.config.useConfirmationTokens
+		);
+
+		return {
+			credentialId: credential.id,
+			credentialType: credential.type,
+			expressPaymentType: this.config.expressPaymentType,
+			stripePaymentMethodTypes: this.getPaymentMethodTypes(),
+		};
+	}
+
+	// A method may have no dedicated Stripe type (the server emits one for the
+	// express methods, but it can be absent), in which case Stripe is left to
+	// infer the types - hence the empty-string filter rather than `['']`.
+	private getPaymentMethodTypes(): string[] {
+		return [ this.config.stripePaymentMethodType ].filter(
+			Boolean
+		) as string[];
+	}
+
+	private getLineItems():
+		| ReturnType< typeof transformCartDataForDisplayItems >
+		| undefined {
+		if ( ! this.config.cartData ) {
+			return undefined;
+		}
+
+		try {
+			return transformCartDataForDisplayItems( this.config.cartData );
+		} catch {
+			return undefined;
+		}
+	}
+}

--- a/client/express-checkout/session/express-payment-session.ts
+++ b/client/express-checkout/session/express-payment-session.ts
@@ -13,12 +13,38 @@ import {
 import { getSetupFutureUsageForCart } from 'wcpay/express-checkout/utils/subscriptions';
 import { transformCartDataForDisplayItems } from 'wcpay/express-checkout/transformers/wc-to-stripe';
 import { validateElements } from 'wcpay/checkout/utils/validate-elements';
-import type { ExpressPaymentResult } from './payment-result';
+import type {
+	ExpressPaymentCredential,
+	ExpressPaymentResult,
+} from './payment-result';
 
 // The Store API cart shape, kept loose - only the fields the transformers and
 // subscription helpers read are relevant here.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CartData = any;
+
+/**
+ * Submits the elements and creates a payment credential. The shared primitive
+ * behind every confirm: the session uses it for the dynamic paths, and the
+ * standalone paths call it directly (they have no per-method session).
+ *
+ * @throws The Stripe error if element validation or credential creation fails.
+ */
+export async function confirmExpressCredential(
+	stripe: Stripe,
+	elements: StripeElements,
+	useConfirmationTokens: boolean
+): Promise< ExpressPaymentCredential > {
+	await validateElements( elements );
+
+	const credential = await createPaymentCredential(
+		stripe,
+		elements,
+		useConfirmationTokens
+	);
+
+	return { credentialId: credential.id, credentialType: credential.type };
+}
 
 export interface ExpressPaymentSessionConfig {
 	/** camelCase method key: 'applePay' | 'googlePay' | 'amazonPay'. */
@@ -115,17 +141,14 @@ export class ExpressPaymentSession {
 		stripe: Stripe,
 		elements: StripeElements
 	): Promise< ExpressPaymentResult > {
-		await validateElements( elements );
-
-		const credential = await createPaymentCredential(
+		const credential = await confirmExpressCredential(
 			stripe,
 			elements,
 			this.config.useConfirmationTokens
 		);
 
 		return {
-			credentialId: credential.id,
-			credentialType: credential.type,
+			...credential,
 			expressPaymentType: this.config.expressPaymentType,
 			stripePaymentMethodTypes: this.getPaymentMethodTypes(),
 		};

--- a/client/express-checkout/session/payment-result.ts
+++ b/client/express-checkout/session/payment-result.ts
@@ -1,0 +1,16 @@
+/**
+ * The outcome of a successful express checkout authorization, normalized so the
+ * environment-specific sinks can serialize it without re-deriving Stripe details.
+ *
+ * Both dynamic paths (blocks and classic) produce the same logical fields; only
+ * the transport differs - see the sinks in `./sinks`.
+ */
+export interface ExpressPaymentResult {
+	/** The Stripe confirmation token id or payment method id. */
+	credentialId: string;
+	credentialType: 'confirmation_token' | 'payment_method';
+	/** The express method, snake_cased: 'apple_pay' | 'google_pay' | 'amazon_pay'. */
+	expressPaymentType: string;
+	/** Stripe PaymentMethod types for the PaymentIntent (e.g. ['card'], ['amazon_pay']). */
+	stripePaymentMethodTypes: string[];
+}

--- a/client/express-checkout/session/payment-result.ts
+++ b/client/express-checkout/session/payment-result.ts
@@ -1,14 +1,21 @@
 /**
- * The outcome of a successful express checkout authorization, normalized so the
- * environment-specific sinks can serialize it without re-deriving Stripe details.
- *
- * Both dynamic paths (blocks and classic) produce the same logical fields; only
- * the transport differs - see the sinks in `./sinks`.
+ * The Stripe credential produced by authorizing an express payment - the part
+ * every path shares, regardless of how it reaches WooCommerce.
  */
-export interface ExpressPaymentResult {
+export interface ExpressPaymentCredential {
 	/** The Stripe confirmation token id or payment method id. */
 	credentialId: string;
 	credentialType: 'confirmation_token' | 'payment_method';
+}
+
+/**
+ * A credential plus the method identity the per-method "dynamic place order
+ * button" paths carry. The standalone paths derive that identity from the
+ * wallet event instead, so they work with the bare {@link ExpressPaymentCredential}.
+ *
+ * The sinks in `./sinks` map one of these to each environment's transport.
+ */
+export interface ExpressPaymentResult extends ExpressPaymentCredential {
 	/** The express method, snake_cased: 'apple_pay' | 'google_pay' | 'amazon_pay'. */
 	expressPaymentType: string;
 	/** Stripe PaymentMethod types for the PaymentIntent (e.g. ['card'], ['amazon_pay']). */

--- a/client/express-checkout/session/sinks.ts
+++ b/client/express-checkout/session/sinks.ts
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import {
@@ -8,7 +14,12 @@ import {
 	appendFraudPreventionTokenInputToForm,
 } from 'wcpay/checkout/classic/upe-utils';
 import { appendFingerprintInputToForm } from 'wcpay/checkout/utils/fingerprint';
-import type { ExpressPaymentResult } from './payment-result';
+import { getErrorMessageFromNotice } from 'wcpay/express-checkout/utils';
+import { transformStripePaymentMethodForStoreApi } from 'wcpay/express-checkout/transformers/stripe-to-wc';
+import type {
+	ExpressPaymentCredential,
+	ExpressPaymentResult,
+} from './payment-result';
 
 declare global {
 	interface Window {
@@ -17,13 +28,18 @@ declare global {
 }
 
 /**
- * Delivers an {@link ExpressPaymentResult} (or an authorization error) to
- * WooCommerce. Each environment hands the credential to WooCommerce differently;
- * this is the seam where that knowledge - and the exact field names the WCPay
- * server expects - lives.
+ * Delivers a credential (or an authorization error) to WooCommerce. Each
+ * environment hands the credential over differently; this is the seam where
+ * that knowledge - and the exact field names the WCPay server expects - lives.
+ *
+ * The dynamic paths carry the full {@link ExpressPaymentResult}; the standalone
+ * paths only have the bare {@link ExpressPaymentCredential}, hence the type
+ * parameter.
  */
-export interface ExpressPaymentResultSink {
-	success( result: ExpressPaymentResult ): unknown;
+export interface ExpressPaymentResultSink<
+	T extends ExpressPaymentCredential = ExpressPaymentResult
+> {
+	success( result: T ): unknown;
 	error( message: string ): unknown;
 }
 
@@ -110,5 +126,113 @@ export const createClassicFormSink = ( {
 	},
 	error( message: string ): void {
 		onError( message );
+	},
+} );
+
+interface StoreApiSinkContext {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	api: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	cartApi: any;
+	/** The Stripe Express Checkout `confirm` event (billing, shipping, payer, express type). */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	event: any;
+	/** Stripe PaymentMethod types the elements were initialized with. */
+	paymentMethodTypes?: string[];
+	completePayment: ( redirectUrl: string ) => void;
+	abortPayment: ( message: string ) => void;
+}
+
+/**
+ * Standalone express buttons: the wallet sheet owns the address and totals, so
+ * the order is placed through the Store API (bypassing the checkout form) and
+ * any required intent is confirmed afterwards. The billing/shipping details
+ * come from the wallet `event`, and the express type is whichever wallet the
+ * shopper picked - so this works from the bare credential.
+ */
+export const createStoreApiSink = ( {
+	api,
+	cartApi,
+	event,
+	paymentMethodTypes = [],
+	completePayment,
+	abortPayment,
+}: StoreApiSinkContext ): ExpressPaymentResultSink< ExpressPaymentCredential > => ( {
+	async success( {
+		credentialId,
+		credentialType,
+	}: ExpressPaymentCredential ): Promise< void > {
+		const useConfirmationToken = credentialType === 'confirmation_token';
+
+		try {
+			const orderResponse = await cartApi.placeOrder( {
+				// adding extension data as a separate action,
+				// so that we make it harder for external plugins to modify or intercept checkout data.
+				...transformStripePaymentMethodForStoreApi(
+					event,
+					credentialId,
+					useConfirmationToken,
+					paymentMethodTypes
+				),
+				extensions: applyFilters(
+					'wcpay.express-checkout.cart-place-order-extension-data',
+					{}
+				),
+			} );
+
+			if ( orderResponse.payment_result.payment_status !== 'success' ) {
+				return abortPayment(
+					getErrorMessageFromNotice(
+						orderResponse.message ??
+							orderResponse.payment_result?.payment_details.find(
+								( detail: { key: string } ) =>
+									detail.key === 'errorMessage'
+							)?.value ??
+							''
+					) ?? ''
+				);
+			}
+
+			// Extract redirect URL from payment_details if redirect_url is empty
+			let redirectUrl = orderResponse.payment_result.redirect_url;
+			if ( ! redirectUrl ) {
+				const redirectDetail =
+					orderResponse.payment_result.payment_details?.find(
+						( detail: { key: string } ) => detail.key === 'redirect'
+					);
+				redirectUrl = redirectDetail?.value || '';
+			}
+
+			const confirmationRequest = api.confirmIntent( redirectUrl );
+
+			// `true` means there is no intent to confirm.
+			if ( confirmationRequest === true ) {
+				completePayment( redirectUrl );
+			} else {
+				completePayment( await confirmationRequest );
+			}
+		} catch ( e ) {
+			// API errors are not parsed, so we need to do it ourselves.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const raw = e as any;
+			const error = raw?.json ? await Promise.resolve( raw.json() ) : raw;
+
+			return abortPayment(
+				getErrorMessageFromNotice(
+					error.message ||
+						error.payment_result?.payment_details.find(
+							( detail: { key: string } ) =>
+								detail.key === 'errorMessage'
+						)?.value ||
+						__(
+							'There was a problem processing the order.',
+							'woocommerce-payments'
+						)
+				) ?? ''
+			);
+		}
+	},
+	error( message: string ): void {
+		abortPayment( message );
 	},
 } );

--- a/client/express-checkout/session/sinks.ts
+++ b/client/express-checkout/session/sinks.ts
@@ -1,0 +1,114 @@
+/**
+ * Internal dependencies
+ */
+import {
+	appendPaymentMethodIdToForm,
+	appendConfirmationTokenToForm,
+	appendExpressPaymentTypeToForm,
+	appendFraudPreventionTokenInputToForm,
+} from 'wcpay/checkout/classic/upe-utils';
+import { appendFingerprintInputToForm } from 'wcpay/checkout/utils/fingerprint';
+import type { ExpressPaymentResult } from './payment-result';
+
+declare global {
+	interface Window {
+		wcpayFraudPreventionToken?: string;
+	}
+}
+
+/**
+ * Delivers an {@link ExpressPaymentResult} (or an authorization error) to
+ * WooCommerce. Each environment hands the credential to WooCommerce differently;
+ * this is the seam where that knowledge - and the exact field names the WCPay
+ * server expects - lives.
+ */
+export interface ExpressPaymentResultSink {
+	success( result: ExpressPaymentResult ): unknown;
+	error( message: string ): unknown;
+}
+
+interface BlocksMetaSinkContext {
+	gatewayId: string;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	responseTypes: { SUCCESS: string; ERROR: string; FAIL: string };
+}
+
+interface BlocksPaymentSetupResponse {
+	type: string;
+	message?: string;
+	meta?: { paymentMethodData: Record< string, string > };
+}
+
+/**
+ * Blocks checkout: WooCommerce reads `paymentMethodData` from the value the
+ * `onPaymentSetup` callback returns, then submits the order itself.
+ */
+export const createBlocksMetaSink = ( {
+	gatewayId,
+	responseTypes,
+}: BlocksMetaSinkContext ): ExpressPaymentResultSink => ( {
+	success( result: ExpressPaymentResult ): BlocksPaymentSetupResponse {
+		const credentialKey =
+			result.credentialType === 'confirmation_token'
+				? 'wcpay-confirmation-token'
+				: 'wcpay-payment-method';
+
+		return {
+			type: responseTypes.SUCCESS,
+			meta: {
+				paymentMethodData: {
+					payment_method: gatewayId,
+					[ credentialKey ]: result.credentialId,
+					express_payment_type: result.expressPaymentType,
+					'wcpay-express-payment-method-types': JSON.stringify(
+						result.stripePaymentMethodTypes
+					),
+					'wcpay-fraud-prevention-token':
+						window.wcpayFraudPreventionToken ?? '',
+				},
+			},
+		};
+	},
+	error( message: string ): BlocksPaymentSetupResponse {
+		return { type: responseTypes.ERROR, message };
+	},
+} );
+
+interface ClassicFormSinkContext {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	$form: any;
+	fingerprint: string;
+	/** Triggers the checkout form submission (the WC custom-place-order `api.submit`). */
+	onSubmit: () => void;
+	/** Renders the authorization error to the shopper (jQuery notice, scroll, ...). */
+	onError: ( message: string ) => void;
+}
+
+/**
+ * Classic (shortcode) checkout: append the credential as hidden inputs on the
+ * checkout form, then submit it. `payment_method` is already on the form (the
+ * selected radio), so unlike the blocks sink we don't re-send it.
+ */
+export const createClassicFormSink = ( {
+	$form,
+	fingerprint,
+	onSubmit,
+	onError,
+}: ClassicFormSinkContext ): ExpressPaymentResultSink => ( {
+	success( result: ExpressPaymentResult ): void {
+		if ( result.credentialType === 'confirmation_token' ) {
+			appendConfirmationTokenToForm( $form, result.credentialId );
+		} else {
+			appendPaymentMethodIdToForm( $form, result.credentialId );
+		}
+
+		appendExpressPaymentTypeToForm( $form, result.expressPaymentType );
+		appendFingerprintInputToForm( $form, fingerprint );
+		appendFraudPreventionTokenInputToForm( $form );
+
+		onSubmit();
+	},
+	error( message: string ): void {
+		onError( message );
+	},
+} );

--- a/client/express-checkout/shortcode-buttons-dynamic/index.ts
+++ b/client/express-checkout/shortcode-buttons-dynamic/index.ts
@@ -15,32 +15,19 @@ import { applyFilters } from '@wordpress/hooks';
 import { getUPEConfig } from 'wcpay/utils/checkout';
 import {
 	shouldUseConfirmationTokens,
-	createPaymentCredential,
 	getExpressCheckoutData,
-	buildStripeElementsOptions,
 } from 'wcpay/express-checkout/utils';
-import { getSetupFutureUsageForCart } from 'wcpay/express-checkout/utils/subscriptions';
-import {
-	transformCartDataForDisplayItems,
-	transformPrice,
-} from 'wcpay/express-checkout/transformers/wc-to-stripe';
+import { transformPrice } from 'wcpay/express-checkout/transformers/wc-to-stripe';
 import ExpressCheckoutCartApi from 'wcpay/express-checkout/cart-api';
 // Side-effect import: registers the WC Subscriptions compatibility filters
 // (`total-amount`, `is-cart-eligible`, ...) used below.
 import 'wcpay/express-checkout/compatibility/wc-subscriptions';
-import {
-	appendPaymentMethodIdToForm,
-	appendConfirmationTokenToForm,
-	appendExpressPaymentTypeToForm,
-	appendFraudPreventionTokenInputToForm,
-} from 'wcpay/checkout/classic/upe-utils';
-import {
-	appendFingerprintInputToForm,
-	getFingerprint,
-} from 'wcpay/checkout/utils/fingerprint';
+import { getFingerprint } from 'wcpay/checkout/utils/fingerprint';
 import { getPaymentMethodsOverride } from 'wcpay/express-checkout/utils/payment-method-overrides';
 import { checkAllExpressMethodsAvailability } from 'wcpay/express-checkout/utils/checkPaymentMethodIsAvailable';
 import { snakeToCamel } from 'wcpay/express-checkout/constants';
+import { ExpressPaymentSession } from 'wcpay/express-checkout/session/express-payment-session';
+import { createClassicFormSink } from 'wcpay/express-checkout/session/sinks';
 import type WCPayAPI from 'wcpay/checkout/api';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -186,6 +173,26 @@ function showPaymentMethod( gatewayId: string ): void {
 }
 
 /**
+ * Renders an authorization error to the shopper, replacing any previous one and
+ * scrolling it into view - the classic checkout's notice convention.
+ */
+function showCheckoutError( message: string ): void {
+	const $notices = jQuery( '.woocommerce-notices-wrapper' ).first();
+	if ( ! $notices.length ) {
+		return;
+	}
+
+	$notices.find( '.woocommerce-error' ).remove();
+	$notices.append(
+		jQuery( '<div class="woocommerce-error" />' ).text( message )
+	);
+	jQuery( 'html, body' ).animate(
+		{ scrollTop: $notices.offset()!.top - 100 },
+		1000
+	);
+}
+
+/**
  * Registers a single express payment method with the WC Custom Place Order Button API.
  */
 function registerCustomPlaceOrderButton(
@@ -235,23 +242,26 @@ function registerCustomPlaceOrderButton(
 
 			try {
 				const stripe = ( await api.getStripe() ) as Stripe;
+
+				const session = new ExpressPaymentSession( {
+					method: camelKey,
+					expressPaymentType: paymentMethodId,
+					stripePaymentMethodType: stripePaymentMethodType ?? '',
+					amount: getEffectiveCartTotal(),
+					currency: currency!,
+					useConfirmationTokens,
+					isManualCapture: Boolean(
+						getExpressCheckoutData( 'is_manual_capture' )
+					),
+					cartData: cachedCartData,
+					storeName: getExpressCheckoutData( 'store_name' ) as
+						| string
+						| null,
+					needsPayerPhone: false,
+				} );
+
 				state.elements = stripe.elements(
-					buildStripeElementsOptions( {
-						amount: getEffectiveCartTotal(),
-						currency: currency!,
-						useConfirmationTokens,
-						paymentMethodTypes: stripePaymentMethodType
-							? [ stripePaymentMethodType ]
-							: [],
-						captureMethod: getExpressCheckoutData(
-							'is_manual_capture'
-						)
-							? 'manual'
-							: undefined,
-						setupFutureUsage: getSetupFutureUsageForCart(
-							cachedCartData ?? undefined
-						),
-					} )
+					session.getElementsOptions()
 				);
 
 				state.eceButton = state.elements.create( 'expressCheckout', {
@@ -288,83 +298,25 @@ function registerCustomPlaceOrderButton(
 						return;
 					}
 
-					// The checkout form owns address, shipping, and totals -
-					// the payment sheet only authorizes the payment, so no
-					// shipping address collection is needed here.
-					let lineItems;
-					try {
-						lineItems = cachedCartData
-							? transformCartDataForDisplayItems( cachedCartData )
-							: undefined;
-					} catch {
-						lineItems = undefined;
-					}
-
-					const storeName = getExpressCheckoutData( 'store_name' ) as
-						| string
-						| null;
-
-					event.resolve( {
-						...( storeName
-							? { business: { name: storeName } }
-							: {} ),
-						emailRequired: true,
-						phoneNumberRequired: false,
-						shippingAddressRequired: false,
-						lineItems,
-					} );
+					event.resolve( session.buildClickResolution() );
 				} );
 
 				state.eceButton.on( 'confirm', async () => {
+					const sink = createClassicFormSink( {
+						$form: jQuery( 'form.checkout' ),
+						fingerprint,
+						onSubmit: () => wcApi.submit(),
+						onError: showCheckoutError,
+					} );
+
 					try {
-						const { error: submitError } =
-							await state.elements!.submit();
-						if ( submitError ) {
-							throw new Error( submitError.message );
-						}
-
-						const $form = jQuery( 'form.checkout' );
-
-						const credential = await createPaymentCredential(
+						const result = await session.confirm(
 							stripe,
-							state.elements!,
-							useConfirmationTokens
+							state.elements!
 						);
-
-						if ( credential.type === 'confirmation_token' ) {
-							appendConfirmationTokenToForm(
-								$form,
-								credential.id
-							);
-						} else {
-							appendPaymentMethodIdToForm( $form, credential.id );
-						}
-
-						appendExpressPaymentTypeToForm(
-							$form,
-							paymentMethodId
-						);
-						appendFingerprintInputToForm( $form, fingerprint );
-						appendFraudPreventionTokenInputToForm( $form );
-						wcApi.submit();
+						sink.success( result );
 					} catch ( error ) {
-						const $notices = jQuery(
-							'.woocommerce-notices-wrapper'
-						).first();
-						if ( $notices.length ) {
-							$notices.find( '.woocommerce-error' ).remove();
-							$notices.append(
-								jQuery(
-									'<div class="woocommerce-error" />'
-								).text( ( error as Error ).message )
-							);
-							jQuery( 'html, body' ).animate(
-								{
-									scrollTop: $notices.offset()!.top - 100,
-								},
-								1000
-							);
-						}
+						sink.error( ( error as Error ).message );
 					}
 				} );
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on `feat/dynamic-place-order-buttons-combo-implementation` (PR #11377) — base it there so the diff shows only this refactor. This is an architecture follow-up, not new product behavior.

#### Changes proposed in this Pull Request

A deepening refactor that pulls the express checkout paths onto one shared seam. Before this, each path re-implemented the same Stripe Express Checkout Element lifecycle and shaped its own payment-method data:

- **Blocks dynamic** — `block-buttons/components/dynamic-button-container.tsx`
- **Classic dynamic** — `shortcode-buttons-dynamic/index.ts`
- **Standalone** (blocks + classic big buttons) — `onConfirmHandler` in `event-handlers.js`

This introduces a small `client/express-checkout/session/` module with two seams:

1. **`ExpressPaymentSession`** (the deep module) — owns the shared, environment-agnostic lifecycle: assembling the Stripe Elements options, resolving the payment sheet on click, and turning a confirm into a normalized result. The submit + create-credential step is a shared primitive (`confirmExpressCredential`) that the standalone path calls directly too, so every path creates a credential one way.
2. **`PaymentResultSink`** — maps a credential to each environment's transport, with **three adapters**:
   - `createBlocksMetaSink` — WC Blocks `onPaymentSetup` meta
   - `createClassicFormSink` — classic hidden-input form append + submit
   - `createStoreApiSink` — the standalone Store API order placement (place order → payment-status check → intent confirmation/redirect)

   The exact field names the WCPay server expects now live in one place with the adapters beside them.

Net effect: ~210 lines of duplicated orchestration removed from the dynamic paths and ~90 from `onConfirmHandler` (now a thin credential → sink delegation); the wire contract centralized; and a documented smell fixed — the blocks dynamic path now returns a proper `ERROR` response on a failed authorization instead of a `SUCCESS`-with-`'error'`-sentinel.

**Why the standalone path uses the bare credential, not a session:** it is multi-method (the one ECE button covers card + Amazon Pay), and the wallet `event` owns the billing/shipping address and the chosen express type — so a *per-method* `ExpressPaymentSession` doesn't model it. It adopts the **sink** seam (`StoreApiSink`) but not the session. `onConfirmHandler` keeps its exact signature, so both standalone call sites are untouched.

**Deliberately preserved** (per the #11377 verification notes): `mode: 'payment'` only (no subscription mode / `stripe-mode.ts`); `captureMethod`/`setupFutureUsage` gated on confirmation tokens and passed explicitly (incl. `null`); the `total-amount` + `is-cart-eligible` compatibility filters; and **per-method** Elements instances (no shared instance across rows).

**Out of scope (follow-up):** cart-total/amount resolution (DOM fallback, the `total-amount` filter) still lives in the callers — it draws from environment-specific sources, so it stays out of the session for now.

#### Testing instructions

This is a behavior-preserving refactor of #11377, so the parent's testing instructions apply unchanged — see `.claude/docs/analysis/2026-06-10-pr-11377-merge-and-verification.md` and PR #11377.

- `npm run test:js -- client/express-checkout` — 313 passing, incl. new `session/__tests__/` suites for the session and all three sinks, and the existing `event-handlers.test.js` (which now exercises `onConfirmHandler` → `StoreApiSink` end-to-end) unchanged.
- `npm run lint:js` — clean (`tsc --noEmit` + eslint).
- **Standalone buttons** (the higher-traffic path): with the feature OFF, confirm the Apple Pay / Google Pay buttons on product, cart, and both checkouts still place an order, and a declined authorization surfaces an error.
- **Dynamic rows:** enable the feature (`wp option update _wcpay_feature_dynamic_checkout_place_order_button 1`, then the gateway setting) and confirm on both shortcode and blocks checkout that the wallet rows appear, selecting one swaps the Place Order button, a successful authorization places the order, and a declined one surfaces an error (no silent success).

- [x] Covered with tests
- [ ] Tested on mobile (or does not apply)
