### PR TITLE
fix: read agent-pipeline workflow inputs from env vars in shell steps

### DIFF
--- a/.github/workflows/agent-address-comments.yml
+++ b/.github/workflows/agent-address-comments.yml
@@ -72,13 +72,10 @@ jobs:
             exit 1
           fi
 
-          # Substitute variables. Inputs are read from the environment so their
-          # values never reach the shell parser as literal command text.
-          sed \
-            -e "s|{{PR_NUMBER}}|${PR_NUMBER}|g" \
-            -e "s|{{TARGET_BRANCH}}|${TARGET_BRANCH}|g" \
-            -e "s|{{BRANCH_NAME}}|${BRANCH_NAME}|g" \
-            "$TEMPLATE" > /tmp/address-comments-prompt.md
+          # Substitute placeholders. Values come from the environment and are
+          # inserted literally, so metacharacters in an input can't break out
+          # of the command or corrupt the substitution.
+          perl -pe 's/\{\{PR_NUMBER\}\}/$ENV{PR_NUMBER}/g; s/\{\{TARGET_BRANCH\}\}/$ENV{TARGET_BRANCH}/g; s/\{\{BRANCH_NAME\}\}/$ENV{BRANCH_NAME}/g;' "$TEMPLATE" > /tmp/address-comments-prompt.md
 
           # Write multiline output
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)

--- a/.github/workflows/agent-address-comments.yml
+++ b/.github/workflows/agent-address-comments.yml
@@ -61,6 +61,10 @@ jobs:
 
       - name: Prepare prompt from template
         id: prompt
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          BRANCH_NAME: ${{ inputs.branch_name }}
         run: |
           TEMPLATE=".gamma-ai-tools/prompts/pipeline/address-comments.md"
           if [ ! -f "$TEMPLATE" ]; then
@@ -68,11 +72,12 @@ jobs:
             exit 1
           fi
 
-          # Substitute variables
+          # Substitute variables. Inputs are read from the environment so their
+          # values never reach the shell parser as literal command text.
           sed \
-            -e 's|{{PR_NUMBER}}|${{ inputs.pr_number }}|g' \
-            -e 's|{{TARGET_BRANCH}}|${{ inputs.target_branch }}|g' \
-            -e 's|{{BRANCH_NAME}}|${{ inputs.branch_name }}|g' \
+            -e "s|{{PR_NUMBER}}|${PR_NUMBER}|g" \
+            -e "s|{{TARGET_BRANCH}}|${TARGET_BRANCH}|g" \
+            -e "s|{{BRANCH_NAME}}|${BRANCH_NAME}|g" \
             "$TEMPLATE" > /tmp/address-comments-prompt.md
 
           # Write multiline output
@@ -101,10 +106,15 @@ jobs:
 
       - name: Write job summary
         if: always()
+        env:
+          LINEAR_ISSUE_ID: ${{ inputs.linear_issue_id }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          MODEL: ${{ inputs.model }}
         run: |
           echo "## Address Comments Agent Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Issue:** ${{ inputs.linear_issue_id }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**PR:** #${{ inputs.pr_number }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Branch:** ${{ inputs.branch_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Model:** ${{ inputs.model }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Issue:** ${LINEAR_ISSUE_ID}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**PR:** #${PR_NUMBER}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Branch:** ${BRANCH_NAME}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Model:** ${MODEL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/agent-plan.yml
+++ b/.github/workflows/agent-plan.yml
@@ -52,6 +52,9 @@ jobs:
 
       - name: Prepare prompt from template
         id: prompt
+        env:
+          LINEAR_ISSUE_ID: ${{ inputs.linear_issue_id }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
           TEMPLATE=".gamma-ai-tools/prompts/pipeline/plan.md"
           if [ ! -f "$TEMPLATE" ]; then
@@ -59,10 +62,11 @@ jobs:
             exit 1
           fi
 
-          # Substitute variables
+          # Substitute variables. Inputs are read from the environment so their
+          # values never reach the shell parser as literal command text.
           sed \
-            -e 's|{{LINEAR_ISSUE_ID}}|${{ inputs.linear_issue_id }}|g' \
-            -e 's|{{TARGET_BRANCH}}|${{ inputs.target_branch }}|g' \
+            -e "s|{{LINEAR_ISSUE_ID}}|${LINEAR_ISSUE_ID}|g" \
+            -e "s|{{TARGET_BRANCH}}|${TARGET_BRANCH}|g" \
             "$TEMPLATE" > /tmp/plan-prompt.md
 
           # Write multiline output
@@ -95,12 +99,16 @@ jobs:
 
       - name: Write job summary
         if: always()
+        env:
+          LINEAR_ISSUE_ID: ${{ inputs.linear_issue_id }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          MODEL: ${{ inputs.model }}
         run: |
           echo "## Plan Agent Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Issue:** ${{ inputs.linear_issue_id }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Branch:** ${{ inputs.target_branch }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Model:** ${{ inputs.model }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Issue:** ${LINEAR_ISSUE_ID}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Branch:** ${TARGET_BRANCH}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Model:** ${MODEL}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [ -f plan.md ]; then

--- a/.github/workflows/agent-plan.yml
+++ b/.github/workflows/agent-plan.yml
@@ -62,12 +62,10 @@ jobs:
             exit 1
           fi
 
-          # Substitute variables. Inputs are read from the environment so their
-          # values never reach the shell parser as literal command text.
-          sed \
-            -e "s|{{LINEAR_ISSUE_ID}}|${LINEAR_ISSUE_ID}|g" \
-            -e "s|{{TARGET_BRANCH}}|${TARGET_BRANCH}|g" \
-            "$TEMPLATE" > /tmp/plan-prompt.md
+          # Substitute placeholders. Values come from the environment and are
+          # inserted literally, so metacharacters in an input can't break out
+          # of the command or corrupt the substitution.
+          perl -pe 's/\{\{LINEAR_ISSUE_ID\}\}/$ENV{LINEAR_ISSUE_ID}/g; s/\{\{TARGET_BRANCH\}\}/$ENV{TARGET_BRANCH}/g;' "$TEMPLATE" > /tmp/plan-prompt.md
 
           # Write multiline output
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -56,6 +56,10 @@ jobs:
 
       - name: Prepare prompt from template
         id: prompt
+        env:
+          LINEAR_ISSUE_ID: ${{ inputs.linear_issue_id }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          BRANCH_NAME: ${{ inputs.branch_name }}
         run: |
           TEMPLATE=".gamma-ai-tools/prompts/pipeline/review.md"
           if [ ! -f "$TEMPLATE" ]; then
@@ -63,11 +67,12 @@ jobs:
             exit 1
           fi
 
-          # Substitute variables
+          # Substitute variables. Inputs are read from the environment so their
+          # values never reach the shell parser as literal command text.
           sed \
-            -e 's|{{LINEAR_ISSUE_ID}}|${{ inputs.linear_issue_id }}|g' \
-            -e 's|{{TARGET_BRANCH}}|${{ inputs.target_branch }}|g' \
-            -e 's|{{BRANCH_NAME}}|${{ inputs.branch_name }}|g' \
+            -e "s|{{LINEAR_ISSUE_ID}}|${LINEAR_ISSUE_ID}|g" \
+            -e "s|{{TARGET_BRANCH}}|${TARGET_BRANCH}|g" \
+            -e "s|{{BRANCH_NAME}}|${BRANCH_NAME}|g" \
             "$TEMPLATE" > /tmp/review-prompt.md
 
           # Write multiline output
@@ -100,13 +105,18 @@ jobs:
 
       - name: Write job summary
         if: always()
+        env:
+          LINEAR_ISSUE_ID: ${{ inputs.linear_issue_id }}
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          MODEL: ${{ inputs.model }}
         run: |
           echo "## Review Agent Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Issue:** ${{ inputs.linear_issue_id }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Branch:** ${{ inputs.branch_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Base:** ${{ inputs.target_branch }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Model:** ${{ inputs.model }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Issue:** ${LINEAR_ISSUE_ID}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Branch:** ${BRANCH_NAME}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Base:** ${TARGET_BRANCH}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Model:** ${MODEL}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [ -f review-report.md ]; then

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -67,13 +67,10 @@ jobs:
             exit 1
           fi
 
-          # Substitute variables. Inputs are read from the environment so their
-          # values never reach the shell parser as literal command text.
-          sed \
-            -e "s|{{LINEAR_ISSUE_ID}}|${LINEAR_ISSUE_ID}|g" \
-            -e "s|{{TARGET_BRANCH}}|${TARGET_BRANCH}|g" \
-            -e "s|{{BRANCH_NAME}}|${BRANCH_NAME}|g" \
-            "$TEMPLATE" > /tmp/review-prompt.md
+          # Substitute placeholders. Values come from the environment and are
+          # inserted literally, so metacharacters in an input can't break out
+          # of the command or corrupt the substitution.
+          perl -pe 's/\{\{LINEAR_ISSUE_ID\}\}/$ENV{LINEAR_ISSUE_ID}/g; s/\{\{TARGET_BRANCH\}\}/$ENV{TARGET_BRANCH}/g; s/\{\{BRANCH_NAME\}\}/$ENV{BRANCH_NAME}/g;' "$TEMPLATE" > /tmp/review-prompt.md
 
           # Write multiline output
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)

--- a/changelog/fix-woopmnt-5946-agent-workflow-input-interpolation
+++ b/changelog/fix-woopmnt-5946-agent-workflow-input-interpolation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Pass agent-pipeline workflow inputs through environment variables instead of interpolating them directly into shell steps.


### PR DESCRIPTION
Fixes WOOPMNT-5948
Fixes WOOPMNT-5946
Fixes WOOPMNT-5969

#### Changes proposed in this Pull Request

The agent-pipeline workflows (`plan`, `review`, `address-comments`) interpolate their `${{ inputs.* }}` values straight into the `sed` and `echo` commands in a couple of `run:` steps. That means the raw input becomes part of the shell command text before the shell parses it — brittle for anything that could carry quotes or shell metacharacters.

Binding those inputs to step-level `env:` blocks and reading them back as `${VAR}` in the scripts instead. Behavior is unchanged for normal inputs.

#### Testing instructions

> [!NOTE]
>  This PR was entirely vibecoded, since I don't have insight on how these workflows are run (I believe they're all disabled). I'm mainly trying to close those tickets.

They're `workflow_call` CI files (two of the three aren't wired into the orchestrator yet), so there's nothing to exercise at runtime. GitHub validates workflow syntax on push - just confirm the checks on this PR are green.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — CI-config only, no runtime surface to unit test.
- [x] Tested on mobile (or does not apply) — does not apply.

**Post merge**

- [x] QA Testing Not Applicable
