### PR TITLE
fix: security hardening for dispute evidence abilities and fraud token (WOOPMNT-6235)

### DIFF
--- a/changelog/agent-woopmnt-6235
+++ b/changelog/agent-woopmnt-6235
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Security hardening for dispute evidence abilities and fraud prevention token handling

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1216,8 +1216,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			 */
 			if ( WC()->session && ! apply_filters( 'wcpay_is_woopay_store_api_request', false ) ) {
 				$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				if ( $fraud_prevention_service->is_enabled() && ! $fraud_prevention_service->verify_token( $_POST['wcpay-fraud-prevention-token'] ?? null ) ) {
+				$fraud_token              = isset( $_POST['wcpay-fraud-prevention-token'] ) ? wc_clean( wp_unslash( $_POST['wcpay-fraud-prevention-token'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				if ( $fraud_prevention_service->is_enabled() && ! $fraud_prevention_service->verify_token( $fraud_token ) ) {
 					throw new Fraud_Prevention_Enabled_Exception(
 						__( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-payments' ),
 						'fraud_prevention_enabled'
@@ -4414,8 +4414,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 			if ( WC()->session ) {
 				$fraud_prevention_service = Fraud_Prevention_Service::get_instance();
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				if ( $fraud_prevention_service->is_enabled() && ! $fraud_prevention_service->verify_token( $_POST['wcpay-fraud-prevention-token'] ?? null ) ) {
+				$fraud_token              = isset( $_POST['wcpay-fraud-prevention-token'] ) ? wc_clean( wp_unslash( $_POST['wcpay-fraud-prevention-token'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				if ( $fraud_prevention_service->is_enabled() && ! $fraud_prevention_service->verify_token( $fraud_token ) ) {
 					throw new Fraud_Prevention_Enabled_Exception(
 						__( "We're not able to add this payment method. Please refresh the page and try again.", 'woocommerce-payments' ),
 						'fraud_prevention_enabled'

--- a/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
+++ b/src/Internal/Abilities/Domain/SubmitDisputeEvidence.php
@@ -113,8 +113,10 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 						'description' => __( 'Whether to submit to the card network (irreversible). Default false stages a draft.', 'woocommerce-payments' ),
 					],
 					'metadata'   => [
-						'type'        => 'object',
-						'description' => __( 'Optional metadata to attach to the dispute.', 'woocommerce-payments' ),
+						'type'                 => 'object',
+						'description'          => __( 'Optional metadata to attach to the dispute. Maximum 10 keys; keys up to 40 characters; values up to 500 characters.', 'woocommerce-payments' ),
+						'additionalProperties' => [ 'type' => 'string' ],
+						'maxProperties'        => 10,
 					],
 				],
 				'additionalProperties' => false,
@@ -153,6 +155,19 @@ class SubmitDisputeEvidence extends AbstractWCPayAbility implements AbilityDefin
 		$evidence   = ( isset( $input['evidence'] ) && is_array( $input['evidence'] ) ) ? $input['evidence'] : [];
 		$submit     = true === ( $input['submit'] ?? false );
 		$metadata   = ( isset( $input['metadata'] ) && is_array( $input['metadata'] ) ) ? $input['metadata'] : [];
+
+		if ( count( $metadata ) > 10 ) {
+			return new \WP_Error( 'wcpay_too_many_metadata_keys', __( 'Metadata may not contain more than 10 keys.', 'woocommerce-payments' ) );
+		}
+
+		foreach ( $metadata as $key => $value ) {
+			if ( ! is_string( $key ) || strlen( $key ) > 40 ) {
+				return new \WP_Error( 'wcpay_invalid_metadata_key', __( 'Metadata keys must be strings of 40 characters or fewer.', 'woocommerce-payments' ) );
+			}
+			if ( ! is_string( $value ) || strlen( $value ) > 500 ) {
+				return new \WP_Error( 'wcpay_invalid_metadata_value', __( 'Metadata values must be strings of 500 characters or fewer.', 'woocommerce-payments' ) );
+			}
+		}
 
 		return self::get_dispute_service()->submit_evidence( $dispute_id, $evidence, $submit, $metadata );
 	}

--- a/src/Internal/Abilities/Domain/UploadDisputeEvidenceFile.php
+++ b/src/Internal/Abilities/Domain/UploadDisputeEvidenceFile.php
@@ -116,7 +116,7 @@ class UploadDisputeEvidenceFile extends AbstractWCPayAbility implements AbilityD
 			$input = [];
 		}
 
-		$file_name     = ( isset( $input['file_name'] ) && is_string( $input['file_name'] ) ) ? $input['file_name'] : '';
+		$file_name     = ( isset( $input['file_name'] ) && is_string( $input['file_name'] ) ) ? sanitize_file_name( $input['file_name'] ) : '';
 		$file_type     = ( isset( $input['file_type'] ) && is_string( $input['file_type'] ) ) ? $input['file_type'] : '';
 		$file_contents = ( isset( $input['file_contents'] ) && is_string( $input['file_contents'] ) ) ? $input['file_contents'] : '';
 

--- a/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/SubmitDisputeEvidenceTest.php
@@ -43,6 +43,43 @@ class SubmitDisputeEvidenceTest extends WCPAY_UnitTestCase {
 		$this->assertSame( 'wcpay_missing_dispute_id', $result->get_error_code() );
 	}
 
+	public function test_execute_returns_error_when_metadata_key_too_long(): void {
+		$result = SubmitDisputeEvidence::execute(
+			[
+				'dispute_id' => 'du_1',
+				'metadata'   => [ str_repeat( 'k', 41 ) => 'value' ],
+			]
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_invalid_metadata_key', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_metadata_value_too_long(): void {
+		$result = SubmitDisputeEvidence::execute(
+			[
+				'dispute_id' => 'du_1',
+				'metadata'   => [ 'key' => str_repeat( 'v', 501 ) ],
+			]
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_invalid_metadata_value', $result->get_error_code() );
+	}
+
+	public function test_execute_returns_error_when_too_many_metadata_keys(): void {
+		$metadata = [];
+		for ( $i = 0; $i < 11; $i++ ) {
+			$metadata[ 'key' . $i ] = 'value';
+		}
+		$result = SubmitDisputeEvidence::execute(
+			[
+				'dispute_id' => 'du_1',
+				'metadata'   => $metadata,
+			]
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wcpay_too_many_metadata_keys', $result->get_error_code() );
+	}
+
 	public function test_execute_delegates_to_dispute_service(): void {
 		$evidence     = [ 'customer_communication' => 'file_1' ];
 		$metadata     = [ 'k' => 'v' ];

--- a/tests/unit/src/Internal/Abilities/Domain/UploadDisputeEvidenceFileTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/UploadDisputeEvidenceFileTest.php
@@ -90,7 +90,7 @@ class UploadDisputeEvidenceFileTest extends WCPAY_UnitTestCase {
 		$contents     = base64_encode( 'file-bytes' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		$mock_service = $this->createMock( FileService::class );
 		$mock_service->expects( $this->once() )->method( 'upload_evidence_file' )
-			->with( $contents, '....evil.pdf', 'application/pdf', 'dispute_evidence' )
+			->with( $contents, 'evil.pdf', 'application/pdf', 'dispute_evidence' )
 			->willReturn( [ 'id' => 'file_1' ] );
 		wcpay_get_test_container()->replace( FileService::class, $mock_service );
 		try {

--- a/tests/unit/src/Internal/Abilities/Domain/UploadDisputeEvidenceFileTest.php
+++ b/tests/unit/src/Internal/Abilities/Domain/UploadDisputeEvidenceFileTest.php
@@ -86,6 +86,26 @@ class UploadDisputeEvidenceFileTest extends WCPAY_UnitTestCase {
 		$this->assertSame( 'wcpay_file_too_large', $result->get_error_code() );
 	}
 
+	public function test_execute_sanitizes_file_name_path_traversal(): void {
+		$contents     = base64_encode( 'file-bytes' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$mock_service = $this->createMock( FileService::class );
+		$mock_service->expects( $this->once() )->method( 'upload_evidence_file' )
+			->with( $contents, '....evil.pdf', 'application/pdf', 'dispute_evidence' )
+			->willReturn( [ 'id' => 'file_1' ] );
+		wcpay_get_test_container()->replace( FileService::class, $mock_service );
+		try {
+			UploadDisputeEvidenceFile::execute(
+				[
+					'file_name'     => '../../evil.pdf',
+					'file_type'     => 'application/pdf',
+					'file_contents' => $contents,
+				]
+			);
+		} finally {
+			wcpay_get_test_container()->reset_all_replacements();
+		}
+	}
+
 	public function test_execute_delegates_to_file_service(): void {
 		$contents     = base64_encode( 'file-bytes' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		$mock_service = $this->createMock( FileService::class );


### PR DESCRIPTION
Fixes WOOPMNT-6235

#### Changes proposed in this Pull Request

See  WOOPMNT-6235

#### Testing instructions

* Mostly rely on PHPUnit tests. 

---

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-instructions) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)