### PR TITLE
Scope WooPayments repo access with branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Changes to this repository require review from a designated Code Owner
+# before they can land on a protected branch.
+# Refs WOOPMNT-6229
+* @Automattic/chronos @Automattic/gamma @Automattic/moltres @rtio

--- a/.github/workflows/branch-protection-alert.yml
+++ b/.github/workflows/branch-protection-alert.yml
@@ -1,0 +1,54 @@
+name: Branch protection change alert
+
+# Fires on any change to a classic branch-protection rule in this repo.
+# The default branch (develop) hosts this workflow, so it is the version
+# that runs for branch_protection_rule events. Refs WOOPMNT-6229.
+on:
+  branch_protection_rule:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+
+jobs:
+  alert:
+    name: Notify Slack of branch protection change
+    # Only the upstream repo carries the webhook secret; skip on forks so the
+    # absence of the secret doesn't surface as a misleading failed run.
+    if: github.repository == 'Automattic/woocommerce-payments'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack ping
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
+        with:
+          webhook: ${{ secrets.BRANCH_PROTECTION_ALERT_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":lock: Branch protection changed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Repository:*\n${{ github.repository }}" },
+                    { "type": "mrkdwn", "text": "*Action:*\n${{ github.event.action }}" },
+                    { "type": "mrkdwn", "text": "*Branch rule:*\n${{ github.event.rule.name }}" },
+                    { "type": "mrkdwn", "text": "*Changed by:*\n${{ github.event.sender.login }}" }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<https://github.com/${{ github.repository }}/settings/branches|Review branch protection settings>"
+                  }
+                }
+              ]
+            }

--- a/changelog/add-woopmnt-6229-branch-protection
+++ b/changelog/add-woopmnt-6229-branch-protection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Scope WooPayments repo access with branch protection: add CODEOWNERS and a branch-protection-change Slack alert workflow. CI/governance only, not user-facing. Refs WOOPMNT-6229.
+
+


### PR DESCRIPTION
## Summary

Adds the repository artifacts for scoping who can land changes on protected branches (`develop`, `trunk`):

- `.github/CODEOWNERS` — catch-all designated Code Owners (chronos, gamma, moltres teams + @rtio); any one owner satisfies the gate.
- `.github/workflows/branch-protection-alert.yml` — event-driven Slack alert (`branch_protection_rule`) to an internal channel on any protection change.

Refs WOOPMNT-6229

## Testing instructions

1. `gh api "repos/Automattic/woocommerce-payments/codeowners/errors?ref=add/woopmnt-6229-branch-protection"` returns `[]`.
2. CI is green and the changelog check is skipped (changes are all under `.github/`).
3. Post-merge steps (branch-protection settings, alert smoke-test) tracked in the internal plan / Field Guide runbook.