### PR TITLE
Avoid multi-currency cache churn for filtered currencies

### DIFF
--- a/changelog/codex-fix-mc-cache-base-currency
+++ b/changelog/codex-fix-mc-cache-base-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid invalidating multi-currency rate cache for visitor-filtered currencies

--- a/includes/multi-currency/Currency.php
+++ b/includes/multi-currency/Currency.php
@@ -85,7 +85,7 @@ class Currency implements \JsonSerializable {
 		$this->code                 = $code;
 		$this->rate                 = $rate;
 
-		if ( get_woocommerce_currency() === $code ) {
+		if ( get_option( 'woocommerce_currency', '' ) === $code ) {
 			$this->is_default = true;
 		}
 

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -1800,7 +1800,7 @@ class MultiCurrency {
 	 * @return string
 	 */
 	private function get_store_currency_code(): string {
-		return get_option( 'woocommerce_currency' );
+		return (string) get_option( 'woocommerce_currency', '' );
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -302,12 +302,13 @@ class MultiCurrency {
 		// If the store currency is not in the list of available WooCommerce currencies
 		// (e.g. a custom currency was removed), bail out to avoid fatal errors.
 		// Multi-Currency cannot function without a valid base currency.
-		if ( ! array_key_exists( get_woocommerce_currency(), get_woocommerce_currencies() ) ) {
+		$store_currency = $this->get_store_currency_code();
+		if ( ! array_key_exists( $store_currency, get_woocommerce_currencies() ) ) {
 			Logger::error(
 				sprintf(
 					'Multi-Currency disabled: store currency "%s" is not a recognized WooCommerce currency. '
 					. 'A custom currency may have been removed. Update the currency at WooCommerce → Settings → General.',
-					get_woocommerce_currency()
+					$store_currency
 				)
 			);
 			// Initialize properties to safe defaults so lazy-init getters and
@@ -500,7 +501,7 @@ class MultiCurrency {
 			MultiCurrencyCacheInterface::CURRENCIES_KEY,
 			function () {
 				try {
-					$currency_data = $this->payments_api_client->get_currency_rates( strtolower( get_woocommerce_currency() ) );
+					$currency_data = $this->payments_api_client->get_currency_rates( strtolower( $this->get_store_currency_code() ) );
 					return [
 						'currencies' => $currency_data,
 						'updated'    => time(),
@@ -736,7 +737,7 @@ class MultiCurrency {
 			$this->init();
 		}
 
-		return $this->default_currency ?? new Currency( $this->localization_service, get_woocommerce_currency() );
+		return $this->default_currency ?? new Currency( $this->localization_service, $this->get_store_currency_code() );
 	}
 
 	/**
@@ -1703,7 +1704,7 @@ class MultiCurrency {
 	 */
 	private function initialize_available_currencies() {
 		// Add default store currency with a rate of 1.0.
-		$woocommerce_currency                                = get_woocommerce_currency();
+		$woocommerce_currency                                = $this->get_store_currency_code();
 		$this->available_currencies[ $woocommerce_currency ] = new Currency( $this->localization_service, $woocommerce_currency, 1.0 );
 
 		$available_currencies = [];
@@ -1783,7 +1784,23 @@ class MultiCurrency {
 	 */
 	private function set_default_currency() {
 		$available_currencies   = $this->get_available_currencies();
-		$this->default_currency = $available_currencies[ get_woocommerce_currency() ] ?? null;
+		$this->default_currency = $available_currencies[ $this->get_store_currency_code() ] ?? null;
+	}
+
+	/**
+	 * Returns the configured WooCommerce store currency.
+	 *
+	 * This intentionally reads the raw option instead of get_woocommerce_currency().
+	 * WooCommerce filters that helper for display and compatibility purposes, and
+	 * visitor-facing currency switchers can use it to return the selected currency.
+	 * Multi-Currency base-currency state must be tied to the admin setting instead.
+	 * Keep cache invalidation and base-currency initialization on this helper to
+	 * avoid reintroducing visitor-triggered cache churn.
+	 *
+	 * @return string
+	 */
+	private function get_store_currency_code(): string {
+		return get_option( 'woocommerce_currency' );
 	}
 
 	/**
@@ -1812,7 +1829,7 @@ class MultiCurrency {
 	 */
 	private function check_store_currency_for_change(): bool {
 		$last_known_currency  = get_option( $this->id . '_store_currency', false );
-		$woocommerce_currency = get_woocommerce_currency();
+		$woocommerce_currency = $this->get_store_currency_code();
 
 		// If the last known currency was not set, update the option to set it and return false.
 		if ( ! $last_known_currency ) {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -225,13 +225,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function test_get_available_currencies_adds_store_currency() {
 		// Use a real WooCommerce currency that is not in the mock Stripe account currencies.
-		add_filter(
-			'woocommerce_currency',
-			function () {
-				return 'JPY';
-			},
-			901
-		);
+		update_option( 'woocommerce_currency', 'JPY' );
 
 		$this->init_multi_currency();
 
@@ -239,6 +233,30 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 		$this->assertSame( 'JPY', $default_currency->get_code() );
 		$this->assertSame( 1.0, $default_currency->get_rate() );
+	}
+
+	public function test_get_available_currencies_uses_store_currency_when_woocommerce_currency_is_filtered() {
+		update_option( 'woocommerce_currency', 'USD' );
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => 'EUR', 999 );
+
+		$this->init_multi_currency();
+
+		$available_currencies = $this->multi_currency->get_available_currencies();
+
+		$this->assertArrayHasKey( 'USD', $available_currencies );
+		$this->assertSame( 'USD', $available_currencies['USD']->get_code() );
+		$this->assertSame( 1.0, $available_currencies['USD']->get_rate() );
+	}
+
+	public function test_get_default_currency_uses_store_currency_when_woocommerce_currency_is_filtered() {
+		update_option( 'woocommerce_currency', 'USD' );
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => 'EUR', 999 );
+
+		$this->init_multi_currency();
+
+		$this->assertSame( 'USD', $this->multi_currency->get_default_currency()->get_code() );
 	}
 
 	public function test_available_currencies_can_be_filtered() {
@@ -937,6 +955,42 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 			$this->mock_available_currencies,
 			$result['currencies']
 		);
+	}
+
+	public function test_get_cached_currencies_uses_store_currency_when_woocommerce_currency_is_filtered() {
+		$get_or_add_call_count = 1;
+		$mock_cache            = $this->createMock( MultiCurrencyCacheInterface::class );
+		$mock_cache
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_or_add' )
+			->with( MultiCurrencyCacheInterface::CURRENCIES_KEY, $this->anything(), $this->anything() )
+			->willReturnCallback(
+				function ( $key, $generator, $_unused_validator ) use ( &$get_or_add_call_count ) {
+					if ( 1 === $get_or_add_call_count ) {
+						// Call that happens inside the init function in MultiCurrency, still use cached data.
+						$get_or_add_call_count++;
+						return $this->mock_cached_currencies;
+					}
+
+					// Second call from get_cached_currencies below.
+					return $generator();
+				}
+			);
+
+		update_option( 'woocommerce_currency', 'USD' );
+		update_option( 'wcpay_multi_currency_store_currency', 'USD' );
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => 'EUR', 999 );
+
+		$this->init_multi_currency( null, true, null, $mock_cache );
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_currency_rates' )
+			->with( 'usd' )
+			->willReturn( $this->mock_available_currencies );
+
+		$this->multi_currency->get_cached_currencies();
 	}
 
 	public function test_storefront_integration_init_with_compatible_themes() {
@@ -1798,11 +1852,11 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function test_init_invalidates_cache_when_store_currency_changes() {
 		// Simulate previously known currency was USD, but store currency is now EUR.
+		update_option( 'woocommerce_currency', 'EUR' );
 		update_option( 'wcpay_multi_currency_store_currency', 'USD' );
 
 		// Clear filters from prior init (FrontendCurrencies adds one at priority 900).
 		remove_all_filters( 'woocommerce_currency' );
-		add_filter( 'woocommerce_currency', fn() => 'EUR' );
 
 		$mock_cache = $this->createMock( MultiCurrencyCacheInterface::class );
 		$mock_cache->method( 'get_or_add' )->willReturn( $this->mock_cached_currencies );
@@ -1816,11 +1870,30 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertSame( 'EUR', get_option( 'wcpay_multi_currency_store_currency' ) );
 	}
 
-	public function test_init_does_not_invalidate_cache_when_store_currency_unchanged() {
-		// Store currency matches the current WooCommerce currency (both USD).
+	public function test_init_does_not_invalidate_cache_when_woocommerce_currency_is_filtered() {
+		update_option( 'woocommerce_currency', 'USD' );
 		update_option( 'wcpay_multi_currency_store_currency', 'USD' );
 
-		// Clear filters from prior init to ensure get_woocommerce_currency() returns USD.
+		// Simulate another plugin returning a visitor-specific currency.
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => 'EUR', 999 );
+
+		$mock_cache = $this->createMock( MultiCurrencyCacheInterface::class );
+		$mock_cache->method( 'get_or_add' )->willReturn( $this->mock_cached_currencies );
+		$mock_cache->expects( $this->never() )
+			->method( 'delete' );
+
+		$this->init_multi_currency( null, true, null, $mock_cache );
+
+		$this->assertSame( 'USD', get_option( 'wcpay_multi_currency_store_currency' ) );
+	}
+
+	public function test_init_does_not_invalidate_cache_when_store_currency_unchanged() {
+		// Store currency matches the current WooCommerce currency (both USD).
+		update_option( 'woocommerce_currency', 'USD' );
+		update_option( 'wcpay_multi_currency_store_currency', 'USD' );
+
+		// Clear filters from prior init to ensure configured and filtered currency values match.
 		remove_all_filters( 'woocommerce_currency' );
 
 		$mock_cache = $this->createMock( MultiCurrencyCacheInterface::class );
@@ -1833,9 +1906,10 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function test_init_does_not_invalidate_cache_on_first_install() {
 		// No store_currency option exists yet (first-time install).
+		update_option( 'woocommerce_currency', 'USD' );
 		delete_option( 'wcpay_multi_currency_store_currency' );
 
-		// Clear filters from prior init to ensure get_woocommerce_currency() returns USD.
+		// Clear filters from prior init to ensure configured and filtered currency values match.
 		remove_all_filters( 'woocommerce_currency' );
 
 		$mock_cache = $this->createMock( MultiCurrencyCacheInterface::class );

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -240,11 +240,20 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		remove_all_filters( 'woocommerce_currency' );
 		add_filter( 'woocommerce_currency', fn() => 'EUR', 999 );
 
-		$this->init_multi_currency();
+		$mock_account = $this->createMock( MultiCurrencyAccountInterface::class );
+		$mock_account
+			->method( 'get_cached_account_data' )
+			->willReturn( [ 'id' => 'acct' ] );
+		$mock_account
+			->method( 'get_account_customer_supported_currencies' )
+			->willReturn( [ 'usd', 'cad' ] );
+
+		$this->init_multi_currency( null, true, $mock_account );
 
 		$available_currencies = $this->multi_currency->get_available_currencies();
 
 		$this->assertArrayHasKey( 'USD', $available_currencies );
+		$this->assertArrayNotHasKey( 'EUR', $available_currencies );
 		$this->assertSame( 'USD', $available_currencies['USD']->get_code() );
 		$this->assertSame( 1.0, $available_currencies['USD']->get_rate() );
 	}
@@ -257,6 +266,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->init_multi_currency();
 
 		$this->assertSame( 'USD', $this->multi_currency->get_default_currency()->get_code() );
+		$this->assertTrue( $this->multi_currency->get_default_currency()->get_is_default() );
 	}
 
 	public function test_available_currencies_can_be_filtered() {


### PR DESCRIPTION
Fixes WOOPMNT-6262
Fixes #11901

#### Changes proposed in this Pull Request

WooPayments no longer treats a visitor-selected currency from another plugin as a store base currency change. Previously, plugins that filtered `get_woocommerce_currency()` per visitor could make the Multi-Currency module build base-currency state from the visitor currency and invalidate `wcpay_multi_currency_cached_currencies` on normal frontend requests, causing repeated currency-rate refreshes under traffic.

This keeps the visitor-facing filtered currency flow intact, but centralizes Multi-Currency's base-currency reads on WooCommerce's raw configured `woocommerce_currency` option. Cache invalidation, rate-refresh base selection, available-currency initialization, default-currency initialization, and the invalid-store-currency guard now all use the admin setting instead of the filterable helper. That is still a compatible fix because it does not reorder Multi-Currency initialization or change the shared cache structure.

Historical note: #11548 restored invalidation when the real store base currency changes after #11045 removed the old cache-clearing path. This PR keeps that behavior, but closes the separate gap where the store-currency detector and sibling initialization paths could read a visitor-filtered currency as if it were the configured base currency.

#### Testing instructions

* Run the focused regression tests:
  * `docker compose exec -u www-data wordpress bash -c "cd /var/www/html/wp-content/plugins/woocommerce-payments && vendor/bin/phpunit --configuration phpunit.xml.dist --filter 'test_(get_available_currencies_adds_store_currency|get_available_currencies_uses_store_currency_when_woocommerce_currency_is_filtered|get_default_currency_uses_store_currency_when_woocommerce_currency_is_filtered|init_does_not_invalidate_cache_when_woocommerce_currency_is_filtered|get_cached_currencies_uses_store_currency_when_woocommerce_currency_is_filtered|init_invalidates_cache_when_store_currency_changes|init_does_not_invalidate_cache_when_store_currency_unchanged|init_does_not_invalidate_cache_on_first_install|init_returns_early_when_store_currency_not_in_available_wc_currencies)'"`
* Run the full Multi-Currency unit test class:
  * `docker compose exec -u www-data wordpress bash -c "cd /var/www/html/wp-content/plugins/woocommerce-payments && vendor/bin/phpunit --configuration phpunit.xml.dist --filter 'WCPay_Multi_Currency_Tests'"`
* Run PHPCS on the touched PHP files:
  * `vendor/bin/phpcs --standard=phpcs.xml.dist includes/multi-currency/MultiCurrency.php tests/unit/multi-currency/test-class-multi-currency.php`
* Manual verification performed locally:
  * Added a temporary local-only MU plugin that filters `woocommerce_currency` to `EUR` for a single browser request.
  * Loaded `http://localhost:8082/?codex_currency_filter=1` with WooPayments active.
  * Confirmed the request saw the filtered currency as `EUR`, while `wcpay_multi_currency_store_currency` remained `USD`.
  * Removed the temporary MU plugin and marker option after verification.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
