### PR TITLE
chore(e2e): log dev-tools clone identity (temporary verification)

### DIFF
--- a/changelog/debug-e2e-dev-tools-clone-identity
+++ b/changelog/debug-e2e-dev-tools-clone-identity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Temporary: log the cloned dev-tools commit and plugin version during E2E setup to confirm which dev-tools repo CI uses.

--- a/tests/e2e/env/setup.sh
+++ b/tests/e2e/env/setup.sh
@@ -553,6 +553,14 @@ if [[ -d "$DEV_TOOLS_PATH" && ! -f "$DEV_TOOLS_PATH/vendor/autoload.php" ]]; the
 	success "Dev tools dependencies installed"
 fi
 
+# TEMP DEBUG — remove after verification. WCP_DEV_TOOLS_REPO is a masked secret, so the repo
+# URL never appears in CI logs; print the cloned commit + plugin version instead, which uniquely
+# identify which dev-tools repo CI used (-ci trunk HEAD vs the private repo's).
+section "Dev Tools — clone identity (temporary debug)"
+info "HEAD:    $( git -C "$DEV_TOOLS_PATH" rev-parse HEAD 2>/dev/null || echo unknown )"
+info "Commit:  $( git -C "$DEV_TOOLS_PATH" log -1 --pretty=format:'%h %ad %s' --date=short 2>/dev/null || echo unknown )"
+info "Version: $( grep -m1 -E '^\s*\*\s*Version:' "$DEV_TOOLS_PATH/woocommerce-payments-dev-tools.php" 2>/dev/null | tr -d '\r' || echo '(no Version header)' )"
+
 # ─── Client containers ───────────────────────────────────────────────────────
 
 section "WordPress client"


### PR DESCRIPTION
## Purpose (temporary — do not merge)

We're refactoring how E2E/CI gets the WCPay Dev Tools plugin, and the plan hinges on a claim: **CI clones the public `woocommerce-payments-dev-tools-ci` mirror**, not the private repo. That's currently only provable forensically (a PHP fatal matched `-ci`'s code). This PR makes it **show up directly in the E2E log**.

## What it does

`WCP_DEV_TOOLS_REPO` is a masked secret, and `clone_repo()` logs no URL/SHA on success — so the repo is invisible in logs. This adds a small block to the E2E "Dev Tools" setup step that prints the **cloned commit + plugin Version** (neither is a secret):

```
section "Dev Tools — clone identity (temporary debug)"
info "HEAD:    $( git -C "$DEV_TOOLS_PATH" rev-parse HEAD )"
info "Commit:  $( git -C "$DEV_TOOLS_PATH" log -1 --pretty=format:'%h %ad %s' )"
info "Version: $( grep '^\s*\*\s*Version:' "$DEV_TOOLS_PATH/woocommerce-payments-dev-tools.php" )"
```

## What to look for in the E2E run log

Under the **"Dev Tools — clone identity"** section, match the printed values:

| | `-ci` mirror (expected) | private repo |
|---|---|---|
| trunk HEAD | `261050d43  Update readme` | `12fb2bfdb  Add local WPCOM-hosted WooPay wiring for end-to-end dev testing (#157)` |
| Version header | *(none)* | `* Version: 1.25.0` |

If HEAD matches `-ci`'s trunk and Version is blank → confirmed CI uses the public mirror.

## After confirming
Revert / close this PR — it's a one-off verification aid, not meant to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
