### PR TITLE
fix: rename reserved keyword parameter names in Multi-Currency classes

### DIFF
--- a/changelog/fix-8537-mccy-reserved-keyword-param-names
+++ b/changelog/fix-8537-mccy-reserved-keyword-param-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Rename reserved keyword parameter names flagged by phpcs in Multi-Currency classes

--- a/includes/multi-currency/AdminNotices.php
+++ b/includes/multi-currency/AdminNotices.php
@@ -88,13 +88,13 @@ class AdminNotices {
 	 * Adds admin notice to be displayed.
 	 *
 	 * @param string $slug        Slug for the notice.
-	 * @param string $class       Class(es) for the notice.
+	 * @param string $class_name  Class(es) for the notice.
 	 * @param string $message     Message in the notice.
 	 * @param bool   $dismissible Whether the notice can be dismissed or not.
 	 */
-	private function add_admin_notice( $slug, $class, $message, $dismissible = false ) {
+	private function add_admin_notice( $slug, $class_name, $message, $dismissible = false ) {
 		$this->notices[ $slug ] = [
-			'class'       => $class,
+			'class'       => $class_name,
 			'message'     => $message,
 			'dismissible' => $dismissible,
 		];

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -490,14 +490,14 @@ class Analytics {
 	/**
 	 * Generate a case when statement using the provided variables.
 	 *
-	 * @param string $variable The SQL variable we want to check for NULL.
-	 * @param string $then     The THEN clause.
-	 * @param string $else     The ELSE clause.
+	 * @param string $variable    The SQL variable we want to check for NULL.
+	 * @param string $then        The THEN clause.
+	 * @param string $else_clause The ELSE clause.
 	 *
 	 * @return string
 	 */
-	private function generate_case_when( string $variable, string $then, string $else ): string {
-		return "CASE WHEN {$variable} IS NOT NULL THEN {$then} ELSE {$else} END";
+	private function generate_case_when( string $variable, string $then, string $else_clause ): string {
+		return "CASE WHEN {$variable} IS NOT NULL THEN {$then} ELSE {$else_clause} END";
 	}
 
 	/**

--- a/includes/multi-currency/AsyncPriceRenderer.php
+++ b/includes/multi-currency/AsyncPriceRenderer.php
@@ -63,7 +63,7 @@ class AsyncPriceRenderer {
 	/**
 	 * Wraps a price with skeleton markup for client-side conversion.
 	 *
-	 * @param string $return           The formatted price string.
+	 * @param string $price_html        The formatted price string.
 	 * @param float  $price            The raw price.
 	 * @param array  $args             Arguments passed to wc_price.
 	 * @param float  $unformatted_price The unformatted price.
@@ -71,7 +71,7 @@ class AsyncPriceRenderer {
 	 *
 	 * @return string The wrapped price markup.
 	 */
-	public function wrap_price_with_skeleton( $return, $price, $args, $unformatted_price, $original_price ) {
+	public function wrap_price_with_skeleton( $price_html, $price, $args, $unformatted_price, $original_price ) {
 		// The async renderer only runs on non-session pages (catalog/product).
 		// Cart/checkout have active sessions and use server-side FrontendPrices.
 		// Default to 'product' since catalog pages only call wc_price for products.
@@ -95,7 +95,7 @@ class AsyncPriceRenderer {
 			'<span class="woocommerce-Price-amount amount wcpay-async-price" data-wcpay-price="%s" data-wcpay-price-type="%s"><bdi class="wcpay-price-skeleton"></bdi><span class="screen-reader-text wcpay-price-placeholder">%s</span></span>',
 			esc_attr( $unformatted_price ),
 			esc_attr( $price_type ),
-			wp_kses_post( $return )
+			wp_kses_post( $price_html )
 		);
 	}
 

--- a/includes/multi-currency/Compatibility/WooCommerceBookings.php
+++ b/includes/multi-currency/Compatibility/WooCommerceBookings.php
@@ -127,15 +127,15 @@ class WooCommerceBookings extends BaseCompatibility {
 	/**
 	 * Checks to see if the product's price should be converted.
 	 *
-	 * @param bool       $return Whether to convert the product's price or not. Default is true.
-	 * @param WC_Product $product The product instance being checked.
+	 * @param bool       $should_convert Whether to convert the product's price or not. Default is true.
+	 * @param WC_Product $product        The product instance being checked.
 	 *
 	 * @return bool True if it should be converted.
 	 */
-	public function should_convert_product_price( bool $return, WC_Product $product ): bool {
+	public function should_convert_product_price( bool $should_convert, WC_Product $product ): bool {
 		// If it's already false, or the product is not a booking, ignore it.
-		if ( ! $return || $product->get_type() !== 'booking' ) {
-			return $return;
+		if ( ! $should_convert || $product->get_type() !== 'booking' ) {
+			return $should_convert;
 		}
 
 		// Fixes price display on product page and in shop.
@@ -143,7 +143,7 @@ class WooCommerceBookings extends BaseCompatibility {
 			return false;
 		}
 
-		return $return;
+		return $should_convert;
 	}
 
 	/**

--- a/includes/multi-currency/Compatibility/WooCommerceFedEx.php
+++ b/includes/multi-currency/Compatibility/WooCommerceFedEx.php
@@ -43,40 +43,40 @@ class WooCommerceFedEx extends BaseCompatibility {
 	/**
 	 * Checks to see if the product's price should be converted.
 	 *
-	 * @param bool $return Whether to convert the product's price or not. Default is true.
+	 * @param bool $should_convert Whether to convert the product's price or not. Default is true.
 	 *
 	 * @return bool True if it should be converted.
 	 */
-	public function should_convert_product_price( bool $return ): bool {
+	public function should_convert_product_price( bool $should_convert ): bool {
 		// If it's already false, return it.
-		if ( ! $return ) {
-			return $return;
+		if ( ! $should_convert ) {
+			return $should_convert;
 		}
 
 		if ( $this->utils->is_call_in_backtrace( self::WC_SHIPPING_FEDEX_CALLS ) ) {
 			return false;
 		}
 
-		return $return;
+		return $should_convert;
 	}
 
 	/**
 	 * Determine whether to return the store currency or not.
 	 *
-	 * @param bool $return Whether to return the store currency or not.
+	 * @param bool $should_return Whether to return the store currency or not.
 	 *
 	 * @return bool
 	 */
-	public function should_return_store_currency( bool $return ): bool {
+	public function should_return_store_currency( bool $should_return ): bool {
 		// If it's already true, return it.
-		if ( $return ) {
-			return $return;
+		if ( $should_return ) {
+			return $should_return;
 		}
 
 		if ( $this->utils->is_call_in_backtrace( self::WC_SHIPPING_FEDEX_CALLS ) ) {
 			return true;
 		}
 
-		return $return;
+		return $should_return;
 	}
 }

--- a/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
+++ b/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
@@ -111,22 +111,22 @@ class WooCommerceNameYourPrice extends BaseCompatibility {
 	/**
 	 * Checks to see if the product's price should be converted.
 	 *
-	 * @param bool   $return  Whether to convert the product's price or not. Default is true.
-	 * @param object $product Product object to test.
+	 * @param bool   $should_convert Whether to convert the product's price or not. Default is true.
+	 * @param object $product        Product object to test.
 	 *
 	 * @return bool True if it should be converted.
 	 */
-	public function should_convert_product_price( bool $return, $product ): bool {
+	public function should_convert_product_price( bool $should_convert, $product ): bool {
 		// If it's already false, return it.
-		if ( ! $return ) {
-			return $return;
+		if ( ! $should_convert ) {
+			return $should_convert;
 		}
 
 		$currency = $this->multi_currency->get_selected_currency();
 
 		// Check for cart items to see if they are in the original currency.
 		if ( $currency->get_code() === $product->get_meta( self::NYP_CURRENCY ) ) {
-			$return = false;
+			$should_convert = false;
 		}
 
 		// Check to see if the product is a NYP product.
@@ -134,7 +134,7 @@ class WooCommerceNameYourPrice extends BaseCompatibility {
 			return false;
 		}
 
-		return $return;
+		return $should_convert;
 	}
 
 	/**

--- a/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
+++ b/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
@@ -46,15 +46,15 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 	/**
 	 * Checks to see if the product's price should be converted.
 	 *
-	 * @param bool   $return  Whether to convert the product's price or not. Default is true.
-	 * @param object $product Product object to test.
+	 * @param bool   $should_convert Whether to convert the product's price or not. Default is true.
+	 * @param object $product        Product object to test.
 	 *
 	 * @return bool True if it should be converted.
 	 */
-	public function should_convert_product_price( bool $return, $product ): bool {
+	public function should_convert_product_price( bool $should_convert, $product ): bool {
 		// If it's already false, return it.
-		if ( ! $return ) {
-			return $return;
+		if ( ! $should_convert ) {
+			return $should_convert;
 		}
 
 		// Check for cart items to see if they have already been converted.
@@ -62,7 +62,7 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 			return false;
 		}
 
-		return $return;
+		return $should_convert;
 	}
 
 	/**

--- a/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
+++ b/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
@@ -167,14 +167,14 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 	 *
 	 * The running_override_selected_currency_filters property is used here to avoid infinite loops.
 	 *
-	 * @param mixed $return Default is false, but could be three letter currency code.
+	 * @param mixed $selected_currency Default is false, but could be three letter currency code.
 	 *
 	 * @return mixed Three letter currency code or false if not.
 	 */
-	public function override_selected_currency( $return ) {
+	public function override_selected_currency( $selected_currency ) {
 		// If it's not false, or we are already running filters, exit.
-		if ( $return || $this->running_override_selected_currency_filters ) {
-			return $return;
+		if ( $selected_currency || $this->running_override_selected_currency_filters ) {
+			return $selected_currency;
 		}
 
 		// If we have a subscription in $current_my_account_subscription, we want to use the currency from that subscription.
@@ -193,27 +193,27 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 				$subscription      = $this->get_subscription( $cart_item[ $subscription_type ]['subscription_id'] );
 
 				$this->running_override_selected_currency_filters = false;
-				return $subscription ? $subscription->get_currency() : $return;
+				return $subscription ? $subscription->get_currency() : $selected_currency;
 			}
 		}
 
 		// This instance is for when the customer lands on the product page to choose a new subscription tier.
 		$switch_subscription = $this->get_subscription_from_superglobal_switch_id();
-		return $switch_subscription ? $switch_subscription->get_currency() : $return;
+		return $switch_subscription ? $switch_subscription->get_currency() : $selected_currency;
 	}
 
 	/**
 	 * Checks to see if the product's price should be converted.
 	 *
-	 * @param bool   $return  Whether to convert the product's price or not. Default is true.
-	 * @param object $product Product object to test.
+	 * @param bool   $should_convert Whether to convert the product's price or not. Default is true.
+	 * @param object $product        Product object to test.
 	 *
 	 * @return bool True if it should be converted.
 	 */
-	public function should_convert_product_price( bool $return, $product ): bool {
+	public function should_convert_product_price( bool $should_convert, $product ): bool {
 		// If it's already false, return it.
-		if ( ! $return ) {
-			return $return;
+		if ( ! $should_convert ) {
+			return $should_convert;
 		}
 
 		$calls = [
@@ -228,7 +228,7 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 			// When WCPay Subs programmatically sets up the cart, we need to return the
 			// converted price so the user lands at the checkout with the correct price.
 			if ( $this->utils->is_call_in_backtrace( [ 'WCS_Cart_Renewal->setup_cart' ] ) ) {
-				return $return;
+				return $should_convert;
 			}
 
 			if ( $this->utils->is_call_in_backtrace( $calls ) ) {
@@ -248,21 +248,21 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 			return false;
 		}
 
-		return $return;
+		return $should_convert;
 	}
 
 	/**
 	 * Checks to see if the coupon's amount should be converted.
 	 *
-	 * @param bool   $return Whether to convert the coupon's price or not. Default is true.
-	 * @param object $coupon Coupon object to test.
+	 * @param bool   $should_convert Whether to convert the coupon's price or not. Default is true.
+	 * @param object $coupon         Coupon object to test.
 	 *
 	 * @return bool True if it should be converted.
 	 */
-	public function should_convert_coupon_amount( bool $return, $coupon ): bool {
+	public function should_convert_coupon_amount( bool $should_convert, $coupon ): bool {
 		// If it's already false, return it.
-		if ( ! $return ) {
-			return $return;
+		if ( ! $should_convert ) {
+			return $should_convert;
 		}
 
 		// We do not need to convert percentage coupons.
@@ -287,20 +287,20 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 			return false;
 		}
 
-		return $return;
+		return $should_convert;
 	}
 
 	/**
 	 * Checks to see if currency switching should be disabled.
 	 *
-	 * @param bool $return Whether widgets should be hidden or not. Default is false.
+	 * @param bool $should_disable Whether widgets should be hidden or not. Default is false.
 	 *
 	 * @return bool
 	 */
-	public function should_disable_currency_switching( bool $return ): bool {
+	public function should_disable_currency_switching( bool $should_disable ): bool {
 		// If it's already true, return it.
-		if ( $return ) {
-			return $return;
+		if ( $should_disable ) {
+			return $should_disable;
 		}
 
 		if ( $this->get_subscription_type_from_cart( 'renewal' )
@@ -310,7 +310,7 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 			return true;
 		}
 
-		return $return;
+		return $should_disable;
 	}
 
 	/**

--- a/includes/multi-currency/Compatibility/WooCommerceUPS.php
+++ b/includes/multi-currency/Compatibility/WooCommerceUPS.php
@@ -30,14 +30,14 @@ class WooCommerceUPS extends BaseCompatibility {
 	/**
 	 * Determine whether to return the store currency or not.
 	 *
-	 * @param bool $return Whether to return the store currency or not.
+	 * @param bool $should_return Whether to return the store currency or not.
 	 *
 	 * @return bool
 	 */
-	public function should_return_store_currency( bool $return ): bool {
+	public function should_return_store_currency( bool $should_return ): bool {
 		// If it's already true, return it.
-		if ( $return ) {
-			return $return;
+		if ( $should_return ) {
+			return $should_return;
 		}
 
 		$calls = [
@@ -49,6 +49,6 @@ class WooCommerceUPS extends BaseCompatibility {
 			return true;
 		}
 
-		return $return;
+		return $should_return;
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,11 +45,6 @@
 		<exclude name="WooCommerce.Commenting.CommentHooks.MissingHookComment" />
 		<exclude name="WooCommerce.Commenting.CommentHooks.MissingSinceComment" />
 		<exclude name="WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle" />
-
-		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8438 is closed. -->
-		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.elseFound" />
-		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.classFound" />
-		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.returnFound" />
 	</rule>
 
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">


### PR DESCRIPTION
Fixes #8537

#### Changes proposed in this Pull Request

Renames Multi-Currency method parameters that shadow PHP reserved keywords, so the `Universal.NamingConventions.NoReservedKeywordParameterNames` sniff no longer has to be suppressed for them.

Most are the `should_*` filter callbacks, where the incoming filter value was named `$return`.

With the sibling fixes for #8539 and #8541 now on `develop`, Multi-Currency was the last area with violations, so this removes the entire `NoReservedKeywordParameterNames` suppression block (and its `FIXME` comment) from `phpcs.xml.dist`, completing #8438.

#### Testing instructions

Should be EZ - just renaming.

* Run `npm run lint:php` — passes, with no `NoReservedKeywordParameterNames` reports in the Multi-Currency files.
* No functional change, so no manual testing required.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

