### PR TITLE
fix: define refund failure note on the insufficient-balance path

### DIFF
--- a/changelog/fix-woopmnt-5977-refund-failure-note
+++ b/changelog/fix-woopmnt-5977-refund-failure-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Record the correct failure reason and avoid a PHP warning when a refund fails because of insufficient account balance.

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2820,6 +2820,8 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			$currency = strtoupper( $refund['currency'] );
 			Tracker::track_admin( 'wcpay_edit_order_refund_success' );
 		} catch ( Exception $e ) {
+			// Default reason so the failure tracking below always has a value, even on branches that don't build a richer note.
+			$note = $e->getMessage();
 			if ( $e instanceof API_Exception && 'insufficient_balance_for_refund' === $e->get_error_code() ) {
 				// Handle insufficient_balance_for_refund error.
 				$this->order_service->handle_insufficient_balance_for_refund( $order, WC_Payments_Utils::prepare_amount( $amount, $order->get_currency() ) );

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -91,7 +91,7 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$this->mock_token_service            = $this->createMock( WC_Payments_Token_Service::class );
 		$this->mock_action_scheduler_service = $this->createMock( WC_Payments_Action_Scheduler_Service::class );
 		$this->mock_rate_limiter             = $this->createMock( Session_Rate_Limiter::class );
-		$this->mock_order_service            = $this->getMockBuilder( WC_Payments_Order_Service::class )->disableOriginalConstructor()->onlyMethods( [ 'get_charge_id_for_order', 'get_payment_method_id_for_order', 'get_intent_id_for_order', 'get_intention_status_for_order', 'get_wcpay_refund_status_for_order', 'get_wcpay_intent_currency_for_order' ] )->getMock();
+		$this->mock_order_service            = $this->getMockBuilder( WC_Payments_Order_Service::class )->disableOriginalConstructor()->onlyMethods( [ 'get_charge_id_for_order', 'get_payment_method_id_for_order', 'get_intent_id_for_order', 'get_intention_status_for_order', 'get_wcpay_refund_status_for_order', 'get_wcpay_intent_currency_for_order', 'handle_insufficient_balance_for_refund' ] )->getMock();
 		$mock_dpps                           = $this->createMock( Duplicate_Payment_Prevention_Service::class );
 		$mock_payment_method                 = $this->createMock( UPE_Payment_Method::class );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-refund.php
@@ -1083,6 +1083,44 @@ class WC_Payment_Gateway_WCPay_Process_Refund_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( wc_price( 19.99, [ 'currency' => 'EUR' ] ), $latest_wcpay_note->content );
 	}
 
+	public function test_process_refund_insufficient_balance_reaches_failure_tracking() {
+		$intent_id = 'pi_xxxxxxxxxxxxx';
+		$charge_id = 'ch_yyyyyyyyyyyyy';
+
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_intent_id', $intent_id );
+		$order->update_meta_data( '_charge_id', $charge_id );
+		$order->update_status( Order_Status::PROCESSING );
+		$order->save();
+
+		$order_id = $order->get_id();
+
+		$request = $this->mock_wcpay_request( Refund_Charge::class );
+
+		$request->expects( $this->once() )
+			->method( 'set_charge' )
+			->with( $charge_id );
+
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willThrowException( new API_Exception( 'Balance too low', 'insufficient_balance_for_refund', 400 ) );
+
+		$this->mock_order_service
+			->method( 'get_charge_id_for_order' )
+			->willReturn( $charge_id );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'handle_insufficient_balance_for_refund' );
+
+		// This branch skips the note-building code, so the shared failure-tracking call must still find a defined $note.
+		$result = $this->wcpay_gateway->process_refund( $order_id, 19.99 );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'wcpay_edit_order_refund_failure', $result->get_error_code() );
+		$this->assertEquals( 'Balance too low', $result->get_error_message() );
+	}
+
 	public function test_process_refund_returns_error_when_refund_not_found() {
 		$intent_id = 'pi_xxxxxxxxxxxxx';
 		$charge_id = 'ch_yyyyyyyyyyyyy';


### PR DESCRIPTION
Fixes WOOPMNT-5977

#### Changes proposed in this Pull Request

In `process_refund()`, the `insufficient_balance_for_refund` catch branch never assigns `$note`, but the shared `Tracker::track_admin( 'wcpay_edit_order_refund_failure' )` call right after the branches reads `$note` regardless of which branch ran.

Defaulting `$note` to the exception message before the branches, so that it's always defined and the tracking call always has a value.

#### Testing instructions

This branch is hard to trigger by hand (it needs the API to come back with `insufficient_balance_for_refund`), so the main coverage is the CI validation.

If you _can_ force the API to return `insufficient_balance_for_refund` (e.g. a refund on an account with no available balance), refund from the order screen. Before: a warning shows up in the logs and the `wcpay_edit_order_refund_failure` event records `reason: null`. After: no warning, and the event carries the actual error message.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
