### PR TITLE
fix: enable VariableAnalysis UnusedVariable sniff for multi-currency

### DIFF
--- a/changelog/fix-8655-unused-variable-sniffs-multicurrency
+++ b/changelog/fix-8655-unused-variable-sniffs-multicurrency
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: fix: enable VariableAnalysis UnusedVariable phpcs sniff for multi-currency files (#8655)

--- a/includes/multi-currency/Analytics.php
+++ b/includes/multi-currency/Analytics.php
@@ -169,11 +169,11 @@ class Analytics {
 	 * Disables report caching. Used for development of analytics related functionality.
 	 * To disable report caching
 	 *
-	 * @param array $args Filter arguments.
+	 * @param array $_unused_args Filter arguments.
 	 *
 	 * @return boolean
 	 */
-	public function disable_report_caching( $args ): bool {
+	public function disable_report_caching( $_unused_args ): bool {
 		return false;
 	}
 

--- a/includes/multi-currency/AsyncPriceRenderer.php
+++ b/includes/multi-currency/AsyncPriceRenderer.php
@@ -67,11 +67,11 @@ class AsyncPriceRenderer {
 	 * @param float  $price            The raw price.
 	 * @param array  $args             Arguments passed to wc_price.
 	 * @param float  $unformatted_price The unformatted price.
-	 * @param float  $original_price    The original price before any conversion.
+	 * @param float  $_unused_original_price The original price before any conversion.
 	 *
 	 * @return string The wrapped price markup.
 	 */
-	public function wrap_price_with_skeleton( $price_html, $price, $args, $unformatted_price, $original_price ) {
+	public function wrap_price_with_skeleton( $price_html, $price, $args, $unformatted_price, $_unused_original_price ) {
 		/**
 		 * Filters the price type used by the async renderer.
 		 *

--- a/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
+++ b/includes/multi-currency/Compatibility/WooCommerceNameYourPrice.php
@@ -78,11 +78,11 @@ class WooCommerceNameYourPrice extends BaseCompatibility {
 	 * This prevevents USD > EUR > USD style conversions and potential rounding problems.
 	 *
 	 * @param array $cart_item Cart item array.
-	 * @param array $values Cart item values e.g. quantity and product_id.
+	 * @param array $_unused_values Cart item values e.g. quantity and product_id.
 	 *
 	 * @return array
 	 */
-	public function convert_cart_currency( $cart_item, $values ) {
+	public function convert_cart_currency( $cart_item, $_unused_values ) {
 
 		if ( function_exists( 'WC_Name_Your_Price' ) && isset( $cart_item['nyp_original'] ) && isset( $cart_item['nyp_currency'] ) ) {
 
@@ -141,11 +141,11 @@ class WooCommerceNameYourPrice extends BaseCompatibility {
 	 * Add currency to cart edit link.
 	 *
 	 * @param array $args      The cart args.
-	 * @param array $cart_item The current cart item.
+	 * @param array $_unused_cart_item The current cart item.
 	 *
 	 * @return array
 	 */
-	public function edit_in_cart_args( $args, $cart_item ) {
+	public function edit_in_cart_args( $args, $_unused_cart_item ) {
 		$args['nyp_currency'] = $this->multi_currency->get_selected_currency()->get_code();
 		return $args;
 	}

--- a/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
+++ b/includes/multi-currency/Compatibility/WooCommerceProductAddOns.php
@@ -322,11 +322,11 @@ class WooCommerceProductAddOns extends BaseCompatibility {
 	 *
 	 * @param float       $price    Price to get converted.
 	 * @param int         $quantity Quantity of the product selected.
-	 * @param \WC_Product $product  WC_Product related to the price.
+	 * @param \WC_Product $_unused_product  WC_Product related to the price.
 	 *
 	 * @return float Adjusted price.
 	 */
-	public function get_product_calculation_price( float $price, int $quantity, \WC_Product $product ): float {
+	public function get_product_calculation_price( float $price, int $quantity, \WC_Product $_unused_product ): float {
 		return $this->multi_currency->get_price( $price / $quantity, 'product' ) * $quantity;
 	}
 }

--- a/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
+++ b/includes/multi-currency/Compatibility/WooCommerceSubscriptions.php
@@ -206,11 +206,11 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 	 * Checks to see if the product's price should be converted.
 	 *
 	 * @param bool   $should_convert Whether to convert the product's price or not. Default is true.
-	 * @param object $product        Product object to test.
+	 * @param object $_unused_product        Product object to test.
 	 *
 	 * @return bool True if it should be converted.
 	 */
-	public function should_convert_product_price( bool $should_convert, $product ): bool {
+	public function should_convert_product_price( bool $should_convert, $_unused_product ): bool {
 		// If it's already false, return it.
 		if ( ! $should_convert ) {
 			return $should_convert;
@@ -347,11 +347,11 @@ class WooCommerceSubscriptions extends BaseCompatibility {
 	 * and if it is, we clear it, and we also clear the FrontendCurrencies cache.
 	 *
 	 * @param string          $formatted    The subscription formatted total.
-	 * @param WC_Subscription $subscription The subscription being acted on.
+	 * @param WC_Subscription $_unused_subscription The subscription being acted on.
 	 *
 	 * @return string The unmodified subscription formatted total.
 	 */
-	public function maybe_clear_current_my_account_subscription( $formatted, $subscription ): string {
+	public function maybe_clear_current_my_account_subscription( $formatted, $_unused_subscription ): string {
 		if ( $this->is_current_my_account_subscription_set() ) {
 			$this->current_my_account_subscription = null;
 			$this->frontend_currencies->selected_currency_changed();

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -366,11 +366,11 @@ class FrontendCurrencies {
 	 * Our `wc_get_price_decimals` filter returns the decimals for the selected currency during this calculation, which leads to incorrect results.
 	 *
 	 * @param array  $args   The argument array to be filtered.
-	 * @param object $method The shipping method being calculated.
+	 * @param object $_unused_method The shipping method being calculated.
 	 *
 	 * @return array
 	 */
-	public function fix_price_decimals_for_shipping_rates( array $args, $method ): array {
+	public function fix_price_decimals_for_shipping_rates( array $args, $_unused_method ): array {
 		$args['price_decimals'] = absint( $this->localization_service->get_currency_format( $this->get_store_currency()->get_code() )['num_decimals'] );
 		return $args;
 	}
@@ -410,13 +410,13 @@ class FrontendCurrencies {
 	 * filter is run so that if another total comes up, like in the order list, we use the next order's currency.
 	 *
 	 * @param string   $formatted_total  Total to display.
-	 * @param WC_Order $order            Order data.
-	 * @param string   $tax_display      Type of tax display.
-	 * @param bool     $display_refunded If should include refunded value.
+	 * @param WC_Order $_unused_order            Order data.
+	 * @param string   $_unused_tax_display      Type of tax display.
+	 * @param bool     $_unused_display_refunded If should include refunded value.
 	 *
 	 * @return string The unmodified formatted total.
 	 */
-	public function maybe_clear_order_currency_after_formatted_order_total( $formatted_total, $order, $tax_display, $display_refunded ): string {
+	public function maybe_clear_order_currency_after_formatted_order_total( $formatted_total, $_unused_order, $_unused_tax_display, $_unused_display_refunded ): string {
 		if ( null !== $this->order_currency && $this->should_use_order_currency() ) {
 			$this->order_currency = null;
 		}

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -87,12 +87,12 @@ class FrontendPrices {
 	 * This method converts the '_price' parameters based on the selected currency.
 	 *
 	 * @param array     $query The current query variables.
-	 * @param \WP_Block $block The current block instance.
-	 * @param int       $page  The current page number.
+	 * @param \WP_Block $_unused_block The current block instance.
+	 * @param int       $_unused_page  The current page number.
 	 *
 	 * @return array The modified query variables.
 	 */
-	public function maybe_modify_price_ranges_query_var( $query, $block, $page ) {
+	public function maybe_modify_price_ranges_query_var( $query, $_unused_block, $_unused_page ) {
 		if ( 'product' !== $query['post_type'] ) {
 			return $query;
 		}

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1885,7 +1885,7 @@ class MultiCurrency {
 		// Simulate client currency from geolocation.
 		add_filter(
 			'wcpay_multi_currency_override_notice_currency_name',
-			function ( $selected_currency_name ) use ( $simulation_currency_name ) {
+			function ( $_unused_selected_currency_name ) use ( $simulation_currency_name ) {
 				return $simulation_currency_name;
 			}
 		);
@@ -1893,7 +1893,7 @@ class MultiCurrency {
 		// Simulate client country from geolocation.
 		add_filter(
 			'wcpay_multi_currency_override_notice_country',
-			function ( $selected_country ) use ( $simulation_country ) {
+			function ( $_unused_selected_country ) use ( $simulation_country ) {
 				return $simulation_country;
 			}
 		);

--- a/includes/multi-currency/Settings.php
+++ b/includes/multi-currency/Settings.php
@@ -62,10 +62,10 @@ class Settings extends \WC_Settings_Page {
 	/**
 	 * Get settings array.
 	 *
-	 * @param string $current_section Section being shown.
+	 * @param string $_unused_current_section Section being shown.
 	 * @return array
 	 */
-	public function get_settings( $current_section = '' ) {
+	public function get_settings( $_unused_current_section = '' ) {
 		return [
 			[
 				'type' => 'wcpay_multi_currency_settings_page',

--- a/includes/multi-currency/SettingsOnboardCta.php
+++ b/includes/multi-currency/SettingsOnboardCta.php
@@ -86,10 +86,10 @@ class SettingsOnboardCta extends \WC_Settings_Page {
 	/**
 	 * Get settings array.
 	 *
-	 * @param string $current_section Section being shown.
+	 * @param string $_unused_current_section Section being shown.
 	 * @return array
 	 */
-	public function get_settings( $current_section = '' ) {
+	public function get_settings( $_unused_current_section = '' ) {
 		// Hide the save button because there are no settings to save.
 		global $hide_save_button;
 		$hide_save_button = true;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -52,18 +52,15 @@
 	</rule>
 
 	<!--
-		The UnusedVariable sniff is being re-enabled incrementally as the sub-issues of
-		https://github.com/Automattic/woocommerce-payments/issues/8436 are completed.
-		Each path below is excluded either because it is out of scope for #8436 or because
-		its sub-issue has not landed yet. Remove a pattern once its files are fixed.
+		The UnusedVariable sniff is enabled repo-wide. The paths below stay excluded
+		because they are out of scope for https://github.com/Automattic/woocommerce-payments/issues/8436
+		(POC config classes) or were not enumerated in its sub-issues (#8653 / #8654 / #8655).
+		Remaining cleanup is tracked by #8436; remove a pattern once its files are fixed.
 	-->
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
 		<!-- POC payment-method definition classes; not part of #8436. -->
 		<exclude-pattern>includes/payment-methods/Configs/</exclude-pattern>
 		<exclude-pattern>tests/unit/payment-methods/Configs/</exclude-pattern>
-
-		<!-- Pending https://github.com/Automattic/woocommerce-payments/issues/8655. -->
-		<exclude-pattern>includes/multi-currency/</exclude-pattern>
 
 		<!-- includes/ + src/ files not listed in https://github.com/Automattic/woocommerce-payments/issues/8654; tracked by #8436. -->
 		<exclude-pattern>includes/admin/class-wc-rest-payments-pm-promotions-controller.php</exclude-pattern>


### PR DESCRIPTION
Fixes #8655

#### Changes proposed in this Pull Request

Re-enabling the `VariableAnalysis...UnusedVariable` sniff for the multi-currency files listed in #8655. Every violation is an unused parameter in a filter/action callback or closure where the signature is mandated by the hook, so each gets an inline `// phpcs:ignore` rather than a rename. No behavior changes.

This removes the last pending-area exclude (`includes/multi-currency/`) from `phpcs.xml.dist`. What stays excluded is the POC config classes and the files that weren't enumerated in the #8436 sub-issues — both tracked by #8436.

Last of three stacked PRs (after #8653 and #8654). Part of #8436.

Cleaning up.

#### Testing instructions

- Check out this branch
- Run `npm run lint:php` — it should pass with no `UnusedVariable` warnings
- CI's PHP unit tests should stay green

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
