### PR TITLE
fix(ci): compile Xdebug from a pinned GitHub release instead of PECL

### DIFF
--- a/changelog/fix-docker-xdebug-pecl-install
+++ b/changelog/fix-docker-xdebug-pecl-install
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix Docker image builds by compiling Xdebug from a pinned GitHub release instead of the unreachable PECL channel

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -5,7 +5,17 @@ ARG XDEBUG_REMOTE_HOST=host.docker.internal
 ARG XDEBUG_START_WITH_REQUEST=trigger
 ARG XDEBUG_SHOW_ERROR_TRACE=0
 ARG XDEBUG_SHOW_EXCEPTION_TRACE=0
-RUN pecl install xdebug \
+# pecl.php.net is deprecated upstream (PIE is the successor) and unreachable
+# since early June 2026, so build Xdebug from a pinned GitHub release tarball
+# instead of `pecl install xdebug`. Xdebug 3.4.x is the last line supporting PHP 8.1.
+RUN curl -fsSL https://github.com/xdebug/xdebug/archive/refs/tags/3.4.7.tar.gz -o /tmp/xdebug.tar.gz \
+    && tar -xzf /tmp/xdebug.tar.gz -C /tmp \
+    && cd /tmp/xdebug-3.4.7 \
+    && phpize \
+    && ./configure --quiet \
+    && make --quiet -j"$(nproc)" \
+    && make --quiet install \
+    && rm -rf /tmp/xdebug.tar.gz /tmp/xdebug-3.4.7 \
     && echo "xdebug.mode=${XDEBUG_MODE}" >> $PHP_INI_DIR/php.ini \
     && echo "xdebug.client_port=${XDEBUG_REMOTE_PORT}" >> $PHP_INI_DIR/php.ini \
     && echo "xdebug.client_host=${XDEBUG_REMOTE_HOST}" >> $PHP_INI_DIR/php.ini \

--- a/tests/e2e/env/wordpress-xdebug/Dockerfile
+++ b/tests/e2e/env/wordpress-xdebug/Dockerfile
@@ -1,5 +1,15 @@
 FROM wordpress:php8.1
-RUN pecl install xdebug \
+# pecl.php.net is deprecated upstream (PIE is the successor) and unreachable
+# since early June 2026, so build Xdebug from a pinned GitHub release tarball
+# instead of `pecl install xdebug`. Xdebug 3.4.x is the last line supporting PHP 8.1.
+RUN curl -fsSL https://github.com/xdebug/xdebug/archive/refs/tags/3.4.7.tar.gz -o /tmp/xdebug.tar.gz \
+	&& tar -xzf /tmp/xdebug.tar.gz -C /tmp \
+	&& cd /tmp/xdebug-3.4.7 \
+	&& phpize \
+	&& ./configure --quiet \
+	&& make --quiet -j"$(nproc)" \
+	&& make --quiet install \
+	&& rm -rf /tmp/xdebug.tar.gz /tmp/xdebug-3.4.7 \
 	&& echo 'xdebug.remote_enable=1' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_port=9000' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.remote_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \


### PR DESCRIPTION
Fixes the E2E CI breakage visible on every PR today (for example [this run](https://github.com/Automattic/woocommerce-payments/actions/runs/27423745107)).

#### Changes proposed in this Pull Request

All `E2E Tests - Pull Request` jobs that miss the cached Docker layer fail in ~2 minutes while building `tests/e2e/env/wordpress-xdebug/Dockerfile`:

```
No releases available for package "pecl.php.net/xdebug"
install failed
```

Root cause: `pecl.php.net` is unreachable, so the unpinned `pecl install xdebug` fails on any cold build. Verified independently of CI: the same command fails identically in fresh `wordpress:php8.1` and `php:8.3-cli` containers, and even `mlocati/docker-php-extension-installer` fails because its remote-module path also resolves through pecl.php.net. The occasional green run is a Docker layer cache hit.

Upstream context: PECL is formally deprecated in favor of [PIE](https://github.com/php/pie) ([RFC accepted 2025-09-22](https://wiki.php.net/rfc/adopt_pie_deprecate_pecl)); PIE 1.0 shipped in early 2026 and PECL stopped accepting new packages. The RFC promised the site would keep operating, but pecl.php.net has been returning 504s on and off since June 3 ([php/web-pecl#113](https://github.com/php/web-pecl/issues/113)) and is now unreachable, with no committed restoration timeline. Multiple unrelated projects are patching `pecl` out of their CI this week; the official Docker PHP image tracks the same migration in [docker-library/php#1554](https://github.com/docker-library/php/issues/1554). Regardless of whether the outage is permanent, a deprecated unpinned registry is not a dependency CI should keep.

The fix compiles Xdebug from a pinned GitHub release tarball (3.4.7, the latest in the last line supporting PHP 8.1) in the two affected Dockerfiles:

- `tests/e2e/env/wordpress-xdebug/Dockerfile` (E2E CI, the one breaking PRs)
- `docker/wordpress_xdebug/Dockerfile` (local dev with Xdebug)

The build toolchain (`phpize`, gcc, make) already ships in the base image; `pecl install` was compiling from source before too, so the resulting extension is equivalent. The version is pinned deliberately: today's breakage came from an unpinned external dependency.

These are the only two `pecl install` call sites in the repo (the other grep hits are WP core docblocks).

#### Testing instructions

CI on this PR is the real test: the `E2E Tests - Pull Request` jobs build this exact image. Locally:

- `docker build tests/e2e/env/wordpress-xdebug/` completes
- `docker build --build-arg XDEBUG_REMOTE_PORT=9003 docker/wordpress_xdebug/` completes
- `php -v` inside both images reports "with Xdebug v3.4.7"

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description): CI infrastructure change, exercised directly by the E2E workflow on this PR
- [x] Tested on mobile (or does not apply): does not apply

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

Generated with [Claude Code](https://claude.com/claude-code)
