### PR TITLE
Enable multi-currency cache-optimized rendering mode by default

### DIFF
--- a/changelog/enable-mc-cache-optimized-by-default
+++ b/changelog/enable-mc-cache-optimized-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable the multi-currency cache-optimized rendering mode feature by default

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -388,12 +388,12 @@ class WC_Payments_Features {
 	}
 
 	/**
-	 * Checks whether the multi-currency cache-optimized rendering mode is enabled.
+	 * Checks whether the multi-currency cache-optimized rendering mode is enabled. Enabled by default.
 	 *
 	 * @return bool
 	 */
 	public static function is_mc_cache_optimized_enabled(): bool {
-		return '1' === get_option( self::MC_CACHE_OPTIMIZED_FLAG_NAME, '0' );
+		return '1' === get_option( self::MC_CACHE_OPTIMIZED_FLAG_NAME, '1' );
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -103,6 +103,15 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Features::is_customer_multi_currency_enabled() );
 	}
 
+	public function test_is_mc_cache_optimized_enabled_by_default() {
+		$this->assertTrue( WC_Payments_Features::is_mc_cache_optimized_enabled() );
+	}
+
+	public function test_is_mc_cache_optimized_can_be_disabled() {
+		$this->set_feature_flag_option( WC_Payments_Features::MC_CACHE_OPTIMIZED_FLAG_NAME, '0' );
+		$this->assertFalse( WC_Payments_Features::is_mc_cache_optimized_enabled() );
+	}
+
 	public function test_is_dispute_additional_evidence_types_enabled_by_default() {
 		$this->assertTrue( WC_Payments_Features::is_dispute_additional_evidence_types_enabled() );
 	}


### PR DESCRIPTION
Resolves [WOOPMNT-6013](https://linear.app/a8c/issue/WOOPMNT-6013/turn-on-feature-flag-by-default)

#### Changes proposed in this Pull Request

Flips the `_wcpay_feature_mc_cache_optimized` feature flag default from **off** to **on**, enabling the multi-currency cache-optimized rendering mode by default.

Auto-detecting the caching environment to recommend/enable the mode (WOOPMNT-6025) is intentionally a **follow-up**, not part of this release.

#### Testing instructions

1. On a fresh site with WooPayments + Multi-Currency enabled and **no** `_wcpay_feature_mc_cache_optimized` option set, go to **Payments → Multi-currency settings**.
2. Confirm the **rendering mode** option (Speed vs Cache) is now visible by default.
3. Confirm the store still renders prices server-side ("speed") — i.e. switching currency converts as before, since `rendering_mode` defaults to `'speed'`.
4. Switch the rendering mode to **Cache**, visit the shop/category/product pages, and confirm client-side async price rendering works (prices populate from the REST rates endpoint, pages are cacheable).
5. Set `_wcpay_feature_mc_cache_optimized` to `0` (e.g. `wp option update _wcpay_feature_mc_cache_optimized 0`) and confirm the toggle disappears and behavior reverts to server-side only.

-------------------

- [x] Run `npm run changelog` to add a changelog file — `changelog/enable-mc-cache-optimized-by-default` (`add` / `minor`).
- [x] Covered with tests
- [x] Tested on mobile (or does not apply) — N/A, backend default flip

**Post merge**

- [ ] Link to testing instructions from release testing doc: _QA Testing Not Applicable / Add link here_
