### PR TITLE
fix: rename reserved keyword parameter name in WooPay tracker test

### DIFF
--- a/changelog/fix-8539-woopay-tracker-reserved-keyword-param
+++ b/changelog/fix-8539-woopay-tracker-reserved-keyword-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Rename reserved keyword parameter name $object in the WooPay tracker test helper

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -49,7 +49,6 @@
 		<!-- FIXME: Remove these ignores once https://github.com/Automattic/woocommerce-payments/issues/8438 is closed. -->
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.elseFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.classFound" />
-		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.returnFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.stringFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound" />

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -130,11 +130,11 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 	/**
 	 * Utility method to access protected methods for testing.
 	 */
-	protected function invoke_method( &$object, $method_name, array $parameters = [] ) {
-		$reflection = new \ReflectionClass( get_class( $object ) );
+	protected function invoke_method( &$instance, $method_name, array $parameters = [] ) {
+		$reflection = new \ReflectionClass( get_class( $instance ) );
 		$method     = $reflection->getMethod( $method_name );
 		$method->setAccessible( true );
-		return $method->invokeArgs( $object, $parameters );
+		return $method->invokeArgs( $instance, $parameters );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8539

#### Changes proposed in this Pull Request

Renaming the `&$object` parameter to `&$instance` in `WooPay_Tracker_Test::invoke_method()`, flagged by the `Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound` sniff.

#### Testing instructions

EZ. It's just tests.

* Run `npm run lint:php` — passes, with no `objectFound` reports.
* WooPay tracker unit tests pass unchanged.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
