### PR TITLE
Fix WooPay express button infinite spinner on classic variable products

### DIFF
--- a/changelog/fix-woopay-express-button-variable-product-spinner
+++ b/changelog/fix-woopay-express-button-variable-product-spinner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooPay express checkout button showing an infinite spinner on classic variable product pages

--- a/client/utils/__tests__/wc-product-page-selectors.test.js
+++ b/client/utils/__tests__/wc-product-page-selectors.test.js
@@ -70,6 +70,29 @@ describe( 'wc-product-page-selectors', () => {
 			expect( getProductId() ).toBe( '42' );
 		} );
 
+		it( 'returns parent product ID for a classic variable product', () => {
+			// Variable products render the add-to-cart button with no value
+			// attribute; the parent ID lives in a hidden input in the form.
+			document.body.innerHTML = [
+				'<form class="variations_form cart">',
+				'  <input type="hidden" name="product_id" value="55" />',
+				'  <input type="hidden" name="variation_id" class="variation_id" value="0" />',
+				'  <button type="submit" class="single_add_to_cart_button">Add to cart</button>',
+				'</form>',
+			].join( '' );
+			expect( getProductId() ).toBe( '55' );
+		} );
+
+		it( 'prefers the classic button value when it is set', () => {
+			document.body.innerHTML = [
+				'<form class="cart">',
+				'  <input type="hidden" name="product_id" value="55" />',
+				'  <button type="submit" class="single_add_to_cart_button" value="42">Add to cart</button>',
+				'</form>',
+			].join( '' );
+			expect( getProductId() ).toBe( '42' );
+		} );
+
 		it( 'returns product ID from new block hidden input', () => {
 			document.body.innerHTML =
 				'<div class="wp-block-add-to-cart-with-options"><input type="hidden" name="add-to-cart" value="99" /></div>';

--- a/client/utils/wc-product-page-selectors.js
+++ b/client/utils/wc-product-page-selectors.js
@@ -28,7 +28,9 @@ export const getAddToCartButtonElement = () => {
 /**
  * Get the product ID from the add-to-cart form.
  *
- * Classic block: .single_add_to_cart_button value attribute
+ * Classic simple product: .single_add_to_cart_button value attribute
+ * Classic variable product: the button has NO value attribute, so read the
+ *   hidden input[name="product_id"] the variations form renders instead
  * Add to Cart + Options block: hidden input[name="add-to-cart"] value
  *
  * @return {string|undefined} The product ID, or undefined.
@@ -37,8 +39,17 @@ export const getProductId = () => {
 	const classicButton = document.querySelector(
 		'.single_add_to_cart_button'
 	);
-	if ( classicButton ) {
+	if ( classicButton?.value ) {
 		return classicButton.value;
+	}
+
+	// Variable products render an <button> without a value attribute; the parent
+	// product ID lives in a hidden input alongside the variations form.
+	const productIdInput = document.querySelector(
+		'form.cart input[name="product_id"]'
+	);
+	if ( productIdInput?.value ) {
+		return productIdInput.value;
 	}
 
 	const hiddenInput = document.querySelector(


### PR DESCRIPTION
Fixes WOOPMNT-6263

#### Changes proposed in this Pull Request

The WooPay express checkout button on **classic variable product pages** stopped working in 10.7.0 — clicking it left the button in an infinite spinning state and never opened WooPay.

The regression was introduced in #11401 ("Fix express checkout incompatibility with Add to Cart + Options block"), which added an early return to the WooPay product handler:

```js
const productId = getProductId();
if ( ! productId ) {
    return false; // no add-to-cart request → the button spins forever
}
```

`getProductId()` reads `.single_add_to_cart_button`'s `value`. WooCommerce's variable-product template (`variation-add-to-cart-button.php`) renders that button **without a `value` attribute** (unlike simple products), so `getProductId()` returned `""`, the guard treated it as falsy, `getProductData()` returned `false`, and the flow never started.

Before 10.7.0 there was no early return, so execution reached the variation branch that reads the real ID from the hidden `input[name="product_id"]`.

**Fix:** `getProductId()` now trusts the classic button value only when it is actually set, and otherwise falls back to `form.cart input[name="product_id"]` — the hidden input variable products render. The Add to Cart + Options block path is unchanged.

Because the fix lives in the shared `wc-product-page-selectors` util, it also covers the ECE/blocks handler that consumes `getProductId()`, not just the WooPay button.

- **How can this code break?** If a theme/extension renders a variable product without the standard `input[name="product_id"]` inside `form.cart`.
- **What are we doing to make sure this code doesn't break?** Added unit tests covering the classic variable product case and the simple-product precedence case.

#### Testing instructions

1. On a store using the **classic** (shortcode) product page with WooPay enabled, open a **variable** product.
2. Select a variation and click the **WooPay** express button.
3. Confirm WooPay opens as expected (no infinite spinner).
4. Repeat on a **simple** product to confirm no regression.
5. Confirm the Add to Cart + Options (blocks) product page still works.

* Verified via unit tests: `npx jest --config tests/js/jest.config.js client/utils/__tests__/wc-product-page-selectors.test.js`

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from release testing doc: _QA Testing Not Applicable_
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
