### PR TITLE
[no review, just for testing] fix: changelog formatter PCRE JIT stack exhaustion on large changelog…

### DIFF
--- a/bin/class-wcpay-changelog-formatter.php
+++ b/bin/class-wcpay-changelog-formatter.php
@@ -76,8 +76,12 @@ class WCPay_Changelog_Formatter extends Parser implements FormatterPlugin {
 		}
 
 		// Entries make up the rest of the document.
+		// (*NO_JIT) prevents JIT stack exhaustion on large changelogs; interpreter limits are far more generous.
 		$entries = [];
-		preg_match_all( '/^=\s+([^\n=]+)\s+=(((?!^=).)+)/ms', $changelog, $version_sections );
+		$matched = preg_match_all( '/(*NO_JIT)^=\s+([^\n=]+)\s+=(((?!^=).)+)/ms', $changelog, $version_sections );
+		if ( false === $matched ) {
+			throw new \RuntimeException( 'Failed to parse changelog: PCRE error ' . preg_last_error_msg() );
+		}
 
 		foreach ( $version_sections[0] as $section ) {
 			$heading_pattern = '/^= +(\[?[^] ]+\]?) - (.+?) =/';

--- a/changelog/fix-changelog-formatter-pcre-jit
+++ b/changelog/fix-changelog-formatter-pcre-jit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix changelog formatter PCRE JIT stack exhaustion causing changelogger --amend to wipe all existing entries


### PR DESCRIPTION
Fixes #

See p1782790979602929/1782295427.360899-slack-C08LLP85KNW
#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

-------------------

- [ ] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.