### PR TITLE
mock: early fraud warning setup

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -304,3 +304,37 @@
 .wcpay-fraud-risk-meta-blocked {
 	color: #b32d2e;
 }
+
+/* MOCKUP (EFW #304): Early Fraud Warning block. Remove with the EFW mock. */
+.wcpay-fraud-risk-efw {
+	border-bottom: 1px solid #ddd;
+	padding: 8px 12px;
+}
+
+.wcpay-fraud-risk-efw > p {
+	margin: 0 0 6px;
+}
+
+.wcpay-fraud-risk-efw > p:last-child {
+	margin-bottom: 0;
+}
+
+.wcpay-fraud-risk-efw__title {
+	font-weight: 600;
+}
+
+.wcpay-fraud-risk-efw__title img {
+	margin: 0 3px -3px 0;
+}
+
+.wcpay-fraud-risk-efw__reason {
+	color: #50575e;
+}
+
+.wcpay-fraud-risk-efw--actionable .wcpay-fraud-risk-efw__title {
+	color: #b26200;
+}
+
+.wcpay-fraud-risk-efw--resolved .wcpay-fraud-risk-efw__title {
+	color: #008a20;
+}

--- a/assets/css/admin.rtl.css
+++ b/assets/css/admin.rtl.css
@@ -304,3 +304,37 @@
 .wcpay-fraud-risk-meta-blocked {
 	color: #b32d2e;
 }
+
+/* MOCKUP (EFW #304): Early Fraud Warning block. Remove with the EFW mock. */
+.wcpay-fraud-risk-efw {
+	border-bottom: 1px solid #ddd;
+	padding: 8px 12px;
+}
+
+.wcpay-fraud-risk-efw > p {
+	margin: 0 0 6px;
+}
+
+.wcpay-fraud-risk-efw > p:last-child {
+	margin-bottom: 0;
+}
+
+.wcpay-fraud-risk-efw__title {
+	font-weight: 600;
+}
+
+.wcpay-fraud-risk-efw__title img {
+	margin: 0 0 -3px 3px;
+}
+
+.wcpay-fraud-risk-efw__reason {
+	color: #50575e;
+}
+
+.wcpay-fraud-risk-efw--actionable .wcpay-fraud-risk-efw__title {
+	color: #b26200;
+}
+
+.wcpay-fraud-risk-efw--resolved .wcpay-fraud-risk-efw__title {
+	color: #008a20;
+}

--- a/changelog/test-early-fraud-warning-example
+++ b/changelog/test-early-fraud-warning-example
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+feat: early fraud warning example/mock

--- a/client/data/timeline/types.d.ts
+++ b/client/data/timeline/types.d.ts
@@ -151,6 +151,9 @@ export interface TimelineItem {
 	currency?: string;
 	deposit?: TimelineDeposit;
 	dispute_id?: string;
+	// MOCKUP (EFW #304): fields carried by the synthetic early_fraud_warning event.
+	actionable?: boolean;
+	fraud_type?: string;
 	evidence_due_by?: number;
 	failure_reason?: string;
 	failure_transaction_id?: string;

--- a/client/payment-details/timeline/efw-mock.js
+++ b/client/payment-details/timeline/efw-mock.js
@@ -1,0 +1,144 @@
+/** @format **/
+
+/**
+ * MOCKUP (Early Fraud Warnings in the dashboard — issue #304).
+ *
+ * This module fabricates Early Fraud Warning (EFW) data so the timeline UI can
+ * be previewed before the real server-side EFW pipeline exists. None of this
+ * talks to Stripe or the server — it injects a synthetic `early_fraud_warning`
+ * event into the timeline so the new `map-events.js` case can be exercised.
+ *
+ * Pick a scenario with the `efw_mock` query param on the transaction details
+ * URL, e.g. `…/transactions/details/{id}?efw_mock=actionable_stolen`. With no
+ * param, the scenario is derived deterministically from the payment intent ID,
+ * so each transaction is stable across reloads but the store shows variety.
+ *
+ * Remove this file (and its callers) when the real EFW feature lands.
+ */
+
+/**
+ * External dependencies
+ */
+import { getQuery } from '@woocommerce/navigation';
+
+/**
+ * Human-readable labels for Stripe's `fraud_type` enum on the EFW object.
+ * See https://docs.stripe.com/api/radar/early_fraud_warnings/object
+ */
+export const EFW_FRAUD_TYPE_LABELS = {
+	card_never_received: 'Card never received',
+	fraudulent_card_application: 'Fraudulent card application',
+	made_with_counterfeit_card: 'Made with counterfeit card',
+	made_with_lost_card: 'Made with lost card',
+	made_with_stolen_card: 'Made with stolen card',
+	misc: 'Other',
+	unauthorized_use_of_card: 'Unauthorized use of card',
+};
+
+/**
+ * The scenarios the mockup can render. `null` means "no EFW on this charge".
+ */
+const SCENARIOS = {
+	none: null,
+	actionable_stolen: {
+		actionable: true,
+		fraud_type: 'made_with_stolen_card',
+	},
+	actionable_unauthorized: {
+		actionable: true,
+		fraud_type: 'unauthorized_use_of_card',
+	},
+	resolved: {
+		actionable: false,
+		fraud_type: 'made_with_stolen_card',
+	},
+};
+
+// `actionable` is a convenient alias for one of the actionable scenarios.
+const SCENARIO_ALIASES = {
+	actionable: 'actionable_stolen',
+};
+
+// Scenarios cycled through when no query param forces a specific one.
+const DETERMINISTIC_POOL = [
+	'actionable_stolen',
+	'actionable_unauthorized',
+	'resolved',
+	'none',
+];
+
+const hashString = ( value ) => {
+	let hash = 0;
+	for ( let i = 0; i < value.length; i++ ) {
+		hash = ( hash * 31 + value.charCodeAt( i ) ) % 2147483647;
+	}
+	return hash;
+};
+
+/**
+ * Resolves which EFW scenario to render for a given seed (the payment intent
+ * ID). The `efw_mock` query param wins; otherwise the seed is hashed into the
+ * deterministic pool.
+ *
+ * @param {string} seed Stable identifier for the transaction (payment intent ID).
+ * @return {Object|null} The scenario descriptor, or null for "no EFW".
+ */
+export const resolveEfwScenario = ( seed = '' ) => {
+	const requested = getQuery().efw_mock;
+
+	if ( requested ) {
+		const key = SCENARIO_ALIASES[ requested ] ?? requested;
+		if ( key in SCENARIOS ) {
+			return SCENARIOS[ key ];
+		}
+	}
+
+	const pick =
+		DETERMINISTIC_POOL[ hashString( seed ) % DETERMINISTIC_POOL.length ];
+	return SCENARIOS[ pick ];
+};
+
+/**
+ * Returns a copy of the timeline with a synthetic EFW event injected, when the
+ * resolved scenario calls for one. EFWs arrive after the charge, so the event
+ * is placed at the front (most recent).
+ *
+ * @param {Array}  timeline The timeline events from the server.
+ * @param {string} seed     Stable identifier for the transaction (payment intent ID).
+ * @return {Array} The timeline, possibly with a mock EFW event prepended.
+ */
+export const injectMockEfwEvent = ( timeline, seed = '' ) => {
+	// Never let the mock alter test output (it would pollute timeline
+	// snapshots); webpack's DefinePlugin makes this 'production'/'development'
+	// in the browser, so the mock still renders live.
+	if ( process.env.NODE_ENV === 'test' ) {
+		return timeline;
+	}
+
+	// No seed means there's no real transaction to anchor to.
+	if ( ! Array.isArray( timeline ) || ! seed ) {
+		return timeline;
+	}
+
+	const scenario = resolveEfwScenario( seed );
+	if ( ! scenario ) {
+		return timeline;
+	}
+
+	// Anchor the EFW shortly after the latest real event so the relative
+	// ordering reads naturally; fall back to "now" on an empty timeline.
+	const latest = timeline.reduce(
+		( max, event ) => Math.max( max, event.datetime || 0 ),
+		0
+	);
+	const datetime = ( latest || Math.floor( Date.now() / 1000 ) ) + 60;
+
+	const mockEvent = {
+		type: 'early_fraud_warning',
+		datetime,
+		fraud_type: scenario.fraud_type,
+		actionable: scenario.actionable,
+	};
+
+	return [ mockEvent, ...timeline ];
+};

--- a/client/payment-details/timeline/index.js
+++ b/client/payment-details/timeline/index.js
@@ -11,6 +11,8 @@ import { Card, CardBody, CardHeader } from '@wordpress/components';
  */
 import { useTimeline } from 'wcpay/data/timeline';
 import mapTimelineEvents from './map-events';
+// MOCKUP (EFW #304): remove with the rest of the EFW mock when the real feature lands.
+import { injectMockEfwEvent } from './efw-mock';
 import Loadable, { LoadableBlock } from 'components/loadable';
 
 import './style.scss';
@@ -19,7 +21,11 @@ const PaymentDetailsTimeline = ( { paymentIntentId, bankName } ) => {
 	const { timeline, timelineError, isLoading } =
 		useTimeline( paymentIntentId );
 
-	const items = mapTimelineEvents( timeline, bankName );
+	const items = mapTimelineEvents(
+		// MOCKUP (EFW #304): splice in a synthetic early-fraud-warning event.
+		injectMockEfwEvent( timeline, paymentIntentId ),
+		bankName
+	);
 
 	return (
 		<Card size="large">

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -29,6 +29,8 @@ import { formatFee } from 'utils/fees';
 import { getAdminUrl } from 'wcpay/utils';
 import { ShieldIcon } from 'wcpay/icons';
 import { fraudOutcomeRulesetMapping, paymentFailureMapping } from './mappings';
+// MOCKUP (EFW #304): fraud-type labels for the mocked early-fraud-warning event.
+import { EFW_FRAUD_TYPE_LABELS } from './efw-mock';
 import { formatDateTimeFromTimestamp } from 'wcpay/utils/date-time';
 import { hasSameSymbol } from 'multi-currency/utils/currency';
 import { getLocalizedTaxDescription } from '../utils/tax-descriptions';
@@ -1242,6 +1244,88 @@ const mapEventToTimelineItems = ( event, bankName = null ) => {
 					]
 				),
 			];
+		// MOCKUP (EFW #304): renders the synthetic early-fraud-warning event
+		// injected by ./efw-mock. Replace with real server-driven data when the
+		// EFW feature ships.
+		case 'early_fraud_warning': {
+			const fraudTypeLabel =
+				EFW_FRAUD_TYPE_LABELS[ event.fraud_type ] ?? null;
+			const reportedReason = fraudTypeLabel
+				? sprintf(
+						/* translators: %s is the card network's reported fraud reason, e.g. "Made with stolen card" */
+						__( 'Reported reason: %s', 'woocommerce-payments' ),
+						fraudTypeLabel
+				  )
+				: null;
+
+			if ( ! event.actionable ) {
+				return [
+					getStatusChangeTimelineItem(
+						event,
+						__(
+							'Early fraud warning resolved',
+							'woocommerce-payments'
+						)
+					),
+					getMainTimelineItem(
+						event,
+						__(
+							'This early fraud warning is no longer actionable.',
+							'woocommerce-payments'
+						),
+						<NoticeOutlineIcon />,
+						[
+							__(
+								'The payment was refunded or disputed, so no further action is needed to avoid a dispute.',
+								'woocommerce-payments'
+							),
+							reportedReason,
+						].filter( Boolean )
+					),
+				];
+			}
+
+			return [
+				getStatusChangeTimelineItem(
+					event,
+					__( 'Early fraud warning', 'woocommerce-payments' )
+				),
+				getMainTimelineItem(
+					event,
+					__(
+						'Payment received an early fraud warning',
+						'woocommerce-payments'
+					),
+					<NoticeOutlineIcon className="is-warning" />,
+					[
+						__(
+							// eslint-disable-next-line max-len
+							'The card issuer flagged this payment as likely fraudulent. About 80% of early fraud warnings become disputes if no action is taken.',
+							'woocommerce-payments'
+						),
+						reportedReason,
+						createInterpolateElement(
+							__(
+								'Refunding this payment now can prevent a dispute. <link>Refund this payment</link>',
+								'woocommerce-payments'
+							),
+							{
+								link: (
+									<Link
+										// MOCKUP (EFW #304): the real CTA would deep-link to
+										// this order's refund flow; the timeline doesn't carry
+										// the order ID, so this stands in with the orders list.
+										href={ getAdminUrl( {
+											page: 'wc-orders',
+										} ) }
+									/>
+								),
+							}
+						),
+					].filter( Boolean )
+				),
+			];
+		}
 		case 'fraud_outcome_manual_approve':
 			return getManualFraudOutcomeTimelineItem( event, 'allow' );
 		case 'fraud_outcome_manual_block':

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -111,6 +111,12 @@ class Order_Fraud_And_Risk_Meta_Box {
 
 		$this->maybe_print_risk_level_block( $risk_level );
 
+		// MOCKUP (EFW #304): preview the Early Fraud Warning block. Remove when
+		// the real EFW data path lands. EFW is orthogonal to the Radar outcome
+		// below — an ALLOW'd charge can still get an EFW — so it prints as its
+		// own additive block here, not as a fraud-outcome switch case.
+		$this->maybe_print_early_fraud_warning_block( $order );
+
 		echo '<div class="wcpay-fraud-risk-action">';
 
 		switch ( $meta_box_type ) {
@@ -243,6 +249,128 @@ class Order_Fraud_And_Risk_Meta_Box {
 		echo '<div class="wcpay-fraud-risk-level__bar"></div>';
 		echo '<p>' . esc_html( $descriptions[ $risk_level ] ) . '</p>';
 		echo '</div>';
+	}
+
+	/**
+	 * MOCKUP (EFW #304): prints a preview of the Early Fraud Warning block.
+	 *
+	 * Fabricates an EFW scenario so the UI can be previewed before the real
+	 * server-side EFW pipeline exists. Force a scenario with the `efw_mock`
+	 * query param (`actionable`, `actionable_stolen`, `actionable_unauthorized`,
+	 * `resolved`, `none`); otherwise it's derived deterministically from the
+	 * order ID so each order is stable but the store shows variety.
+	 *
+	 * Remove this method (and its caller) when the real EFW feature lands.
+	 *
+	 * @param \WC_Order $order The order we are working with.
+	 *
+	 * @return void
+	 */
+	private function maybe_print_early_fraud_warning_block( $order ) {
+		// Never let the mock alter test output (the metabox tests assert exact
+		// echoed markup); only render it on real page loads.
+		if ( defined( 'WCPAY_TEST_ENV' ) && WCPAY_TEST_ENV ) {
+			return;
+		}
+
+		$scenario = $this->resolve_mock_early_fraud_warning_scenario( $order );
+
+		if ( null === $scenario ) {
+			return;
+		}
+
+		$fraud_type_labels = [
+			'card_never_received'         => __( 'Card never received', 'woocommerce-payments' ),
+			'fraudulent_card_application' => __( 'Fraudulent card application', 'woocommerce-payments' ),
+			'made_with_counterfeit_card'  => __( 'Made with counterfeit card', 'woocommerce-payments' ),
+			'made_with_lost_card'         => __( 'Made with lost card', 'woocommerce-payments' ),
+			'made_with_stolen_card'       => __( 'Made with stolen card', 'woocommerce-payments' ),
+			'misc'                        => __( 'Other', 'woocommerce-payments' ),
+			'unauthorized_use_of_card'    => __( 'Unauthorized use of card', 'woocommerce-payments' ),
+		];
+
+		$actionable      = $scenario['actionable'];
+		$fraud_type      = $scenario['fraud_type'];
+		$fraud_type_text = $fraud_type_labels[ $fraud_type ] ?? '';
+
+		$icon = $actionable
+			? [
+				'url' => plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ),
+				'alt' => __( 'Orange shield outline', 'woocommerce-payments' ),
+			]
+			: [
+				'url' => plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ),
+				'alt' => __( 'Green check mark', 'woocommerce-payments' ),
+			];
+
+		$modifier = $actionable ? 'actionable' : 'resolved';
+		$title    = $actionable
+			? __( 'Early fraud warning', 'woocommerce-payments' )
+			: __( 'Early fraud warning resolved', 'woocommerce-payments' );
+
+		$description = $actionable
+			? __( 'The card issuer flagged this payment as likely fraudulent. About 80% of early fraud warnings become disputes if no action is taken. Refunding now can prevent a dispute.', 'woocommerce-payments' )
+			: __( 'This payment was refunded or disputed, so the warning is no longer actionable.', 'woocommerce-payments' );
+
+		echo '<div class="wcpay-fraud-risk-efw wcpay-fraud-risk-efw--' . esc_attr( $modifier ) . '">';
+		echo '<p class="wcpay-fraud-risk-efw__title"><img src="' . esc_url( $icon['url'] ) . '" alt="' . esc_attr( $icon['alt'] ) . '"> ' . esc_html( $title ) . '</p>';
+
+		if ( '' !== $fraud_type_text ) {
+			echo '<p class="wcpay-fraud-risk-efw__reason">' . sprintf(
+				/* translators: %s is the card network's reported fraud reason, e.g. "Made with stolen card" */
+				esc_html__( 'Reported reason: %s', 'woocommerce-payments' ),
+				esc_html( $fraud_type_text )
+			) . '</p>';
+		}
+
+		echo '<p>' . esc_html( $description ) . '</p>';
+
+		if ( $actionable ) {
+			// MOCKUP (EFW #304): the real CTA would launch the refund flow; this
+			// anchors to the order items panel on this page, where Refund lives.
+			echo '<p><a href="#woocommerce-order-items">' . esc_html__( 'Refund to avoid a dispute', 'woocommerce-payments' ) . '</a></p>';
+		}
+
+		echo '</div>';
+	}
+
+	/**
+	 * MOCKUP (EFW #304): resolves which mock EFW scenario to render for an order.
+	 *
+	 * @param \WC_Order $order The order we are working with.
+	 *
+	 * @return array|null Scenario as [ 'actionable' => bool, 'fraud_type' => string ], or null for "no EFW".
+	 */
+	private function resolve_mock_early_fraud_warning_scenario( $order ) {
+		$scenarios = [
+			'none'                    => null,
+			'actionable_stolen'       => [
+				'actionable' => true,
+				'fraud_type' => 'made_with_stolen_card',
+			],
+			'actionable_unauthorized' => [
+				'actionable' => true,
+				'fraud_type' => 'unauthorized_use_of_card',
+			],
+			'resolved'                => [
+				'actionable' => false,
+				'fraud_type' => 'made_with_stolen_card',
+			],
+		];
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only mock display toggle, no state change.
+		$requested = isset( $_GET['efw_mock'] ) ? sanitize_text_field( wp_unslash( $_GET['efw_mock'] ) ) : '';
+		if ( 'actionable' === $requested ) {
+			$requested = 'actionable_stolen';
+		}
+		if ( '' !== $requested && array_key_exists( $requested, $scenarios ) ) {
+			return $scenarios[ $requested ];
+		}
+
+		$pool = [ 'actionable_stolen', 'actionable_unauthorized', 'resolved', 'none' ];
+		$pick = $pool[ crc32( (string) $order->get_id() ) % count( $pool ) ];
+
+		return $scenarios[ $pick ];
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOPMNT-191

#### Changes proposed in this Pull Request

UI-only mock of Early Fraud Warnings (#304) - no server/Stripe wiring, it just fabricates EFW scenarios so we can see how they'd look before building the real data path. Two surfaces: the transaction **timeline** (a new `early_fraud_warning` event) and the **Fraud & Risk** order metabox (an additive EFW block above the existing risk outcome). Everything is tagged `MOCKUP (EFW #304)` for easy removal, and suppressed under tests (`NODE_ENV` / `WCPAY_TEST_ENV`) so it never touches snapshots or assertions.

#### Testing instructions

The scenario is picked by a `?efw_mock=` query param: `actionable_stolen`, `actionable_unauthorized`, `actionable` (alias), `resolved`, `none`. With no param it's derived from the charge/order id - stable per transaction, varies across the store.

1. Create an order paid with WooPayments (or open an existing card order).
2. **Metabox** - on the order edit screen, append `&efw_mock=actionable_stolen` to the URL. The "Fraud & Risk" box shows an amber EFW block + a "Refund to avoid a dispute" link.
3. **Timeline** - open the transaction details page for that payment (Payments → Transactions → the payment), append `&efw_mock=actionable_stolen`. The EFW event shows at the top of the timeline, above any dispute.
4. Try `&efw_mock=resolved` on both - the EFW renders muted ("no longer actionable", no refund link); `&efw_mock=none` hides it.

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
