### PR TITLE
fix: use add_filter for order total hooks in FrontendCurrencies

### DIFF
--- a/changelog/fix-9335-order-total-filter
+++ b/changelog/fix-9335-order-total-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Register the order total hooks in FrontendCurrencies with add_filter instead of add_action, since they're filters.

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -116,8 +116,8 @@ class FrontendCurrencies {
 			add_filter( 'woocommerce_price_format', [ $this, 'get_woocommerce_price_format' ], 900 );
 			add_filter( 'option_woocommerce_currency_pos', [ $this, 'get_woocommerce_currency_pos' ], 900 );
 			add_action( 'before_woocommerce_pay', [ $this, 'init_order_currency_from_query_vars' ] );
-			add_action( 'woocommerce_order_get_total', [ $this, 'maybe_init_order_currency_from_order_total_prop' ], 900, 2 );
-			add_action( 'woocommerce_get_formatted_order_total', [ $this, 'maybe_clear_order_currency_after_formatted_order_total' ], 900, 4 );
+			add_filter( 'woocommerce_order_get_total', [ $this, 'maybe_init_order_currency_from_order_total_prop' ], 900, 2 );
+			add_filter( 'woocommerce_get_formatted_order_total', [ $this, 'maybe_clear_order_currency_after_formatted_order_total' ], 900, 4 );
 		}
 
 		add_filter( 'woocommerce_thankyou_order_id', [ $this, 'init_order_currency' ] );


### PR DESCRIPTION
Fixes #9335

#### Changes proposed in this Pull Request

`FrontendCurrencies::init_hooks()` wires up `woocommerce_order_get_total` and `woocommerce_get_formatted_order_total` with `add_action`, but both of those are filters.

Swapping `add_action` for `add_filter` so the registration matches what's actually happening.

This shouldn't change behavior: `add_action` is literally an alias of `add_filter` in WordPress core (same hook, same `$priority`/`$accepted_args`), so the runtime wiring is identical either way.

I also fixed the sibling `woocommerce_get_formatted_order_total` line right below it, since it has the same mismatch.

#### Testing instructions

Since this is a no-op rename, the goal is just to confirm nothing regressed in the order-total currency handling:

1. With Multi-Currency enabled, place an order in a non-store currency.
2. View it from **My Account → Orders** and on the order received (thank you) page — the total should still render in the order's currency.
3. As admin, open the order in **WooCommerce → Orders** and confirm the total displays in the order's currency.
4. Check an order list that mixes currencies (e.g. the admin Orders list) — each row's total should show in its own currency, not bleed into the next.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions): QA Testing Not Applicable
