### PR TITLE
fix: file purpose key generation

### DIFF
--- a/changelog/fix-woopay-file-purpose-cache
+++ b/changelog/fix-woopay-file-purpose-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: ensure file purpose cache key value is consistent

--- a/includes/admin/class-wc-rest-payments-files-controller.php
+++ b/includes/admin/class-wc-rest-payments-files-controller.php
@@ -59,6 +59,11 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_file' ],
+				// Intentionally public: authorization is enforced per file purpose inside get_file().
+				// Public branding assets (business_logo/business_icon) must be served to logged-out
+				// shoppers (e.g. the WooPay checkout store logo); every other purpose still requires
+				// manage_woocommerce. A static permission_callback can't express that split because the
+				// decision depends on the fetched file's purpose.
 				'permission_callback' => [],
 			]
 		);
@@ -85,7 +90,8 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 		$as_account = (bool) $request->get_param( 'as_account' );
 
 		$file_service = new WC_Payments_File_Service();
-		$purpose      = get_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . $file_id . '_' . ( $as_account ? '1' : '0' ) );
+		$cache_key    = WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . $file_id . '_' . ( $as_account ? '1' : '0' );
+		$purpose      = get_transient( $cache_key );
 
 		if ( ! $purpose ) {
 			$file = $this->forward_request( 'get_file', [ $file_id, $as_account ] );
@@ -94,7 +100,7 @@ class WC_REST_Payments_Files_Controller extends WC_Payments_REST_Controller {
 				return $this->file_error_response( $file );
 			}
 			$purpose = $file->get_data()['purpose'];
-			set_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . $file_id, $purpose, WC_Payments_File_Service::CACHE_PERIOD );
+			set_transient( $cache_key, $purpose, WC_Payments_File_Service::CACHE_PERIOD );
 		}
 
 		if ( ! $file_service->is_file_public( $purpose ) && ! $this->check_permission() ) {

--- a/includes/class-wc-payments-file-service.php
+++ b/includes/class-wc-payments-file-service.php
@@ -18,7 +18,7 @@ class WC_Payments_File_Service {
 		'business_icon',
 	];
 
-	const CACHE_KEY_PREFIX_PURPOSE = 'file_purpoose_';
+	const CACHE_KEY_PREFIX_PURPOSE = 'file_purpose_';
 	const CACHE_PERIOD             = 86400;  // 24 h
 
 

--- a/tests/unit/admin/test-class-wc-rest-payments-files-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-files-controller.php
@@ -56,7 +56,40 @@ class WC_REST_Payments_Files_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'test_file_content', $response->get_data() );
 		$this->assertSame( 200, $response->status );
 
-		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID' );
+		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID_0' );
+	}
+
+	public function test_get_file_caches_purpose_between_requests() {
+		$file_response = [
+			'file_content' => base64_encode( 'test_file_content' ), // @codingStandardsIgnoreLine
+			'content_type' => 'image/png',
+		];
+
+		// The purpose lookup must round-trip to the server only on the first request; the second
+		// request has to read the purpose the first one wrote to the transient cache. The cache
+		// read and write keys must agree for this to hold.
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'get_file' )
+			->with( 'file_mock_ID' )
+			->willReturn( [ 'purpose' => 'business_logo' ] );
+
+		$this->mock_api_client
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_file_contents' )
+			->with( 'file_mock_ID' )
+			->willReturn( $file_response );
+
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'file_id', 'file_mock_ID' );
+
+		$this->controller->get_file( $request );
+		$second_response = $this->controller->get_file( $request );
+
+		$this->assertSame( 'test_file_content', $second_response->get_data() );
+		$this->assertSame( 200, $second_response->status );
+
+		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID_0' );
 	}
 
 	public function test_get_file_no_file() {
@@ -81,7 +114,7 @@ class WC_REST_Payments_Files_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'status', $data );
 		$this->assertSame( 404, $data['status'] );
 
-		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID' );
+		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID_0' );
 	}
 
 	public function test_get_file_content_exception() {
@@ -106,7 +139,7 @@ class WC_REST_Payments_Files_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertArrayHasKey( 'status', $data );
 		$this->assertSame( 500, $data['status'] );
 
-		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID' );
+		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID_0' );
 	}
 
 	public function test_get_file_no_permission() {
@@ -123,7 +156,7 @@ class WC_REST_Payments_Files_Controller_Test extends WCPAY_UnitTestCase {
 		$data = $response->get_error_data();
 		$this->assertSame( $data['status'], 401 );
 
-		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID' );
+		delete_transient( WC_Payments_File_Service::CACHE_KEY_PREFIX_PURPOSE . 'file_mock_ID_0' );
 	}
 
 	public function test_get_file_exception() {


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

Reported here: p3btAN-3Eo-p2

The transient cache for a file's purpose was never hitting: the read key appends the `as_account` suffix (`_0`/`_1`), but the write key didn't. Every request ended up re-fetching the purpose from the server.

Computing the key once and reusing it for both the read and the write, so the two can't drift apart again. Also fixing a typo in the cache key constant (`file_purpoose_` ( 💩  ) → `file_purpose_`).


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The issue can be tested in CI.

- Check out this branch
- Run the unit tests for the files controller: `WC_REST_Payments_Files_Controller_Test`
- They should pass, including the new `test_get_file_caches_purpose_between_requests` - which asserts a second request for the same file reuses the cached purpose instead of hitting the server again

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.