### PR TITLE
Add filter to control explicit currency code on Multi-Currency totals

### DIFF
--- a/changelog/add-woopmnt-4898-explicit-price-filter
+++ b/changelog/add-woopmnt-4898-explicit-price-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Multi-Currency: add the `wcpay_multi_currency_should_output_explicit_price` filter so merchants can force the currency code suffix on totals (e.g. "765 Kč CZK") on or off.

--- a/includes/class-wc-payments-explicit-price-formatter.php
+++ b/includes/class-wc-payments-explicit-price-formatter.php
@@ -53,28 +53,24 @@ class WC_Payments_Explicit_Price_Formatter {
 	 * @return  bool  Whether if it should return explicit price or not
 	 */
 	public static function should_output_explicit_price() {
-		// If customer Multi-Currency is disabled, don't use explicit currencies.
-		// Because it'll have only the store currency active, same as count == 1.
-		if ( ! WC_Payments_Features::is_customer_multi_currency_enabled() ) {
-			return false;
-		}
+		$should_output_explicit_price = self::is_explicit_price_required();
 
-		// If the MultiCurrency instance hasn't been defined yet, fetch the instance.
-		if ( null === self::$multi_currency_instance ) {
-			self::$multi_currency_instance = WC_Payments_Multi_Currency();
-		}
-
-		// If the instance isn't initialized yet, skip the checks.
-		if ( ! self::$multi_currency_instance->is_initialized() ) {
-			return false;
-		}
-
-		// If no additional currencies are enabled, skip it.
-		if ( ! self::$multi_currency_instance->has_additional_currencies_enabled() ) {
-			return false;
-		}
-
-		return true;
+		/**
+		 * Filters whether the explicit price (currency code suffix) should be
+		 * displayed alongside the currency symbol on total amounts.
+		 *
+		 * By default, when Multi-Currency is enabled with additional currencies,
+		 * totals are rendered with an explicit currency code (e.g. "765 Kč CZK")
+		 * to make the charged currency unambiguous. Merchants who only use
+		 * currencies with distinct symbols can return `false` to display the
+		 * symbol only (e.g. "765 Kč"). Returning `true` forces the explicit
+		 * price on regardless of the default checks.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param bool $should_output_explicit_price Whether the explicit currency code suffix should be output.
+		 */
+		return (bool) apply_filters( 'wcpay_multi_currency_should_output_explicit_price', $should_output_explicit_price );
 	}
 
 	/**
@@ -160,5 +156,36 @@ class WC_Payments_Explicit_Price_Formatter {
 			$args['price_format'] = sprintf( '%s&nbsp;%s', $args['price_format'], $args['currency'] );
 		}
 		return $args;
+	}
+
+	/**
+	 * Determines, based on the Multi-Currency configuration, whether the explicit
+	 * price should be output by default (before the filter is applied).
+	 *
+	 * @return  bool  Whether the explicit price is required by the current configuration.
+	 */
+	private static function is_explicit_price_required() {
+		// If customer Multi-Currency is disabled, don't use explicit currencies.
+		// Because it'll have only the store currency active, same as count == 1.
+		if ( ! WC_Payments_Features::is_customer_multi_currency_enabled() ) {
+			return false;
+		}
+
+		// If the MultiCurrency instance hasn't been defined yet, fetch the instance.
+		if ( null === self::$multi_currency_instance ) {
+			self::$multi_currency_instance = WC_Payments_Multi_Currency();
+		}
+
+		// If the instance isn't initialized yet, skip the checks.
+		if ( ! self::$multi_currency_instance->is_initialized() ) {
+			return false;
+		}
+
+		// If no additional currencies are enabled, skip it.
+		if ( ! self::$multi_currency_instance->has_additional_currencies_enabled() ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/tests/unit/test-class-wc-payments-explicit-price-formatter.php
+++ b/tests/unit/test-class-wc-payments-explicit-price-formatter.php
@@ -121,6 +121,7 @@ class WC_Payments_Explicit_Price_Formatter_Test extends WCPAY_UnitTestCase {
 		WC()->session->__unset( MultiCurrency::CURRENCY_SESSION_KEY );
 		remove_all_filters( 'wcpay_multi_currency_apply_charm_only_to_products' );
 		remove_all_filters( 'wcpay_multi_currency_available_currencies' );
+		remove_all_filters( 'wcpay_multi_currency_should_output_explicit_price' );
 		remove_all_filters( 'woocommerce_currency' );
 		remove_all_filters( 'stylesheet' );
 
@@ -214,6 +215,27 @@ class WC_Payments_Explicit_Price_Formatter_Test extends WCPAY_UnitTestCase {
 
 	public function test_get_explicit_price_skips_already_explicit_prices_on_frontend_with_multiple_enabled_currencies() {
 		$this->assertSame( '$10.30 USD', WC_Payments_Explicit_Price_Formatter::get_explicit_price( '$10.30 USD' ) );
+	}
+
+	public function test_filter_can_force_explicit_price_off_with_multiple_enabled_currencies() {
+		add_filter( 'wcpay_multi_currency_should_output_explicit_price', '__return_false' );
+
+		// Without the filter this would return 'R$ 5,90 BRL' (see the test above).
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_currency' )->willReturn( 'BRL' );
+
+		$this->assertSame( 'R$ 5,90', WC_Payments_Explicit_Price_Formatter::get_explicit_price( 'R$ 5,90', $order ) );
+	}
+
+	public function test_filter_can_force_explicit_price_on_with_one_enabled_currency() {
+		$this->prepare_one_enabled_currency();
+		add_filter( 'wcpay_multi_currency_should_output_explicit_price', '__return_true' );
+
+		// Without the filter this would return 'R$ 5,90' (see the test above).
+		$order = $this->createMock( WC_Order::class );
+		$order->method( 'get_currency' )->willReturn( 'BRL' );
+
+		$this->assertSame( 'R$ 5,90 BRL', WC_Payments_Explicit_Price_Formatter::get_explicit_price( 'R$ 5,90', $order ) );
 	}
 
 	private function prepare_one_enabled_currency() {


### PR DESCRIPTION
Fixes [#10654](https://github.com/Automattic/woocommerce-payments/issues/10654) / [WOOPMNT-4898](https://linear.app/a8c/issue/WOOPMNT-4898/wrong-currency-name-and-symbol-display)

#### Changes proposed in this Pull Request

When Multi-Currency is enabled with additional currencies, cart/checkout totals (and order totals in the admin) are rendered with an explicit currency code appended after the symbol, e.g. `765 Kč CZK` or `30,63 € EUR`. This is intentional — it disambiguates which currency a shopper is being charged in when symbols are shared across currencies (e.g. `$` for USD/CAD). However, merchants who only trade in currencies with distinct symbols find the appended code redundant and noisy, and there was previously no way to turn it off (see the discussion in #10654).

This PR adds a new filter, `wcpay_multi_currency_should_output_explicit_price`, inside `WC_Payments_Explicit_Price_Formatter::should_output_explicit_price()`. It receives the value computed by the existing default logic, so merchants can:

- Return `false` to **always** display the symbol only (`765 Kč`), or
- Return `true` to **force** the explicit code on regardless of the default checks.

The default behavior is unchanged — without the filter, the method returns exactly what it did before. The existing detection logic was extracted into a private `is_explicit_price_required()` helper, and the public method now wraps its result in the filter.

This follows the approach suggested by a developer in the linked issue (adding a filter so merchants can force explicit prices all the time or none of the time).

**How can this code break?** The filter is a single, additive extension point; the default path is behavior-preserving. The cast to `(bool)` guards against a misbehaving filter callback returning a non-boolean.

**What are we doing to make sure this code doesn't break?** Added unit tests covering both filter directions, and the existing default-behavior tests continue to pass unchanged.

#### Testing instructions

1. Set up WooPayments with Multi-Currency enabled and **at least two** currencies (e.g. USD + EUR).
2. Add a product to the cart and view the cart/checkout totals — confirm the total still shows the explicit code by default (e.g. `30,63 € EUR`). This is the unchanged baseline.
3. Add the following snippet to a mu-plugin or your theme's `functions.php`:
   ```php
   add_filter( 'wcpay_multi_currency_should_output_explicit_price', '__return_false' );
   ```
4. Reload the cart/checkout — the total should now show the **symbol only** (e.g. `30,63 €`). Confirm the same on the admin order totals.
5. Remove the snippet and confirm the explicit code returns.
6. (Optional) With a single enabled currency, add `add_filter( 'wcpay_multi_currency_should_output_explicit_price', '__return_true' );` and confirm the code is now forced on.

*

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — backend filter, no UI of its own.

**Post merge**

- [ ] Link to testing instructions from release testing doc.
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
