### PR TITLE
fix: doubled express checkout button spacing on Cart block with WC 10.8+

### DIFF
--- a/changelog/fix-ece-block-cart-button-spacing
+++ b/changelog/fix-ece-block-cart-button-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix doubled spacing between express checkout buttons on the Cart block with WooCommerce 10.8+

--- a/client/express-checkout/block-buttons/express-checkout-element.scss
+++ b/client/express-checkout/block-buttons/express-checkout-element.scss
@@ -1,14 +1,3 @@
-// Cart Block
-.wc-block-components-express-payment--cart {
-	.wc-block-components-express-payment__event-buttons > li {
-		padding-bottom: 12px !important;
-
-		&:last-child {
-			padding-bottom: 0 !important;
-		}
-	}
-}
-
 // OR separator
 .wc-block-components-express-payment-continue-rule--cart {
 	margin: 24px 0 !important;


### PR DESCRIPTION
Fixes WOOPMNT-6267

#### Changes proposed in this Pull Request

Removes the `padding-bottom: 12px !important` rules that WooPayments applies to each express payment `<li>` on the Cart block (`client/express-checkout/block-buttons/express-checkout-element.scss`).

**Why:** WooCommerce 10.8.0 ([woocommerce/woocommerce#64074](https://github.com/woocommerce/woocommerce/pull/64074)) changed how the Cart block spaces express payment buttons — from `padding-bottom: 12px` on each item to flexbox with `gap: 12px` on the list and `padding: 0` on the items. Our `!important` padding now wins over WC's `padding: 0` and **stacks with the new flex gap: 12px gap + 12px padding = 24px between stacked buttons — double the intended spacing**. 

<details><summary>Why the `!important` rule existed — and why it's safe to remove now:</summary>
<p>
When it was added in #9258 (Aug 2024, fixing #9169), it was doing real work: WooCommerce then spaced these buttons with `padding-bottom: $gap` (**16px**), while the design spec required a uniform **12px**. `!important` was needed because our selector is identical to wc-blocks', so without it the winner would depend on stylesheet load order. One month later, WooCommerce adopted 12px itself ([woocommerce/woocommerce#50791](https://github.com/woocommerce/woocommerce/pull/50791), Sept 2024, ~WC 9.4), making our rule a dormant duplicate — until WC 10.8's flex-gap change turned it into a double-spacer.
</p>
</details> 
<p>
On every WooCommerce version in our support window, WC core itself provides the 12px spacing (via its own `padding-bottom` on < 10.8, via flex `gap` on ≥ 10.8), so removal changes nothing except fixing the doubled spacing on ≥ 10.8. 
</p>

#### Screenshots

**Before**

<img width="568" height="705" alt="Screenshot 2026-07-02 at 12 18 33" src="https://github.com/user-attachments/assets/2c07f139-bfdf-4f0e-bc2c-892a5e8dd0d9" />

**After**

<img width="433" height="643" alt="Screenshot 2026-07-02 at 16 18 10" src="https://github.com/user-attachments/assets/4b1c803a-c36c-4a57-abaf-2be7438dc5dc" />



#### Testing instructions

1. On a store with WooCommerce ≥ 10.8 and the **Cart block**, enable at least two express checkout buttons (e.g. WooPay + Google Pay, or Apple Pay in Safari).
2. Add a product to the cart and view the cart page **without this branch's build** (e.g. `develop`): the stacked express buttons are 24px apart (inspect an express button `<li>` — it has `padding-bottom: 12px !important` on top of the list's `gap: 12px`).
3. Check out this branch, `npm run build:client`, reload the cart: buttons are 12px apart and each `<li>` is exactly the button height (48px by default).
4. Regression check on WC < 10.8 (e.g. `wp plugin install woocommerce --version=10.7.0 --force`): spacing on the cart remains 12px with this branch (the 12px `padding-bottom` on the `<li>` now comes from WC core's own stylesheet).
5. Check the Checkout block and the product page (PDP) express buttons: unchanged.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)