### PR TITLE
fix: restore Payments Overview card spacing after route code splitting

### DIFF
--- a/changelog/fix-overview-card-spacing-regression
+++ b/changelog/fix-overview-card-spacing-regression
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Payments Overview cards rendering with no spacing between them after admin route code splitting

--- a/changelog/fix-overview-card-spacing-regression
+++ b/changelog/fix-overview-card-spacing-regression
@@ -1,4 +1,3 @@
 Significance: patch
-Type: fix
-
-Fix Payments Overview cards rendering with no spacing between them after admin route code splitting
+Type: dev
+Comment: fix: restore Payments Overview card spacing lost to the unreleased route code-splitting in #11776 (not user-facing).

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -4,10 +4,6 @@
 	.components-card__header {
 		font-size: 20px;
 	}
-
-	.components-card {
-		margin-bottom: 24px;
-	}
 }
 
 .payment-details-summary {

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -1,11 +1,5 @@
 /** @format */
 
-.woocommerce-payments-page {
-	.components-card__header {
-		font-size: 20px;
-	}
-}
-
 .payment-details-summary {
 	display: flex;
 	flex: 1;

--- a/client/style.scss
+++ b/client/style.scss
@@ -11,6 +11,16 @@
 }
 
 .woocommerce-payments-page {
+	// `@wordpress/components` Card ships with no margin, so this is the only
+	// thing spacing stacked cards apart across every WooPayments admin screen
+	// (the overview, payment details, disputes, etc.). It must live in this
+	// always-loaded global stylesheet rather than a route-specific one — when
+	// it sat in payment-details, route code splitting kept it out of the
+	// overview chunk and the cards collapsed flush against each other.
+	.components-card {
+		margin-bottom: 24px;
+	}
+
 	.components-card__body {
 		> *:first-child {
 			margin-top: 0;

--- a/client/style.scss
+++ b/client/style.scss
@@ -11,14 +11,20 @@
 }
 
 .woocommerce-payments-page {
-	// `@wordpress/components` Card ships with no margin, so this is the only
-	// thing spacing stacked cards apart across every WooPayments admin screen
-	// (the overview, payment details, disputes, etc.). It must live in this
-	// always-loaded global stylesheet rather than a route-specific one — when
-	// it sat in payment-details, route code splitting kept it out of the
-	// overview chunk and the cards collapsed flush against each other.
+	// Global card styling for every WooPayments admin screen (overview,
+	// payment details, disputes, etc.): `@wordpress/components` Card ships with
+	// no margin and a small default header, so these rules are the only thing
+	// giving stacked cards their gap and their larger title. They must live in
+	// this always-loaded global stylesheet rather than a route-specific one —
+	// while they sat in payment-details, route code splitting kept them out of
+	// the overview chunk, so its cards collapsed flush and lost their header
+	// size.
 	.components-card {
 		margin-bottom: 24px;
+	}
+
+	.components-card__header {
+		font-size: 20px;
 	}
 
 	.components-card__body {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed the Overview cards lost their spacing after the route code-splitting in #11776 .

<img width="743" height="1144" alt="Screenshot 2026-06-16 at 11 53 37 AM" src="https://github.com/user-attachments/assets/6c77eb0b-6368-4a6f-a23a-a1314d4784db" />

The 24px inter-card gap relied on a global `.woocommerce-payments-page .components-card` rule that happened to live in `payment-details/summary/style.scss`. Back when everything was one bundle it leaked onto every page; now that payment-details is its own chunk, the Overview doesn't get it.

Moving it to `client/style.scss`, which is always loaded. Fixing.

Same file had a sibling global — `.components-card__header { font-size: 20px }` — broken the same way (Overview card titles fell back to the default size). Moving that too.

<img width="760" height="1140" alt="Screenshot 2026-06-16 at 12 03 44 PM" src="https://github.com/user-attachments/assets/03240c6a-93ad-47bf-8f2c-d011677d48ec" />


#### Testing instructions

1. Navigate to **Payments → Overview**.
2. Confirm the Balance / Payouts / Account details cards are spaced apart again, not flush, and the card titles render at the larger size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
