### PR TITLE
fix: refund payment inquiries inline instead of redirecting to the order

### DIFF
--- a/changelog/fix-7963-inquiry-refund-modal
+++ b/changelog/fix-7963-inquiry-refund-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Issue refunds for payment inquiries directly from the transaction details page instead of redirecting to the order screen.

--- a/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
@@ -687,11 +687,10 @@ describe( 'DisputeAwaitingResponseDetails - Klarna Inquiry', () => {
 			screen.getByRole( 'button', { name: /Issue refund/i } )
 		);
 
-		// The inquiry refund flow opens the transaction refund modal inline
-		// rather than redirecting to the order screen.
+		// The inquiry "Issue refund" button opens the refund modal inline.
 		expect( mockOnIssueRefund ).toHaveBeenCalledTimes( 1 );
 
-		// No local confirmation dialog is shown for inquiries anymore.
+		// Inquiries don't show the local confirmation dialog.
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 
 		expect( recordEvent ).toHaveBeenCalledWith(

--- a/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
@@ -16,6 +16,7 @@ import WCPaySettingsContext from 'wcpay/settings/wcpay-settings-context';
 import { recordEvent } from 'tracks';
 
 const mockDisputeDoAccept = jest.fn();
+const mockOnIssueRefund = jest.fn();
 
 jest.mock( 'wcpay/data/disputes', () => ( {
 	useDisputeAccept: jest.fn( () => ( {
@@ -166,7 +167,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -199,7 +200,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -231,7 +232,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -254,7 +255,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -276,7 +277,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -315,7 +316,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -344,7 +345,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -370,7 +371,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -435,7 +436,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -461,7 +462,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -489,7 +490,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -511,7 +512,7 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="card"
 				bankName="Chase Bank"
 			/>
@@ -580,7 +581,7 @@ describe( 'DisputeAwaitingResponseDetails - Klarna Inquiry', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="klarna"
 				bankName={ null }
 			/>
@@ -615,7 +616,7 @@ describe( 'DisputeAwaitingResponseDetails - Klarna Inquiry', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="klarna"
 				bankName={ null }
 			/>
@@ -653,7 +654,7 @@ describe( 'DisputeAwaitingResponseDetails - Klarna Inquiry', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl="https://example.com/order/123"
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="klarna"
 				bankName={ null }
 			/>
@@ -662,7 +663,7 @@ describe( 'DisputeAwaitingResponseDetails - Klarna Inquiry', () => {
 		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'fires inquiry refund modal tracks event with dispute identifiers', async () => {
+	test( 'opens the refund modal and fires tracks event when issuing an inquiry refund', async () => {
 		const dispute: ChargeDispute = {
 			...getBaseDispute(),
 			reason: 'credit_not_processed' as const,
@@ -676,7 +677,7 @@ describe( 'DisputeAwaitingResponseDetails - Klarna Inquiry', () => {
 				dispute={ dispute }
 				customer={ customer }
 				chargeCreated={ 1693453017 }
-				orderUrl=""
+				onIssueRefund={ mockOnIssueRefund }
 				paymentMethod="klarna"
 				bankName={ null }
 			/>
@@ -686,24 +687,15 @@ describe( 'DisputeAwaitingResponseDetails - Klarna Inquiry', () => {
 			screen.getByRole( 'button', { name: /Issue refund/i } )
 		);
 
+		// The inquiry refund flow opens the transaction refund modal inline
+		// rather than redirecting to the order screen.
+		expect( mockOnIssueRefund ).toHaveBeenCalledTimes( 1 );
+
+		// No local confirmation dialog is shown for inquiries anymore.
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+
 		expect( recordEvent ).toHaveBeenCalledWith(
 			'wcpay_dispute_inquiry_refund_modal_view',
-			{
-				dispute_id: dispute.id,
-				dispute_status: dispute.status,
-				dispute_reason: dispute.reason,
-				on_page: 'transaction_details',
-			}
-		);
-
-		await userEvent.click(
-			within( screen.getByRole( 'dialog' ) ).getByRole( 'button', {
-				name: /View order to issue refund/i,
-			} )
-		);
-
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'wcpay_dispute_inquiry_refund_click',
 			{
 				dispute_id: dispute.id,
 				dispute_status: dispute.status,

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -253,10 +253,10 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 
 	// Inquiries refund inline via the transaction refund modal; disputes open
 	// the accept-dispute modal. The primary action button reflects whichever.
-	const primaryActionLabel = isInquiryStatus
+	const primaryButtonLabel = isInquiryStatus
 		? __( 'Issue refund', 'woocommerce-payments' )
 		: disputeAcceptAction.acceptButtonLabel;
-	const primaryActionTracksEvent = isInquiryStatus
+	const primaryButtonTracksEvent = isInquiryStatus
 		? 'wcpay_dispute_inquiry_refund_modal_view'
 		: disputeAcceptAction.acceptButtonTracksEvent;
 
@@ -412,7 +412,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 							data-testid="open-accept-dispute-modal-button"
 							onClick={ () => {
 								recordEvent(
-									primaryActionTracksEvent,
+									primaryButtonTracksEvent,
 									disputeTracksProperties
 								);
 
@@ -424,7 +424,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 							} }
 							__next40pxDefaultSize
 						>
-							{ primaryActionLabel }
+							{ primaryButtonLabel }
 						</Button>
 
 						{ ! isDefendable && (

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -5,8 +5,7 @@
  */
 import React, { useState, useContext } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { backup, edit, lock, arrowRight } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
+import { backup, edit, lock } from '@wordpress/icons';
 import { createInterpolateElement } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
 
@@ -61,9 +60,14 @@ interface Props {
 	>;
 	customer: ChargeBillingDetails | null;
 	chargeCreated: number;
-	orderUrl: string | undefined;
 	paymentMethod: string | null;
 	bankName: string | null;
+	/**
+	 * Opens the refund modal on the transaction details page. The inquiry
+	 * "Issue refund" flow uses this to refund inline instead of redirecting
+	 * to the order screen.
+	 */
+	onIssueRefund: () => void;
 }
 
 /**
@@ -102,8 +106,10 @@ interface AcceptDisputeProps {
 }
 
 /**
- * Disputes and Inquiries have different text for buttons and the modal.
- * They also have different icons and tracks events. This function returns the correct props.
+ * Returns the copy and tracks events for the dispute-accept modal.
+ *
+ * Inquiries no longer use this modal — their "Issue refund" button opens the
+ * transaction refund modal directly — so this only covers the dispute case.
  */
 function getAcceptDisputeProps( {
 	dispute,
@@ -121,35 +127,6 @@ function getAcceptDisputeProps( {
 	>;
 	isDisputeAcceptRequestPending: boolean;
 } ): AcceptDisputeProps {
-	if ( isInquiry( dispute.status ) ) {
-		return {
-			acceptButtonLabel: __( 'Issue refund', 'woocommerce-payments' ),
-			acceptButtonTracksEvent: 'wcpay_dispute_inquiry_refund_modal_view',
-			modalTitle: __( 'Issue a refund?', 'woocommerce-payments' ),
-			modalLines: [
-				{
-					icon: <Icon icon={ backup } size={ 24 } />,
-					description: __(
-						'Issuing a refund will close the inquiry, returning the amount in question back to the cardholder. No additional fees apply.',
-						'woocommerce-payments'
-					),
-				},
-				{
-					icon: <Icon icon={ arrowRight } size={ 24 } />,
-					description: __(
-						'You will be taken to the order, where you must complete the refund process manually.',
-						'woocommerce-payments'
-					),
-				},
-			],
-			modalButtonLabel: __(
-				'View order to issue refund',
-				'woocommerce-payments'
-			),
-			modalButtonTracksEvent: 'wcpay_dispute_inquiry_refund_click',
-		};
-	}
-
 	return {
 		acceptButtonLabel: __( 'Accept dispute', 'woocommerce-payments' ),
 		acceptButtonTracksEvent: 'wcpay_dispute_accept_modal_view',
@@ -190,9 +167,9 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 	dispute,
 	customer,
 	chargeCreated,
-	orderUrl,
 	paymentMethod,
 	bankName,
+	onIssueRefund,
 } ) => {
 	const { doAccept, isLoading: isDisputeAcceptRequestPending } =
 		useDisputeAccept( dispute );
@@ -202,7 +179,6 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 		isVisaComplianceConditionAccepted,
 		setVisaComplianceConditionAccepted,
 	] = useState( hasStagedEvidence );
-	const { createErrorNotice } = useDispatch( 'core/notices' );
 
 	const {
 		featureFlags: { isDisputeIssuerEvidenceEnabled },
@@ -262,20 +238,6 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 		setModalOpen( false );
 	};
 
-	const viewOrder = () => {
-		if ( orderUrl ) {
-			window.location.href = orderUrl;
-			return;
-		}
-
-		createErrorNotice(
-			__(
-				'Unable to view order. Order not found.',
-				'woocommerce-payments'
-			)
-		);
-	};
-
 	const disputeTracksProperties = {
 		dispute_id: dispute.id,
 		dispute_status: dispute.status,
@@ -287,6 +249,17 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 		dispute,
 		isDisputeAcceptRequestPending,
 	} );
+
+	const isInquiryStatus = isInquiry( dispute.status );
+
+	// Inquiries refund inline via the transaction refund modal; disputes open
+	// the accept-dispute modal. The primary action button reflects whichever.
+	const primaryActionLabel = isInquiryStatus
+		? __( 'Issue refund', 'woocommerce-payments' )
+		: disputeAcceptAction.acceptButtonLabel;
+	const primaryActionTracksEvent = isInquiryStatus
+		? 'wcpay_dispute_inquiry_refund_modal_view'
+		: disputeAcceptAction.acceptButtonTracksEvent;
 
 	/**
 	 * The following cases cannot be defended:
@@ -440,14 +413,19 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 							data-testid="open-accept-dispute-modal-button"
 							onClick={ () => {
 								recordEvent(
-									disputeAcceptAction.acceptButtonTracksEvent,
+									primaryActionTracksEvent,
 									disputeTracksProperties
 								);
-								setModalOpen( true );
+
+								if ( isInquiryStatus ) {
+									onIssueRefund();
+								} else {
+									setModalOpen( true );
+								}
 							} }
 							__next40pxDefaultSize
 						>
-							{ disputeAcceptAction.acceptButtonLabel }
+							{ primaryActionLabel }
 						</Button>
 
 						{ ! isDefendable && (
@@ -543,15 +521,7 @@ const DisputeAwaitingResponseDetails: React.FC< Props > = ( {
 												disputeTracksProperties
 											);
 
-											/**
-											 * Handle the primary modal action.
-											 * If it's an inquiry, redirect to the order page; otherwise, continue with the default dispute acceptance.
-											 */
-											if ( isInquiry( dispute.status ) ) {
-												viewOrder();
-											} else {
-												doAccept();
-											}
+											doAccept();
 										} }
 										__next40pxDefaultSize
 									>

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -63,9 +63,8 @@ interface Props {
 	paymentMethod: string | null;
 	bankName: string | null;
 	/**
-	 * Opens the refund modal on the transaction details page. The inquiry
-	 * "Issue refund" flow uses this to refund inline instead of redirecting
-	 * to the order screen.
+	 * Opens the refund modal on the transaction details page so the inquiry
+	 * "Issue refund" flow can refund inline.
 	 */
 	onIssueRefund: () => void;
 }
@@ -108,8 +107,8 @@ interface AcceptDisputeProps {
 /**
  * Returns the copy and tracks events for the dispute-accept modal.
  *
- * Inquiries no longer use this modal — their "Issue refund" button opens the
- * transaction refund modal directly — so this only covers the dispute case.
+ * Inquiries open the refund modal directly, so this only covers the dispute
+ * case.
  */
 function getAcceptDisputeProps( {
 	dispute,

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -100,7 +100,8 @@ const isTapToPay = ( model: string ) => {
 const renderDisputeDetails = (
 	dispute: NonNullable< Charge[ 'dispute' ] >,
 	charge: Charge,
-	bankName: string | null
+	bankName: string | null,
+	onIssueRefund: () => void
 ) => {
 	if ( isAwaitingResponse( dispute.status ) ) {
 		return (
@@ -108,9 +109,9 @@ const renderDisputeDetails = (
 				dispute={ dispute }
 				customer={ charge.billing_details }
 				chargeCreated={ charge.created }
-				orderUrl={ charge.order?.url }
 				paymentMethod={ charge.payment_method_details?.type }
 				bankName={ bankName }
+				onIssueRefund={ onIssueRefund }
 			/>
 		);
 	}
@@ -750,13 +751,19 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 
 			{ charge.dispute && (
 				<ErrorBoundary>
-					{ renderDisputeDetails( charge.dispute, charge, bankName ) }
+					{ renderDisputeDetails(
+						charge.dispute,
+						charge,
+						bankName,
+						() => setIsRefundModalOpen( true )
+					) }
 				</ErrorBoundary>
 			) }
 			{ isRefundModalOpen && (
 				<RefundModal
 					charge={ charge }
 					formattedAmount={ formattedAmount }
+					orderUrl={ charge.order?.url }
 					onModalClose={ () => {
 						setIsRefundModalOpen( false );
 						recordEvent(

--- a/client/payment-details/summary/missing-order-notice/index.tsx
+++ b/client/payment-details/summary/missing-order-notice/index.tsx
@@ -12,7 +12,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 
-import './style.scss';
 import CardNotice from 'wcpay/components/card-notice';
 import Loadable from 'wcpay/components/loadable';
 import { Charge } from 'wcpay/types/charges';

--- a/client/payment-details/summary/missing-order-notice/style.scss
+++ b/client/payment-details/summary/missing-order-notice/style.scss
@@ -8,3 +8,8 @@
 		}
 	}
 }
+
+.missing-order-notice-modal__partial-refund {
+	margin-top: 16px;
+	margin-bottom: 0;
+}

--- a/client/payment-details/summary/missing-order-notice/style.scss
+++ b/client/payment-details/summary/missing-order-notice/style.scss
@@ -9,10 +9,12 @@
 	}
 }
 
-.missing-order-notice-modal__partial-refund {
-	// Give the helper link room to breathe below the radio group so it reads
-	// as a distinct note rather than another option.
-	margin-top: 24px;
-	margin-bottom: 0;
-	line-height: 1.5;
+// The confirmation modal resets paragraph margins (`.components-modal__content
+// p { margin: 0 }`), so a plain class can't add room above this helper link.
+// Match that selector's specificity to separate it from the radio group above,
+// otherwise it reads as another reason option.
+.wcpay-confirmation-modal
+	.components-modal__content
+	p.missing-order-notice-modal__partial-refund {
+	margin-top: 1em;
 }

--- a/client/payment-details/summary/missing-order-notice/style.scss
+++ b/client/payment-details/summary/missing-order-notice/style.scss
@@ -10,6 +10,9 @@
 }
 
 .missing-order-notice-modal__partial-refund {
-	margin-top: 16px;
+	// Give the helper link room to breathe below the radio group so it reads
+	// as a distinct note rather than another option.
+	margin-top: 24px;
 	margin-bottom: 0;
+	line-height: 1.5;
 }

--- a/client/payment-details/summary/refund-modal/__tests__/index.test.tsx
+++ b/client/payment-details/summary/refund-modal/__tests__/index.test.tsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -23,71 +23,106 @@ const mockUsePaymentIntentWithChargeFallback =
 		typeof usePaymentIntentWithChargeFallback
 	>;
 
-describe( 'RefundModal', () => {
-	test( 'it renders correctly', () => {
-		const charge: any = {
-			id: '776',
-			amount: 1500,
-			amount_captured: 0,
-			amount_refunded: 0,
-			application_fee_amount: 0,
-			balance_transaction: { currency: 'USD', amount: 1500, fee: 0 },
-			billing_details: {
-				address: {
-					city: 'San Francisco',
-					country: 'US',
-					line1: '60 29th street',
-					line2: '',
-					postal_code: '91140',
-					state: 'CA',
-				},
-				email: 'admin_test_example@email.com',
-				name: 'First Last',
-				phone: '20000000000',
-				formatted_address: '60 29th street<br/>San Francisco, CA 91140',
-			},
-			created: 1679922581,
-			currency: 'USD',
-			disputed: false,
-			outcome: null,
-			order: {
-				number: 776,
-				url: 'http://wcpay.test/wp-admin/post.php?post=776&action=edit',
-				customer_url:
-					'admin.php?page=wc-admin&path=/customers&filter=single_customer&customers=55',
-				customer_name: '',
-				customer_email: '',
-				subscriptions: [],
-				fraud_meta_box_type: 'succeeded',
-			},
-			paid: false,
-			paydown: null,
-			payment_method: '',
-			payment_intent: null,
-			payment_method_details: {
-				card: { country: 'US', checks: [], network: '' },
-				type: 'card' as any,
-			},
-			refunded: false,
-			refunds: null,
-			status: 'pending',
-		};
+const getMockCharge = (): any => ( {
+	id: '776',
+	amount: 1500,
+	amount_captured: 0,
+	amount_refunded: 0,
+	application_fee_amount: 0,
+	balance_transaction: { currency: 'USD', amount: 1500, fee: 0 },
+	billing_details: {
+		address: {
+			city: 'San Francisco',
+			country: 'US',
+			line1: '60 29th street',
+			line2: '',
+			postal_code: '91140',
+			state: 'CA',
+		},
+		email: 'admin_test_example@email.com',
+		name: 'First Last',
+		phone: '20000000000',
+		formatted_address: '60 29th street<br/>San Francisco, CA 91140',
+	},
+	created: 1679922581,
+	currency: 'USD',
+	disputed: false,
+	outcome: null,
+	order: {
+		number: 776,
+		url: 'http://wcpay.test/wp-admin/post.php?post=776&action=edit',
+		customer_url:
+			'admin.php?page=wc-admin&path=/customers&filter=single_customer&customers=55',
+		customer_name: '',
+		customer_email: '',
+		subscriptions: [],
+		fraud_meta_box_type: 'succeeded',
+	},
+	paid: false,
+	paydown: null,
+	payment_method: '',
+	payment_intent: null,
+	payment_method_details: {
+		card: { country: 'US', checks: [], network: '' },
+		type: 'card' as any,
+	},
+	refunded: false,
+	refunds: null,
+	status: 'pending',
+} );
 
+describe( 'RefundModal', () => {
+	beforeEach( () => {
 		mockUsePaymentIntentWithChargeFallback.mockReturnValue( {
 			doRefund: jest.fn(),
-			data: charge,
+			data: getMockCharge(),
 			error: {} as ApiError,
 			isLoading: false,
 		} );
+	} );
 
+	test( 'it renders correctly', () => {
 		const { container: modal } = render(
 			<RefundModal
-				charge={ charge as Charge }
+				charge={ getMockCharge() as Charge }
 				formattedAmount={ 'USD 15' }
 				onModalClose={ jest.fn() }
 			/>
 		);
 
 		expect( modal ).toMatchSnapshot();
+	} );
+
+	test( 'offers a link to the order when orderUrl is provided', () => {
+		const charge = getMockCharge();
+
+		render(
+			<RefundModal
+				charge={ charge as Charge }
+				formattedAmount={ 'USD 15' }
+				orderUrl={ charge.order.url }
+				onModalClose={ jest.fn() }
+			/>
+		);
+
+		const orderLink = screen.getByRole( 'link', {
+			name: /Go to the order/i,
+		} );
+
+		expect( orderLink ).toHaveAttribute( 'href', charge.order.url );
+	} );
+
+	test( 'does not offer the order link when orderUrl is omitted', () => {
+		render(
+			<RefundModal
+				charge={ getMockCharge() as Charge }
+				formattedAmount={ 'USD 15' }
+				onModalClose={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.queryByRole( 'link', { name: /Go to the order/i } )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/payment-details/summary/refund-modal/__tests__/index.test.tsx
+++ b/client/payment-details/summary/refund-modal/__tests__/index.test.tsx
@@ -4,7 +4,8 @@
  * External dependencies
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -13,10 +14,21 @@ import { Charge } from 'wcpay/types/charges';
 import RefundModal from '..';
 import { usePaymentIntentWithChargeFallback } from 'wcpay/data/payment-intents';
 import { ApiError } from 'wcpay/types/errors';
+import { recordEvent } from 'tracks';
 
 jest.mock( 'wcpay/data/payment-intents', () => ( {
 	usePaymentIntentWithChargeFallback: jest.fn(),
 } ) );
+
+jest.mock( 'tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+const getOpenInquiryDispute = (): any => ( {
+	id: 'dp_inquiry_1',
+	status: 'warning_needs_response',
+	reason: 'fraudulent',
+} );
 
 const mockUsePaymentIntentWithChargeFallback =
 	usePaymentIntentWithChargeFallback as jest.MockedFunction<
@@ -73,6 +85,7 @@ const getMockCharge = (): any => ( {
 
 describe( 'RefundModal', () => {
 	beforeEach( () => {
+		jest.clearAllMocks();
 		mockUsePaymentIntentWithChargeFallback.mockReturnValue( {
 			doRefund: jest.fn(),
 			data: getMockCharge(),
@@ -124,5 +137,65 @@ describe( 'RefundModal', () => {
 		expect(
 			screen.queryByRole( 'link', { name: /Go to the order/i } )
 		).not.toBeInTheDocument();
+	} );
+
+	test( 'explains the inquiry will be closed when the charge has an open inquiry', () => {
+		const charge = { ...getMockCharge(), dispute: getOpenInquiryDispute() };
+
+		render(
+			<RefundModal
+				charge={ charge as Charge }
+				formattedAmount={ 'USD 15' }
+				onModalClose={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText( /Issuing a refund will close the inquiry/i )
+		).toBeInTheDocument();
+	} );
+
+	test( 'does not mention the inquiry for a charge without an open inquiry', () => {
+		render(
+			<RefundModal
+				charge={ getMockCharge() as Charge }
+				formattedAmount={ 'USD 15' }
+				onModalClose={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.queryByText( /Issuing a refund will close the inquiry/i )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'fires the inquiry refund tracks event when refunding an open inquiry', async () => {
+		const dispute = getOpenInquiryDispute();
+		const charge = { ...getMockCharge(), dispute };
+
+		render(
+			<RefundModal
+				charge={ charge as Charge }
+				formattedAmount={ 'USD 15' }
+				onModalClose={ jest.fn() }
+			/>
+		);
+
+		// Wrap in act so the refund promise and its trailing state updates flush.
+		await act( async () => {
+			await userEvent.click(
+				screen.getByRole( 'button', { name: /Refund transaction/i } )
+			);
+		} );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcpay_dispute_inquiry_refund_click',
+			{
+				dispute_id: dispute.id,
+				dispute_status: dispute.status,
+				dispute_reason: dispute.reason,
+				on_page: 'transaction_details',
+			}
+		);
 	} );
 } );

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -6,8 +6,9 @@
 import React from 'react';
 import { Button, RadioControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, createInterpolateElement } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies.
@@ -21,12 +22,18 @@ import { recordEvent } from 'tracks';
 interface RefundModalProps {
 	charge: Charge;
 	formattedAmount: string;
+	/**
+	 * URL of the associated order, when one exists. When provided, the modal
+	 * offers a link to the order screen for a partial / more granular refund.
+	 */
+	orderUrl?: string;
 	onModalClose: () => void;
 }
 
 const RefundModal: React.FC< RefundModalProps > = ( {
 	charge,
 	formattedAmount,
+	orderUrl,
 	onModalClose,
 } ) => {
 	const [ reason, setReason ] = useState< string | null >( null );
@@ -122,6 +129,33 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 				] }
 				onChange={ ( value: string ) => setReason( value ) }
 			/>
+			{ orderUrl && (
+				<p className="missing-order-notice-modal__partial-refund">
+					{ createInterpolateElement(
+						__(
+							'Need to refund part of the order? <link>Go to the order</link>.',
+							'woocommerce-payments'
+						),
+						{
+							link: (
+								<Link
+									href={ orderUrl }
+									onClick={ () =>
+										recordEvent(
+											'payments_transactions_details_partial_refund',
+											{
+												payment_intent_id:
+													charge.payment_intent,
+												order_id: charge.order?.id,
+											}
+										)
+									}
+								/>
+							),
+						}
+					) }
+				</p>
+			) }
 		</ConfirmationModal>
 	);
 };

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -17,6 +17,7 @@ import ConfirmationModal from 'wcpay/components/confirmation-modal';
 import { Charge } from 'wcpay/types/charges';
 import { usePaymentIntentWithChargeFallback } from 'wcpay/data/payment-intents';
 import { PaymentChargeDetailsResponse } from 'wcpay/payment-details/types';
+import { isAwaitingResponse, isInquiry } from 'wcpay/disputes/utils';
 import { recordEvent } from 'tracks';
 
 interface RefundModalProps {
@@ -45,6 +46,14 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 		charge.payment_intent as string
 	) as PaymentChargeDetailsResponse;
 
+	// Refunding a charge that still has an open inquiry resolves the inquiry,
+	// so we surface that context and keep the inquiry-specific tracking.
+	const dispute = charge.dispute;
+	const isOpenInquiry =
+		!! dispute &&
+		isInquiry( dispute.status ) &&
+		isAwaitingResponse( dispute.status );
+
 	const handleModalCancel = () => {
 		onModalClose();
 	};
@@ -53,6 +62,16 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 		recordEvent( 'payments_transactions_details_refund_full', {
 			payment_intent_id: charge.payment_intent,
 		} );
+
+		if ( isOpenInquiry && dispute ) {
+			recordEvent( 'wcpay_dispute_inquiry_refund_click', {
+				dispute_id: dispute.id,
+				dispute_status: dispute.status,
+				dispute_reason: dispute.reason,
+				on_page: 'transaction_details',
+			} );
+		}
+
 		setIsRefundInProgress( true );
 		await doRefund( charge, reason === 'other' ? null : reason );
 		setIsRefundInProgress( false );
@@ -85,6 +104,14 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 			}
 			onRequestClose={ handleModalCancel }
 		>
+			{ isOpenInquiry && (
+				<p>
+					{ __(
+						'Issuing a refund will close the inquiry, returning the amount in question back to the cardholder. No additional fees apply.',
+						'woocommerce-payments'
+					) }
+				</p>
+			) }
 			<p>
 				{ interpolateComponents( {
 					mixedString: sprintf(

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -140,6 +140,7 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 							link: (
 								<Link
 									href={ orderUrl }
+									type="external"
 									onClick={ () =>
 										recordEvent(
 											'payments_transactions_details_partial_refund',

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -19,6 +19,7 @@ import { usePaymentIntentWithChargeFallback } from 'wcpay/data/payment-intents';
 import { PaymentChargeDetailsResponse } from 'wcpay/payment-details/types';
 import { isAwaitingResponse, isInquiry } from 'wcpay/disputes/utils';
 import { recordEvent } from 'tracks';
+import './style.scss';
 
 interface RefundModalProps {
 	charge: Charge;
@@ -80,7 +81,7 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 
 	return (
 		<ConfirmationModal
-			className="missing-order-notice-modal"
+			className="wcpay-refund-modal"
 			title={ __( 'Refund transaction', 'woocommerce-payments' ) }
 			actions={
 				<>
@@ -127,7 +128,7 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 				} ) }
 			</p>
 			<RadioControl
-				className="missing-order-notice-modal__reason"
+				className="wcpay-refund-modal__reason"
 				label={ __(
 					'Select a reason (Optional)',
 					'woocommerce-payments'
@@ -157,7 +158,7 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 				onChange={ ( value: string ) => setReason( value ) }
 			/>
 			{ orderUrl && (
-				<p className="missing-order-notice-modal__partial-refund">
+				<p className="wcpay-refund-modal__partial-refund">
 					{ createInterpolateElement(
 						__(
 							'Need to refund part of the order? <link>Go to the order</link>.',

--- a/client/payment-details/summary/refund-modal/index.tsx
+++ b/client/payment-details/summary/refund-modal/index.tsx
@@ -46,8 +46,8 @@ const RefundModal: React.FC< RefundModalProps > = ( {
 		charge.payment_intent as string
 	) as PaymentChargeDetailsResponse;
 
-	// Refunding a charge that still has an open inquiry resolves the inquiry,
-	// so we surface that context and keep the inquiry-specific tracking.
+	// Refunding a charge with an open inquiry resolves the inquiry, so the
+	// modal surfaces that context and records the inquiry-specific event.
 	const dispute = charge.dispute;
 	const isOpenInquiry =
 		!! dispute &&

--- a/client/payment-details/summary/refund-modal/style.scss
+++ b/client/payment-details/summary/refund-modal/style.scss
@@ -1,4 +1,4 @@
-.missing-order-notice-modal__reason {
+.wcpay-refund-modal__reason {
 	.components-base-control__label {
 		font-weight: bold;
 	}
@@ -15,6 +15,6 @@
 // otherwise it reads as another reason option.
 .wcpay-confirmation-modal
 	.components-modal__content
-	p.missing-order-notice-modal__partial-refund {
+	p.wcpay-refund-modal__partial-refund {
 	margin-top: 1em;
 }


### PR DESCRIPTION
Fixes #7963

#### Changes proposed in this Pull Request

Refunding an inquiry from the transaction details page used to open an informational modal that then sent the merchant to the order screen to complete the refund by hand. 
The "Issue refund" button now opens the same full-refund modal we already use elsewhere on that page (#7742), so the refund happens inline and closes the inquiry, without redirects.

Partial refunds still happen on the order screen, so the refund modal links there when the transaction has an associated order, for merchants who want more granular control.

I considered keeping an intermediate dialog to pick full vs partial up front, but that's an extra step for the common case (a full refund), so the button jumps straight to the modal and the order link covers the partial case. This matches the lean flow agreed on in #7963.

#### Testing instructions

- On local environment, ensure you have `npm run listen` running on the server, so that webhooks come through
- As a customer, create an inquiry on a transaction by paying with the card `4000000000001976` at checkout
- As a merchant, navigate to the order details page in WooCommerce > Orders for the latest order placed
- Click on the inquiry notice
<img width="888" height="112" alt="Screenshot 2026-06-11 at 11 06 44 AM" src="https://github.com/user-attachments/assets/4b32d56d-30a5-4f7b-865e-2c4f04fed089" />

- On the transaction page, click the **Issue refund** button
<img width="376" height="169" alt="Screenshot 2026-06-11 at 11 07 28 AM" src="https://github.com/user-attachments/assets/2c76b295-84e9-4126-87ba-cf6ef0cf31ea" />

- The **Refund transaction** modal should open inline
<img width="638" height="493" alt="Screenshot 2026-06-11 at 11 07 56 AM" src="https://github.com/user-attachments/assets/298c2134-b5e7-4c7d-95c7-e1834c5ce1ac" />

- Optionally pick a reason, then click **Refund transaction**. The transaction should be refunded and the inquiry closed


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
