### PR TITLE
fix: redact address autocomplete token from API response logs

### DIFF
--- a/changelog/fix-woopmnt-5952-redact-autocomplete-token
+++ b/changelog/fix-woopmnt-5952-redact-autocomplete-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: redact the address autocomplete token from API response logs.

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -112,6 +112,8 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		'customer_email',
 		// Free-text refund reason can contain merchant-entered PII, so keep it out of logs.
 		'merchant_refund_reason',
+		// Address autocomplete JWT is a credential; keep it out of logs.
+		'token',
 	];
 
 	const EVENT_AUTHORIZED            = 'authorized';

--- a/includes/wc-payment-api/class-wc-payments-api-client.php
+++ b/includes/wc-payment-api/class-wc-payments-api-client.php
@@ -107,7 +107,6 @@ class WC_Payments_API_Client implements MultiCurrencyApiClientInterface {
 		'state',
 		'city',
 		'country',
-		'company',
 		'customer_name',
 		'customer_email',
 		// Free-text refund reason can contain merchant-entered PII, so keep it out of logs.


### PR DESCRIPTION
Fixes WOOPMNT-5952

#### Changes proposed in this Pull Request

The address autocomplete endpoint returns a JWT in its response body, but the `token` key isn't part of `API_KEYS_TO_REDACT`.
Adding `token` to the redaction list so it's masked before anything is logged.

EZ change.

#### Testing instructions

(I tested on JN for simplicity)
1. Enable address autocomplete in WooCommerce > Settings
<img width="617" height="108" alt="Screenshot 2026-07-02 at 12 30 58 PM" src="https://github.com/user-attachments/assets/cd0eb657-bbf9-4c08-94b9-27e021a85a5b" />

2. Add a product to the cart
3. Trigger a fresh token fetch so the endpoint is actually called, the token is cached after the first request, so clear the WCPay address autocomplete cache (or use a fresh site) and load a page that requests it.
<img width="859" height="459" alt="Screenshot 2026-07-02 at 12 32 18 PM" src="https://github.com/user-attachments/assets/9f5aa04b-f968-40ca-abaf-9aae4085de1e" />

4. Open the latest log under **WooCommerce → Status → Logs** and find the `API RESPONSE (...): POST .../address-autocomplete-token` entry.
5. Confirm the `token` field now reads `(redacted)`
<img width="674" height="477" alt="Screenshot 2026-07-02 at 12 33 10 PM" src="https://github.com/user-attachments/assets/591787ed-a90b-4cdb-8201-ce8105d22bf8" />


* Covered by the existing redaction path; no behaviour changes beyond what's logged.
