### PR TITLE
refactor: move hooks out of WooPay class constructors

### DIFF
--- a/changelog/fix-hooks-7260
+++ b/changelog/fix-hooks-7260
@@ -1,1 +1,3 @@
+Significance: patch
+Type: dev
 Comment: refactor: move hooks out of WooPay class constructors to init_hooks()

--- a/changelog/fix-hooks-7260
+++ b/changelog/fix-hooks-7260
@@ -1,0 +1,1 @@
+Comment: refactor: move hooks out of WooPay class constructors to init_hooks()

--- a/dev/phpcs/WCPay/ruleset.xml
+++ b/dev/phpcs/WCPay/ruleset.xml
@@ -2,10 +2,5 @@
 <ruleset name="WCPay">
 	<description>WCPay custom coding standards.</description>
 
-	<rule ref="WCPay.Hooks.DisallowHooksInConstructor">
-		<!-- https://github.com/Automattic/woocommerce-payments/issues/7260 -->
-		<exclude-pattern>*/includes/class-woopay-tracker.php</exclude-pattern>
-		<exclude-pattern>*/includes/woopay/*</exclude-pattern>
-		<exclude-pattern>*/includes/woopay-user/*</exclude-pattern>
-	</rule>
+	<rule ref="WCPay.Hooks.DisallowHooksInConstructor" />
 </ruleset>

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -596,6 +596,7 @@ class WC_Payments {
 		( new WooPay_Scheduler( self::$api_client ) )->init();
 
 		// Initialise hooks.
+		self::$woopay_tracker->init_hooks();
 		self::$order_service->init_hooks();
 		self::$order_success_page->init_hooks();
 		self::$action_scheduler_service->init_hooks();
@@ -1834,7 +1835,7 @@ class WC_Payments {
 				add_action( 'admin_init', [ $draft_orders, 'install' ] );
 			}
 
-			new WooPay_Order_Status_Sync( self::$api_client, self::$account );
+			( new WooPay_Order_Status_Sync( self::$api_client, self::$account ) )->init_hooks();
 		}
 	}
 
@@ -2107,7 +2108,7 @@ class WC_Payments {
 
 			include_once __DIR__ . '/woopay-user/class-woopay-save-user.php';
 
-			new WooPay_Save_User();
+			( new WooPay_Save_User() )->init_hooks();
 		}
 	}
 

--- a/includes/class-woopay-tracker.php
+++ b/includes/class-woopay-tracker.php
@@ -58,7 +58,12 @@ class WooPay_Tracker extends Jetpack_Tracks_Client {
 	public function __construct( $http ) {
 
 		$this->http = $http;
+	}
 
+	/**
+	 * Register hooks.
+	 */
+	public function init_hooks() {
 		add_action( 'wp_ajax_platform_tracks', [ $this, 'ajax_tracks' ] );
 		add_action( 'wp_ajax_nopriv_platform_tracks', [ $this, 'ajax_tracks' ] );
 		add_action( 'wp_ajax_get_identity', [ $this, 'ajax_tracks_id' ] );

--- a/includes/woopay-user/class-woopay-save-user.php
+++ b/includes/woopay-user/class-woopay-save-user.php
@@ -27,7 +27,12 @@ class WooPay_Save_User {
 	 */
 	public function __construct() {
 		$this->woopay_util = new WooPay_Utilities();
+	}
 
+	/**
+	 * Register hooks.
+	 */
+	public function init_hooks() {
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_checkout_page_scripts' ] );
 		add_filter( 'wcpay_metadata_from_order', [ $this, 'maybe_add_userdata_to_metadata' ], 10, 2 );
 		add_action( 'woocommerce_payment_complete', [ $this, 'maybe_clear_session_key' ], 10, 2 );

--- a/includes/woopay/class-woopay-order-status-sync.php
+++ b/includes/woopay/class-woopay-order-status-sync.php
@@ -46,7 +46,12 @@ class WooPay_Order_Status_Sync {
 
 		$this->payments_api_client = $payments_api_client;
 		$this->account             = $account;
+	}
 
+	/**
+	 * Register hooks.
+	 */
+	public function init_hooks() {
 		add_filter( 'woocommerce_webhook_topic_hooks', [ __CLASS__, 'add_topics' ], 20, 2 );
 		add_filter( 'woocommerce_webhook_payload', [ __CLASS__, 'create_payload' ], 10, 4 );
 		add_filter( 'woocommerce_valid_webhook_resources', [ __CLASS__, 'add_resource' ], 10, 1 );

--- a/tests/unit/test-class-woopay-tracker.php
+++ b/tests/unit/test-class-woopay-tracker.php
@@ -44,6 +44,7 @@ class WooPay_Tracker_Test extends WCPAY_UnitTestCase {
 		$this->http_client_stub->method( 'get_connected_user_data' )->willReturn( [ 'ID' => 1234 ] );
 
 		$this->tracker = new WooPay_Tracker( $this->http_client_stub );
+		$this->tracker->init_hooks();
 
 		$this->cache      = WC_Payments::get_database_cache();
 		$this->mock_cache = $this->createMock( WCPay\Database_Cache::class );

--- a/tests/unit/woopay/test-class-woopay-order-status-sync.php
+++ b/tests/unit/woopay/test-class-woopay-order-status-sync.php
@@ -49,6 +49,7 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 		$this->account_mock      = $this->createMock( WC_Payments_Account::class );
 		$this->api_client_mock   = $this->createMock( WC_Payments_API_Client::class );
 		$this->webhook_sync_mock = new WCPay\WooPay\WooPay_Order_Status_Sync( $this->api_client_mock, $this->account_mock );
+		$this->webhook_sync_mock->init_hooks();
 
 		// Mock the main class's cache service.
 		$this->cache      = WC_Payments::get_database_cache();


### PR DESCRIPTION
Fixes #7260

#### Changes proposed in this Pull Request

Moving hooks out of constructors in `WooPay_Tracker`, `WooPay_Order_Status_Sync`, and `WooPay_Save_User`. Drops the corresponding exclusions from the PHPCS ruleset.

Moving.

#### Testing instructions

Pure refactor, no behavior changes. `init_hooks()` is called immediately after instantiation in `class-wc-payments.php`, in pretty much the same place the constructors were previously registering hooks.

1. Run `npm run lint:php` — should pass clean with the three WooPay exclusions removed.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.