### PR TITLE
fix: request capability when its key is absent

### DIFF
--- a/changelog/fix-request-absent-bnpl-capabilities-on-settings-save
+++ b/changelog/fix-request-absent-bnpl-capabilities-on-settings-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Request unrequested payment method capabilities (e.g. BNPL) on settings save when the capability is absent from cached account data

--- a/includes/admin/class-wc-rest-payments-settings-controller.php
+++ b/includes/admin/class-wc-rest-payments-settings-controller.php
@@ -730,6 +730,9 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 			)
 		);
 
+		// The list is now restricted to available methods, i.e. those the account has fees for
+		// (see get_upe_available_payment_methods). So the capability request below is already
+		// scoped to fee-backed methods and doesn't need to re-check fees itself.
 		$this->request_unrequested_payment_methods( $payment_method_ids_to_enable );
 
 		$active_payment_methods   = $this->wcpay_gateway->get_upe_enabled_payment_method_ids();
@@ -805,11 +808,16 @@ class WC_REST_Payments_Settings_Controller extends WC_Payments_REST_Controller {
 		$cache_needs_refresh     = false;
 		foreach ( $payment_method_ids_to_enable as $payment_method_id_to_enable ) {
 			$stripe_key = $capability_key_map[ $payment_method_id_to_enable ] ?? null;
-			if ( array_key_exists( $stripe_key, $payment_method_statuses ) ) {
-				if ( 'unrequested' === $payment_method_statuses[ $stripe_key ]['status'] ) {
-					$request_result      = $this->api_client->request_capability( $stripe_key, true );
-					$cache_needs_refresh = $cache_needs_refresh || 'unrequested' !== $request_result['status'];
-				}
+			if ( null === $stripe_key ) {
+				continue;
+			}
+
+			// A never-requested capability is absent from the cached account data rather than
+			// reported as 'unrequested' — and the settings UI treats that absence as 'unrequested',
+			// letting the merchant enable the method. Default the same way so it gets requested here.
+			if ( 'unrequested' === ( $payment_method_statuses[ $stripe_key ]['status'] ?? 'unrequested' ) ) {
+				$request_result      = $this->api_client->request_capability( $stripe_key, true );
+				$cache_needs_refresh = $cache_needs_refresh || 'unrequested' !== $request_result['status'];
 			}
 		}
 

--- a/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-settings-controller.php
@@ -435,6 +435,10 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	public function test_update_settings_saves_enabled_payment_methods() {
 		WC_Payments::get_gateway()->update_option( 'upe_enabled_payment_method_ids', [ Payment_Method::CARD ] );
 
+		$this->mock_api_client
+			->method( 'request_capability' )
+			->willReturn( [ 'status' => 'pending' ] );
+
 		$request = new WP_REST_Request();
 
 		$request->set_param( 'enabled_payment_method_ids', [ Payment_Method::CARD, Payment_Method::IDEAL ] );
@@ -442,6 +446,32 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$this->controller->update_settings( $request );
 
 		$this->assertEquals( [ Payment_Method::CARD, Payment_Method::IDEAL ], WC_Payments::get_gateway()->get_option( 'upe_enabled_payment_method_ids' ) );
+	}
+
+	public function test_update_settings_requests_capability_absent_from_cached_account_data() {
+		// On a fresh account the cached account data does not enumerate every capability.
+		// Enabling such a method must still request its capability from the server, otherwise
+		// it shows as enabled in settings while never being activated on the account.
+		WC_Payments::get_gateway()->update_option( 'upe_enabled_payment_method_ids', [ Payment_Method::CARD ] );
+
+		$this->mock_wcpay_account
+			->method( 'get_cached_account_data' )
+			->willReturn(
+				[
+					'capabilities' => [ 'card_payments' => 'active' ],
+				]
+			);
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'request_capability' )
+			->with( 'ideal_payments', true )
+			->willReturn( [ 'status' => 'pending' ] );
+
+		$request = new WP_REST_Request();
+		$request->set_param( 'enabled_payment_method_ids', [ Payment_Method::CARD, Payment_Method::IDEAL ] );
+
+		$this->controller->update_settings( $request );
 	}
 
 	public function test_update_settings_calls_promotion_activation_for_newly_enabled_payment_methods() {
@@ -453,6 +483,10 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 		$mock_pm_promotions_service->expects( $this->once() )
 			->method( 'maybe_activate_promotion_for_payment_method' )
 			->with( Payment_Method::IDEAL );
+
+		$this->mock_api_client
+			->method( 'request_capability' )
+			->willReturn( [ 'status' => 'pending' ] );
 
 		// Create controller with the specific mock.
 		$controller = new WC_REST_Payments_Settings_Controller(
@@ -516,6 +550,10 @@ class WC_REST_Payments_Settings_Controller_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_settings_manual_capture_keeps_payment_methods_with_capture_later_capability() {
+		$this->mock_api_client
+			->method( 'request_capability' )
+			->willReturn( [ 'status' => 'pending' ] );
+
 		$request = new WP_REST_Request();
 		$request->set_param( 'is_manual_capture_enabled', true );
 		$request->set_param(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While testing on a new site, I ran into the BNPL methods showing as enabled in the settings, while their capabilities were never requested from Stripe.

When we save settings, we request the capability of any newly-enabled method whose status is `unrequested`. The catch is that we were only doing that when the capability key was already present in the cached account data. On a fresh account, a never-requested capability can be missing from that cache entirely (it's not always reported back as `unrequested`), so we'd silently skip the request - even though the settings UI already treats a missing status as `unrequested` and happily lets you enable the method.

So now we default a missing status to `unrequested` (same as the UI does) and request it.

It's unclear how to reproduce this reliably, but the behavior should stay the same for accounts that already have the capability in their cache.

We're still gating the request on methods that _do_ have an associated fee (the list is already filtered down to the available methods, i.e. the ones the account has fees for), so we're not firing off weird capability requests to Stripe for methods that aren't actually available.

#### Testing instructions

1. Connect a brand new account / site (one that hasn't requested the method yet), like a new JN site.
2. Before saving anything, check the cached account data in the WCPay Dev tools and note the capability's status (it should be absent / `unrequested`).
<img width="322" height="62" alt="Screenshot 2026-06-26 at 11 42 50 PM" src="https://github.com/user-attachments/assets/639fc172-ed62-44f1-8796-592ec8da2481" />

3. Go to **Payments → Settings**, enable a method that isn't active yet (e.g. P24), and save.
<img width="899" height="127" alt="Screenshot 2026-06-26 at 11 43 22 PM" src="https://github.com/user-attachments/assets/20059fa3-fddc-42e3-a884-1610103a7481" />

4. Check the cached account data again and confirm it changed - the capability is now there and its status moved away from `unrequested`.
<img width="364" height="72" alt="Screenshot 2026-06-26 at 11 43 40 PM" src="https://github.com/user-attachments/assets/d81ebd58-1dae-4cb0-ab96-faa2773825f3" />

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
