### PR TITLE
Fix PHP 8.5 "null as array offset" deprecation in multi-currency selection

### DIFF
--- a/changelog/WOOPMNT-6238-fix-null-array-offset-selected-currency
+++ b/changelog/WOOPMNT-6238-fix-null-array-offset-selected-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix PHP 8.5 deprecation notice when selecting a currency before any currency is stored for the user or session

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -775,6 +775,10 @@ class MultiCurrency {
 		$multi_currency_code = $this->compatibility->override_selected_currency();
 		$currency_code       = $multi_currency_code ? $multi_currency_code : $this->get_stored_currency_code();
 
+		if ( null === $currency_code ) {
+			return $this->get_default_currency();
+		}
+
 		return $this->get_enabled_currencies()[ $currency_code ] ?? $this->get_default_currency();
 	}
 

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -358,6 +358,38 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertSame( get_woocommerce_currency(), $this->multi_currency->get_selected_currency()->get_code() );
 	}
 
+	public function test_get_selected_currency_does_not_trigger_null_offset_deprecation_without_stored_currency() {
+		// Regression test for WOOPMNT-6238. With no currency stored for the user or
+		// session, the resolved currency code is null. Subscripting the enabled
+		// currencies array with that null key is deprecated as of PHP 8.5. This suite
+		// does not convert deprecations to exceptions, so assert the absence explicitly.
+		$null_offset_deprecations = [];
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Scoped handler asserting the absence of a deprecation; restored in finally below.
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$null_offset_deprecations ) {
+				if ( false !== strpos( $errstr, 'null as an array offset' ) ) {
+					$null_offset_deprecations[] = $errstr;
+					return true;
+				}
+				return false;
+			},
+			E_DEPRECATED
+		);
+
+		try {
+			$selected_code = $this->multi_currency->get_selected_currency()->get_code();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( get_woocommerce_currency(), $selected_code );
+		$this->assertSame(
+			[],
+			$null_offset_deprecations,
+			'get_selected_currency() must not use null as an array offset when no currency is stored.'
+		);
+	}
+
 	public function test_get_selected_currency_returns_default_currency_for_invalid_session_currency() {
 		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'UNSUPPORTED_CURRENCY' );
 


### PR DESCRIPTION
Closes WOOPMNT-6238

### Description
On a fresh install (e.g. WP + Woo 10.8.1 + WooPayments 10.8.0) running PHP 8.5, the storefront emits `Deprecated: Using null as an array offset` from `MultiCurrency::get_selected_currency()`.

When no currency is stored for the user or session, `get_stored_currency_code()` returns `null`, and that `null` flowed straight into `$this->get_enabled_currencies()[ $currency_code ]`. PHP 8.5 newly deprecates using `null` as an array offset, surfacing the notice.

This guards against a `null` currency code and returns the default currency before the array access. Behavior is unchanged — the existing `?? get_default_currency()` fallback already returned the default currency in this case; only the deprecation notice is gone.

**Key commit:**
- Avoid null array offset in `get_selected_currency()` (319783c4)

### Testing Steps
1. On a site running PHP 8.5 with WooPayments multi-currency available, ensure no currency is stored for the current user/session (fresh install / incognito, no currency switch).
2. Load the storefront.
- [ ] Confirm no `Deprecated: Using null as an array offset ... MultiCurrency.php` notice appears.
- [ ] Confirm the storefront still renders prices in the store's default currency.
3. Switch to an enabled currency, reload.
- [ ] Confirm the selected currency is applied as before (no regression).

Unit coverage: `test_get_selected_currency_returns_default_currency_for_empty_session_and_user` already exercises the empty-session/user path and asserts the default currency is returned.
