### PR TITLE
fix: enable VariableAnalysis UnusedVariable sniff on test files

### DIFF
--- a/changelog/fix-unused-variable-sniffs-remaining-tests
+++ b/changelog/fix-unused-variable-sniffs-remaining-tests
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: fix: enable VariableAnalysis UnusedVariable phpcs sniff on remaining test files (part of #8436)

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -60,7 +60,6 @@
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
 		<!-- POC payment-method definition classes; not part of #8436. -->
 		<exclude-pattern>includes/payment-methods/Configs/</exclude-pattern>
-		<exclude-pattern>tests/unit/payment-methods/Configs/</exclude-pattern>
 
 		<!-- Pending https://github.com/Automattic/woocommerce-payments/issues/8655. -->
 		<exclude-pattern>includes/multi-currency/</exclude-pattern>
@@ -76,21 +75,6 @@
 		<exclude-pattern>includes/subscriptions/class-wc-payments-subscriptions-disabler.php</exclude-pattern>
 		<exclude-pattern>includes/woopay/class-woopay-session.php</exclude-pattern>
 		<exclude-pattern>src/Internal/Abilities/Domain/</exclude-pattern>
-
-		<!-- Test files not listed in https://github.com/Automattic/woocommerce-payments/issues/8653; tracked by #8436. -->
-		<exclude-pattern>tests/WCPAY_UnitTestCase.php</exclude-pattern>
-		<exclude-pattern>tests/unit/bootstrap.php</exclude-pattern>
-		<exclude-pattern>tests/unit/admin/test-class-wc-rest-payments-tos-controller.php</exclude-pattern>
-		<exclude-pattern>tests/unit/helpers/class-wc-subscriptions-change-payment-gateway.php</exclude-pattern>
-		<exclude-pattern>tests/unit/multi-currency/test-class-frontend-currencies.php</exclude-pattern>
-		<exclude-pattern>tests/unit/multi-currency/test-class-frontend-prices.php</exclude-pattern>
-		<exclude-pattern>tests/unit/src/Internal/LoggerContextTest.php</exclude-pattern>
-		<exclude-pattern>tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php</exclude-pattern>
-		<exclude-pattern>tests/unit/test-class-wc-payments-non-reusable-payment-methods-integration.php</exclude-pattern>
-		<exclude-pattern>tests/unit/test-class-wc-payments-order-service.php</exclude-pattern>
-		<exclude-pattern>tests/unit/test-class-wc-payments-styles-cache.php</exclude-pattern>
-		<exclude-pattern>tests/unit/test-class-wc-payments-subscription-service-creation-logic.php</exclude-pattern>
-		<exclude-pattern>tests/unit/wc-payment-api/test-class-wc-payments-api-client.php</exclude-pattern>
 	</rule>
 
 	<!-- Disallow long array syntax -->

--- a/tests/WCPAY_UnitTestCase.php
+++ b/tests/WCPAY_UnitTestCase.php
@@ -46,13 +46,13 @@ class WCPAY_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @see WP_Http::request()
 	 *
-	 * @param false|array|WP_Error $response    A preemptive return value of an HTTP request. Default false.
-	 * @param array                $parsed_args HTTP request arguments.
-	 * @param string               $url         The request URL.
+	 * @param false|array|WP_Error $_unused_response    A preemptive return value of an HTTP request. Default false.
+	 * @param array                $_unused_parsed_args HTTP request arguments.
+	 * @param string               $_unused_url         The request URL.
 	 *
 	 * @return array
 	 */
-	public function filter_intercept_external_requests( $response, $parsed_args, $url ) {
+	public function filter_intercept_external_requests( $_unused_response, $_unused_parsed_args, $_unused_url ) {
 		// Return a service unavailable response.
 		return [
 			'body'          => '',

--- a/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-tos-controller.php
@@ -60,7 +60,6 @@ class WC_REST_Payments_Tos_Controller_Test extends WCPAY_UnitTestCase {
 
 		$mock_wcpay_account                = $this->createMock( WC_Payments_Account::class );
 		$mock_fraud_service                = $this->createMock( WC_Payments_Fraud_Service::class );
-		$mock_db_cache                     = $this->createMock( Database_Cache::class );
 		$mock_session_service              = $this->createMock( WC_Payments_Session_Service::class );
 		$order_service                     = new WC_Payments_Order_Service( $this->createMock( WC_Payments_API_Client::class ) );
 		$customer_service                  = new WC_Payments_Customer_Service( $mock_api_client, $mock_wcpay_account, $mock_session_service, $order_service );

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -56,7 +56,7 @@ function _manually_load_plugin() {
 	// via update_option().
 	add_filter(
 		'default_option__wcpay_feature_subscriptions',
-		function ( $default_value ) {
+		function ( $_unused_default_value ) {
 			return '1';
 		},
 		10,

--- a/tests/unit/helpers/class-wc-subscriptions-change-payment-gateway.php
+++ b/tests/unit/helpers/class-wc-subscriptions-change-payment-gateway.php
@@ -39,10 +39,10 @@ if ( ! class_exists( 'WC_Subscriptions_Change_Payment_Gateway' ) ) {
 		/**
 		 * Stub for will_subscription_update_all_payment_methods.
 		 *
-		 * @param WC_Order $order The order.
+		 * @param WC_Order $_unused_order The order.
 		 * @return bool
 		 */
-		public static function will_subscription_update_all_payment_methods( $order ) {
+		public static function will_subscription_update_all_payment_methods( $_unused_order ) {
 			return self::$will_update_all_return;
 		}
 

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -452,7 +452,7 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WCPAY_UnitTestCase 
 		add_filter( 'wcpay_multi_currency_should_convert_product_price', $should_convert_product_price, 999 );
 
 		// Act.
-		$price_html = $mock_product->get_price_html();
+		$mock_product->get_price_html();
 
 		// Assert.
 		$this->assertEquals( $store_currency_args, ( $spy_return_store_currency->received_args )() );

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -586,7 +586,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 		$this->mock_multi_currency
 			->method( 'get_raw_conversion' )
 			->willReturnCallback(
-				function ( $price, $from_currency, $to_currency ) {
+				function ( $price, $_unused_from_currency, $_unused_to_currency ) {
 					return (float) $price * 0.75;
 				}
 			);

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition-two.php
@@ -35,23 +35,23 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 		return 'SecondMockPaymentMethod';
 	}
 
-	public static function get_title( ?string $account_country = null ): string {
+	public static function get_title( ?string $_unused_account_country = null ): string {
 		return 'Second Mock Method';
 	}
 
-	public static function get_title_from_charge_details( string $account_country, array $payment_details ): ?string {
+	public static function get_title_from_charge_details( string $_unused_account_country, array $_unused_payment_details ): ?string {
 		return null;
 	}
 
-	public static function get_settings_label( ?string $account_country = null ): string {
+	public static function get_settings_label( ?string $_unused_account_country = null ): string {
 		return 'Second Mock Method';
 	}
 
-	public static function get_description( ?string $account_country = null ): string {
+	public static function get_description( ?string $_unused_account_country = null ): string {
 		return 'Second mock payment method for testing';
 	}
 
-	public static function get_supported_countries( ?string $account_country = null ): array {
+	public static function get_supported_countries( ?string $_unused_account_country = null ): array {
 		return [ 'US' ];
 	}
 
@@ -63,19 +63,19 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 		return [];
 	}
 
-	public static function get_icon_url( ?string $account_country = null ): string {
+	public static function get_icon_url( ?string $_unused_account_country = null ): string {
 		return 'https://example.com/icon.png';
 	}
 
-	public static function get_dark_icon_url( ?string $account_country = null ): string {
+	public static function get_dark_icon_url( ?string $_unused_account_country = null ): string {
 		return 'https://example.com/dark-icon.png';
 	}
 
-	public static function get_settings_icon_url( ?string $account_country = null ): string {
+	public static function get_settings_icon_url( ?string $_unused_account_country = null ): string {
 		return 'https://example.com/settings-icon.png';
 	}
 
-	public static function get_testing_instructions( string $account_country ): string {
+	public static function get_testing_instructions( string $_unused_account_country ): string {
 		return 'Test instructions';
 	}
 
@@ -88,11 +88,11 @@ class SecondMockPaymentMethodDefinition implements PaymentMethodDefinitionInterf
 		return [];
 	}
 
-	public static function get_minimum_amount( string $currency, string $country ): ?int {
+	public static function get_minimum_amount( string $_unused_currency, string $_unused_country ): ?int {
 		return null;
 	}
 
-	public static function get_maximum_amount( string $currency, string $country ): ?int {
+	public static function get_maximum_amount( string $_unused_currency, string $_unused_country ): ?int {
 		return null;
 	}
 }

--- a/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
+++ b/tests/unit/payment-methods/Configs/mocks/class-mock-payment-method-definition.php
@@ -35,7 +35,7 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return 'MockPaymentMethod';
 	}
 
-	public static function get_title( ?string $account_country = null ): string {
+	public static function get_title( ?string $_unused_account_country = null ): string {
 		return 'Mock Method';
 	}
 
@@ -46,11 +46,11 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return null;
 	}
 
-	public static function get_settings_label( ?string $account_country = null ): string {
+	public static function get_settings_label( ?string $_unused_account_country = null ): string {
 		return 'Mock Method';
 	}
 
-	public static function get_description( ?string $account_country = null ): string {
+	public static function get_description( ?string $_unused_account_country = null ): string {
 		return 'Mock payment method for testing';
 	}
 
@@ -58,7 +58,7 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return [ Currency_Code::UNITED_STATES_DOLLAR, Currency_Code::CANADIAN_DOLLAR ];
 	}
 
-	public static function get_supported_countries( ?string $account_country = null ): array {
+	public static function get_supported_countries( ?string $_unused_account_country = null ): array {
 		return [ 'US', 'CA' ];
 	}
 
@@ -66,19 +66,19 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return [];
 	}
 
-	public static function get_icon_url( ?string $account_country = null ): string {
+	public static function get_icon_url( ?string $_unused_account_country = null ): string {
 		return 'https://example.com/icon.png';
 	}
 
-	public static function get_dark_icon_url( ?string $account_country = null ): string {
+	public static function get_dark_icon_url( ?string $_unused_account_country = null ): string {
 		return 'https://example.com/dark-icon.png';
 	}
 
-	public static function get_settings_icon_url( ?string $account_country = null ): string {
+	public static function get_settings_icon_url( ?string $_unused_account_country = null ): string {
 		return 'https://example.com/settings-icon.png';
 	}
 
-	public static function get_testing_instructions( string $account_country ): string {
+	public static function get_testing_instructions( string $_unused_account_country ): string {
 		return 'Test instructions';
 	}
 
@@ -91,11 +91,11 @@ class MockPaymentMethodDefinition implements PaymentMethodDefinitionInterface {
 		return [];
 	}
 
-	public static function get_minimum_amount( string $currency, string $country ): ?int {
+	public static function get_minimum_amount( string $_unused_currency, string $_unused_country ): ?int {
 		return null;
 	}
 
-	public static function get_maximum_amount( string $currency, string $country ): ?int {
+	public static function get_maximum_amount( string $_unused_currency, string $_unused_country ): ?int {
 		return null;
 	}
 }

--- a/tests/unit/src/Internal/LoggerContextTest.php
+++ b/tests/unit/src/Internal/LoggerContextTest.php
@@ -78,7 +78,7 @@ class LoggerContextTest extends WCPAY_UnitTestCase {
 				},
 			],
 			[
-				function ( $instance ) {
+				function ( $_unused_instance ) {
 					wcpay_get_container()->get( LoggerContext::class )->init_hooks();
 					Logger_Context::set_value( 'foo', 'bar' );
 				},

--- a/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
+++ b/tests/unit/subscriptions/test-class-wc-payments-subscriptions-disabler.php
@@ -630,7 +630,7 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 
 		// Mock the wcs_create_renewal_order function.
 		WC_Subscriptions::wcs_create_renewal_order(
-			function ( $subscription ) use ( &$renewal_order_created ) {
+			function ( $_unused_subscription ) use ( &$renewal_order_created ) {
 				$renewal_order_created = true;
 				return WC_Helper_Order::create_order();
 			}
@@ -1168,7 +1168,7 @@ class WC_Payments_Subscriptions_Disabler_Test extends WCPAY_UnitTestCase {
 
 		// Mock the wcs_get_page_screen_id function.
 		if ( ! function_exists( 'wcs_get_page_screen_id' ) ) {
-			function wcs_get_page_screen_id( $type ) {
+			function wcs_get_page_screen_id( $_unused_type ) {
 				return 'wc-orders--shop_order';
 			}
 		}

--- a/tests/unit/test-class-wc-payments-non-reusable-payment-methods-integration.php
+++ b/tests/unit/test-class-wc-payments-non-reusable-payment-methods-integration.php
@@ -116,12 +116,12 @@ class WC_Payments_Non_Reusable_Payment_Methods_Integration_Test extends WCPAY_Un
 
 		// Mock required functions.
 		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
-			function ( $order_id ) use ( $subscription ) {
+			function ( $_unused_order_id ) use ( $subscription ) {
 				return [ $subscription ];
 			}
 		);
 		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
-			function ( $order_id ) use ( $subscription ) {
+			function ( $_unused_order_id ) use ( $subscription ) {
 				return [ $subscription ];
 			}
 		);

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1978,7 +1978,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$order->save();
 
 		$refund_amount = 10;
-		$refund        = wc_create_refund(
+		wc_create_refund(
 			[
 				'amount'   => $refund_amount,
 				'reason'   => 'Testing refund',

--- a/tests/unit/test-class-wc-payments-styles-cache.php
+++ b/tests/unit/test-class-wc-payments-styles-cache.php
@@ -242,7 +242,7 @@ class WC_Payments_Styles_Cache_Test extends WCPAY_UnitTestCase {
 	public function test_get_styles_cache_version_recomputes_after_invalidation() {
 		// Populate the cache.
 		delete_option( 'wcpay_styles_cache_version' );
-		$first_version = WC_Payments_Styles_Cache::get_styles_cache_version();
+		WC_Payments_Styles_Cache::get_styles_cache_version();
 
 		// Invalidate.
 		WC_Payments_Styles_Cache::invalidate_styles_cache_version();

--- a/tests/unit/test-class-wc-payments-subscription-service-creation-logic.php
+++ b/tests/unit/test-class-wc-payments-subscription-service-creation-logic.php
@@ -202,7 +202,7 @@ class WC_Payments_Subscription_Service_Creation_Logic_Test extends WCPAY_UnitTes
 
 		// Mock wcs_get_subscriptions_for_renewal_order function.
 		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
-			function ( $order_id ) use ( $subscription ) {
+			function ( $_unused_order_id ) use ( $subscription ) {
 				return [ $subscription ];
 			}
 		);
@@ -237,7 +237,7 @@ class WC_Payments_Subscription_Service_Creation_Logic_Test extends WCPAY_UnitTes
 
 		// Mock wcs_get_subscriptions_for_renewal_order function.
 		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
-			function ( $order_id ) use ( $subscription ) {
+			function ( $_unused_order_id ) use ( $subscription ) {
 				return [ $subscription ];
 			}
 		);
@@ -271,7 +271,7 @@ class WC_Payments_Subscription_Service_Creation_Logic_Test extends WCPAY_UnitTes
 
 		// Mock wcs_get_subscriptions_for_renewal_order function.
 		WC_Subscriptions::set_wcs_get_subscriptions_for_renewal_order(
-			function ( $order_id ) use ( $subscription ) {
+			function ( $_unused_order_id ) use ( $subscription ) {
 				return [ $subscription ];
 			}
 		);

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -697,10 +697,6 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 	 * Data provider for test_redacting_params
 	 */
 	public function redacting_params_data() {
-		$string_should_not_include_secret = function ( $input ) {
-			return false === strpos( $input, 'some-secret' );
-		};
-
 		return [
 			'delete' => [
 				[ [ 'client_secret' => 'some-secret' ], 'abc', 'DELETE' ],
@@ -1037,7 +1033,6 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 
 	public function test_get_readers_charge_summary() {
 		$transaction_id = uniqid( 'trx_' );
-		$charge_date    = gmdate( 'Y-m-d', 1634291278 );
 		$this->mock_http_client
 			->expects( $this->once() )
 			->method( 'remote_request' )


### PR DESCRIPTION
Part of #8436.

#### Changes proposed in this Pull Request

Removing the rest of the `VariableAnalysis…UnusedVariable` exclusions on test files (the drift left over from #8653 plus the POC config mocks).
Unused params get the `$_unused_` prefix, dead locals are dropped (keeping any side-effecting call).

Cleaning up.

#### Testing instructions

Safe to skim: it only touches test files, no production code.

- Check out this branch
- Run `npm run lint:php` — it should pass with no `UnusedVariable` warnings
- CI's PHP unit tests should stay green

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
