### PR TITLE
fix: default reports date filter to the Between operator

### DIFF
--- a/changelog/fix-reports-date-filter-default-between
+++ b/changelog/fix-reports-date-filter-default-between
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Default the payments reports date filter to the Between operator so its date range presets are offered by default.

--- a/client/reports/balance/__tests__/balance-dataview.test.tsx
+++ b/client/reports/balance/__tests__/balance-dataview.test.tsx
@@ -1,0 +1,21 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { balanceDateFilterOperators } from '../balance-dataview';
+
+describe( 'Balance date filter operators', () => {
+	it( 'leads with Between so a newly added filter defaults to it', () => {
+		// DataViews uses operators[0] as the default operator for a newly added
+		// (or re-added) filter; `between` must lead so Balance avoids the
+		// confusing single-date "Past week / Past month" anchors (WOOPMNT-6243).
+		expect( balanceDateFilterOperators[ 0 ] ).toBe( 'between' );
+		expect( balanceDateFilterOperators ).toEqual( [
+			'between',
+			'before',
+			'after',
+			'on',
+		] );
+	} );
+} );

--- a/client/reports/balance/balance-dataview.tsx
+++ b/client/reports/balance/balance-dataview.tsx
@@ -167,7 +167,12 @@ export const BalanceDataView = ( {
 						// the chip and leaves only the funnel toggle, which
 						// re-adds it (primary filters also hard-disable the
 						// funnel in DataViews).
-						operators: [ 'before', 'after', 'between', 'on' ],
+						//
+						// `between` leads so a re-added filter defaults to it
+						// (operators[0]); its range presets avoid the confusing
+						// single-date "Past week / Past month" anchors that a
+						// `before` default surfaced (see WOOPMNT-6243).
+						operators: [ 'between', 'before', 'after', 'on' ],
 					},
 					getValue: () => displayPeriod.start,
 				},

--- a/client/reports/balance/balance-dataview.tsx
+++ b/client/reports/balance/balance-dataview.tsx
@@ -35,6 +35,15 @@ import type { ReportsPeriodRange } from 'wcpay/reports/period-selector';
 import type { DateFilterValue } from 'wcpay/reports/date-filter';
 import { DataViewsDateRangePresetPortal } from 'wcpay/reports/date-filter/dataviews-date-range-preset-portal';
 
+// Date-filter operators for the Balance report. `between` leads so a newly
+// added (or re-added) filter defaults to it — DataViews uses operators[0] —
+// surfacing the range presets instead of the confusing single-date
+// "Past week / Past month" anchors a `before` default produced (WOOPMNT-6243).
+// Exported so the ordering is guarded by a unit test.
+export const balanceDateFilterOperators: Array<
+	'between' | 'before' | 'after' | 'on'
+> = [ 'between', 'before', 'after', 'on' ];
+
 // DataViews keeps the chips row collapsed until the funnel is toggled —
 // `isShowingFilter` starts false for non-primary filters and isn't part of the
 // public API. We open it once by clicking the funnel button so the active Date
@@ -167,12 +176,7 @@ export const BalanceDataView = ( {
 						// the chip and leaves only the funnel toggle, which
 						// re-adds it (primary filters also hard-disable the
 						// funnel in DataViews).
-						//
-						// `between` leads so a re-added filter defaults to it
-						// (operators[0]); its range presets avoid the confusing
-						// single-date "Past week / Past month" anchors that a
-						// `before` default surfaced (see WOOPMNT-6243).
-						operators: [ 'between', 'before', 'after', 'on' ],
+						operators: balanceDateFilterOperators,
 					},
 					getValue: () => displayPeriod.start,
 				},

--- a/client/reports/fees/__tests__/fields.test.tsx
+++ b/client/reports/fees/__tests__/fields.test.tsx
@@ -209,14 +209,17 @@ describe( 'getFeesFields field configuration', () => {
 		} );
 	} );
 
-	it( 'configures Date as a native DataViews date filter', () => {
+	it( 'configures Date as a native DataViews date filter defaulting to Between', () => {
 		const field = getTestFeesFields().find( ( f ) => f.id === 'date' );
 		expect( field?.label ).toBe( 'Date' );
 		expect( field?.header ).toBe( 'Date & time' );
 		expect( field?.type ).toBe( 'date' );
 		expect( field?.elements ).toBeUndefined();
+		// `between` leads so DataViews defaults a newly added date filter to it
+		// (operators[0]); range presets live there, avoiding the confusing
+		// single-date "Past week / Past month" anchors under before/after/on.
 		expect( field?.filterBy ).toEqual( {
-			operators: [ 'on', 'before', 'after', 'between' ],
+			operators: [ 'between', 'on', 'before', 'after' ],
 		} );
 	} );
 

--- a/client/reports/fees/fields.tsx
+++ b/client/reports/fees/fields.tsx
@@ -57,7 +57,10 @@ export const getFeesFields = ( {
 			type: 'date',
 			enableSorting: true,
 			enableGlobalSearch: false,
-			filterBy: { operators: [ 'on', 'before', 'after', 'between' ] },
+			// `between` leads so DataViews defaults a newly added date filter to
+			// it (operators[0]); its range presets avoid the confusing
+			// single-date "Past week / Past month" anchors (see WOOPMNT-6243).
+			filterBy: { operators: [ 'between', 'on', 'before', 'after' ] },
 			getValue: ( { item }: { item: ReportsFee } ) => item.date,
 			render: ( { item }: { item: ReportsFee } ) => (
 				<>


### PR DESCRIPTION
Closes WOOPMNT-6243

#### Changes proposed in this Pull Request

The payments reports date filter (Balance + Fees) exposed the native DataViews single-date presets **Past week** / **Past month** under the before/after/on operators. Those presets only set a single anchor date, so selecting **Past month** while the operator was **Before** rendered a confusing `Before <a month ago>` chip. On the **Balance** report the `before` operator maps to *the anchor's month-to-date*, so a store without recent activity saw **no results** — the symptom reported in WOOPMNT-6243.

This PR makes **Between** the default operator for the date filter on both the Balance and Fees tabs. DataViews uses `operators[0]` as the default when a filter is added (and for the operator dropdown), so reordering the `operators` array is sufficient. Between is where the meaningful range presets already live (Previous month/year, Last 7/30 days, Month/Year to date), so defaulting there sidesteps the misleading single-date anchors entirely.

This is the lightweight, agreed-upon fix; a deeper review of the single-date presets (hiding Past week/Past month, dropping Today/Yesterday on Balance, etc.) is deferred to a wider Product & Design discussion.

> The reports area is gated behind the `_wcpay_feature_reports_area` flag (off by default), so this is not merchant-facing yet.

**How can this code break?** A future `@wordpress/dataviews` upgrade could change how the default operator is derived from the field config.
**What prevents that?** A unit test pins `operators[0] === 'between'` for the Fees date field; the Balance ordering is covered by the manual testing below.

#### Testing instructions

1. Enable the reports area feature flag (`_wcpay_feature_reports_area`).
2. Go to **Payments → Reports**.
3. **Fees tab:** open **Add filter → Date**. Confirm the operator defaults to **Between (inc)** and the range presets (Previous month, Previous year, Last 7 days, …) are shown — not the single-date Today/Yesterday/Past week/Past month set.
4. **Balance tab:** the report loads with a **Between** range by default. Clear the date filter (×) and re-add it via the funnel → confirm it defaults to **Between** again (previously defaulted to *Before*, which produced the confusing "Before … / no results" chip).
5. Switching the operator to Before / After / On still works and shows the single-date calendar.

-------------------

- [x] Run `npm run changelog` to add a changelog file — added `changelog/fix-reports-date-filter-default-between` (Type: fix, Significance: patch).
- [x] Covered with tests — `client/reports/fees/__tests__/fields.test.tsx` pins Between as the default operator.
- [x] Tested on mobile (or does not apply) — admin Reports UI; no mobile-specific surface.

**Post merge**

- [ ] Link to testing instructions from release testing doc: _QA Testing Not Applicable (feature flag off by default)_
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
