### PR TITLE
Avoid slow order query in admin banner notice eligibility checks

### DIFF
--- a/changelog/WOOPMNT-6240-fix-one-and-done-notice-eligibility-query
+++ b/changelog/WOOPMNT-6240-fix-one-and-done-notice-eligibility-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed the one-and-done and test-to-live notice eligibility checks running a slow, unbounded order query that could block admin order pages on large stores.

--- a/includes/admin/class-wc-payments-admin-banner.php
+++ b/includes/admin/class-wc-payments-admin-banner.php
@@ -288,12 +288,15 @@ class WC_Payments_Admin_Banner {
 	 * @return void
 	 */
 	public function enqueue_test_to_live_notice_script() {
-		if ( ! $this->should_show_test_to_live_notice() ) {
+		// Screen gate first: the eligibility check runs an order query, so skip it
+		// entirely on admin screens where the notice can never render rather than
+		// paying that cost on every admin page load.
+		$screen = get_current_screen();
+		if ( $screen && ! in_array( $screen->id, wc_get_screen_ids(), true ) && ! wc_admin_is_registered_page() ) {
 			return;
 		}
 
-		$screen = get_current_screen();
-		if ( $screen && ! in_array( $screen->id, wc_get_screen_ids(), true ) && ! wc_admin_is_registered_page() ) {
+		if ( ! $this->should_show_test_to_live_notice() ) {
 			return;
 		}
 
@@ -489,12 +492,15 @@ class WC_Payments_Admin_Banner {
 	 * @return void
 	 */
 	public function enqueue_one_and_done_notice_script() {
-		if ( ! $this->should_show_one_and_done_notice() ) {
+		// Screen gate first: the eligibility check runs order queries, so skip it
+		// entirely on admin screens where the notice can never render rather than
+		// paying that cost on every admin page load.
+		$screen = get_current_screen();
+		if ( $screen && ! in_array( $screen->id, wc_get_screen_ids(), true ) && ! wc_admin_is_registered_page() ) {
 			return;
 		}
 
-		$screen = get_current_screen();
-		if ( $screen && ! in_array( $screen->id, wc_get_screen_ids(), true ) && ! wc_admin_is_registered_page() ) {
+		if ( ! $this->should_show_one_and_done_notice() ) {
 			return;
 		}
 
@@ -755,10 +761,14 @@ class WC_Payments_Admin_Banner {
 			return false;
 		}
 
+		// Existence-only check: `orderby => 'none'` lets the LIMIT 1 short-circuit
+		// instead of sorting every matching order (a filesort over millions of rows
+		// on large stores). Same hotspot as WOOPMNT-6240's one-and-done query.
 		$orders = wc_get_orders(
 			[
 				'payment_method' => 'woocommerce_payments',
 				'limit'          => 1,
+				'orderby'        => 'none',
 				'return'         => 'ids',
 				'status'         => [ 'wc-completed', 'wc-processing' ],
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
@@ -1102,14 +1112,17 @@ class WC_Payments_Admin_Banner {
 	 * - That single order's date_created is at least ONE_AND_DONE_NOTICE_DAYS_THRESHOLD
 	 *   days in the past.
 	 *
-	 * Strategy: two narrow indexed queries against post_meta rather than one wide
-	 * unindexed scan.
+	 * Strategy: two narrow queries capped to the smallest row count that answers
+	 * the question, both unsorted (`orderby => 'none'`) so the LIMIT short-circuits
+	 * instead of forcing a filesort over every matching order — the latter is what
+	 * made this check take 60s+ on large stores (see WOOPMNT-6240).
 	 *
 	 *   Q1 — WooPayments live orders capped at 2: filtered server-side by
 	 *        `_payment_method` + `_wcpay_mode` (same shape `compute_test_to_live_notice_eligibility()`
 	 *        already uses). Test-mode WCPay orders are excluded by construction, so
 	 *        the previous saturation false-negative ("19 old test-mode orders + 1
-	 *        live → silently excluded") can no longer occur.
+	 *        live → silently excluded") can no longer occur. Unsorted: the cap only
+	 *        distinguishes 0 / 1 / ≥2, and the exactly-1 case has a single row.
 	 *   Q2 — non-WooPayments orders capped at 1: filtered server-side by
 	 *        `_payment_method IN [other registered gateways]`. Caveat: this misses
 	 *        orders paid via since-uninstalled gateways. Acceptable for the cohort —
@@ -1149,12 +1162,19 @@ class WC_Payments_Admin_Banner {
 		}
 
 		// Q1 — WooPayments live-mode orders, capped at 2.
+		//
+		// `orderby => 'none'` is deliberate: an ORDER BY forces the engine to
+		// locate and sort every matching row before applying LIMIT 2, which is a
+		// filesort over millions of orders on large stores (60s+ on
+		// woocommerce.com). Without it the query stops after the first 2 matches.
+		// We don't need ordering — the 2-row cap only distinguishes 0 / 1 / ≥2,
+		// and in the exactly-1 case there's a single row whose date we read below,
+		// so ordering is irrelevant.
 		$wcpay_live_orders = wc_get_orders(
 			[
 				'payment_method' => 'woocommerce_payments',
 				'limit'          => 2,
-				'orderby'        => 'date',
-				'order'          => 'ASC',
+				'orderby'        => 'none',
 				'status'         => [ 'wc-completed', 'wc-processing' ],
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_key'       => WC_Payments_Order_Service::WCPAY_MODE_META_KEY,
@@ -1187,6 +1207,7 @@ class WC_Payments_Admin_Banner {
 				[
 					'payment_method' => $other_gateway_ids,
 					'limit'          => 1,
+					'orderby'        => 'none',
 					'return'         => 'ids',
 					'status'         => [ 'wc-completed', 'wc-processing' ],
 				]

--- a/includes/admin/class-wc-payments-admin-banner.php
+++ b/includes/admin/class-wc-payments-admin-banner.php
@@ -288,11 +288,8 @@ class WC_Payments_Admin_Banner {
 	 * @return void
 	 */
 	public function enqueue_test_to_live_notice_script() {
-		// Screen gate first: the eligibility check runs an order query, so skip it
-		// entirely on admin screens where the notice can never render rather than
-		// paying that cost on every admin page load.
-		$screen = get_current_screen();
-		if ( $screen && ! in_array( $screen->id, wc_get_screen_ids(), true ) && ! wc_admin_is_registered_page() ) {
+		// Screen gate before the eligibility check, which runs an order query.
+		if ( ! $this->is_banner_screen() ) {
 			return;
 		}
 
@@ -492,11 +489,8 @@ class WC_Payments_Admin_Banner {
 	 * @return void
 	 */
 	public function enqueue_one_and_done_notice_script() {
-		// Screen gate first: the eligibility check runs order queries, so skip it
-		// entirely on admin screens where the notice can never render rather than
-		// paying that cost on every admin page load.
-		$screen = get_current_screen();
-		if ( $screen && ! in_array( $screen->id, wc_get_screen_ids(), true ) && ! wc_admin_is_registered_page() ) {
+		// Screen gate before the eligibility check, which runs order queries.
+		if ( ! $this->is_banner_screen() ) {
 			return;
 		}
 
@@ -791,8 +785,7 @@ class WC_Payments_Admin_Banner {
 	 * @return void
 	 */
 	public function enqueue_post_kyc_activation_notice_script(): void {
-		$screen = get_current_screen();
-		if ( $screen && ! in_array( $screen->id, wc_get_screen_ids(), true ) && ! wc_admin_is_registered_page() ) {
+		if ( ! $this->is_banner_screen() ) {
 			return;
 		}
 
@@ -1271,6 +1264,19 @@ class WC_Payments_Admin_Banner {
 		}
 
 		return $this->is_one_and_done_notice_eligible_to_be_shown();
+	}
+
+	/**
+	 * Whether the current admin screen can host one of this class's banners.
+	 *
+	 * The banner eligibility checks run order queries, so every enqueue callback
+	 * gates on this first to avoid that cost on screens where no notice renders.
+	 *
+	 * @return bool
+	 */
+	private function is_banner_screen(): bool {
+		$screen = get_current_screen();
+		return ! $screen || in_array( $screen->id, wc_get_screen_ids(), true ) || wc_admin_is_registered_page();
 	}
 
 	/**

--- a/includes/admin/class-wc-payments-admin-banner.php
+++ b/includes/admin/class-wc-payments-admin-banner.php
@@ -755,9 +755,8 @@ class WC_Payments_Admin_Banner {
 			return false;
 		}
 
-		// Existence-only check: `orderby => 'none'` lets the LIMIT 1 short-circuit
-		// instead of sorting every matching order (a filesort over millions of rows
-		// on large stores). Same hotspot as WOOPMNT-6240's one-and-done query.
+		// Existence-only check: `orderby => 'none'` keeps the LIMIT from forcing a
+		// filesort over every matching order on large stores (WOOPMNT-6240).
 		$orders = wc_get_orders(
 			[
 				'payment_method' => 'woocommerce_payments',
@@ -1107,15 +1106,13 @@ class WC_Payments_Admin_Banner {
 	 *
 	 * Strategy: two narrow queries capped to the smallest row count that answers
 	 * the question, both unsorted (`orderby => 'none'`) so the LIMIT short-circuits
-	 * instead of forcing a filesort over every matching order — the latter is what
-	 * made this check take 60s+ on large stores (see WOOPMNT-6240).
+	 * instead of forcing a filesort over every matching order (WOOPMNT-6240).
 	 *
 	 *   Q1 — WooPayments live orders capped at 2: filtered server-side by
 	 *        `_payment_method` + `_wcpay_mode` (same shape `compute_test_to_live_notice_eligibility()`
 	 *        already uses). Test-mode WCPay orders are excluded by construction, so
 	 *        the previous saturation false-negative ("19 old test-mode orders + 1
-	 *        live → silently excluded") can no longer occur. Unsorted: the cap only
-	 *        distinguishes 0 / 1 / ≥2, and the exactly-1 case has a single row.
+	 *        live → silently excluded") can no longer occur.
 	 *   Q2 — non-WooPayments orders capped at 1: filtered server-side by
 	 *        `_payment_method IN [other registered gateways]`. Caveat: this misses
 	 *        orders paid via since-uninstalled gateways. Acceptable for the cohort —
@@ -1154,15 +1151,10 @@ class WC_Payments_Admin_Banner {
 			return false;
 		}
 
-		// Q1 — WooPayments live-mode orders, capped at 2.
-		//
-		// `orderby => 'none'` is deliberate: an ORDER BY forces the engine to
-		// locate and sort every matching row before applying LIMIT 2, which is a
-		// filesort over millions of orders on large stores (60s+ on
-		// woocommerce.com). Without it the query stops after the first 2 matches.
-		// We don't need ordering — the 2-row cap only distinguishes 0 / 1 / ≥2,
-		// and in the exactly-1 case there's a single row whose date we read below,
-		// so ordering is irrelevant.
+		// Q1 — WooPayments live-mode orders, capped at 2. The 2-row cap only
+		// distinguishes 0 / 1 / ≥2, so `orderby => 'none'` is intentional: it
+		// avoids the ORDER BY filesort that made this slow on large stores
+		// (WOOPMNT-6240). The exactly-1 case reads the single row's date below.
 		$wcpay_live_orders = wc_get_orders(
 			[
 				'payment_method' => 'woocommerce_payments',

--- a/tests/unit/admin/test-class-wc-payments-admin-banner.php
+++ b/tests/unit/admin/test-class-wc-payments-admin-banner.php
@@ -513,6 +513,82 @@ class WC_Payments_Admin_Banner_Test extends WCPAY_UnitTestCase {
 		$this->tear_down_one_and_done_global_state();
 	}
 
+	/**
+	 * Performance contract (WOOPMNT-6240): the eligibility order queries must pass
+	 * `orderby => 'none'` so their LIMIT short-circuits instead of filesorting
+	 * every matching order on large stores. Captures the args WC receives and
+	 * asserts the contract, so a future refactor can't silently reintroduce the
+	 * default ORDER BY.
+	 */
+	public function test_one_and_done_eligibility_order_queries_use_orderby_none(): void {
+		$this->set_up_one_and_done_global_state();
+		$banner = $this->make_admin_banner_for_notice_test( true, true, false, true, true );
+
+		$captured = [];
+		$capture  = function ( $args ) use ( &$captured ) {
+			$captured[] = $args;
+			return $args;
+		};
+		add_filter( 'woocommerce_order_query_args', $capture );
+
+		$banner->should_show_one_and_done_notice();
+
+		remove_filter( 'woocommerce_order_query_args', $capture );
+
+		// Only assert on the eligibility queries, which always constrain
+		// payment_method. WC core's internal refund fetch (triggered by loading the
+		// returned order objects) leaves payment_method empty and is out of scope.
+		$eligibility_queries = array_filter(
+			$captured,
+			static function ( $args ) {
+				return ! empty( $args['payment_method'] );
+			}
+		);
+
+		$this->assertNotEmpty( $eligibility_queries, 'Eligibility check should issue at least one order query.' );
+		foreach ( $eligibility_queries as $args ) {
+			$this->assertSame( 'none', $args['orderby'] ?? null );
+		}
+
+		$this->tear_down_one_and_done_global_state();
+	}
+
+	/**
+	 * Performance contract (WOOPMNT-6240): mirror of the one-and-done assertion for
+	 * the test-to-live eligibility order query.
+	 */
+	public function test_test_to_live_eligibility_order_query_uses_orderby_none(): void {
+		$this->set_up_notice_global_state();
+		$banner = $this->make_admin_banner_for_notice_test();
+
+		$captured = [];
+		$capture  = function ( $args ) use ( &$captured ) {
+			$captured[] = $args;
+			return $args;
+		};
+		add_filter( 'woocommerce_order_query_args', $capture );
+
+		$banner->should_show_test_to_live_notice();
+
+		remove_filter( 'woocommerce_order_query_args', $capture );
+
+		// Only assert on the eligibility queries, which always constrain
+		// payment_method (see the one-and-done sibling test for rationale).
+		$eligibility_queries = array_filter(
+			$captured,
+			static function ( $args ) {
+				return ! empty( $args['payment_method'] );
+			}
+		);
+
+		$this->assertNotEmpty( $eligibility_queries, 'Eligibility check should issue at least one order query.' );
+		foreach ( $eligibility_queries as $args ) {
+			$this->assertSame( 'none', $args['orderby'] ?? null );
+		}
+
+		$this->tear_down_notice_global_state();
+	}
+
 	public function test_should_show_one_and_done_notice_returns_false_when_user_cannot_manage_woocommerce(): void {
 		$this->set_up_one_and_done_global_state();
 		$subscriber = self::factory()->user->create( [ 'role' => 'subscriber' ] );


### PR DESCRIPTION
Fixes WOOPMNT-6240

#### Changes proposed in this Pull Request

The one-and-done and test-to-live admin banner eligibility checks run a capped `wc_get_orders()` query to decide whether to show their nudge. Although limited to 1–2 rows, the queries carried an implicit `ORDER BY date_created_gmt`, which forces the database to locate and sort **every** matching order before applying the `LIMIT`. On large stores the WooPayments live-order query filesorted over millions of rows and took 60s+, blocking admin order pages — reported on woocommerce.com while viewing an order edit screen.

- Pass `orderby => 'none'` to the eligibility order queries so the `LIMIT` short-circuits after the first matching rows instead of filesorting the whole matched set. The 2-row cap only needs to distinguish 0 / 1 / ≥2 orders, and the single-order case still reads its `date_created` directly, so dropping the sort is behavior-preserving. Applied to the one-and-done `Q1`/`Q2` queries and the test-to-live existence check.
- Run the `get_current_screen()` gate **before** the eligibility check in both enqueue callbacks (matching the post-KYC banner) so the query is skipped entirely on admin screens where the notice can never render.

<!-- Questions for PR author -->

**How can this code break?** Only if ordering were load-bearing for the result — it isn't. The count cap distinguishes 0 / 1 / ≥2, and the single qualifying order is unambiguous; the permanent-ineligible short-circuit and 7-day recency check are unaffected.

**What ensures it doesn't?** The full `WC_Payments_Admin_Banner_Test` suite (89 tests, 120 assertions) passes unchanged against the real `wc_get_orders`, and a runtime SQL capture confirmed the emitted query no longer contains `ORDER BY` while eligibility stays correct across every scenario (0 / 1-old / 1-recent / 2 / 1-WCPay+1-other).

> **Note:** The fix removes the `ORDER BY` filesort that caused the incident; for the reported heavy-WooPayments store the `LIMIT 2` now short-circuits and the permanent-ineligible flag prevents re-runs. Verification was done on a local store; an `EXPLAIN` against a production-scale HPOS table wasn't possible locally.

#### Testing instructions

- Check out this branch and run the banner unit suite:
  - `./bin/run-tests.sh --filter 'WC_Payments_Admin_Banner_Test'`
- [ ] Confirm all 89 tests pass.
- On a store with a connected, live WooPayments account and exactly one completed WooPayments live order older than 7 days, visit a WC admin screen (e.g. Settings) and confirm the one-and-done nudge still appears.
- [ ] Confirm the nudge shows for the eligible cohort, and stops showing once a 2nd order (via any gateway) exists.
- [ ] With Query Monitor open on a non-WooCommerce admin screen (e.g. Dashboard, Plugins), confirm the banner eligibility order query no longer runs there.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — backend-only change, does not apply.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows), if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
