### PR TITLE
fix: reuse WooPay save-user React root on Blocks checkout

### DIFF
--- a/changelog/fix-woopmnt-5951-woopay-save-user-root-reuse
+++ b/changelog/fix-woopmnt-5951-woopay-save-user-root-reuse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reuse the React root for the WooPay save-user section on Blocks checkout so its state is no longer reset on cart/checkout updates.

--- a/client/checkout/woopay/__tests__/index.test.js
+++ b/client/checkout/woopay/__tests__/index.test.js
@@ -1,0 +1,96 @@
+/**
+ * Internal dependencies
+ */
+// The module under test is required fresh inside each test so its module-level
+// root cache is reset between cases.
+
+const mockCreateRoot = jest.fn();
+
+jest.mock( 'react-dom/client', () => ( {
+	createRoot: ( ...args ) => mockCreateRoot( ...args ),
+} ) );
+
+jest.mock(
+	'wcpay/components/woopay/save-user/checkout-page-save-user',
+	() => () => null
+);
+
+const requireModule = () =>
+	require( 'wcpay/checkout/woopay/index' ).renderSaveUserSection;
+
+describe( 'renderSaveUserSection - Blocks checkout', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		mockCreateRoot.mockReset();
+		mockCreateRoot.mockImplementation( () => ( {
+			render: jest.fn(),
+			unmount: jest.fn(),
+		} ) );
+		document.body.innerHTML = '';
+	} );
+
+	it( 'creates the React root once and reuses it across re-renders', () => {
+		document.body.innerHTML = `
+			<div class="wc-block-checkout">
+				<div class="wp-block-woocommerce-checkout-payment-block"></div>
+			</div>
+		`;
+		const renderSaveUserSection = requireModule();
+
+		renderSaveUserSection();
+		renderSaveUserSection();
+
+		expect( mockCreateRoot ).toHaveBeenCalledTimes( 1 );
+
+		const root = mockCreateRoot.mock.results[ 0 ].value;
+		expect( root.render ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'unmounts the previous root and mounts a fresh one when the container is recreated', () => {
+		document.body.innerHTML = `
+			<div class="wc-block-checkout">
+				<div class="wp-block-woocommerce-checkout-payment-block"></div>
+			</div>
+		`;
+		const renderSaveUserSection = requireModule();
+
+		renderSaveUserSection();
+		const firstRoot = mockCreateRoot.mock.results[ 0 ].value;
+
+		// Simulate WC core replacing the checkout subtree, taking our
+		// container with it.
+		document.querySelector( '#remember-me' ).remove();
+
+		renderSaveUserSection();
+
+		expect( firstRoot.unmount ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateRoot ).toHaveBeenCalledTimes( 2 );
+
+		const newContainer = document.querySelector( '#remember-me' );
+		expect( mockCreateRoot ).toHaveBeenLastCalledWith( newContainer );
+	} );
+
+	it( 'does not mount into a detached container when the payment options block is missing', () => {
+		document.body.innerHTML = '<div class="wc-block-checkout"></div>';
+		const renderSaveUserSection = requireModule();
+
+		renderSaveUserSection();
+
+		expect( mockCreateRoot ).not.toHaveBeenCalled();
+		expect( document.querySelector( '#remember-me' ) ).toBeNull();
+
+		const paymentBlock = document.createElement( 'div' );
+		paymentBlock.className = 'wp-block-woocommerce-checkout-payment-block';
+		document
+			.querySelector( '.wc-block-checkout' )
+			.appendChild( paymentBlock );
+
+		renderSaveUserSection();
+
+		expect( mockCreateRoot ).toHaveBeenCalledTimes( 1 );
+
+		const container = document.querySelector( '#remember-me' );
+		expect( container ).not.toBeNull();
+		expect( mockCreateRoot ).toHaveBeenCalledWith( container );
+	} );
+} );

--- a/client/checkout/woopay/__tests__/index.test.js
+++ b/client/checkout/woopay/__tests__/index.test.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-// The module under test is required fresh inside each test so its module-level
-// root cache is reset between cases.
+// The entry module wires renderSaveUserSection to `window.load` and jQuery's
+// `ajaxComplete`. Tests drive those same callbacks rather than the (unexported)
+// function, so they exercise the real public surface.
 
 const mockCreateRoot = jest.fn();
 
@@ -15,12 +16,44 @@ jest.mock(
 	() => () => null
 );
 
-const requireModule = () =>
-	require( 'wcpay/checkout/woopay/index' ).renderSaveUserSection;
+// Load the entry module in isolation (fresh module-level root cache each time)
+// and hand back the callbacks it registers, so a test can trigger the initial
+// render (`load`) and the re-renders that follow checkout updates
+// (`ajaxComplete`).
+const loadCheckoutEntry = () => {
+	let ajaxCompleteHandler;
+
+	global.jQuery = jest.fn( ( arg ) => {
+		if ( typeof arg === 'function' ) {
+			arg( global.jQuery );
+		}
+
+		return {
+			ajaxComplete: ( handler ) => {
+				ajaxCompleteHandler = handler;
+			},
+		};
+	} );
+
+	const addEventListenerSpy = jest.spyOn( window, 'addEventListener' );
+
+	jest.isolateModules( () => {
+		require( 'wcpay/checkout/woopay/index' );
+	} );
+
+	const loadCall = addEventListenerSpy.mock.calls.find(
+		( [ event ] ) => event === 'load'
+	);
+	addEventListenerSpy.mockRestore();
+
+	return {
+		triggerLoad: loadCall[ 1 ],
+		triggerAjaxComplete: () => ajaxCompleteHandler(),
+	};
+};
 
 describe( 'renderSaveUserSection - Blocks checkout', () => {
 	beforeEach( () => {
-		jest.resetModules();
 		mockCreateRoot.mockReset();
 		mockCreateRoot.mockImplementation( () => ( {
 			render: jest.fn(),
@@ -35,14 +68,15 @@ describe( 'renderSaveUserSection - Blocks checkout', () => {
 				<div class="wp-block-woocommerce-checkout-payment-block"></div>
 			</div>
 		`;
-		const renderSaveUserSection = requireModule();
+		const { triggerLoad, triggerAjaxComplete } = loadCheckoutEntry();
 
-		renderSaveUserSection();
-		renderSaveUserSection();
+		triggerLoad();
+		triggerAjaxComplete();
 
 		expect( mockCreateRoot ).toHaveBeenCalledTimes( 1 );
 
 		const root = mockCreateRoot.mock.results[ 0 ].value;
+
 		expect( root.render ).toHaveBeenCalledTimes( 2 );
 	} );
 
@@ -52,29 +86,30 @@ describe( 'renderSaveUserSection - Blocks checkout', () => {
 				<div class="wp-block-woocommerce-checkout-payment-block"></div>
 			</div>
 		`;
-		const renderSaveUserSection = requireModule();
+		const { triggerLoad, triggerAjaxComplete } = loadCheckoutEntry();
 
-		renderSaveUserSection();
+		triggerLoad();
 		const firstRoot = mockCreateRoot.mock.results[ 0 ].value;
 
 		// Simulate WC core replacing the checkout subtree, taking our
 		// container with it.
 		document.querySelector( '#remember-me' ).remove();
 
-		renderSaveUserSection();
+		triggerAjaxComplete();
 
 		expect( firstRoot.unmount ).toHaveBeenCalledTimes( 1 );
 		expect( mockCreateRoot ).toHaveBeenCalledTimes( 2 );
 
 		const newContainer = document.querySelector( '#remember-me' );
+
 		expect( mockCreateRoot ).toHaveBeenLastCalledWith( newContainer );
 	} );
 
 	it( 'does not mount into a detached container when the payment options block is missing', () => {
 		document.body.innerHTML = '<div class="wc-block-checkout"></div>';
-		const renderSaveUserSection = requireModule();
+		const { triggerLoad, triggerAjaxComplete } = loadCheckoutEntry();
 
-		renderSaveUserSection();
+		triggerLoad();
 
 		expect( mockCreateRoot ).not.toHaveBeenCalled();
 		expect( document.querySelector( '#remember-me' ) ).toBeNull();
@@ -85,11 +120,12 @@ describe( 'renderSaveUserSection - Blocks checkout', () => {
 			.querySelector( '.wc-block-checkout' )
 			.appendChild( paymentBlock );
 
-		renderSaveUserSection();
+		triggerAjaxComplete();
 
 		expect( mockCreateRoot ).toHaveBeenCalledTimes( 1 );
 
 		const container = document.querySelector( '#remember-me' );
+
 		expect( container ).not.toBeNull();
 		expect( mockCreateRoot ).toHaveBeenCalledWith( container );
 	} );

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -32,8 +32,7 @@ export const renderSaveUserSection = () => {
 				'wp-block-woocommerce-checkout-payment-block'
 			)?.[ 0 ];
 
-			// Without the payment options block there's nowhere to attach the
-			// section, so bail rather than mount into a detached node.
+			// Nowhere to attach it, so bail rather than root a detached node.
 			if ( ! paymentOptions ) {
 				return;
 			}
@@ -51,16 +50,13 @@ export const renderSaveUserSection = () => {
 				paymentOptions.nextSibling
 			);
 
-			// A fresh container means any cached root points at a stale node, so
-			// unmount it (freeing its store subscriptions and listeners) and
-			// mount into the new one.
+			// Fresh container: the cached root is stale, so unmount and drop it.
 			blocksCheckoutRoot?.unmount();
 			blocksCheckoutRoot = null;
 		}
 
-		// Reuse the root across the AJAX-driven re-renders that fire on every
-		// checkout update; a second createRoot() on the same node resets the
-		// component (losing the checkbox state) and warns under React 18.
+		// Reuse the root across AJAX re-renders; re-rooting the same node would
+		// reset the component and warn under React 18.
 		if ( ! blocksCheckoutRoot ) {
 			blocksCheckoutRoot = createRoot( checkoutPageSaveUserContainer );
 		}

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -9,7 +9,9 @@ import { createRoot } from 'react-dom/client';
  */
 import CheckoutPageSaveUser from 'wcpay/components/woopay/save-user/checkout-page-save-user';
 
-const renderSaveUserSection = () => {
+let blocksCheckoutRoot = null;
+
+export const renderSaveUserSection = () => {
 	const saveUserSection = document.getElementsByClassName(
 		'woopay-save-new-user-container'
 	)?.[ 0 ];
@@ -30,6 +32,12 @@ const renderSaveUserSection = () => {
 				'wp-block-woocommerce-checkout-payment-block'
 			)?.[ 0 ];
 
+			// Without the payment options block there's nowhere to attach the
+			// section, so bail rather than mount into a detached node.
+			if ( ! paymentOptions ) {
+				return;
+			}
+
 			checkoutPageSaveUserContainer =
 				document.createElement( 'fieldset' );
 
@@ -37,17 +45,29 @@ const renderSaveUserSection = () => {
 				'wc-block-checkout__payment-method wp-block-woocommerce-checkout-remember-block wc-block-components-checkout-step ';
 			checkoutPageSaveUserContainer.id = 'remember-me';
 
-			if ( paymentOptions ) {
-				// Render right after the payment options block, as a sibling element.
-				paymentOptions.parentNode.insertBefore(
-					checkoutPageSaveUserContainer,
-					paymentOptions.nextSibling
-				);
-			}
+			// Render right after the payment options block, as a sibling element.
+			paymentOptions.parentNode.insertBefore(
+				checkoutPageSaveUserContainer,
+				paymentOptions.nextSibling
+			);
+
+			// A fresh container means any cached root points at a stale node, so
+			// unmount it (freeing its store subscriptions and listeners) and
+			// mount into the new one.
+			blocksCheckoutRoot?.unmount();
+			blocksCheckoutRoot = null;
 		}
 
-		const root = createRoot( checkoutPageSaveUserContainer );
-		root.render( <CheckoutPageSaveUser isBlocksCheckout={ true } /> );
+		// Reuse the root across the AJAX-driven re-renders that fire on every
+		// checkout update; a second createRoot() on the same node resets the
+		// component (losing the checkbox state) and warns under React 18.
+		if ( ! blocksCheckoutRoot ) {
+			blocksCheckoutRoot = createRoot( checkoutPageSaveUserContainer );
+		}
+
+		blocksCheckoutRoot.render(
+			<CheckoutPageSaveUser isBlocksCheckout={ true } />
+		);
 	} else {
 		const checkoutPageSaveUserContainer = document.createElement( 'div' );
 		checkoutPageSaveUserContainer.className =

--- a/client/checkout/woopay/index.js
+++ b/client/checkout/woopay/index.js
@@ -11,7 +11,7 @@ import CheckoutPageSaveUser from 'wcpay/components/woopay/save-user/checkout-pag
 
 let blocksCheckoutRoot = null;
 
-export const renderSaveUserSection = () => {
+const renderSaveUserSection = () => {
 	const saveUserSection = document.getElementsByClassName(
 		'woopay-save-new-user-container'
 	)?.[ 0 ];


### PR DESCRIPTION
Fixes WOOPMNT-5951

#### Changes proposed in this Pull Request

The WooPay "save my info" section on Blocks checkout mounts a React root on the `#remember-me` container, but `renderSaveUserSection()` runs again on every `ajaxComplete` - i.e. on each cart/checkout update.
Calling `createRoot()` on the same node every time tears the component down and remounts it on each update, and React 18 logs a warning about re-rooting a container.

Worth mentioning that the issue only happened on a dev build - in production (and on a JN site) you won't be able to reproduce the original issue.

Caching the root and reusing it via `root.render()`.

#### Testing instructions

> [!NOTE]
>  The warning only shows on a **dev build** (`npm run watch` / an unminified bundle) - production strips it.

> [!NOTE]
>  The re-render is triggered by a jQuery `ajaxComplete`. Blocks checkout coupon/shipping updates go through the Store API (`fetch`), which doesn't fire `ajaxComplete`, so those don't reproduce it. The reliable way to re-run the render is from the console.

- As a merchant, enable WooPay
- As a customer, add a product to the cart and open the block-based checkout page (the "Checkout" menu item, not the shortcode one)
- Open the console and run `jQuery( document ).trigger( 'ajaxComplete' )` two or three times (each call re-runs the render against the same `#remember-me`)
- On `develop` the console logs `You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before`; on this branch it's gone
- Repeat on the classic (shortcode-based) checkout to confirm no regression


-------------------

- [x] Run `npm run changelog` to add a changelog file
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

