### PR TITLE
fix: VariableAnalysis UnusedVariable sniff in stragglers `includes`

### DIFF
--- a/changelog/fix-unused-variable-sniffs-remaining-includes
+++ b/changelog/fix-unused-variable-sniffs-remaining-includes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: fix: enable VariableAnalysis UnusedVariable sniff on remaining includes/ and src/ files (part of #8436)

--- a/includes/admin/class-wc-rest-payments-pm-promotions-controller.php
+++ b/includes/admin/class-wc-rest-payments-pm-promotions-controller.php
@@ -131,12 +131,12 @@ class WC_REST_Payments_PM_Promotions_Controller extends WC_Payments_REST_Control
 	 * Validate the promotion ID parameter.
 	 *
 	 * @param mixed           $value   The parameter value.
-	 * @param WP_REST_Request $request The request object.
-	 * @param string          $param   The parameter name.
+	 * @param WP_REST_Request $_unused_request The request object.
+	 * @param string          $_unused_param   The parameter name.
 	 *
 	 * @return bool True if valid, false otherwise.
 	 */
-	public function validate_promotion_id( $value, WP_REST_Request $request, string $param ): bool {
+	public function validate_promotion_id( $value, WP_REST_Request $_unused_request, string $_unused_param ): bool {
 		if ( ! is_string( $value ) || empty( $value ) ) {
 			return false;
 		}

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -511,7 +511,7 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_settings(): WP_REST_Response {
-		$wcpay_form_fields = $this->wcpay_gateway->get_form_fields();
+		$this->wcpay_gateway->get_form_fields();
 
 		$available_upe_payment_methods = $this->wcpay_gateway->get_upe_available_payment_methods();
 

--- a/includes/class-wc-payment-token-wcpay-amazon-pay.php
+++ b/includes/class-wc-payment-token-wcpay-amazon-pay.php
@@ -44,10 +44,10 @@ class WC_Payment_Token_WCPay_Amazon_Pay extends WC_Payment_Token {
 	/**
 	 * Get payment method type to display to user.
 	 *
-	 * @param  string $deprecated Deprecated since WooCommerce 3.0.
+	 * @param  string $_unused_deprecated Deprecated since WooCommerce 3.0.
 	 * @return string
 	 */
-	public function get_display_name( $deprecated = '' ) {
+	public function get_display_name( $_unused_deprecated = '' ) {
 		$email = $this->get_email();
 		if ( ! empty( $email ) ) {
 			return sprintf(
@@ -93,10 +93,10 @@ class WC_Payment_Token_WCPay_Amazon_Pay extends WC_Payment_Token {
 	/**
 	 * Returns the type of this payment token.
 	 *
-	 * @param  string $deprecated Deprecated since WooCommerce 3.0.
+	 * @param  string $_unused_deprecated Deprecated since WooCommerce 3.0.
 	 * @return string Payment Token Type.
 	 */
-	public function get_type( $deprecated = '' ) {
+	public function get_type( $_unused_deprecated = '' ) {
 		return self::TYPE;
 	}
 

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -840,9 +840,9 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	 * to immediately redirect to the main "Welcome to WooPayments" onboarding page.
 	 * Note that this function immediately ends the execution.
 	 *
-	 * @param string|null $error_message Optional error message to show in a notice.
+	 * @param string|null $_unused_error_message Optional error message to show in a notice.
 	 */
-	public function redirect_to_onboarding_welcome_page( $error_message = null ) {
+	public function redirect_to_onboarding_welcome_page( $_unused_error_message = null ) {
 		$this->redirect_service->redirect_to_nox_flow();
 	}
 
@@ -2910,7 +2910,7 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 			return [];
 		}
 
-		$gateway_form_fields = $gateway->get_form_fields();
+		$gateway->get_form_fields();
 
 		$payment_methods_available = $gateway->get_upe_available_payment_methods();
 		$payment_methods_enabled   = $gateway->get_upe_enabled_payment_method_ids();

--- a/includes/class-wc-payments-payment-request-session-handler.php
+++ b/includes/class-wc-payments-payment-request-session-handler.php
@@ -120,9 +120,9 @@ final class WC_Payments_Payment_Request_Session_Handler extends WC_Session_Handl
 	/**
 	 * Delete the session from the cache and database.
 	 *
-	 * @param int $customer_id Customer ID.
+	 * @param int $_unused_customer_id Customer ID.
 	 */
-	public function delete_session( $customer_id ) {
+	public function delete_session( $_unused_customer_id ) {
 		parent::delete_session( $this->session_id );
 	}
 
@@ -162,9 +162,9 @@ final class WC_Payments_Payment_Request_Session_Handler extends WC_Session_Handl
 	/**
 	 * Save data - copy of parent method with a few modifications.
 	 *
-	 * @param int $old_session_key session ID before user logs in.
+	 * @param int $_unused_old_session_key session ID before user logs in.
 	 */
-	public function save_data( $old_session_key = 0 ) {
+	public function save_data( $_unused_old_session_key = 0 ) {
 		// Dirty if something changed - prevents saving nothing new.
 		if ( $this->_dirty ) {
 			global $wpdb;

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -333,10 +333,10 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	 *
 	 * @param bool            $update_payment_method Whether to update the payment method.
 	 * @param string          $new_payment_method The new payment method.
-	 * @param WC_Subscription $subscription The subscription.
+	 * @param WC_Subscription $_unused_subscription The subscription.
 	 * @return bool
 	 */
-	public function update_payment_method_for_subscriptions( $update_payment_method, $new_payment_method, $subscription ) {
+	public function update_payment_method_for_subscriptions( $update_payment_method, $new_payment_method, $_unused_subscription ) {
 		// Skip if the change payment method request was not made yet.
 		if ( ! isset( $_POST['_wcsnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wcsnonce'] ), 'wcs_change_payment_method' ) ) {
 			return $update_payment_method;
@@ -1094,12 +1094,12 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	 * want it to inherit from the parent order.
 	 *
 	 * @param string $order_meta_query The metadata query (a valid SQL query).
-	 * @param int    $to_order         The renewal order.
-	 * @param int    $from_order       The source (parent) order.
+	 * @param int    $_unused_to_order         The renewal order.
+	 * @param int    $_unused_from_order       The source (parent) order.
 	 *
 	 * @return string
 	 */
-	public function update_renewal_meta_data( $order_meta_query, $to_order, $from_order ) {
+	public function update_renewal_meta_data( $order_meta_query, $_unused_to_order, $_unused_from_order ) {
 		$order_meta_query .= " AND `meta_key` NOT IN ('_new_order_tracking_complete')";
 
 		return $order_meta_query;

--- a/includes/subscriptions/class-wc-payments-invoice-service.php
+++ b/includes/subscriptions/class-wc-payments-invoice-service.php
@@ -297,8 +297,6 @@ class WC_Payments_Invoice_Service {
 			return;
 		}
 
-		$charge = $intent_object->get_charge();
-
 		$this->order_service->attach_intent_info_to_order( $order, $intent_object );
 	}
 

--- a/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
+++ b/includes/subscriptions/class-wc-payments-subscriptions-disabler.php
@@ -118,11 +118,11 @@ class WC_Payments_Subscriptions_Disabler {
 	 *
 	 * We run this at priority 99 to ensure it executes after WCS adds the meta box.
 	 *
-	 * @param string                $post_type The post type of the current post being edited.
-	 * @param WP_Post|WC_Order|null $post_or_order_object The post or order currently being edited.
+	 * @param string                $_unused_post_type The post type of the current post being edited.
+	 * @param WP_Post|WC_Order|null $_unused_post_or_order_object The post or order currently being edited.
 	 * @return void
 	 */
-	public function remove_related_orders_meta_box( $post_type, $post_or_order_object = null ) {
+	public function remove_related_orders_meta_box( $_unused_post_type, $_unused_post_or_order_object = null ) {
 		// Only process when WCS functions are available.
 		if ( ! function_exists( 'wcs_get_page_screen_id' ) ) {
 			return;

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -293,9 +293,9 @@ class WooPay_Session {
 	 *
 	 * @param bool      $needs_payment If the order needs payment.
 	 * @param \WC_Order $order The order.
-	 * @param array     $valid_order_statuses The valid order statuses.
+	 * @param array     $_unused_valid_order_statuses The valid order statuses.
 	 */
-	public static function woopay_trial_subscriptions_handler( $needs_payment, $order, $valid_order_statuses ) {
+	public static function woopay_trial_subscriptions_handler( $needs_payment, $order, $_unused_valid_order_statuses ) {
 		if ( ! self::is_request_from_woopay() || ! \WC_Payments_Utils::is_store_api_request() ) {
 			return $needs_payment;
 		}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -52,26 +52,12 @@
 	</rule>
 
 	<!--
-		The UnusedVariable sniff is enabled repo-wide. The paths below stay excluded
-		because they are out of scope for https://github.com/Automattic/woocommerce-payments/issues/8436
-		(POC config classes) or were not enumerated in its sub-issues (#8653 / #8654 / #8655).
-		Remaining cleanup is tracked by #8436; remove a pattern once its files are fixed.
+		The UnusedVariable sniff is enabled repo-wide. The only path still excluded is the
+		POC payment-method definition classes, which are out of scope for
+		https://github.com/Automattic/woocommerce-payments/issues/8436.
 	-->
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable">
-		<!-- POC payment-method definition classes; not part of #8436. -->
 		<exclude-pattern>includes/payment-methods/Configs/</exclude-pattern>
-
-		<!-- includes/ + src/ files not listed in https://github.com/Automattic/woocommerce-payments/issues/8654; tracked by #8436. -->
-		<exclude-pattern>includes/admin/class-wc-rest-payments-pm-promotions-controller.php</exclude-pattern>
-		<exclude-pattern>includes/admin/class-wc-rest-payments-settings-controller.php</exclude-pattern>
-		<exclude-pattern>includes/class-wc-payment-token-wcpay-amazon-pay.php</exclude-pattern>
-		<exclude-pattern>includes/class-wc-payments-account.php</exclude-pattern>
-		<exclude-pattern>includes/class-wc-payments-payment-request-session-handler.php</exclude-pattern>
-		<exclude-pattern>includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php</exclude-pattern>
-		<exclude-pattern>includes/subscriptions/class-wc-payments-invoice-service.php</exclude-pattern>
-		<exclude-pattern>includes/subscriptions/class-wc-payments-subscriptions-disabler.php</exclude-pattern>
-		<exclude-pattern>includes/woopay/class-woopay-session.php</exclude-pattern>
-		<exclude-pattern>src/Internal/Abilities/Domain/</exclude-pattern>
 	</rule>
 
 	<!-- Disallow long array syntax -->

--- a/src/Internal/Abilities/Domain/GetAccount.php
+++ b/src/Internal/Abilities/Domain/GetAccount.php
@@ -72,11 +72,11 @@ class GetAccount implements AbilityDefinition {
 	 *
 	 * @see \WC_REST_Payments_Accounts_Controller::get_account_data()
 	 *
-	 * @param mixed $input Unused (zero-arg ability).
+	 * @param mixed $_unused_input Unused (zero-arg ability).
 	 * @return array|\WP_Error Account data, or `wcpay_not_initialized` WP_Error
 	 *                        when the WooPayments account is not initialized.
 	 */
-	public static function execute( $input = null ) {
+	public static function execute( $_unused_input = null ) {
 		$result = AbilitiesRegistrar::delegate_to_rest_controller( 'GET', '/wc/v3/payments/accounts' );
 
 		// `false` from the controller (unwrapped to `[]` here) means WooPayments

--- a/src/Internal/Abilities/Domain/GetActiveLoanSummary.php
+++ b/src/Internal/Abilities/Domain/GetActiveLoanSummary.php
@@ -69,10 +69,10 @@ class GetActiveLoanSummary implements AbilityDefinition {
 	 *
 	 * @see \WC_REST_Payments_Capital_Controller::get_active_loan_summary()
 	 *
-	 * @param mixed $input Unused (zero-arg ability).
+	 * @param mixed $_unused_input Unused (zero-arg ability).
 	 * @return array|\WP_Error
 	 */
-	public static function execute( $input = null ) {
+	public static function execute( $_unused_input = null ) {
 		return AbilitiesRegistrar::delegate_to_rest_controller( 'GET', '/wc/v3/payments/capital/active_loan_summary' );
 	}
 }

--- a/src/Internal/Abilities/Domain/GetAuthorizationsSummary.php
+++ b/src/Internal/Abilities/Domain/GetAuthorizationsSummary.php
@@ -69,10 +69,10 @@ class GetAuthorizationsSummary implements AbilityDefinition {
 	 *
 	 * @see \WC_REST_Payments_Authorizations_Controller::get_authorizations_summary()
 	 *
-	 * @param mixed $input Unused (zero-arg ability).
+	 * @param mixed $_unused_input Unused (zero-arg ability).
 	 * @return array|\WP_Error
 	 */
-	public static function execute( $input = null ) {
+	public static function execute( $_unused_input = null ) {
 		return AbilitiesRegistrar::delegate_to_rest_controller( 'GET', '/wc/v3/payments/authorizations/summary' );
 	}
 }

--- a/src/Internal/Abilities/Domain/GetDepositsOverview.php
+++ b/src/Internal/Abilities/Domain/GetDepositsOverview.php
@@ -69,10 +69,10 @@ class GetDepositsOverview implements AbilityDefinition {
 	 *
 	 * @see \WC_REST_Payments_Deposits_Controller::get_all_deposits_overviews()
 	 *
-	 * @param mixed $input Unused (zero-arg ability).
+	 * @param mixed $_unused_input Unused (zero-arg ability).
 	 * @return array|\WP_Error
 	 */
-	public static function execute( $input = null ) {
+	public static function execute( $_unused_input = null ) {
 		return AbilitiesRegistrar::delegate_to_rest_controller( 'GET', '/wc/v3/payments/deposits/overview-all' );
 	}
 }


### PR DESCRIPTION
Part of #8436.

#### Changes proposed in this Pull Request

Removing the `includes/` and `src/` `UnusedVariable` exclusions left over from #8654 — the files that weren't in the original issue list and fixing them.
Unused params get the `$_unused_` prefix, dead locals are dropped while keeping any side-effecting call (the `get_form_fields()` calls still run, they populate the gateway's form fields).

After this the only `UnusedVariable` exclude left is the POC payment-method `Configs/` (handled in a follow-up on top of this one).

#### Testing instructions

There are no functional changes.

- Check out this branch
- Run `npm run lint:php` — it should pass with no `UnusedVariable` warnings
- CI's PHP unit tests should stay green

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)
