### PR TITLE
fix: point dev-tools clone at the GHES remote after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Your site will be available at `http://localhost:<PORT>/wp-admin/` (check `.env`
 Install the following plugins:
 
 -   WooCommerce
--   WCPay Dev Tools (clone or download [the GitHub repo](https://github.com/Automattic/woocommerce-payments-dev-tools))
+-   WCPay Dev Tools (clone or download [the GitHub repo](https://github.a8c.com/Automattic/woocommerce-payments-dev-tools))
     - This dependency is automatically updated to the latest version each time you perform a `git pull` or `git merge` in this repository, as long as the WCPay Dev Tools repository is cloned locally and remains on the `trunk` branch. For more details, please refer to the [post-merge](.husky/post-merge) hook.
 
 ### Optional local.env file

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -183,7 +183,7 @@ if [[ -d "$DEV_TOOLS_CLONE_PATH/.git" ]]; then
 	echo "Dev tools already cloned at $DEV_TOOLS_CLONE_PATH — skipping clone."
 	cli wp plugin activate woocommerce-payments-dev-tools
 else
-	git clone git@github.com:Automattic/woocommerce-payments-dev-tools.git "$DEV_TOOLS_CLONE_PATH"
+	git clone git@github.a8c.com:Automattic/woocommerce-payments-dev-tools.git "$DEV_TOOLS_CLONE_PATH"
 	if [[ $? -eq 0 ]]; then
 		cli wp plugin activate woocommerce-payments-dev-tools
 	else

--- a/changelog/fix-dev-tools-ghes-remote
+++ b/changelog/fix-dev-tools-ghes-remote
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Point the local WCPay Dev Tools clone and docs at the GHES remote following the github.com to GHES migration.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The private `Automattic/woocommerce-payments-dev-tools` repo was migrated to the Automattic GHES instance (`github.a8c.com`) and its github.com copy was **archived**. Our local Docker setup still cloned it over SSH from github.com, so a fresh `npm run up:recreate` now pulls an **archived (frozen) copy** — and will fail outright if that copy is ever removed.

This repoints the local dev-tools source to the new GHES remote:

- `bin/docker-setup.sh` — clone from `git@github.a8c.com:Automattic/woocommerce-payments-dev-tools.git`.
- `README.md` — update the dev-tools repo link to `https://github.a8c.com/...`.

**Scope notes**
- **E2E/CI is intentionally untouched.** CI and Jurassic Ninja clone the *public* mirror `woocommerce-payments-dev-tools-ci` via the `WCP_DEV_TOOLS_REPO` secret — that lives on github.com and is unaffected by the GHES migration.
- The `.husky/post-merge` auto-updater needs no change: it `git pull`s whatever remote the existing clone has. **Developers with an existing clone** should `git remote set-url` their dev-tools checkout to GHES (the migration's "update local clones" step) — that can't be done from this repo.

#### Testing instructions

1. With GHES SSH access configured, remove any existing dev-tools clone/volume and run `npm run up:recreate` (or `bin/docker-setup.sh`).
2. Confirm the WCPay Dev Tools plugin clones from `github.a8c.com` and activates without error.
3. Confirm the README link resolves to the GHES repo.

> ⚠️ I could not verify the SSH clone from the authoring environment (no GHES network access). The host (`github.a8c.com`) matches this repo's existing GHES usage in `.github/workflows/agent-*.yml`; please confirm the `git@github.a8c.com:…` SSH form against a working migrated clone (`git remote -v`) when testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
