### PR TITLE
fix: resolve WooCommerce.Commenting phpcs errors in straggler test files

### DIFF
--- a/changelog/fix-wc-commenting-stragglers-tests
+++ b/changelog/fix-wc-commenting-stragglers-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: fix: resolve WooCommerce.Commenting phpcs hook comment errors in test files added after the #8437 sweep (not user-facing).
+
+

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -571,7 +571,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->init_multi_currency();
 
 		// Simulate an active session (e.g. after add-to-cart) by setting the session cookie.
-		$cookie_name             = apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH );
+		$cookie_name             = apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
 		$_COOKIE[ $cookie_name ] = 'test-session-id';
 
 		try {

--- a/tests/unit/src/Internal/LoggerContextTest.php
+++ b/tests/unit/src/Internal/LoggerContextTest.php
@@ -47,7 +47,7 @@ class LoggerContextTest extends WCPAY_UnitTestCase {
 		$message    = "Test log entry...\non two lines";
 		$level      = WC_Log_Levels::INFO;
 
-		$filtered_entry = apply_filters(
+		$filtered_entry = apply_filters( // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			'woocommerce_format_log_entry',
 			$message,
 			[
@@ -117,7 +117,7 @@ class LoggerContextTest extends WCPAY_UnitTestCase {
 
 		$this->sut->set_value( 'foo', 'bar' );
 
-		$filtered_entry = apply_filters(
+		$filtered_entry = apply_filters( // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			'woocommerce_format_log_entry',
 			$message,
 			[
@@ -130,7 +130,7 @@ class LoggerContextTest extends WCPAY_UnitTestCase {
 
 		$this->assertSame( $message, $filtered_entry, 'Filtered entry is the same as the original message' );
 
-		$filtered_entry = apply_filters(
+		$filtered_entry = apply_filters( // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			'woocommerce_format_log_entry',
 			$message,
 			[

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -2675,7 +2675,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 			[ 'is_changing_payment_method_for_subscription' => true ]
 		);
 
-		do_action( 'shutdown' );
+		do_action( 'shutdown' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 		$this->assertSame( 'cus_existing', $customer_id );
 	}
@@ -2700,7 +2700,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$manage->setAccessible( true );
 		$manage->invoke( $this->card_gateway, $order, [] );
 
-		do_action( 'shutdown' );
+		do_action( 'shutdown' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 	}
 
 	public function test_add_payment_method_no_intent() {

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -361,16 +361,16 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->assertStringContainsString(
 			'[Test]',
-			apply_filters( 'woocommerce_email_subject_new_order', '[Apparel Clothing]: New order #1811', $this->order )
+			apply_filters( 'woocommerce_email_subject_new_order', '[Apparel Clothing]: New order #1811', $this->order ) // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		);
 		$this->assertStringContainsString(
 			'[Test]',
-			apply_filters( 'woocommerce_email_heading_new_order', 'New order: #1811', $this->order )
+			apply_filters( 'woocommerce_email_heading_new_order', 'New order: #1811', $this->order ) // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		);
 		// Paid-invoice variant: the dominant path for invoice resends on WooPayments orders.
 		$this->assertStringContainsString(
 			'[Test]',
-			apply_filters( 'woocommerce_email_subject_customer_invoice_paid', 'Invoice for order #1811', $this->order )
+			apply_filters( 'woocommerce_email_subject_customer_invoice_paid', 'Invoice for order #1811', $this->order ) // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		);
 	}
 

--- a/tests/unit/test-class-wc-payments-payment-request-session-handler.php
+++ b/tests/unit/test-class-wc-payments-payment-request-session-handler.php
@@ -110,7 +110,7 @@ class WC_Payments_Payment_Request_Session_Handler_Test extends WCPAY_UnitTestCas
 		$this->assertArrayNotHasKey( 'wp_woocommerce_session_' . COOKIEHASH, $this->cookies_jar );
 
 		$session_handler->save_data();
-		do_action( 'woocommerce_set_cart_cookies', true );
+		do_action( 'woocommerce_set_cart_cookies', true ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 		$session_data = $wpdb->get_row(
 			$wpdb->prepare(
@@ -154,7 +154,7 @@ class WC_Payments_Payment_Request_Session_Handler_Test extends WCPAY_UnitTestCas
 		$this->assertArrayNotHasKey( 'wp_woocommerce_session_' . COOKIEHASH, $this->cookies_jar );
 
 		$session_handler->save_data();
-		do_action( 'woocommerce_set_cart_cookies', true );
+		do_action( 'woocommerce_set_cart_cookies', true ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 		$session_data = $wpdb->get_row(
 			$wpdb->prepare(

--- a/tests/unit/test-class-wc-payments-payment-request-session.php
+++ b/tests/unit/test-class-wc-payments-payment-request-session.php
@@ -58,9 +58,9 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 
 		$response = rest_do_request( $request );
 		// manually calling 'rest_post_dispatch' because it is not called within the context of unit tests.
-		$response = apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
+		$response = apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
 
-		$this->assertSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) );
+		$this->assertSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertIsString( $response->get_headers()['X-WooPayments-Tokenized-Cart-Session'] );
 	}
 
@@ -81,9 +81,9 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 
 		$response = rest_do_request( $request );
 		// manually calling 'rest_post_dispatch' because it is not called within the context of unit tests.
-		$response = apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
+		$response = apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
 
-		$this->assertNotSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) );
+		$this->assertNotSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$this->assertNotContains( 'X-WooPayments-Tokenized-Cart-Session', array_keys( $response->get_headers() ) );
 	}
 
@@ -99,7 +99,7 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 		$session = new WC_Payments_Payment_Request_Session();
 		$session->init();
 
-		$this->assertNotSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) );
+		$this->assertNotSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 	}
 
 	public function test_uses_custom_session_handler() {
@@ -124,7 +124,7 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 
 		rest_do_request( $request );
 
-		$this->assertSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) );
+		$this->assertSame( WC_Payments_Payment_Request_Session_Handler::class, apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 
 		$this->assertInstanceOf( WC_Payments_Payment_Request_Session_Handler::class, WC()->session );
 		// cart contents are not cleared.
@@ -154,7 +154,7 @@ class WC_Payments_Payment_Request_Session_Test extends WCPAY_UnitTestCase {
 
 		$response = rest_do_request( $request );
 		// manually calling 'rest_post_dispatch' because it is not called within the context of unit tests.
-		apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
+		apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
 
 		// cart contents are cleared, because the `X-WooPayments-Tokenized-Cart-Is-Ephemeral-Cart` header has been provided.
 		$this->assertCount( 0, WC()->cart->cart_contents );


### PR DESCRIPTION
Follow-up to #8437.

#### Changes proposed in this Pull Request

While preparing to remove the `WooCommerce.Commenting` excludes from `phpcs.xml.dist`, I noticed a batch of hook calls that landed after the original #8437 sweep and aren't covered by it yet. Splitting the cleanup into smaller PRs by area; this one is the test files.

All test files, so they get inline `phpcs:ignore` on the `apply_filters`/`do_action` calls rather than hook docblocks, same as the test files in #10126:

* `tests/unit/test-class-wc-payments-payment-request-session.php`
* `tests/unit/test-class-wc-payments-payment-request-session-handler.php`
* `tests/unit/test-class-wc-payments-order-service.php`
* `tests/unit/test-class-wc-payment-gateway-wcpay.php`
* `tests/unit/src/Internal/LoggerContextTest.php`
* `tests/unit/multi-currency/test-class-multi-currency.php`

Leaving the `WooCommerce.Commenting` exclude in `phpcs.xml.dist` in place until the email-template and production stragglers are done too.

#### Testing instructions

1. Remove the `WooCommerce.Commenting.CommentHooks.*` excludes from `phpcs.xml.dist`.
2. Run `./vendor/bin/phpcs --standard=phpcs.xml.dist` on the files above.
3. There should be no errors.

-------------------

- [x] Run `npm run changelog` to add a changelog file: **N/A** — non-user-facing, added a `Comment:` entry.
- [x] Covered with tests (or have a good reason not to test ☝️): **N/A**
- [x] Tested on mobile (or does not apply): **N/A**
