### PR TITLE
Save and recover missing subscription renewal payment tokens

### DIFF
--- a/changelog/fix-woopmnt-6259-webhook-subscription-token
+++ b/changelog/fix-woopmnt-6259-webhook-subscription-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Attach WooPayments subscription tokens when webhook payment completion runs without checkout AJAX finalization.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2733,11 +2733,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			throw new Exception( __( 'Unable to save payment method for subscription. The order customer could not be found.', 'woocommerce-payments' ) );
 		}
 
-		$tokens = WC_Payment_Tokens::get_customer_tokens( $user->ID, self::GATEWAY_ID );
-		foreach ( $tokens as $customer_token ) {
-			if ( $customer_token instanceof WC_Payment_Token && $payment_method_id === $customer_token->get_token() ) {
-				$this->add_token_to_order( $order, $customer_token );
-				return $customer_token;
+		$gateway_ids      = [ self::GATEWAY_ID ];
+		$order_gateway_id = $order->get_payment_method();
+		if ( is_string( $order_gateway_id ) && 0 === strpos( $order_gateway_id, self::GATEWAY_ID ) ) {
+			$gateway_ids[] = $order_gateway_id;
+		}
+
+		foreach ( array_unique( $gateway_ids ) as $gateway_id ) {
+			$tokens = WC_Payment_Tokens::get_customer_tokens( $user->ID, $gateway_id );
+			foreach ( $tokens as $customer_token ) {
+				if ( $customer_token instanceof WC_Payment_Token && $payment_method_id === $customer_token->get_token() ) {
+					$this->add_token_to_order( $order, $customer_token );
+					return $customer_token;
+				}
 			}
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2712,6 +2712,42 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Ensures a payment method is saved as a WooCommerce token and attached to the order/subscription.
+	 *
+	 * @param WC_Order     $order             The order.
+	 * @param string       $payment_method_id The payment method ID.
+	 * @param WP_User|null $user              The user to attach the token to.
+	 * @return WC_Payment_Token The saved token.
+	 *
+	 * @throws Exception When the payment method cannot be saved for the order customer.
+	 */
+	public function ensure_payment_method_token_for_order( $order, $payment_method_id, $user = null ) {
+		$token = $this->get_payment_token( $order );
+		if ( $token instanceof WC_Payment_Token && $payment_method_id === $token->get_token() ) {
+			$this->add_token_to_order( $order, $token );
+			return $token;
+		}
+
+		$user = $this->get_payment_token_user_for_order( $order, $user );
+		if ( ! $user instanceof WP_User || empty( $user->ID ) ) {
+			throw new Exception( __( 'Unable to save payment method for subscription. The order customer could not be found.', 'woocommerce-payments' ) );
+		}
+
+		$tokens = WC_Payment_Tokens::get_customer_tokens( $user->ID, self::GATEWAY_ID );
+		foreach ( $tokens as $customer_token ) {
+			if ( $customer_token instanceof WC_Payment_Token && $payment_method_id === $customer_token->get_token() ) {
+				$this->add_token_to_order( $order, $customer_token );
+				return $customer_token;
+			}
+		}
+
+		$token = $this->token_service->add_payment_method_to_user( $payment_method_id, $user );
+		$this->add_token_to_order( $order, $token );
+
+		return $token;
+	}
+
+	/**
 	 * Retrieve payment token from a subscription or order.
 	 *
 	 * @param WC_Order $order Order or subscription object.
@@ -4141,8 +4177,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$token = null;
 			if ( $intent->is_authorized() && $should_save_payment_method && ! empty( $payment_method_id ) ) {
 				try {
-					$token = $this->token_service->add_payment_method_to_user( $payment_method_id, wp_get_current_user() );
-					$this->add_token_to_order( $order, $token );
+					$token = $this->ensure_payment_method_token_for_order( $order, $payment_method_id, wp_get_current_user() );
 				} catch ( Exception $e ) {
 					Logger::log( 'Error when saving payment method: ' . $e->getMessage() );
 
@@ -4932,6 +4967,21 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	private function get_payment_method_type_for_setup_intent( $intent, $token ) {
 		return 'wcpay_link' !== $token->get_type() ? $intent->get_payment_method_type() : LinkDefinition::get_id();
+	}
+
+	/**
+	 * Resolves the user that should own a payment token for an order.
+	 *
+	 * @param WC_Order     $order The order.
+	 * @param WP_User|null $user  The preferred user.
+	 * @return WP_User|false
+	 */
+	private function get_payment_token_user_for_order( $order, $user = null ) {
+		if ( $user instanceof WP_User && ! empty( $user->ID ) ) {
+			return $user;
+		}
+
+		return $order->get_user();
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -608,12 +608,60 @@ class WC_Payments_Webhook_Processing_Service {
 			return;
 		}
 
+		$previous_token_id = $this->get_order_last_payment_token_id( $order );
+
 		try {
-			$this->wcpay_gateway->ensure_payment_method_token_for_order( $order, $payment_method_id, $order->get_user() );
+			$token = $this->wcpay_gateway->ensure_payment_method_token_for_order( $order, $payment_method_id, $order->get_user() );
+			$this->maybe_add_subscription_token_repair_note( $order, $previous_token_id, $token );
 		} catch ( Exception $e ) {
 			Logger::log( 'Error when saving payment method from webhook: ' . $e->getMessage() );
 			$order->add_order_note( __( 'Unable to save payment method for subscription. Please try again or use a different payment method.', 'woocommerce-payments' ) );
 		}
+	}
+
+	/**
+	 * Gets the last payment token ID attached to an order.
+	 *
+	 * @param WC_Order $order The order.
+	 * @return int|null The last payment token ID, or null if none exists.
+	 */
+	private function get_order_last_payment_token_id( $order ) {
+		$payment_token_ids = $order->get_payment_tokens();
+		if ( ! is_array( $payment_token_ids ) || empty( $payment_token_ids ) ) {
+			return null;
+		}
+
+		$payment_token_id = end( $payment_token_ids );
+
+		return $payment_token_id ? (int) $payment_token_id : null;
+	}
+
+	/**
+	 * Adds observability when webhook token repair changes an existing subscription token.
+	 *
+	 * @param WC_Order         $order             The order.
+	 * @param int|null         $previous_token_id The token ID previously attached to the order.
+	 * @param WC_Payment_Token $token             The token attached after repair.
+	 */
+	private function maybe_add_subscription_token_repair_note( $order, $previous_token_id, $token ) {
+		if ( null === $previous_token_id || ! $token instanceof WC_Payment_Token ) {
+			return;
+		}
+
+		$new_token_id = (int) $token->get_id();
+		if ( $previous_token_id === $new_token_id ) {
+			return;
+		}
+
+		$note = sprintf(
+			/* translators: 1: Previous payment token ID, 2: New payment token ID. */
+			__( 'WooPayments updated the subscription payment method token from token #%1$d to #%2$d after receiving a successful renewal payment webhook.', 'woocommerce-payments' ),
+			$previous_token_id,
+			$new_token_id
+		);
+
+		Logger::log( $note );
+		$order->add_order_note( $note );
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -498,7 +498,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$charge_id     = $this->read_webhook_property( $charges_data[0], 'id' );
 		$charge_amount = $this->read_webhook_property( $event_object, 'amount' );
 
-		$payment_method_id = $charges_data[0]['payment_method'] ?? $event_object['payment_method'] ?? null;
+		$payment_method_id = $this->get_webhook_payment_method_id( $charges_data[0]['payment_method'] ?? $event_object['payment_method'] ?? null );
 		if ( ! $order ) {
 			return;
 		}
@@ -614,6 +614,20 @@ class WC_Payments_Webhook_Processing_Service {
 			Logger::log( 'Error when saving payment method from webhook: ' . $e->getMessage() );
 			$order->add_order_note( __( 'Unable to save payment method for subscription. Please try again or use a different payment method.', 'woocommerce-payments' ) );
 		}
+	}
+
+	/**
+	 * Extracts the payment method ID from a webhook payment method value.
+	 *
+	 * @param mixed $payment_method The payment method value from the webhook.
+	 * @return string|null The payment method ID.
+	 */
+	private function get_webhook_payment_method_id( $payment_method ) {
+		if ( is_array( $payment_method ) ) {
+			return isset( $payment_method['id'] ) && is_string( $payment_method['id'] ) ? $payment_method['id'] : null;
+		}
+
+		return is_string( $payment_method ) ? $payment_method : null;
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -498,7 +498,7 @@ class WC_Payments_Webhook_Processing_Service {
 		$charge_id     = $this->read_webhook_property( $charges_data[0], 'id' );
 		$charge_amount = $this->read_webhook_property( $event_object, 'amount' );
 
-		$payment_method_id = $charges_data[0]['payment_method'] ?? null;
+		$payment_method_id = $charges_data[0]['payment_method'] ?? $event_object['payment_method'] ?? null;
 		if ( ! $order ) {
 			return;
 		}
@@ -574,6 +574,7 @@ class WC_Payments_Webhook_Processing_Service {
 		}
 
 		$payment_intent = $this->api_client->deserialize_payment_intention_object_from_array( $event_object );
+		$this->ensure_order_payment_token_for_successful_recurring_intent( $order, $payment_intent, $payment_method_id );
 		$this->order_service->update_order_status_from_intent( $order, $payment_intent );
 
 		$payment_method = $charges_data[0]['payment_method_details']['type'] ?? null;
@@ -593,6 +594,26 @@ class WC_Payments_Webhook_Processing_Service {
 		// Clear the authorization summary cache to trigger a fetch of new data.
 		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY );
 		$this->database_cache->delete( DATABASE_CACHE::AUTHORIZATION_SUMMARY_KEY_TEST_MODE );
+	}
+
+	/**
+	 * Ensures recurring orders paid by webhook have a token for future renewals.
+	 *
+	 * @param WC_Order                          $order             The order.
+	 * @param WC_Payments_API_Payment_Intention $payment_intent    The payment intent.
+	 * @param string|null                       $payment_method_id The payment method ID.
+	 */
+	private function ensure_order_payment_token_for_successful_recurring_intent( $order, $payment_intent, $payment_method_id ) {
+		if ( ! $payment_intent->is_authorized() || empty( $payment_method_id ) || ! $this->wcpay_gateway->is_payment_recurring( $order->get_id() ) ) {
+			return;
+		}
+
+		try {
+			$this->wcpay_gateway->ensure_payment_method_token_for_order( $order, $payment_method_id, $order->get_user() );
+		} catch ( Exception $e ) {
+			Logger::log( 'Error when saving payment method from webhook: ' . $e->getMessage() );
+			$order->add_order_note( __( 'Unable to save payment method for subscription. Please try again or use a different payment method.', 'woocommerce-payments' ) );
+		}
 	}
 
 	/**

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -66,6 +66,18 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 	abstract public function add_token_to_order( $order, $token );
 
 	/**
+	 * Ensures a payment method is saved as a WooCommerce token and attached to the order/subscription.
+	 *
+	 * @param WC_Order     $order             The order.
+	 * @param string       $payment_method_id The payment method ID.
+	 * @param WP_User|null $user              The user to attach the token to.
+	 * @return WC_Payment_Token The saved token.
+	 *
+	 * @throws Exception When the payment method cannot be saved for the order customer.
+	 */
+	abstract public function ensure_payment_method_token_for_order( $order, $payment_method_id, $user = null );
+
+	/**
 	 * Returns a formatted token list for a user.
 	 *
 	 * @param int         $user_id    The user ID.
@@ -396,6 +408,9 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 		$token = $this->get_payment_token( $renewal_order );
 		if ( is_null( $token ) && ! WC_Payments::is_network_saved_cards_enabled() ) {
+			$token = $this->maybe_repair_renewal_order_payment_token( $renewal_order );
+		}
+		if ( is_null( $token ) && ! WC_Payments::is_network_saved_cards_enabled() ) {
 			$renewal_order->add_order_note( 'Subscription renewal failed: No saved payment method found.' );
 			Logger::error( 'There is no saved payment token for order #' . $renewal_order->get_id() );
 			// TODO: Update to use Order_Service->mark_payment_failed.
@@ -469,6 +484,44 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 
 				$renewal_order->add_order_note( $note );
 			}
+		}
+	}
+
+	/**
+	 * Attempts to repair a renewal order that is missing a token by using its subscription parent order.
+	 *
+	 * @param WC_Order $renewal_order The renewal order.
+	 * @return WC_Payment_Token|null The repaired token, or null when repair is not possible.
+	 */
+	private function maybe_repair_renewal_order_payment_token( $renewal_order ) {
+		if ( ! function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ) {
+			return null;
+		}
+
+		$subscriptions = wcs_get_subscriptions_for_renewal_order( $renewal_order->get_id() );
+		$subscription  = reset( $subscriptions );
+		if ( ! $subscription instanceof WC_Subscription ) {
+			return null;
+		}
+
+		$parent_order = wc_get_order( $subscription->get_parent_id() );
+		if ( ! $parent_order ) {
+			return null;
+		}
+
+		$payment_method_id = $this->order_service->get_payment_method_id_for_order( $parent_order );
+		if ( empty( $payment_method_id ) ) {
+			return null;
+		}
+
+		try {
+			$token = $this->ensure_payment_method_token_for_order( $parent_order, $payment_method_id, get_user_by( 'id', $subscription->get_customer_id() ) );
+			$this->add_token_to_order( $renewal_order, $token );
+			$renewal_order->add_order_note( __( 'Recovered missing subscription payment method token from the parent order.', 'woocommerce-payments' ) );
+			return $token;
+		} catch ( Exception $e ) {
+			Logger::error( 'Error repairing subscription renewal payment token for order #' . $renewal_order->get_id() . ': ' . $e->getMessage() );
+			return null;
 		}
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -367,8 +367,78 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 			->with( true );
 
 		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( WC_Helper_Intention::create_intention() );
+
+		$this->mock_customer_service
+			->expects( $this->any() )
+			->method( 'update_customer_for_user' )
+			->willReturn( self::CUSTOMER_ID );
+
+		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
+
+		$this->assertEquals( 'processing', $renewal_order->get_status() );
+	}
+
+	public function test_scheduled_subscription_payment_repairs_missing_renewal_token_from_parent_order() {
+		$parent_order  = WC_Helper_Order::create_order( self::USER_ID );
+		$renewal_order = WC_Helper_Order::create_order( self::USER_ID );
+		$token         = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
+		$user          = get_user_by( 'id', self::USER_ID );
+
+		$this->order_service->set_payment_method_id_for_order( $parent_order, self::PAYMENT_METHOD_ID );
+
+		$mock_subscription = $this->createMock( WC_Subscription::class );
+		$mock_subscription
+			->method( 'get_parent_id' )
+			->willReturn( $parent_order->get_id() );
+		$mock_subscription
+			->method( 'get_customer_id' )
+			->willReturn( $user->ID );
+
+		$this->mock_wcs_get_subscriptions_for_renewal_order( [ '1' => $mock_subscription ] );
+		$this->mock_wcs_get_subscriptions_for_order( [] );
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_customer_id_by_user_id' )
+			->with( self::USER_ID )
+			->willReturn( self::CUSTOMER_ID );
+
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_customer' )
+			->with( self::CUSTOMER_ID );
+
+		$request->expects( $this->once() )
+			->method( 'set_payment_method' )
+			->with( self::PAYMENT_METHOD_ID );
+
+		$request->expects( $this->once() )
+			->method( 'set_cvc_confirmation' )
+			->with( null );
+
+		$request->expects( $this->once() )
+			->method( 'set_amount' )
+			->with( 5000 )
+			->willReturn( $request );
+
+		$request->expects( $this->once() )
+			->method( 'set_currency_code' )
+			->with( 'usd' )
+			->willReturn( $request );
+
+		$request->expects( $this->never() )
+			->method( 'setup_future_usage' );
+
+		$request->expects( $this->once() )
 			->method( 'set_capture_method' )
 			->with( false );
+
+		$request->expects( $this->once() )
+			->method( 'set_off_session' )
+			->with( true );
 
 		$request->expects( $this->once() )
 			->method( 'format_response' )
@@ -381,6 +451,8 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 
 		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
 
+		$this->assertContains( $token->get_id(), $parent_order->get_payment_tokens() );
+		$this->assertContains( $token->get_id(), $renewal_order->get_payment_tokens() );
 		$this->assertEquals( 'processing', $renewal_order->get_status() );
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5225,6 +5225,24 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		unset( $_POST['payment_method'], $_POST['wcpay-express-payment-method-types'] );
 	}
 
+	public function test_ensure_payment_method_token_for_order_reuses_existing_amazon_pay_token() {
+		$user_id = self::factory()->user->create();
+		$user    = new WP_User( $user_id );
+		$order   = WC_Helper_Order::create_order( $user_id );
+		$order->set_payment_method( 'woocommerce_payments_amazon_pay' );
+		$order->save();
+		$token = WC_Helper_Token::create_amazon_pay_token( 'pm_amazon_mock', $user_id );
+
+		$this->mock_token_service
+			->expects( $this->never() )
+			->method( 'add_payment_method_to_user' );
+
+		$result = $this->card_gateway->ensure_payment_method_token_for_order( $order, 'pm_amazon_mock', $user );
+
+		$this->assertSame( $token->get_id(), $result->get_id() );
+		$this->assertSame( [ $token->get_id() ], wc_get_order( $order->get_id() )->get_payment_tokens() );
+	}
+
 	/**
 	 * Reset the PaymentMethodDefinitionRegistry singleton and register specific definitions.
 	 *

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -858,6 +858,100 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a recurring payment_intent.succeeded event handles an expanded intent payment method fallback.
+	 */
+	public function test_payment_intent_successful_saves_token_from_expanded_intent_payment_method() {
+		$this->event_body['type']           = 'payment_intent.succeeded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'             => 'pi_123123123123123',
+			'object'         => 'payment_intent',
+			'amount'         => 1500,
+			'charges'        => [
+				'data' => [
+					[
+						'id'                     => 'py_123123123123123',
+						'payment_method_details' => [
+							'type' => 'card',
+						],
+					],
+				],
+			],
+			'currency'       => 'eur',
+			'payment_method' => [
+				'id'     => 'pm_expanded',
+				'object' => 'payment_method',
+			],
+			'status'         => Intent_Status::SUCCEEDED,
+			'metadata'       => [],
+		];
+		$user                               = new WP_User( self::factory()->user->create() );
+		$stored_payment_method_id           = null;
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'deserialize_payment_intention_object_from_array' )
+			->with( $this->event_body['data']['object'] )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [ 'request_three_d_secure' => 'automatic' ] ],
+					]
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( $this->mock_order );
+
+		$this->mock_order
+			->method( 'get_user' )
+			->willReturn( $user );
+		$this->mock_order
+			->method( 'get_total' )
+			->willReturn( 15.00 );
+		$this->mock_order
+			->method( 'has_status' )
+			->willReturn( false );
+		$this->mock_order
+			->method( 'get_data_store' )
+			->willReturn( new \WC_Mock_WC_Data_Store() );
+		$this->mock_order
+			->method( 'get_meta' )
+			->willReturn( '' );
+		$this->mock_order
+			->expects( $this->atLeastOnce() )
+			->method( 'update_meta_data' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$stored_payment_method_id ) {
+					if ( '_payment_method_id' === $key ) {
+						$stored_payment_method_id = $value;
+					}
+				}
+			);
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'payment_complete' );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'is_payment_recurring' )
+			->with( 1234 )
+			->willReturn( true );
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'ensure_payment_method_token_for_order' )
+			->with( $this->mock_order, 'pm_expanded', $user );
+
+		$this->webhook_processing_service->process( $this->event_body );
+
+		$this->assertSame( 'pm_expanded', $stored_payment_method_id );
+	}
+
+	/**
 	 * Tests that a recurring payment_intent.succeeded event completes the order when token saving fails.
 	 */
 	public function test_payment_intent_successful_completes_recurring_order_when_token_saving_fails() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -952,6 +952,105 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Tests that token repair notes when a webhook replaces an existing subscription token.
+	 */
+	public function test_payment_intent_successful_notes_when_token_repair_replaces_existing_token() {
+		$this->event_body['type']           = 'payment_intent.succeeded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'pi_123123123123123',
+			'object'   => 'payment_intent',
+			'amount'   => 1500,
+			'charges'  => [
+				'data' => [
+					[
+						'id'                     => 'py_123123123123123',
+						'payment_method'         => 'pm_new',
+						'payment_method_details' => [
+							'type' => 'card',
+						],
+					],
+				],
+			],
+			'currency' => 'eur',
+			'status'   => Intent_Status::SUCCEEDED,
+			'metadata' => [],
+		];
+		$user                               = new WP_User( self::factory()->user->create() );
+		$token                              = $this->createMock( WC_Payment_Token::class );
+		$repair_note_added                  = false;
+
+		$token
+			->method( 'get_id' )
+			->willReturn( 22 );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'deserialize_payment_intention_object_from_array' )
+			->with( $this->event_body['data']['object'] )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [ 'request_three_d_secure' => 'automatic' ] ],
+					]
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( $this->mock_order );
+
+		$this->mock_order
+			->method( 'get_user' )
+			->willReturn( $user );
+		$this->mock_order
+			->method( 'get_total' )
+			->willReturn( 15.00 );
+		$this->mock_order
+			->method( 'has_status' )
+			->willReturn( false );
+		$this->mock_order
+			->method( 'get_data_store' )
+			->willReturn( new \WC_Mock_WC_Data_Store() );
+		$this->mock_order
+			->method( 'get_meta' )
+			->willReturn( '' );
+		$this->mock_order
+			->method( 'get_payment_tokens' )
+			->willReturn( [ 11 ] );
+		$this->mock_order
+			->method( 'add_order_note' )
+			->willReturnCallback(
+				function ( $note ) use ( &$repair_note_added ) {
+					if ( false !== strpos( $note, 'updated the subscription payment method token from token #11 to #22' ) ) {
+						$repair_note_added = true;
+					}
+				}
+			);
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'payment_complete' );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'is_payment_recurring' )
+			->with( 1234 )
+			->willReturn( true );
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'ensure_payment_method_token_for_order' )
+			->with( $this->mock_order, 'pm_new', $user )
+			->willReturn( $token );
+
+		$this->webhook_processing_service->process( $this->event_body );
+
+		$this->assertTrue( $repair_note_added );
+	}
+
+	/**
 	 * Tests that a recurring payment_intent.succeeded event completes the order when token saving fails.
 	 */
 	public function test_payment_intent_successful_completes_recurring_order_when_token_saving_fails() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -769,6 +769,180 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a payment_intent.succeeded event saves a token before completing a recurring order.
+	 */
+	public function test_payment_intent_successful_saves_token_before_completing_recurring_order() {
+		$this->event_body['type']           = 'payment_intent.succeeded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'pi_123123123123123',
+			'object'   => 'payment_intent',
+			'amount'   => 1500,
+			'charges'  => [
+				'data' => [
+					[
+						'id'                     => 'py_123123123123123',
+						'payment_method'         => 'pm_foo',
+						'payment_method_details' => [
+							'type' => 'card',
+						],
+					],
+				],
+			],
+			'currency' => 'eur',
+			'status'   => Intent_Status::SUCCEEDED,
+			'metadata' => [],
+		];
+		$user                               = new WP_User( self::factory()->user->create() );
+		$token_saved                        = false;
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'deserialize_payment_intention_object_from_array' )
+			->with( $this->event_body['data']['object'] )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [ 'request_three_d_secure' => 'automatic' ] ],
+					]
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( $this->mock_order );
+
+		$this->mock_order
+			->method( 'get_user' )
+			->willReturn( $user );
+		$this->mock_order
+			->method( 'get_total' )
+			->willReturn( 15.00 );
+		$this->mock_order
+			->method( 'has_status' )
+			->willReturn( false );
+		$this->mock_order
+			->method( 'get_data_store' )
+			->willReturn( new \WC_Mock_WC_Data_Store() );
+		$this->mock_order
+			->method( 'get_meta' )
+			->willReturn( '' );
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'payment_complete' )
+			->willReturnCallback(
+				function () use ( &$token_saved ) {
+					$this->assertTrue( $token_saved );
+				}
+			);
+
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'is_payment_recurring' )
+			->with( 1234 )
+			->willReturn( true );
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'ensure_payment_method_token_for_order' )
+			->with( $this->mock_order, 'pm_foo', $user )
+			->willReturnCallback(
+				function () use ( &$token_saved ) {
+					$token_saved = true;
+				}
+			);
+
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
+	 * Tests that a recurring payment_intent.succeeded event completes the order when token saving fails.
+	 */
+	public function test_payment_intent_successful_completes_recurring_order_when_token_saving_fails() {
+		$this->event_body['type']           = 'payment_intent.succeeded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'pi_123123123123123',
+			'object'   => 'payment_intent',
+			'amount'   => 1500,
+			'charges'  => [
+				'data' => [
+					[
+						'id'                     => 'py_123123123123123',
+						'payment_method'         => 'pm_foo',
+						'payment_method_details' => [
+							'type' => 'card',
+						],
+					],
+				],
+			],
+			'currency' => 'eur',
+			'status'   => Intent_Status::SUCCEEDED,
+			'metadata' => [],
+		];
+		$user                               = new WP_User( self::factory()->user->create() );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'deserialize_payment_intention_object_from_array' )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [ 'request_three_d_secure' => 'automatic' ] ],
+					]
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( $this->mock_order );
+
+		$this->mock_order
+			->method( 'get_user' )
+			->willReturn( $user );
+		$this->mock_order
+			->expects( $this->exactly( 2 ) )
+			->method( 'add_order_note' )
+			->withConsecutive(
+				[ $this->stringContains( 'Unable to save payment method for subscription.' ) ],
+				[ $this->stringContains( 'A payment of' ) ]
+			);
+		$this->mock_order
+			->method( 'get_total' )
+			->willReturn( 15.00 );
+		$this->mock_order
+			->method( 'has_status' )
+			->willReturn( false );
+		$this->mock_order
+			->method( 'get_data_store' )
+			->willReturn( new \WC_Mock_WC_Data_Store() );
+		$this->mock_order
+			->method( 'get_meta' )
+			->willReturn( '' );
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'payment_complete' );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'is_payment_recurring' )
+			->with( 1234 )
+			->willReturn( true );
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'ensure_payment_method_token_for_order' )
+			->with( $this->mock_order, 'pm_foo', $user )
+			->willThrowException( new Exception( 'Unable to save payment method for subscription.' ) );
+
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
 	 * Tests that a payment_intent.succeeded event will ignore the order due to key mismatch.
 	 */
 	public function test_payment_intent_successful_ignores_order_due_to_key_mismatch() {


### PR DESCRIPTION
Refs WOOPMNT-6259

#### Changes proposed in this Pull Request

Subscription checkout can currently end in a confusing paid-but-broken state when the shopper completes a 3DS challenge but the frontend `update_order_status` AJAX request does not finish. Stripe has already succeeded the payment, and the webhook can complete the WooCommerce order and activate the subscription, but the WooCommerce payment token that future renewals need may never be created or attached. The shopper is left on checkout instead of seeing the order confirmation page, while the merchant later discovers the first renewal fails with `No saved payment method found.`

This PR makes the webhook completion path more robust by saving the WooCommerce token from the successful `payment_intent.succeeded` event before the order is completed. If token creation succeeds, the subscription is activated with the saved payment method it needs for renewals, even when the frontend AJAX call was lost. If token creation fails, the already-successful payment is still allowed to complete so the customer is not left charged with a permanently stuck order; the failure is logged and added as an order note for follow-up.

It also adds a renewal-time repair path for subscriptions that were already created in the broken state. When a renewal order has no token, WooPayments now looks back to the subscription parent order, reads the stored Stripe payment method ID, recreates/reuses the WooCommerce token for the subscription customer, attaches it to the parent/subscription and the renewal order, and then continues the same renewal attempt.

The intended product behavior is:

| Scenario | Before | After |
| --- | --- | --- |
| 3DS succeeds and checkout AJAX succeeds | Subscription activates with token | Same behavior |
| 3DS succeeds but checkout AJAX fails | Webhook can activate subscription without a renewal token | Webhook attempts to create/attach the renewal token before completing the paid order |
| Webhook token save fails after Stripe already succeeded | Earlier implementation would leave the paid order stuck if we re-threw | Order still completes, an order note/log records the token issue, and the renewal repair path can recover later when possible |
| Existing broken subscription reaches renewal | Renewal fails with no saved payment method | Renewal attempts to repair the missing token from the parent order payment method ID before charging |

Technical details:

- Adds `ensure_payment_method_token_for_order()` to centralize WooCommerce token creation/reuse and order/subscription attachment.
- Updates `payment_intent.succeeded` webhook processing to use the payment method ID from the charge, falling back to the intent-level `payment_method` shape when needed.
- Runs token attachment before `update_order_status_from_intent()` for recurring orders so Woo Subscriptions sees the token when paid-order hooks run.
- Keeps webhook completion best-effort for token saving: token failures are logged and noted, but do not block completion of an already-successful Stripe payment.
- Adds a renewal fallback in `scheduled_subscription_payment()` that repairs missing renewal tokens from the subscription parent order when network saved cards are disabled.
- Adds unit coverage for token-before-completion ordering, webhook token-save failure behavior, and renewal-time token repair.
- Adds a patch changelog entry.

Known follow-up:

- Concurrent webhook delivery could still race and create duplicate saved payment tokens for the same Stripe payment method. This PR keeps the fix scoped to the customer-facing broken subscription flow; a per-order lock or token de-duplication pass can be handled separately.

#### Testing instructions

Reproduce the original failure locally:

1. Start the WooPayments local dev site at `http://localhost:8082`.
2. Ensure the local Stripe webhook listener is running and forwarding connect events to the local WooPayments webhook endpoint.
3. Create a subscription product in WooCommerce.
4. Open the storefront in a fresh/guest browser session.
5. Add the subscription product to the cart and proceed to checkout.
6. Pay with Stripe test card `4000000000003220`, any future expiry, any CVC, and a valid postal code.
7. Complete and accept the 3DS challenge.
8. Block or lose the checkout `update_order_status` AJAX completion path, or otherwise reproduce the state where the browser remains on checkout after 3DS instead of redirecting to the order confirmation page.
9. Observe the webhook listener receiving `payment_intent.requires_action`, then `charge.succeeded`, then `payment_intent.succeeded`.
10. Before this fix, the webhook can complete the order/subscription without a WooCommerce payment token, leaving the first renewal to fail with `Subscription renewal failed: No saved payment method found.`
11. With this fix, the `payment_intent.succeeded` webhook should create/reuse the WooCommerce token for the successful Stripe payment method and attach it before order completion.
12. Confirm the parent order/subscription has the WooCommerce payment token attached and the subscription can use it for future renewals.

Manual recovery scenario to test:

1. Create or identify a subscription whose parent order has `_payment_method_id` set but whose subscription/renewal order has no WooCommerce payment token.
2. Trigger a renewal payment attempt.
3. Confirm WooPayments repairs the missing token from the parent order's payment method ID.
4. Confirm the renewal order receives the token and the renewal continues instead of immediately failing with `No saved payment method found.`

Automated validation run locally:

- `php -l includes/class-wc-payment-gateway-wcpay.php`
- `php -l includes/class-wc-payments-webhook-processing-service.php`
- `php -l includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/class-wc-payment-gateway-wcpay.php includes/class-wc-payments-webhook-processing-service.php includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php tests/unit/test-class-wc-payments-webhook-processing-service.php tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php`
- `docker compose exec -u www-data wordpress bash -lc "cd /var/www/html/wp-content/plugins/woocommerce-payments && vendor/bin/phpunit --configuration phpunit.xml.dist --filter WC_Payments_Webhook_Processing_Service_Test"`
- `docker compose exec -u www-data wordpress bash -lc "cd /var/www/html/wp-content/plugins/woocommerce-payments && vendor/bin/phpunit --configuration phpunit.xml.dist --filter WC_Payment_Gateway_WCPay_Subscriptions_Test"`
- `docker compose exec -u www-data wordpress bash -lc "cd /var/www/html/wp-content/plugins/woocommerce-payments && vendor/bin/phpunit --configuration phpunit.xml.dist --filter 'WC_Payments_Webhook_Processing_Service_Test|WC_Payment_Gateway_WCPay_Subscriptions_Trait_Test|WC_Payments_Non_Reusable_Payment_Methods_Integration_Test|WC_Payment_Gateway_WCPay_Subscriptions_Non_Reusable_Methods_Test'"`

Results from this branch:

- `WC_Payments_Webhook_Processing_Service_Test`: 56 tests, 141 assertions.
- `WC_Payment_Gateway_WCPay_Subscriptions_Test`: 62 tests, 146 assertions.
- Combined webhook/trait/non-reusable compatibility filter: 71 tests, 171 assertions.
- Targeted PHPCS passed. It printed existing PHPCS ruleset deprecation notices for comma-separated sniff properties.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply): Does not apply; this is webhook/subscription backend behavior.

**Post merge**

- [ ] Link to testing instructions from release testing doc following these instructions: _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
