### PR TITLE
Fix flaky multi-currency widget E2E setup (strict-mode locator)

### DIFF
--- a/changelog/fix-e2e-multicurrency-widget-strict-mode
+++ b/changelog/fix-e2e-multicurrency-widget-strict-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flaky multi-currency widget E2E setup: scope the post-insert wait to the canvas edit-form title so it no longer matches the block-inspector card and trips Playwright strict mode.

--- a/changelog/fix-e2e-multicurrency-widget-strict-mode
+++ b/changelog/fix-e2e-multicurrency-widget-strict-mode
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Fix flaky multi-currency widget E2E setup: scope the post-insert wait to the canvas edit-form title so it no longer matches the block-inspector card and trips Playwright strict mode.
+Fix flaky multi-currency widget E2E setup: scope the post-insert wait to the inserted legacy-widget block so it no longer also matches the block-inspector card and trips Playwright strict mode.

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -160,8 +160,13 @@ export const addMulticurrencyWidget = async (
 				.locator( `[data-title="${ widgetName }"]` )
 				.waitFor( { timeout: 5000 } );
 		} else {
+			// Scope to the canvas edit-form title only. A bare heading match also
+			// matches the block-inspector card name, which renders the same text and
+			// trips Playwright strict mode intermittently (race between the two).
 			await page
-				.getByRole( 'heading', { name: widgetName } )
+				.locator( '.wp-block-legacy-widget__edit-form-title', {
+					hasText: widgetName,
+				} )
 				.waitFor( { timeout: 5000 } );
 		}
 		// Give the widgets editor a moment to register the inserted block before saving.

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -160,13 +160,13 @@ export const addMulticurrencyWidget = async (
 				.locator( `[data-title="${ widgetName }"]` )
 				.waitFor( { timeout: 5000 } );
 		} else {
-			// Scope to the canvas edit-form title only. A bare heading match also
-			// matches the block-inspector card name, which renders the same text and
-			// trips Playwright strict mode intermittently (race between the two).
+			// Scope the heading to the inserted block by its (locale-independent)
+			// block type. A bare heading match also matches the block-inspector
+			// card name, which renders the same text and trips Playwright strict
+			// mode intermittently (race between the two).
 			await page
-				.locator( '.wp-block-legacy-widget__edit-form-title', {
-					hasText: widgetName,
-				} )
+				.locator( '[data-type="core/legacy-widget"]' )
+				.getByRole( 'heading', { name: widgetName } )
 				.waitFor( { timeout: 5000 } );
 		}
 		// Give the widgets editor a moment to register the inserted block before saving.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

E2E runs report a recurring flaky test:
`shopper-multi-currency-widget.spec.ts › should display currency switcher widget if multi-currency is enabled` (e.g. [run 27460164951](https://github.com/Automattic/woocommerce-payments/actions/runs/27460164951)). The job stays green (it passes on Playwright's retry) but logs as flaky on nearly every shopper job.

The failure is not in that test. It originates in the `beforeAll` hook's `addMulticurrencyWidget` helper, and Playwright attributes a `beforeAll` failure to the first test in the `describe` block. The helper waited for the inserted legacy widget by accessible heading name:

```
getByRole( 'heading', { name: 'Currency Switcher Widget' } ).waitFor()
```

That name renders in two places once the block is inserted: the canvas edit-form title and the block-inspector card (in the "Widgets settings" sidebar). When both are present, the locator matches two elements and Playwright strict mode throws. The real trigger is whether the block-settings sidebar is open during insertion — which is why it flaked across every WC/WP matrix combo, not one version.

This PR scopes the heading to the inserted block by its registered block type, `[data-type="core/legacy-widget"]`. The block type is part of Gutenberg's data model (not presentation), locale-independent, and stable across WP/Gutenberg versions, and it excludes the inspector card.

#### Testing instructions

Verified locally by reproducing the exact failure condition (block-settings sidebar open during insertion) and confirming the before/after on the real widgets DOM:
- OLD `getByRole('heading', { name })` -> matches 2 -> `.waitFor()` throws the strict-mode violation.
- NEW `[data-type="core/legacy-widget"].getByRole('heading', { name })` -> matches 1 -> resolves.
- The real `addMulticurrencyWidget` helper completes cleanly with the sidebar open using the new selector.

> Note: local E2E on `develop` currently fails at browser launch because `tests/e2e/docker-compose.yml` pins the Playwright image to `v1.51.1-jammy` while `@playwright/test` is `1.59.1`. Unrelated to this PR; worth a separate 1-line bump.

-------------------

- [x] Run `npm run changelog` to add a changelog file (added: `dev` / `patch`).
- [x] Covered with tests (fix to existing E2E coverage; exercised by the multi-currency specs).
- [x] Tested on mobile (does not apply: test infrastructure only).

**Post merge**

- [ ] QA Testing Not Applicable (test-infrastructure change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)