### PR TITLE
Point CODEOWNERS at the PCI Guardians team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Changes to this repository require review from a designated Code Owner
-# before they can land on a protected branch.
+# before they can land on a protected branch. The PCI Guardians team is the
+# trained, in-scope reviewer group; any one member's review satisfies the gate.
 # Refs WOOPMNT-6229
-* @Automattic/chronos @Automattic/gamma @Automattic/moltres @rtio
+* @Automattic/pci-guardians

--- a/changelog/update-woopmnt-6229-codeowners-pci-guardians
+++ b/changelog/update-woopmnt-6229-codeowners-pci-guardians
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Point CODEOWNERS at the PCI Guardians team (single trained reviewer group) for protected-branch reviews. CI/governance only, not user-facing. Refs WOOPMNT-6229.


### PR DESCRIPTION
## Summary

Consolidates the protected-branch Code Owners onto the dedicated **`@Automattic/pci-guardians`** team, replacing the previous three-team + individual list:

```diff
-* @Automattic/chronos @Automattic/gamma @Automattic/moltres @rtio
+* @Automattic/pci-guardians
```

Why: a single dedicated team is a cleaner evidence story and **less notification noise**. Refs WOOPMNT-6229.

### Verified before opening (no merge-lockout risk)
- `pci-guardians` has **push** access to this repo → it's a valid Code Owner.
- `gh api .../codeowners/errors?ref=<this-branch>` returns `[]`.
- The team (21 members) includes the prior owners, **including `@rtio`**, so dropping the individual entry loses no coverage.

## Testing instructions

1. `gh api repos/Automattic/woocommerce-payments/codeowners/errors?ref=<this-branch>` → `[]`.
2. CI green incl. the changelog check.
3. After merge: open a trivial test PR to `develop` and confirm the required reviewer is **PCI Guardians**.