### PR TITLE
fix: persist payment intent ID on failed transactions

### DIFF
--- a/changelog/add-woopmnt-4446-add-intent-id-to-failed-transactions
+++ b/changelog/add-woopmnt-4446-add-intent-id-to-failed-transactions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Store the payment intent ID on orders when a payment fails, improving transaction traceability and webhook matching.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1318,7 +1318,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			}
 
 			// Store the intent ID on failed orders too, so a declined transaction stays traceable
-			// and matchable by webhooks — mirroring successful payments. WOOPMNT-4446.
+			// and matchable by webhooks — mirroring successful payments.
 			if ( $e instanceof API_Exception && ! empty( $e->get_intent_id() ) ) {
 				$this->order_service->set_intent_id_for_order( $order, $e->get_intent_id() );
 			}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1317,6 +1317,14 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$order->update_status( Order_Status::FAILED );
 			}
 
+			// Persist the payment intent ID on failed orders so the transaction stays traceable
+			// and matchable by webhooks, mirroring the intent info stored for successful payments.
+			// When a payment is declined after the intent was created, the server embeds the intent
+			// in the error response and we surface its ID via the exception. WOOPMNT-4446.
+			if ( $e instanceof API_Exception && ! empty( $e->get_intent_id() ) ) {
+				$this->order_service->set_intent_id_for_order( $order, $e->get_intent_id() );
+			}
+
 			if ( $e instanceof API_Exception && $this->should_bump_rate_limiter( $e->get_error_code() ) ) {
 				$this->failed_transaction_rate_limiter->bump();
 			}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1317,10 +1317,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				$order->update_status( Order_Status::FAILED );
 			}
 
-			// Persist the payment intent ID on failed orders so the transaction stays traceable
-			// and matchable by webhooks, mirroring the intent info stored for successful payments.
-			// When a payment is declined after the intent was created, the server embeds the intent
-			// in the error response and we surface its ID via the exception. WOOPMNT-4446.
+			// Store the intent ID on failed orders too, so a declined transaction stays traceable
+			// and matchable by webhooks — mirroring successful payments. WOOPMNT-4446.
 			if ( $e instanceof API_Exception && ! empty( $e->get_intent_id() ) ) {
 				$this->order_service->set_intent_id_for_order( $order, $e->get_intent_id() );
 			}

--- a/includes/exceptions/class-api-exception.php
+++ b/includes/exceptions/class-api-exception.php
@@ -42,6 +42,13 @@ class API_Exception extends Base_Exception {
 	private $param = null;
 
 	/**
+	 * The payment intent ID associated with the error, when the server returns one.
+	 *
+	 * @var string|null
+	 */
+	private $intent_id = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @param string     $message    The Exception message to throw.
@@ -52,12 +59,14 @@ class API_Exception extends Base_Exception {
 	 * @param int        $code       The Exception code.
 	 * @param \Throwable $previous   The previous exception used for the exception chaining.
 	 * @param string     $param      The request parameter that triggered the error, if any.
+	 * @param string     $intent_id  The payment intent ID associated with the error, if any.
 	 */
-	public function __construct( $message, $error_code, $http_code, $error_type = null, $decline_code = null, $code = 0, $previous = null, $param = null ) {
+	public function __construct( $message, $error_code, $http_code, $error_type = null, $decline_code = null, $code = 0, $previous = null, $param = null, $intent_id = null ) {
 		$this->http_code    = $http_code;
 		$this->error_type   = $error_type;
 		$this->decline_code = $decline_code;
 		$this->param        = $param;
+		$this->intent_id    = $intent_id;
 
 		parent::__construct( $message, $error_code, $code, $previous );
 	}
@@ -100,5 +109,18 @@ class API_Exception extends Base_Exception {
 	 */
 	public function get_param() {
 		return $this->param;
+	}
+
+	/**
+	 * Returns the payment intent ID associated with the error, if the server returned one.
+	 *
+	 * Present on declined-card responses, where Stripe embeds the payment intent in the error
+	 * body; null for errors that occur before an intent exists (for example an invalid payment
+	 * method).
+	 *
+	 * @return string|null The payment intent ID, or null when none was returned.
+	 */
+	public function get_intent_id() {
+		return $this->intent_id;
 	}
 }

--- a/includes/exceptions/class-api-exception.php
+++ b/includes/exceptions/class-api-exception.php
@@ -51,15 +51,15 @@ class API_Exception extends Base_Exception {
 	/**
 	 * Constructor
 	 *
-	 * @param string     $message    The Exception message to throw.
-	 * @param string     $error_code Error code returned by the server, for example wcpay_account_not_found.
-	 * @param int        $http_code  HTTP response code.
-	 * @param string     $error_type Error type attribute.
-	 * @param string     $decline_code The decline code if it is a card error.
-	 * @param int        $code       The Exception code.
-	 * @param \Throwable $previous   The previous exception used for the exception chaining.
-	 * @param string     $param      The request parameter that triggered the error, if any.
-	 * @param string     $intent_id  The payment intent ID associated with the error, if any.
+	 * @param string          $message      The Exception message to throw.
+	 * @param string          $error_code   Error code returned by the server, for example wcpay_account_not_found.
+	 * @param int             $http_code    HTTP response code.
+	 * @param string|null     $error_type   Error type attribute.
+	 * @param string|null     $decline_code The decline code if it is a card error.
+	 * @param int             $code         The Exception code.
+	 * @param \Throwable|null $previous     The previous exception used for the exception chaining.
+	 * @param string|null     $param        The request parameter that triggered the error, if any.
+	 * @param string|null     $intent_id    The payment intent ID associated with the error, if any.
 	 */
 	public function __construct( $message, $error_code, $http_code, $error_type = null, $decline_code = null, $code = 0, $previous = null, $param = null, $intent_id = null ) {
 		$this->http_code    = $http_code;

--- a/includes/exceptions/class-api-merchant-exception.php
+++ b/includes/exceptions/class-api-merchant-exception.php
@@ -31,11 +31,12 @@ class API_Merchant_Exception extends API_Exception {
 	 * @param string|null     $decline_code The decline code if it is a card error.
 	 * @param int             $code       The Exception code.
 	 * @param \Throwable|null $previous   The previous exception used for the exception chaining.
+	 * @param string|null     $intent_id  The payment intent ID associated with the error, if any.
 	 */
-	public function __construct( $message, $error_code, $http_code, $merchant_message, $error_type = null, $decline_code = null, $code = 0, $previous = null ) {
+	public function __construct( $message, $error_code, $http_code, $merchant_message, $error_type = null, $decline_code = null, $code = 0, $previous = null, $intent_id = null ) {
 		$this->merchant_message = $merchant_message;
 
-		parent::__construct( $message, $error_code, $http_code, $error_type, $decline_code, $code, $previous );
+		parent::__construct( $message, $error_code, $http_code, $error_type, $decline_code, $code, $previous, null, $intent_id );
 	}
 
 	/**

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -2836,9 +2836,10 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 
 		// Check error codes for 4xx and 5xx responses.
 		if ( 400 <= $response_code ) {
-			$error_type   = null;
-			$decline_code = null;
-			$error_param  = null;
+			$error_type        = null;
+			$decline_code      = null;
+			$error_param       = null;
+			$payment_intent_id = null;
 			if ( isset( $response_body['code'] ) && 'amount_too_small' === $response_body['code'] ) {
 				throw new Amount_Too_Small_Exception(
 					$response_body['message'],
@@ -2849,6 +2850,7 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			} elseif ( isset( $response_body['error'] ) ) {
 				$response_body_error_code = $response_body['error']['code'] ?? $response_body['error']['message_code'] ?? null;
 				$payment_intent_status    = $response_body['error']['payment_intent']['status'] ?? null;
+				$payment_intent_id        = $response_body['error']['payment_intent']['id'] ?? null;
 
 				// We redact the API error message to prevent prompting the merchant to contact Stripe support
 				// when attempting to manually capture an amount greater than what's authorized. Contacting support is unnecessary in this scenario.
@@ -2910,10 +2912,10 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 			if ( 'card_declined' === $error_code && isset( $response_body['error']['payment_intent']['charges']['data'][0]['outcome']['seller_message'] ) ) {
 				$merchant_message = $response_body['error']['payment_intent']['charges']['data'][0]['outcome']['seller_message'];
 
-				throw new API_Merchant_Exception( $message, $error_code, $response_code, $merchant_message, $error_type, $decline_code );
+				throw new API_Merchant_Exception( $message, $error_code, $response_code, $merchant_message, $error_type, $decline_code, 0, null, $payment_intent_id );
 			}
 
-			throw new API_Exception( $message, $error_code, $response_code, $error_type, $decline_code, 0, null, $error_param );
+			throw new API_Exception( $message, $error_code, $response_code, $error_type, $decline_code, 0, null, $error_param, $payment_intent_id );
 		}
 	}
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -637,7 +637,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->with( $this->anything(), 'pi_mock_failed_123' );
 
 		// Act: process payment.
-		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id(), false );
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id() );
 		$result_order = wc_get_order( $order->get_id() );
 
 		// Assert: Order failed.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -601,6 +601,51 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( 'A payment of &#36;50.00 failed to complete with the following message: Error: No such payment_method: pm_123.', strip_tags( $notes[0]->content, '' ) );
 	}
 
+	public function test_intent_id_saved_on_failed_payment() {
+		// Arrange: Create an order to test with.
+		$order = WC_Helper_Order::create_order();
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_mock' );
+		WCPay\Payment_Information::from_payment_request( $_POST, $order, WCPay\Constants\Payment_Type::SINGLE(), WCPay\Constants\Payment_Initiated_By::CUSTOMER(), WCPay\Constants\Payment_Capture_Type::AUTOMATIC(), 'card' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		// Arrange: Throw a card-decline exception that carries the failed intent ID,
+		// mirroring how the API client surfaces the intent embedded in the error response.
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->will(
+				$this->throwException(
+					new API_Exception(
+						'Error: Your card was declined.',
+						'card_declined',
+						402,
+						'card_error',
+						'expired_card',
+						0,
+						null,
+						null,
+						'pi_mock_failed_123'
+					)
+				)
+			);
+
+		// Assert: The failed intent ID is persisted on the order.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'set_intent_id_for_order' )
+			->with( $this->anything(), 'pi_mock_failed_123' );
+
+		// Act: process payment.
+		$result       = $this->mock_wcpay_gateway->process_payment( $order->get_id(), false );
+		$result_order = wc_get_order( $order->get_id() );
+
+		// Assert: Order failed.
+		$this->assertEquals( 'fail', $result['result'] );
+		$this->assertEquals( Order_Status::FAILED, $result_order->get_status() );
+	}
+
 	public function test_failure_result_returned_if_phone_number_is_invalid() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_billing_phone( '+1123456789123456789123' );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -608,7 +608,6 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_customer_id_by_user_id' )
 			->willReturn( 'cus_mock' );
-		WCPay\Payment_Information::from_payment_request( $_POST, $order, WCPay\Constants\Payment_Type::SINGLE(), WCPay\Constants\Payment_Initiated_By::CUSTOMER(), WCPay\Constants\Payment_Capture_Type::AUTOMATIC(), 'card' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		// Arrange: Throw a card-decline exception that carries the failed intent ID,
 		// mirroring how the API client surfaces the intent embedded in the error response.

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -642,7 +642,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 
 		// Assert: Order failed.
 		$this->assertEquals( 'fail', $result['result'] );
-		$this->assertEquals( Order_Status::FAILED, $result_order->get_status() );
+		$this->assertEquals( 'failed', $result_order->get_status() );
 	}
 
 	public function test_failure_result_returned_if_phone_number_is_invalid() {

--- a/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
+++ b/tests/unit/wc-payment-api/test-class-wc-payments-api-client.php
@@ -1171,6 +1171,59 @@ class WC_Payments_API_Client_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_api_merchant_exception_includes_payment_intent_id() {
+		$mock_response                                  = [];
+		$mock_response['error']['code']                 = 'card_declined';
+		$mock_response['error']['payment_intent']['id'] = 'pi_mock_failed_123';
+		$mock_response['error']['payment_intent']['charges']['data'][0]['outcome']['seller_message'] = 'Bank declined';
+		$this->set_http_mock_response(
+			401,
+			$mock_response
+		);
+
+		try {
+			$this->payments_api_client->create_subscription();
+			$this->fail( 'Expected API_Merchant_Exception was not thrown.' );
+		} catch ( API_Merchant_Exception $e ) {
+			$this->assertSame( 'pi_mock_failed_123', $e->get_intent_id() );
+		}
+	}
+
+	public function test_api_exception_includes_payment_intent_id() {
+		$mock_response                                  = [];
+		$mock_response['error']['code']                 = 'incorrect_cvc';
+		$mock_response['error']['type']                 = 'card_error';
+		$mock_response['error']['payment_intent']['id'] = 'pi_mock_failed_456';
+		$this->set_http_mock_response(
+			402,
+			$mock_response
+		);
+
+		try {
+			$this->payments_api_client->create_subscription();
+			$this->fail( 'Expected API_Exception was not thrown.' );
+		} catch ( API_Exception $e ) {
+			$this->assertSame( 'pi_mock_failed_456', $e->get_intent_id() );
+		}
+	}
+
+	public function test_api_exception_intent_id_is_null_when_no_payment_intent() {
+		$mock_response                     = [];
+		$mock_response['error']['code']    = 'resource_missing';
+		$mock_response['error']['message'] = 'No such payment_method: pm_123.';
+		$this->set_http_mock_response(
+			400,
+			$mock_response
+		);
+
+		try {
+			$this->payments_api_client->create_subscription();
+			$this->fail( 'Expected API_Exception was not thrown.' );
+		} catch ( API_Exception $e ) {
+			$this->assertNull( $e->get_intent_id() );
+		}
+	}
+
 	/**
 	 * Test sending store setup data.
 	 */


### PR DESCRIPTION
Fixes #9667 ([WOOPMNT-4446](https://linear.app/a8c/issue/WOOPMNT-4446/add-intent-id-to-failed-transactions))

#### Changes proposed in this Pull Request

Successful payments store the payment intent ID on the order (`_intent_id`), but **synchronously-declined cards did not**. When a card is declined at confirm time, the API error response embeds the full payment intent — `check_response_for_errors()` already reads `error.payment_intent.status` — yet the intent's **`id` was discarded** when constructing the exception. The exception is the only object that reaches the gateway's payment catch block, so the ID was lost.

As a result, failed orders had no _intent_id, so the declined transaction was untraceable (for support, debugging, or reconciliation). In addition, webhooks about the declined intent fell back to order-ID matching instead of a direct intent-ID match.

Note: this doesn't change retry behavior. WooPayments creates a new payment intent per card submission by design, and a successful retry already moves the order Failed → Processing. This PR simply preserves the declined attempt's intent ID so it isn't lost.

#### Testing instructions

1. With WooPayments in test mode, check out with a declining test card (e.g. `4000 0000 0000 0002` → generic decline). The order is marked **Failed**.
2. Confirm the failed order now carries the declined intent ID in `_intent_id` meta.
   - Use the HPOS- and legacy-safe CRUD lookup:
     ```bash
     wp eval 'echo wc_get_order( <order_id> )->get_meta( "_intent_id" );'
     # prints the declined pi_… on this branch; empty on develop
     ```
3. Confirm that `pi_…` matches the failed payment intent in the Stripe/WooPayments dashboard.
4. Sanity check: a *successful* checkout still behaves exactly as before (intent ID stored as it is today).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — backend-only change, no UI.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions): _QA Testing Not Applicable (covered by unit tests; merchant-visible only via order meta)_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows), if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
