### PR TITLE
fix(e2e): fix multi-currency switcher test timing out on WP nightly (editor mount race)

### DIFF
--- a/changelog/e2e-WOOPMNT-6249
+++ b/changelog/e2e-WOOPMNT-6249
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Fix flaky multi-currency widget E2E test by waiting for the block editor canvas to mount before inserting the currency switcher block.
+Fix multi-currency widget E2E test timing out on WP nightly by waiting for the block editor canvas to mount before inserting the currency switcher block.

--- a/changelog/e2e-WOOPMNT-6249
+++ b/changelog/e2e-WOOPMNT-6249
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flaky multi-currency widget E2E test by waiting for the block editor canvas to mount before inserting the currency switcher block.

--- a/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
@@ -11,6 +11,7 @@ import {
 	addMulticurrencyWidget,
 	deactivateMulticurrency,
 	disableAllEnabledCurrencies,
+	disableEditorWelcomeGuide,
 	removeMultiCurrencyWidgets,
 	restoreCurrencies,
 } from '../../../utils/merchant';
@@ -63,22 +64,9 @@ test.describe( 'Multi-currency', { tag: '@critical' }, () => {
 
 		await navigation.goToNewPost( page );
 
-		// Modern WP shows the editor Welcome Guide on a fresh post, and its modal
-		// overlay intercepts clicks on the block inserter. Disable it (and
-		// fullscreen mode) deterministically via the preferences store: racing a
-		// "Close" button with isVisible() let the guide slip through on WP nightly
-		// and block the insert. Guarded so it no-ops where core/preferences is
-		// unavailable.
-		await page.waitForFunction( () => ( window as any ).wp?.data );
-		await page.evaluate( async () => {
-			const prefs = ( window as any ).wp?.data?.dispatch?.(
-				'core/preferences'
-			);
-			if ( prefs?.set ) {
-				await prefs.set( 'core/edit-post', 'welcomeGuide', false );
-				await prefs.set( 'core/edit-post', 'fullscreenMode', false );
-			}
-		} );
+		// Disable the editor Welcome Guide so its modal overlay doesn't intercept
+		// clicks on the block inserter (see helper for the WP-nightly background).
+		await disableEditorWelcomeGuide( page );
 
 		// The block editor canvas is iframed on modern WP (6.3+) but rendered
 		// inline on the older WP bundled with WC 7.7.0. `isVisible()` does not

--- a/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page, errors } from '@playwright/test';
 /**
  * Internal dependencies
  */
@@ -74,7 +74,14 @@ test.describe( 'Multi-currency', { tag: '@critical' }, () => {
 		const usesIframedCanvas = await editorCanvas
 			.waitFor( { state: 'visible', timeout: 15000 } )
 			.then( () => true )
-			.catch( () => false );
+			.catch( ( error ) => {
+				// Only a timeout means the inline (non-iframed) WC 7.7.0 editor;
+				// surface anything else (page closed, navigation, bad selector).
+				if ( error instanceof errors.TimeoutError ) {
+					return false;
+				}
+				throw error;
+			} );
 
 		if ( usesIframedCanvas ) {
 			const editor = editorCanvas.contentFrame();

--- a/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
@@ -67,16 +67,23 @@ test.describe( 'Multi-currency', { tag: '@critical' }, () => {
 			await page.getByRole( 'button', { name: 'Close' } ).click();
 		}
 
-		if ( await page.locator( '[name="editor-canvas"]' ).isVisible() ) {
-			await expect(
-				page.locator( '[name="editor-canvas"]' )
-			).toBeAttached();
-			const editor = page
-				.locator( '[name="editor-canvas"]' )
-				.contentFrame();
+		// The block editor canvas is iframed on modern WP (6.3+) but rendered
+		// inline on the older WP bundled with WC 7.7.0. `isVisible()` does not
+		// auto-wait, so checking it immediately after load raced the iframe mount
+		// and — deterministically on WP nightly — fell through to the inline path,
+		// where no page-level "Add block" button exists, hanging the test until it
+		// timed out. Wait for the canvas to mount before choosing a path.
+		const editorCanvas = page.locator( '[name="editor-canvas"]' );
+		const usesIframedCanvas = await editorCanvas
+			.waitFor( { state: 'visible', timeout: 15000 } )
+			.then( () => true )
+			.catch( () => false );
+
+		if ( usesIframedCanvas ) {
+			const editor = editorCanvas.contentFrame();
 			await editor.getByRole( 'button', { name: 'Add block' } ).click();
 		} else {
-			// Fallback for WC 7.7.0.
+			// Fallback for the inline (non-iframed) editor on WC 7.7.0.
 			await page.getByRole( 'button', { name: 'Add block' } ).click();
 		}
 

--- a/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
@@ -64,16 +64,12 @@ test.describe( 'Multi-currency', { tag: '@critical' }, () => {
 
 		await navigation.goToNewPost( page );
 
-		// Disable the editor Welcome Guide so its modal overlay doesn't intercept
-		// clicks on the block inserter (see helper for the WP-nightly background).
+		// Dismiss the Welcome Guide; its overlay blocks the block inserter.
 		await disableEditorWelcomeGuide( page );
 
-		// The block editor canvas is iframed on modern WP (6.3+) but rendered
-		// inline on the older WP bundled with WC 7.7.0. `isVisible()` does not
-		// auto-wait, so checking it immediately after load raced the iframe mount
-		// and — deterministically on WP nightly — fell through to the inline path,
-		// where no page-level "Add block" button exists, hanging the test until it
-		// timed out. Wait for the canvas to mount before choosing a path.
+		// Wait for the iframed canvas before branching — `isVisible()` doesn't
+		// auto-wait, so an early check raced the mount and took the WC 7.7.0
+		// inline path on WP nightly.
 		const editorCanvas = page.locator( '[name="editor-canvas"]' );
 		const usesIframedCanvas = await editorCanvas
 			.waitFor( { state: 'visible', timeout: 15000 } )

--- a/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
@@ -63,9 +63,22 @@ test.describe( 'Multi-currency', { tag: '@critical' }, () => {
 
 		await navigation.goToNewPost( page );
 
-		if ( await page.getByRole( 'button', { name: 'Close' } ).isVisible() ) {
-			await page.getByRole( 'button', { name: 'Close' } ).click();
-		}
+		// Modern WP shows the editor Welcome Guide on a fresh post, and its modal
+		// overlay intercepts clicks on the block inserter. Disable it (and
+		// fullscreen mode) deterministically via the preferences store: racing a
+		// "Close" button with isVisible() let the guide slip through on WP nightly
+		// and block the insert. Guarded so it no-ops where core/preferences is
+		// unavailable.
+		await page.waitForFunction( () => ( window as any ).wp?.data );
+		await page.evaluate( async () => {
+			const prefs = ( window as any ).wp?.data?.dispatch?.(
+				'core/preferences'
+			);
+			if ( prefs?.set ) {
+				await prefs.set( 'core/edit-post', 'welcomeGuide', false );
+				await prefs.set( 'core/edit-post', 'fullscreenMode', false );
+			}
+		} );
 
 		// The block editor canvas is iframed on modern WP (6.3+) but rendered
 		// inline on the older WP bundled with WC 7.7.0. `isVisible()` does not

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -111,6 +111,33 @@ export const deactivateMulticurrency = async ( page: Page ) => {
 	await saveWooPaymentsSettings( page );
 };
 
+/**
+ * Disables the block editor's Welcome Guide (and fullscreen mode) on the current
+ * page via the preferences store.
+ *
+ * The post editor shows the Welcome Guide on a fresh post, and its modal overlay
+ * intercepts clicks on the block inserter. Dismissing it by racing a "Close"
+ * button with `isVisible()` is unreliable: after Gutenberg deferred the editor's
+ * React mount (WordPress/gutenberg#78508, v23.3.0) the guide renders a few ticks
+ * after the page `load` event, so the check ran too early on WP nightly and the
+ * guide stayed up, blocking the insert. Setting the preference is deterministic.
+ * Guarded to no-op where `core/preferences` is unavailable.
+ *
+ * @param {Page} page The page object.
+ */
+export const disableEditorWelcomeGuide = async ( page: Page ) => {
+	await page.waitForFunction( () => ( window as any ).wp?.data );
+	await page.evaluate( async () => {
+		const prefs = ( window as any ).wp?.data?.dispatch?.(
+			'core/preferences'
+		);
+		if ( prefs?.set ) {
+			await prefs.set( 'core/edit-post', 'welcomeGuide', false );
+			await prefs.set( 'core/edit-post', 'fullscreenMode', false );
+		}
+	} );
+};
+
 export const addMulticurrencyWidget = async (
 	page: Page,
 	baseURL: string,

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -113,9 +113,7 @@ export const deactivateMulticurrency = async ( page: Page ) => {
 
 /**
  * Disables the editor Welcome Guide (and fullscreen mode) via the preferences
- * store. Deterministic alternative to racing a "Close" button, which slipped
- * past the guide on WP nightly once Gutenberg deferred the editor mount
- * (WordPress/gutenberg#78508).
+ * store. Deterministic alternative to racing a "Close" button.
  *
  * @param {Page} page The page object.
  */

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -118,15 +118,16 @@ export const deactivateMulticurrency = async ( page: Page ) => {
  * @param {Page} page The page object.
  */
 export const disableEditorWelcomeGuide = async ( page: Page ) => {
-	await page.waitForFunction( () => ( window as any ).wp?.data );
+	// Wait for the preferences store's `set` action, not just `wp.data`: the
+	// store can register a few ticks later, and a silent no-op here would leave
+	// the guide up — the flakiness this helper exists to remove.
+	await page.waitForFunction(
+		() => ( window as any ).wp?.data?.dispatch?.( 'core/preferences' )?.set
+	);
 	await page.evaluate( async () => {
-		const prefs = ( window as any ).wp?.data?.dispatch?.(
-			'core/preferences'
-		);
-		if ( prefs?.set ) {
-			await prefs.set( 'core/edit-post', 'welcomeGuide', false );
-			await prefs.set( 'core/edit-post', 'fullscreenMode', false );
-		}
+		const prefs = ( window as any ).wp.data.dispatch( 'core/preferences' );
+		await prefs.set( 'core/edit-post', 'welcomeGuide', false );
+		await prefs.set( 'core/edit-post', 'fullscreenMode', false );
 	} );
 };
 

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -112,16 +112,10 @@ export const deactivateMulticurrency = async ( page: Page ) => {
 };
 
 /**
- * Disables the block editor's Welcome Guide (and fullscreen mode) on the current
- * page via the preferences store.
- *
- * The post editor shows the Welcome Guide on a fresh post, and its modal overlay
- * intercepts clicks on the block inserter. Dismissing it by racing a "Close"
- * button with `isVisible()` is unreliable: after Gutenberg deferred the editor's
- * React mount (WordPress/gutenberg#78508, v23.3.0) the guide renders a few ticks
- * after the page `load` event, so the check ran too early on WP nightly and the
- * guide stayed up, blocking the insert. Setting the preference is deterministic.
- * Guarded to no-op where `core/preferences` is unavailable.
+ * Disables the editor Welcome Guide (and fullscreen mode) via the preferences
+ * store. Deterministic alternative to racing a "Close" button, which slipped
+ * past the guide on WP nightly once Gutenberg deferred the editor mount
+ * (WordPress/gutenberg#78508).
  *
  * @param {Page} page The page object.
  */

--- a/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { test, expect } from '../../../fixtures/auth';
+import { errors } from '@playwright/test';
 
 /**
  * Internal dependencies
@@ -70,7 +71,14 @@ test.describe( 'Multi-currency', { tag: [ '@merchant', '@critical' ] }, () => {
 		const usesIframedCanvas = await editorCanvas
 			.waitFor( { state: 'visible', timeout: 15000 } )
 			.then( () => true )
-			.catch( () => false );
+			.catch( ( error ) => {
+				// Only a timeout means the inline (non-iframed) WC 7.7.0 editor;
+				// surface anything else (page closed, navigation, bad selector).
+				if ( error instanceof errors.TimeoutError ) {
+					return false;
+				}
+				throw error;
+			} );
 
 		if ( usesIframedCanvas ) {
 			const editor = editorCanvas.contentFrame();

--- a/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
@@ -65,16 +65,23 @@ test.describe( 'Multi-currency', { tag: [ '@merchant', '@critical' ] }, () => {
 			await adminPage.getByRole( 'button', { name: 'Close' } ).click();
 		}
 
-		if ( await adminPage.locator( '[name="editor-canvas"]' ).isVisible() ) {
-			await expect(
-				adminPage.locator( '[name="editor-canvas"]' )
-			).toBeAttached();
-			const editor = adminPage
-				.locator( '[name="editor-canvas"]' )
-				.contentFrame();
+		// The block editor canvas is iframed on modern WP (6.3+) but rendered
+		// inline on the older WP bundled with WC 7.7.0. `isVisible()` does not
+		// auto-wait, so checking it immediately after load raced the iframe mount
+		// and — deterministically on WP nightly — fell through to the inline path,
+		// where no page-level "Add block" button exists, hanging the test until it
+		// timed out. Wait for the canvas to mount before choosing a path.
+		const editorCanvas = adminPage.locator( '[name="editor-canvas"]' );
+		const usesIframedCanvas = await editorCanvas
+			.waitFor( { state: 'visible', timeout: 15000 } )
+			.then( () => true )
+			.catch( () => false );
+
+		if ( usesIframedCanvas ) {
+			const editor = editorCanvas.contentFrame();
 			await editor.getByRole( 'button', { name: 'Add block' } ).click();
 		} else {
-			// Fallback for WC 7.7.0.
+			// Fallback for the inline (non-iframed) editor on WC 7.7.0.
 			await adminPage
 				.getByRole( 'button', { name: 'Add block' } )
 				.click();

--- a/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
@@ -59,11 +59,22 @@ test.describe( 'Multi-currency', { tag: [ '@merchant', '@critical' ] }, () => {
 
 		await goToNewPost( adminPage );
 
-		if (
-			await adminPage.getByRole( 'button', { name: 'Close' } ).isVisible()
-		) {
-			await adminPage.getByRole( 'button', { name: 'Close' } ).click();
-		}
+		// Modern WP shows the editor Welcome Guide on a fresh post, and its modal
+		// overlay intercepts clicks on the block inserter. Disable it (and
+		// fullscreen mode) deterministically via the preferences store: racing a
+		// "Close" button with isVisible() let the guide slip through on WP nightly
+		// and block the insert. Guarded so it no-ops where core/preferences is
+		// unavailable.
+		await adminPage.waitForFunction( () => ( window as any ).wp?.data );
+		await adminPage.evaluate( async () => {
+			const prefs = ( window as any ).wp?.data?.dispatch?.(
+				'core/preferences'
+			);
+			if ( prefs?.set ) {
+				await prefs.set( 'core/edit-post', 'welcomeGuide', false );
+				await prefs.set( 'core/edit-post', 'fullscreenMode', false );
+			}
+		} );
 
 		// The block editor canvas is iframed on modern WP (6.3+) but rendered
 		// inline on the older WP bundled with WC 7.7.0. `isVisible()` does not

--- a/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
@@ -60,16 +60,12 @@ test.describe( 'Multi-currency', { tag: [ '@merchant', '@critical' ] }, () => {
 
 		await goToNewPost( adminPage );
 
-		// Disable the editor Welcome Guide so its modal overlay doesn't intercept
-		// clicks on the block inserter (see helper for the WP-nightly background).
+		// Dismiss the Welcome Guide; its overlay blocks the block inserter.
 		await disableEditorWelcomeGuide( adminPage );
 
-		// The block editor canvas is iframed on modern WP (6.3+) but rendered
-		// inline on the older WP bundled with WC 7.7.0. `isVisible()` does not
-		// auto-wait, so checking it immediately after load raced the iframe mount
-		// and — deterministically on WP nightly — fell through to the inline path,
-		// where no page-level "Add block" button exists, hanging the test until it
-		// timed out. Wait for the canvas to mount before choosing a path.
+		// Wait for the iframed canvas before branching — `isVisible()` doesn't
+		// auto-wait, so an early check raced the mount and took the WC 7.7.0
+		// inline path on WP nightly.
 		const editorCanvas = adminPage.locator( '[name="editor-canvas"]' );
 		const usesIframedCanvas = await editorCanvas
 			.waitFor( { state: 'visible', timeout: 15000 } )

--- a/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/merchant/multi-currency.spec.ts
@@ -11,6 +11,7 @@ import {
 	addMulticurrencyWidget,
 	deactivateMulticurrency,
 	disableAllEnabledCurrencies,
+	disableEditorWelcomeGuide,
 	removeMultiCurrencyWidgets,
 	restoreCurrencies,
 	goToMultiCurrencySettings,
@@ -59,22 +60,9 @@ test.describe( 'Multi-currency', { tag: [ '@merchant', '@critical' ] }, () => {
 
 		await goToNewPost( adminPage );
 
-		// Modern WP shows the editor Welcome Guide on a fresh post, and its modal
-		// overlay intercepts clicks on the block inserter. Disable it (and
-		// fullscreen mode) deterministically via the preferences store: racing a
-		// "Close" button with isVisible() let the guide slip through on WP nightly
-		// and block the insert. Guarded so it no-ops where core/preferences is
-		// unavailable.
-		await adminPage.waitForFunction( () => ( window as any ).wp?.data );
-		await adminPage.evaluate( async () => {
-			const prefs = ( window as any ).wp?.data?.dispatch?.(
-				'core/preferences'
-			);
-			if ( prefs?.set ) {
-				await prefs.set( 'core/edit-post', 'welcomeGuide', false );
-				await prefs.set( 'core/edit-post', 'fullscreenMode', false );
-			}
-		} );
+		// Disable the editor Welcome Guide so its modal overlay doesn't intercept
+		// clicks on the block inserter (see helper for the WP-nightly background).
+		await disableEditorWelcomeGuide( adminPage );
 
 		// The block editor canvas is iframed on modern WP (6.3+) but rendered
 		// inline on the older WP bundled with WC 7.7.0. `isVisible()` does not

--- a/tests/qit/test-package/utils/merchant.ts
+++ b/tests/qit/test-package/utils/merchant.ts
@@ -464,15 +464,16 @@ echo wp_json_encode( array_values( array_unique( $ids ) ) );
  * @param {Page} page The page object.
  */
 export const disableEditorWelcomeGuide = async ( page: Page ) => {
-	await page.waitForFunction( () => ( window as any ).wp?.data );
+	// Wait for the preferences store's `set` action, not just `wp.data`: the
+	// store can register a few ticks later, and a silent no-op here would leave
+	// the guide up — the flakiness this helper exists to remove.
+	await page.waitForFunction(
+		() => ( window as any ).wp?.data?.dispatch?.( 'core/preferences' )?.set
+	);
 	await page.evaluate( async () => {
-		const prefs = ( window as any ).wp?.data?.dispatch?.(
-			'core/preferences'
-		);
-		if ( prefs?.set ) {
-			await prefs.set( 'core/edit-post', 'welcomeGuide', false );
-			await prefs.set( 'core/edit-post', 'fullscreenMode', false );
-		}
+		const prefs = ( window as any ).wp.data.dispatch( 'core/preferences' );
+		await prefs.set( 'core/edit-post', 'welcomeGuide', false );
+		await prefs.set( 'core/edit-post', 'fullscreenMode', false );
 	} );
 };
 

--- a/tests/qit/test-package/utils/merchant.ts
+++ b/tests/qit/test-package/utils/merchant.ts
@@ -457,6 +457,33 @@ echo wp_json_encode( array_values( array_unique( $ids ) ) );
 	}
 };
 
+/**
+ * Disables the block editor's Welcome Guide (and fullscreen mode) on the current
+ * page via the preferences store.
+ *
+ * The post editor shows the Welcome Guide on a fresh post, and its modal overlay
+ * intercepts clicks on the block inserter. Dismissing it by racing a "Close"
+ * button with `isVisible()` is unreliable: after Gutenberg deferred the editor's
+ * React mount (WordPress/gutenberg#78508, v23.3.0) the guide renders a few ticks
+ * after the page `load` event, so the check ran too early on WP nightly and the
+ * guide stayed up, blocking the insert. Setting the preference is deterministic.
+ * Guarded to no-op where `core/preferences` is unavailable.
+ *
+ * @param {Page} page The page object.
+ */
+export const disableEditorWelcomeGuide = async ( page: Page ) => {
+	await page.waitForFunction( () => ( window as any ).wp?.data );
+	await page.evaluate( async () => {
+		const prefs = ( window as any ).wp?.data?.dispatch?.(
+			'core/preferences'
+		);
+		if ( prefs?.set ) {
+			await prefs.set( 'core/edit-post', 'welcomeGuide', false );
+			await prefs.set( 'core/edit-post', 'fullscreenMode', false );
+		}
+	} );
+};
+
 export const addMulticurrencyWidget = async (
 	page: Page,
 	blocksVersion = false

--- a/tests/qit/test-package/utils/merchant.ts
+++ b/tests/qit/test-package/utils/merchant.ts
@@ -458,16 +458,10 @@ echo wp_json_encode( array_values( array_unique( $ids ) ) );
 };
 
 /**
- * Disables the block editor's Welcome Guide (and fullscreen mode) on the current
- * page via the preferences store.
- *
- * The post editor shows the Welcome Guide on a fresh post, and its modal overlay
- * intercepts clicks on the block inserter. Dismissing it by racing a "Close"
- * button with `isVisible()` is unreliable: after Gutenberg deferred the editor's
- * React mount (WordPress/gutenberg#78508, v23.3.0) the guide renders a few ticks
- * after the page `load` event, so the check ran too early on WP nightly and the
- * guide stayed up, blocking the insert. Setting the preference is deterministic.
- * Guarded to no-op where `core/preferences` is unavailable.
+ * Disables the editor Welcome Guide (and fullscreen mode) via the preferences
+ * store. Deterministic alternative to racing a "Close" button, which slipped
+ * past the guide on WP nightly once Gutenberg deferred the editor mount
+ * (WordPress/gutenberg#78508).
  *
  * @param {Page} page The page object.
  */

--- a/tests/qit/test-package/utils/merchant.ts
+++ b/tests/qit/test-package/utils/merchant.ts
@@ -459,9 +459,7 @@ echo wp_json_encode( array_values( array_unique( $ids ) ) );
 
 /**
  * Disables the editor Welcome Guide (and fullscreen mode) via the preferences
- * store. Deterministic alternative to racing a "Close" button, which slipped
- * past the guide on WP nightly once Gutenberg deferred the editor mount
- * (WordPress/gutenberg#78508).
+ * store. Deterministic alternative to racing a "Close" button.
  *
  * @param {Page} page The page object.
  */


### PR DESCRIPTION
Fixes WOOPMNT-6249

#### Changes proposed in this Pull Request

The `Multi-currency › can add the currency switcher to a post/page and verify on frontend` E2E test (`@critical`) started timing out on the **WP nightly** slot on 2026-06-30, in both the standard E2E and QIT pipelines, keeping `develop` red.

**Root cause — upstream, not a product regression.** 
AFAIU the responsible change is [WordPress/gutenberg#78508](https://github.com/WordPress/gutenberg/pull/78508) which moves the post editor's `root.render()` inside an async `preloadResolutions(...).finally(...)`. As a result, both the iframed editor canvas (`<iframe name="editor-canvas">`) **and** the editor Welcome Guide now mount several async ticks *after* the page `load` event instead of synchronously.

That affected the non-waiting `isVisible()` assumptions in the test:
1. The canvas check ran before the iframe mounted → the test fell into the WC 7.7.0 inline-editor fallback and clicked a page-level "Add block" that does not exist in the iframed editor → 120s timeout.
2. The Welcome Guide "Close" check ran before the guide rendered → the guide stayed open and its modal overlay (`components-modal__screen-overlay`) intercepted the inserter click → 120s timeout.

The test hangs during editor *setup*, before it ever exercises the currency-switcher block.

**Fix**:

- Wait for the editor canvas to become visible before choosing the iframe vs. inline path.
- Disable the `welcomeGuide` / `fullscreenMode` preferences via the `core/preferences` store.


#### Testing instructions

This only reproduces on **WP nightly**, which the PR-level E2E workflow does not run (it pins WP `latest`). It was verified by dispatching the nightly workflows on this branch (commit `8bf25e880`):

- **E2E Tests - All** — overall green; the previously-red `WP nightly | WC latest | wcpay - merchant` slot passes: https://github.com/Automattic/woocommerce-payments/actions/runs/28454607278
- **QIT E2E** — `merchant | WP nightly | WC 10.9.1 | PHP 8.3` slot passes: https://github.com/Automattic/woocommerce-payments/actions/runs/28454609657

To reproduce/verify yourself: `gh workflow run e2e-test.yml --ref e2e/WOOPMNT-6249` and watch the `WP nightly … wcpay - merchant` job.

-------------------

- [x] Run `npm run changelog` to add a changelog file (`dev` / `patch` added).
- [x] Covered with tests (this PR *is* a test fix).
- [x] Tested on mobile (does not apply — E2E test change).

**Post merge**

- [ ] QA Testing Not Applicable (E2E test infrastructure fix; no user-facing change).
