### PR TITLE
Harden branch-protection alerting (record quality, outage detection, retention sink)

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,6 +1,6 @@
 # GitHub Actions Scripts
 
-This directory contains scripts used by GitHub Actions workflows for dynamic version management and matrix generation.
+This directory contains scripts used by GitHub Actions workflows for dynamic version management, matrix generation, and governance alerting.
 
 ## Scripts
 
@@ -42,6 +42,27 @@ Single JSON object containing versions array and metadata:
 - Outputs structured JSON for easy parsing
 - Skips beta versions when not available
 - Provides debug output to stderr for troubleshooting
+
+### `branch-protection-event.sh`
+
+Builds the alert payload for the branch-protection change workflow
+(`.github/workflows/branch-protection-alert.yml`) from a `branch_protection_rule`
+event. Using `jq` guarantees valid, injection-safe JSON regardless of rule names
+or change values. Refs WOOPMNT-6229.
+
+**Usage:**
+
+```bash
+# Canonical flat audit JSON (default) — for the long-term retention sink
+.github/scripts/branch-protection-event.sh "$GITHUB_EVENT_PATH"
+
+# Slack Block Kit JSON — for the #payments-engineering alert
+.github/scripts/branch-protection-event.sh --slack "$GITHUB_EVENT_PATH"
+```
+
+The event file argument defaults to `$GITHUB_EVENT_PATH` when omitted. Canonical
+output fields: `repository`, `action`, `rule`, `actor`, `timestamp` (UTC),
+`settings_url`, `changes` (before/after on edits).
 
 ## Matrix Generation Strategy
 

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -53,7 +53,8 @@ or change values. Refs WOOPMNT-6229.
 **Usage:**
 
 ```bash
-# Canonical flat audit JSON (default) — for the long-term retention sink
+# Canonical flat audit JSON (default) — the structured event shape, for
+# downstream logging/retention consumers
 .github/scripts/branch-protection-event.sh "$GITHUB_EVENT_PATH"
 
 # Slack Block Kit JSON — for the #payments-engineering alert

--- a/.github/scripts/branch-protection-event.sh
+++ b/.github/scripts/branch-protection-event.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Build the branch-protection change payload from a branch_protection_rule
+# event file. Default output: canonical flat JSON (for the internal audit sink).
+# With --slack: Slack Block Kit JSON. Using jq guarantees valid, injection-safe
+# JSON regardless of rule names / change values. Refs WOOPMNT-6229.
+set -euo pipefail
+
+format="canonical"
+if [ "${1:-}" = "--slack" ]; then format="slack"; shift; fi
+
+event_file="${1:-${GITHUB_EVENT_PATH:?event file required}}"
+ts="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+canonical="$(
+  jq -c \
+    --arg ts "$ts" \
+    '{
+      repository: (.repository.full_name // "unknown"),
+      action: (.action // "unknown"),
+      rule: (.rule.name // "unknown"),
+      actor: (.sender.login // "unknown"),
+      timestamp: $ts,
+      settings_url: ("https://github.com/" + (.repository.full_name // "") + "/settings/branches"),
+      changes: (.changes // {})
+    }' "$event_file"
+)"
+
+if [ "$format" = "canonical" ]; then
+  printf '%s\n' "$canonical"
+  exit 0
+fi
+
+printf '%s\n' "$canonical" | jq '{
+  blocks: [
+    { type: "header",
+      text: { type: "plain_text", text: ":lock: Branch protection changed", emoji: true } },
+    { type: "section",
+      fields: [
+        { type: "mrkdwn", text: ("*Repository:*\n" + .repository) },
+        { type: "mrkdwn", text: ("*Action:*\n" + .action) },
+        { type: "mrkdwn", text: ("*Branch rule:*\n" + .rule) },
+        { type: "mrkdwn", text: ("*Changed by:*\n" + .actor) },
+        { type: "mrkdwn", text: ("*When (UTC):*\n" + .timestamp) }
+      ] },
+    { type: "section",
+      text: { type: "mrkdwn",
+        text: ("*Changes:*\n```" + (.changes | tojson) + "```") } },
+    { type: "section",
+      text: { type: "mrkdwn",
+        text: ("<" + .settings_url + "|Review branch protection settings>") } }
+  ]
+}'

--- a/.github/workflows/branch-protection-alert.yml
+++ b/.github/workflows/branch-protection-alert.yml
@@ -13,42 +13,63 @@ permissions:
 jobs:
   alert:
     name: Notify Slack of branch protection change
-    # Only the upstream repo carries the webhook secret; skip on forks so the
-    # absence of the secret doesn't surface as a misleading failed run.
+    # Only the upstream repo carries the secrets; skip on forks so their
+    # absence doesn't surface as a misleading failed run.
     if: github.repository == 'Automattic/woocommerce-payments'
     runs-on: ubuntu-latest
+    env:
+      SINK_URL: ${{ secrets.BRANCH_PROTECTION_AUDIT_SINK_URL }}
     steps:
+      - name: Check out scripts
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Build payloads
+        run: |
+          .github/scripts/branch-protection-event.sh --slack "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/slack.json"
+          .github/scripts/branch-protection-event.sh "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/audit.json"
+
       - name: Slack ping
         uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         with:
           webhook: ${{ secrets.BRANCH_PROTECTION_ALERT_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": ":lock: Branch protection changed",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    { "type": "mrkdwn", "text": "*Repository:*\n${{ github.repository }}" },
-                    { "type": "mrkdwn", "text": "*Action:*\n${{ github.event.action }}" },
-                    { "type": "mrkdwn", "text": "*Branch rule:*\n${{ github.event.rule.name }}" },
-                    { "type": "mrkdwn", "text": "*Changed by:*\n${{ github.event.sender.login }}" }
-                  ]
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "<https://github.com/${{ github.repository }}/settings/branches|Review branch protection settings>"
-                  }
-                }
-              ]
-            }
+          payload-file-path: ${{ runner.temp }}/slack.json
+
+      - name: Mirror to internal audit sink (long-term retention)
+        # Inert until Systems provisions the ingestion endpoint + secret.
+        # Best-effort: a sink outage must not fail this job (Slack detection
+        # already ran) or it would falsely trip the outage alarm below.
+        if: env.SINK_URL != ''
+        run: |
+          curl -sS --fail-with-body -X POST "$SINK_URL" \
+            -H 'Content-Type: application/json' \
+            --data @"$RUNNER_TEMP/audit.json" \
+            || echo "::warning::Branch-protection audit-sink POST failed; long-term retention mirror missed this event (Slack detection unaffected)."
+
+  outage:
+    name: Flag detection outage
+    needs: alert
+    # Runs only if the alert job failed — the detector may be blind
+    # (most likely a revoked/missing webhook secret). Uses the built-in
+    # token so it does not depend on the external webhook.
+    if: failure() && needs.alert.result == 'failure' && github.repository == 'Automattic/woocommerce-payments'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update an outage issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Branch-protection alert failed — change detector may be blind"
+          existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          body="The branch-protection change alert workflow failed. Until fixed, changes to branch protection may go unnoticed. Check the webhook secret and the run: $RUN_URL  (Refs WOOPMNT-6229)"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/.github/workflows/branch-protection-alert.yml
+++ b/.github/workflows/branch-protection-alert.yml
@@ -17,8 +17,6 @@ jobs:
     # absence doesn't surface as a misleading failed run.
     if: github.repository == 'Automattic/woocommerce-payments'
     runs-on: ubuntu-latest
-    env:
-      SINK_URL: ${{ secrets.BRANCH_PROTECTION_AUDIT_SINK_URL }}
     steps:
       - name: Check out scripts
         uses: actions/checkout@v4
@@ -26,10 +24,9 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
-      - name: Build payloads
+      - name: Build Slack payload
         run: |
           .github/scripts/branch-protection-event.sh --slack "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/slack.json"
-          .github/scripts/branch-protection-event.sh "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/audit.json"
 
       - name: Slack ping
         uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
@@ -37,17 +34,6 @@ jobs:
           webhook: ${{ secrets.BRANCH_PROTECTION_ALERT_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload-file-path: ${{ runner.temp }}/slack.json
-
-      - name: Mirror to internal audit sink (long-term retention)
-        # Inert until Systems provisions the ingestion endpoint + secret.
-        # Best-effort: a sink outage must not fail this job (Slack detection
-        # already ran) or it would falsely trip the outage alarm below.
-        if: env.SINK_URL != ''
-        run: |
-          curl -sS --fail-with-body -X POST "$SINK_URL" \
-            -H 'Content-Type: application/json' \
-            --data @"$RUNNER_TEMP/audit.json" \
-            || echo "::warning::Branch-protection audit-sink POST failed; long-term retention mirror missed this event (Slack detection unaffected)."
 
   outage:
     name: Flag detection outage

--- a/changelog/update-woopmnt-6229-alert-hardening
+++ b/changelog/update-woopmnt-6229-alert-hardening
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Harden the branch-protection alert (jq-built payload, change diff + timestamp, detection-outage issue, staged long-retention audit sink). CI/governance only, not user-facing. Refs WOOPMNT-6229.

--- a/changelog/update-woopmnt-6229-alert-hardening
+++ b/changelog/update-woopmnt-6229-alert-hardening
@@ -1,3 +1,3 @@
 Significance: patch
 Type: dev
-Comment: Harden the branch-protection alert (jq-built payload, change diff + timestamp, detection-outage issue, staged long-retention audit sink). CI/governance only, not user-facing. Refs WOOPMNT-6229.
+Comment: Harden the branch-protection alert (jq-built payload, change diff + timestamp, detection-outage issue). CI/governance only, not user-facing. Refs WOOPMNT-6229.

--- a/tests/fixtures/branch_protection_rule.edited.json
+++ b/tests/fixtures/branch_protection_rule.edited.json
@@ -1,0 +1,11 @@
+{
+  "action": "edited",
+  "rule": { "name": "develop" },
+  "changes": {
+    "required_pull_request_reviews_enforcement_level": {
+      "from": "off \"was disabled\""
+    }
+  },
+  "repository": { "full_name": "Automattic/woocommerce-payments" },
+  "sender": { "login": "octocat" }
+}


### PR DESCRIPTION
## Summary

Follow-up to #11860, acting on Mo's #grc guidance and Chris's Req 10 framing:

- Build the alert payload with `jq` (`.github/scripts/branch-protection-event.sh`) so event fields can't break or inject into the JSON. Adds a UTC timestamp and the before/after `changes` diff to each record.
- Add an `outage` job that opens a GitHub issue (via the built-in token) if the alert fails, so a blind detector is surfaced.

This keeps the alert **detection-only and real-time** (enriched Slack message with actor + before/after change). The durable ≥12-month retained record (PCI 10.5.1) is **not** built here: rather than a push sink, it will be produced by a separate WP.com scheduled job that publishes branch-protection state to the `security-alerts` dataset in `Automattic/missioncontrol` (git history = unlimited, tamper-evident retention; surfaced at `mc.a8c.com/grc/security-alerts`), mirroring the existing Dependabot-audit job. No public ingestion endpoint and no stored credential.

No admin token is stored. The WP.com record job and any enforce-and-reconcile are tracked separately.

Refs WOOPMNT-6229

## Testing instructions

1. `./.github/scripts/branch-protection-event.sh --slack tests/fixtures/branch_protection_rule.edited.json | jq .` → valid Slack Block Kit.
2. CI green incl. the changelog check.
3. Live: a trivial protection change still posts to #payments-engineering, now with timestamp + changes.
