### PR TITLE
fix: rename reserved keyword parameter names in Payments classes

### DIFF
--- a/changelog/fix-8541-payments-reserved-keyword-param
+++ b/changelog/fix-8541-payments-reserved-keyword-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Rename reserved keyword parameter names flagged by phpcs in Payments classes and tests

--- a/includes/class-wc-payments-payment-request-session-handler.php
+++ b/includes/class-wc-payments-payment-request-session-handler.php
@@ -200,14 +200,14 @@ final class WC_Payments_Payment_Request_Session_Handler extends WC_Session_Handl
 	 * See "WC_Cart_Session::get_cart_from_session".
 	 *
 	 * @param string $key Key to get.
-	 * @param mixed  $default used if the session variable isn't set.
+	 * @param mixed  $default_value used if the session variable isn't set.
 	 * @return array|string value of session variable
 	 */
-	public function get( $key, $default = null ) {
+	public function get( $key, $default_value = null ) {
 		if ( 'cart' === $key && ! isset( $this->_data['cart'] ) ) {
 			return [];
 		}
 
-		return parent::get( $key, $default );
+		return parent::get( $key, $default_value );
 	}
 }

--- a/includes/class-wc-payments-styles-cache.php
+++ b/includes/class-wc-payments-styles-cache.php
@@ -559,11 +559,11 @@ class WC_Payments_Styles_Cache {
 	 * any non-string value that cannot be resolved.
 	 *
 	 * @param mixed  $value          The style value — string, ref object array, or other.
-	 * @param string $default        Fallback value when resolution fails.
+	 * @param string $default_value  Fallback value when resolution fails.
 	 * @param array  $styles_context The already-resolved styles array to look up refs in.
 	 * @return string The resolved string value or the default.
 	 */
-	private static function resolve_style_value( $value, string $default, array $styles_context = [] ): string {
+	private static function resolve_style_value( $value, string $default_value, array $styles_context = [] ): string {
 		// Handle ref objects: {"ref": "styles.typography.fontFamily"}.
 		if ( is_array( $value ) && isset( $value['ref'] ) ) {
 			$path = explode( '.', $value['ref'] );
@@ -576,7 +576,7 @@ class WC_Payments_Styles_Cache {
 		}
 
 		if ( ! is_string( $value ) ) {
-			return $default;
+			return $default_value;
 		}
 
 		return $value;

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -136,22 +136,22 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	 * For other tokens, returns the default title.
 	 *
 	 * @param WC_Payment_Token|null $token   The payment token.
-	 * @param string                $default The default title to return if token cannot be processed.
+	 * @param string                $default_title The default title to return if token cannot be processed.
 	 * @return string The payment method title with identifying details.
 	 */
-	private function get_payment_method_title_from_token( $token, $default ) {
+	private function get_payment_method_title_from_token( $token, $default_title ) {
 		if ( ! $token ) {
-			return $default;
+			return $default_title;
 		}
 
 		if ( $token instanceof WC_Payment_Token_CC ) {
 			$last4 = $token->get_last4();
 			// Avoid duplication if the title already contains the last4.
-			if ( ! empty( $last4 ) && false === strpos( $default, $last4 ) ) {
-				// Use the specific card brand (e.g. "Visa") when available instead of $default,
+			if ( ! empty( $last4 ) && false === strpos( $default_title, $last4 ) ) {
+				// Use the specific card brand (e.g. "Visa") when available instead of $default_title,
 				// which may refer to a different payment method type (e.g. "Link" from a previous subscription payment).
 				$card_type = $token->get_card_type();
-				$title     = ! empty( $card_type ) ? wc_get_credit_card_type_label( $card_type ) : $default;
+				$title     = ! empty( $card_type ) ? wc_get_credit_card_type_label( $card_type ) : $default_title;
 				// translators: 1: payment method likely credit card, 2: last 4 digit.
 				return sprintf( __( '%1$s ending in %2$s', 'woocommerce-payments' ), $title, $last4 );
 			}
@@ -160,23 +160,23 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		if ( $token instanceof WC_Payment_Token_WCPay_Amazon_Pay ) {
 			$email = $token->get_email();
 			// Avoid duplication if the title already contains the email.
-			if ( ! empty( $email ) && false === strpos( $default, $email ) ) {
+			if ( ! empty( $email ) && false === strpos( $default_title, $email ) ) {
 				// translators: 1: payment method (Amazon Pay), 2: redacted customer email.
-				return sprintf( __( '%1$s (%2$s)', 'woocommerce-payments' ), $default, $email );
+				return sprintf( __( '%1$s (%2$s)', 'woocommerce-payments' ), $default_title, $email );
 			}
 		}
 
 		if ( $token instanceof WC_Payment_Token_WCPay_Link ) {
 			$email = $token->get_redacted_email();
 			// Avoid duplication if the title already contains the email.
-			if ( ! empty( $email ) && false === strpos( $default, $email ) ) {
-				// Link uses the card gateway, so $default is "Card". Use "Stripe Link" instead.
+			if ( ! empty( $email ) && false === strpos( $default_title, $email ) ) {
+				// Link uses the card gateway, so $default_title is "Card". Use "Stripe Link" instead.
 				// translators: 1: payment method (Stripe Link), 2: redacted customer email.
 				return sprintf( __( '%1$s (%2$s)', 'woocommerce-payments' ), __( 'Stripe Link', 'woocommerce-payments' ), $email );
 			}
 		}
 
-		return $default;
+		return $default_title;
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -890,11 +890,11 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	/**
 	 * Sanitize string for comparison.
 	 *
-	 * @param string $string String to be sanitized.
+	 * @param string $value String to be sanitized.
 	 *
 	 * @return string The sanitized string.
 	 */
-	public function sanitize_string( $string ) {
-		return trim( wc_strtolower( remove_accents( $string ) ) );
+	public function sanitize_string( $value ) {
+		return trim( wc_strtolower( remove_accents( $value ) ) );
 	}
 }

--- a/includes/woopay/class-woopay-store-api-session-handler.php
+++ b/includes/woopay/class-woopay-store-api-session-handler.php
@@ -76,11 +76,11 @@ final class SessionHandler extends WC_Session {
 	 * Returns the session.
 	 *
 	 * @param string $customer_id Customer ID.
-	 * @param mixed  $default Default session value.
+	 * @param mixed  $default_value Default session value.
 	 *
 	 * @return string|array|bool
 	 */
-	public function get_session( $customer_id, $default = false ) {
+	public function get_session( $customer_id, $default_value = false ) {
 		global $wpdb;
 
 		// This mimics behaviour from default WC_Session_Handler class. There will be no sessions retrieved while WP setup is due.
@@ -96,7 +96,7 @@ final class SessionHandler extends WC_Session {
 		);
 
 		if ( is_null( $value ) ) {
-			$value = $default;
+			$value = $default_value;
 		}
 
 		return maybe_unserialize( $value );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,8 +51,6 @@
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.classFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.objectFound" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.returnFound" />
-		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.stringFound" />
-		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound" />
 	</rule>
 
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -56,7 +56,7 @@ function _manually_load_plugin() {
 	// via update_option().
 	add_filter(
 		'default_option__wcpay_feature_subscriptions',
-		function ( $default ) {
+		function ( $default_value ) {
 			return '1';
 		},
 		10,

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3860,7 +3860,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		$mock_gateway->method( 'get_payment_method_capability_key_map' )->willReturn( $payment_method_capability_map );
 		$mock_gateway->method( 'find_duplicates' )->willReturn( [ 'card' => [ 'woocommerce_payments', 'some_other_gateway' ] ] );
 		$mock_gateway->method( 'get_option' )->willReturnCallback(
-			function ( $key, $default = null ) {
+			function ( $key, $default_value = null ) {
 				$options = [
 					'express_checkout_in_payment_methods'  => 'yes',
 					'manual_capture'                       => 'no',
@@ -3875,7 +3875,7 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 					'express_checkout_cart_methods'        => [ 'payment_request', 'woopay' ],
 					'express_checkout_checkout_methods'    => [],
 				];
-				return $options[ $key ] ?? $default;
+				return $options[ $key ] ?? $default_value;
 			}
 		);
 		$mock_gateway->method( 'is_saved_cards_enabled' )->willReturn( true );

--- a/tests/unit/test-class-wc-payments-status.php
+++ b/tests/unit/test-class-wc-payments-status.php
@@ -300,7 +300,7 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 		$this->mock_gateway->method( 'get_upe_enabled_payment_method_ids' )->willReturn( [ 'card' ] );
 		$this->mock_gateway->method( 'is_payment_request_enabled' )->willReturn( false );
 		$this->mock_gateway->method( 'get_option' )->willReturnCallback(
-			function ( $key, $default = null ) {
+			function ( $key, $default_value = null ) {
 				$map = [
 					'current_protection_level'       => 'standard',
 					'manual_capture'                 => 'no',
@@ -312,7 +312,7 @@ class WC_Payments_Status_Test extends WCPAY_UnitTestCase {
 				if ( strpos( $key, 'express_checkout_' ) === 0 ) {
 					return [];
 				}
-				return $default;
+				return $default_value;
 			}
 		);
 	}


### PR DESCRIPTION
Fixes #8541

#### Changes proposed in this Pull Request

Renaming method and closure parameters that shadow PHP reserved keywords across the Payments code and tests, so the `Universal.NamingConventions.NoReservedKeywordParameterNames` sniff no longer has to be suppressed for them.

These are all positional parameters, the session `get()` forwards to `parent::get()` positionally, and `sanitize_string()`'s callers all pass positionally, so callers are unaffected.

The issue originally listed `class-list-transactions.php`, but that file no longer has any reserved-keyword violations (the codebase has drifted since the issue was filed). What remains under this "Payments" bucket is the set above, so that's what's fixed here.

This removes the `defaultFound` and `stringFound` suppressions from `phpcs.xml.dist`.

#### Testing instructions

Should be straightforward - just renaming, there should be no changes in behavior.

* Run `npm run lint:php` — passes, with no `defaultFound` or `stringFound` reports.
* Run the affected unit tests (`WC_Payments_Status`, `WC_Payments_Account`) — they pass unchanged.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
