### PR TITLE
Harden the Stripe.js origin assertion (selector + i18n)

### DIFF
--- a/changelog/update-woopmnt-6210-stripe-origin-hardening
+++ b/changelog/update-woopmnt-6210-stripe-origin-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Harden the client-side Stripe.js origin assertion: ignore non-script elements sharing the Stripe.js script id, and make the blocked-payment error message translatable.

--- a/client/checkout/utils/__tests__/verify-stripe-origin.test.ts
+++ b/client/checkout/utils/__tests__/verify-stripe-origin.test.ts
@@ -16,9 +16,10 @@ const addScript = ( attrs: Record< string, string > ): void => {
 
 describe( 'verifyStripeJsOrigin', () => {
 	afterEach( () => {
+		// Remove scripts and any non-script element planted with the handle id.
 		document.head
-			.querySelectorAll( 'script' )
-			.forEach( ( script ) => script.remove() );
+			.querySelectorAll( 'script, #stripe-js' )
+			.forEach( ( el ) => el.remove() );
 	} );
 
 	it( 'accepts the canonical WordPress handle tag', () => {
@@ -114,6 +115,24 @@ describe( 'verifyStripeJsOrigin', () => {
 		// handle. querySelector on a selector list returns the first match in
 		// document order, so the handle must be looked up explicitly to win.
 		addScript( { src: 'https://js.stripe.com/v3/' } );
+		addScript( {
+			id: 'stripe-js',
+			src: 'https://js.evil.example/v3/?ver=3.0',
+		} );
+
+		const result = verifyStripeJsOrigin();
+
+		expect( result.ok ).toBe( false );
+		expect( result.detectedOrigin ).toBe( 'https://js.evil.example' );
+	} );
+
+	it( 'ignores a non-script element sharing the stripe-js id', () => {
+		// A planted <div id="stripe-js"> (inserted first) must not divert the
+		// lookup: the tag-qualified `script#stripe-js` selector skips it and
+		// still reads the real repointed handle.
+		const div = document.createElement( 'div' );
+		div.id = 'stripe-js';
+		document.head.appendChild( div );
 		addScript( {
 			id: 'stripe-js',
 			src: 'https://js.evil.example/v3/?ver=3.0',

--- a/client/checkout/utils/__tests__/verify-stripe-origin.test.ts
+++ b/client/checkout/utils/__tests__/verify-stripe-origin.test.ts
@@ -143,6 +143,35 @@ describe( 'verifyStripeJsOrigin', () => {
 		expect( result.ok ).toBe( false );
 		expect( result.detectedOrigin ).toBe( 'https://js.evil.example' );
 	} );
+
+	it( 'fails closed when only a non-script #stripe-js exists and no Stripe.js tag is present', () => {
+		// No real handle and nothing for the fallback to find: report "no tag"
+		// rather than trusting the planted element.
+		const div = document.createElement( 'div' );
+		div.id = 'stripe-js';
+		document.head.appendChild( div );
+
+		expect( verifyStripeJsOrigin() ).toEqual( {
+			ok: false,
+			detectedSrc: null,
+			detectedOrigin: null,
+		} );
+	} );
+
+	it( 'falls back to a genuine js.stripe.com tag when only a non-script #stripe-js exists', () => {
+		// With no real handle, the presence-check fallback accepts a genuine
+		// js.stripe.com tag loaded by another path. This intentionally does NOT
+		// fail closed: a non-script element sharing the id is not a tampered
+		// handle, and an attacker who can also reassign window.Stripe bypasses any
+		// tag check (the acknowledged limitation). We assert tag origin, not the
+		// Stripe object's identity.
+		const div = document.createElement( 'div' );
+		div.id = 'stripe-js';
+		document.head.appendChild( div );
+		addScript( { src: 'https://js.stripe.com/v3/' } );
+
+		expect( verifyStripeJsOrigin().ok ).toBe( true );
+	} );
 } );
 
 describe( 'assertStripeJsOrigin', () => {

--- a/client/checkout/utils/verify-stripe-origin.ts
+++ b/client/checkout/utils/verify-stripe-origin.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Stripe's canonical origin. Stripe.js is only ever served from here
  * (https://docs.stripe.com/js/including); any other origin is unsupported.
  */
@@ -100,5 +105,7 @@ export const assertStripeJsOrigin = ( {
 		`WooPayments: blocking checkout — ${ reason }. Expected Stripe.js from ${ STRIPE_JS_ORIGIN }.`
 	);
 
-	throw new Error( 'Stripe.js provenance check failed.' );
+	throw new Error(
+		__( 'Stripe.js provenance check failed.', 'woocommerce-payments' )
+	);
 };

--- a/client/checkout/utils/verify-stripe-origin.ts
+++ b/client/checkout/utils/verify-stripe-origin.ts
@@ -23,10 +23,11 @@ export interface StripeOriginResult {
  * a skimmer clone render the card iframe from its own origin. We read the tag
  * before `new Stripe()` so the caller can block first.
  *
- * The `#stripe-js` handle is matched by id first and explicitly, so a repointed
- * handle always wins over a legitimate js.stripe.com tag elsewhere in the DOM.
- * Only without a handle tag do we fall back to any js.stripe.com tag — the
- * origin is asserted, not the path.
+ * The `#stripe-js` handle is matched first and explicitly — tag-qualified as
+ * `script#stripe-js`, so a non-script element sharing the id can't divert the
+ * lookup — so a repointed handle always wins over a legitimate js.stripe.com tag
+ * elsewhere in the DOM. Only without a handle tag do we fall back to any
+ * js.stripe.com tag — the origin is asserted, not the path.
  *
  * @param doc Document to inspect. Injectable for tests.
  */
@@ -34,7 +35,7 @@ export const verifyStripeJsOrigin = (
 	doc: Document = document
 ): StripeOriginResult => {
 	const tag =
-		doc.querySelector< HTMLScriptElement >( '#stripe-js' ) ??
+		doc.querySelector< HTMLScriptElement >( 'script#stripe-js' ) ??
 		// Fallback presence check: the `src^=` filter already pins the origin, so
 		// a match here is always ok — it just confirms Stripe.js is present when
 		// no `#stripe-js` handle exists (a total absence still fails closed below).


### PR DESCRIPTION
Partially addresses WOOPMNT-6210. Follow-up to the merged #11853 — backports two
review-driven refinements from the woocommerce-gateway-stripe port
(woocommerce/woocommerce-gateway-stripe#5593) that didn't flow back here.

## Changes proposed in this Pull Request

1. **Tag-qualify the handle selector: `script#stripe-js` (was `#stripe-js`).**
   The bare id selector matches any element with `id="stripe-js"`. A planted
   non-script element sharing the id (e.g. `<div id="stripe-js">` inserted before
   the real handle) is returned first, has no `src`, and yields a misleading "no
   Stripe.js tag" result instead of inspecting the actual repointed handle.
   Qualifying the selector skips non-script id collisions so the real `<script>`
   handle stays authoritative.

2. **Translate the blocked-payment message.** The thrown `Error.message` is
   rendered into the shopper-facing classic checkout notice, so it's now wrapped
   with `__( …, 'woocommerce-payments' )`. Diagnostics (the detected src) remain
   console-only, so no attacker URL is shown to shoppers.

## Testing instructions

Regression sanity-check on a test site — repoint the handle and confirm checkout
is still blocked with a generic notice and the diagnostic only in the console:

    add_filter( 'script_loader_src', fn( $src, $h ) => 'stripe' === $h ? 'https://js.evil.example/v3/' : $src, PHP_INT_MAX, 2 );

- [x] Covered with tests
- [x] Tested on mobile (or does not apply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)