### PR TITLE
Cache selected currency during requests

### DIFF
--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -140,6 +140,13 @@ class MultiCurrency {
 	protected $enabled_currencies;
 
 	/**
+	 * The selected currency for the current request.
+	 *
+	 * @var Currency|null
+	 */
+	protected $selected_currency;
+
+	/**
 	 * Instance of MultiCurrencySettingsInterface.
 	 *
 	 * @var MultiCurrencySettingsInterface
@@ -797,14 +804,24 @@ class MultiCurrency {
 	 * @return Currency
 	 */
 	public function get_selected_currency(): Currency {
+		if ( null !== $this->selected_currency && ! has_filter( self::FILTER_PREFIX . 'override_selected_currency' ) ) {
+			return $this->selected_currency;
+		}
+
 		$multi_currency_code = $this->compatibility->override_selected_currency();
 		$currency_code       = $multi_currency_code ? $multi_currency_code : $this->get_stored_currency_code();
 
 		if ( null === $currency_code ) {
-			return $this->get_default_currency();
+			$currency = $this->get_default_currency();
+		} else {
+			$currency = $this->get_enabled_currencies()[ $currency_code ] ?? $this->get_default_currency();
 		}
 
-		return $this->get_enabled_currencies()[ $currency_code ] ?? $this->get_default_currency();
+		if ( ! has_filter( self::FILTER_PREFIX . 'override_selected_currency' ) ) {
+			$this->selected_currency = $currency;
+		}
+
+		return $currency;
 	}
 
 	/**
@@ -816,6 +833,8 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function update_selected_currency( string $currency_code, bool $persist_change = true ) {
+		$this->selected_currency = null;
+
 		$code     = strtoupper( $currency_code );
 		$user_id  = get_current_user_id();
 		$currency = $this->get_enabled_currencies()[ $code ] ?? null;
@@ -1735,6 +1754,8 @@ class MultiCurrency {
 	 * @return void
 	 */
 	private function initialize_enabled_currencies() {
+		$this->selected_currency = null;
+
 		$available_currencies     = $this->get_available_currencies();
 		$enabled_currency_codes   = get_option( $this->id . '_enabled_currencies', [] );
 		$enabled_currency_codes   = is_array( $enabled_currency_codes ) ? $enabled_currency_codes : [];

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -144,6 +144,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		WC()->session->__unset( MultiCurrency::CURRENCY_SESSION_KEY );
 		remove_all_filters( 'wcpay_multi_currency_apply_charm_only_to_products' );
 		remove_all_filters( 'wcpay_multi_currency_available_currencies' );
+		remove_all_filters( 'wcpay_multi_currency_override_selected_currency' );
 		remove_all_filters( 'woocommerce_currency' );
 		remove_all_filters( 'woocommerce_geolocate_ip' );
 		remove_all_filters( 'stylesheet' );
@@ -419,6 +420,26 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertSame( 'GBP', $this->multi_currency->get_selected_currency()->get_code() );
 	}
 
+	public function test_get_selected_currency_caches_selected_currency_without_override_filter() {
+		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'GBP' );
+
+		$this->assertNull( $this->get_selected_currency_cache() );
+		$this->assertSame( 'GBP', $this->multi_currency->get_selected_currency()->get_code() );
+		$this->assertSame( 'GBP', $this->get_selected_currency_cache()->get_code() );
+	}
+
+	public function test_get_selected_currency_does_not_cache_when_override_filter_exists() {
+		add_filter(
+			'wcpay_multi_currency_override_selected_currency',
+			function () {
+				return 'CAD';
+			}
+		);
+
+		$this->assertSame( 'CAD', $this->multi_currency->get_selected_currency()->get_code() );
+		$this->assertNull( $this->get_selected_currency_cache() );
+	}
+
 	public function test_get_selected_currency_returns_currency_from_user() {
 		wp_set_current_user( self::LOGGED_IN_USER_ID );
 		update_user_meta( self::LOGGED_IN_USER_ID, WCPay\MultiCurrency\MultiCurrency::CURRENCY_META_KEY, 'GBP' );
@@ -446,9 +467,14 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_update_selected_currency_sets_session_currency() {
+		WC()->session->set( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY, 'GBP' );
+		$this->multi_currency->get_selected_currency();
+		$this->assertSame( 'GBP', $this->get_selected_currency_cache()->get_code() );
+
 		$this->multi_currency->update_selected_currency( 'GBP' );
 
 		$this->assertSame( 'GBP', WC()->session->get( WCPay\MultiCurrency\MultiCurrency::CURRENCY_SESSION_KEY ) );
+		$this->assertNull( $this->get_selected_currency_cache() );
 	}
 
 	public function test_update_selected_currency_sets_user_currency() {
@@ -1872,5 +1898,12 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 				return $theme;
 			}
 		);
+	}
+
+	private function get_selected_currency_cache() {
+		$reflection = new ReflectionProperty( MultiCurrency::class, 'selected_currency' );
+		$reflection->setAccessible( true );
+
+		return $reflection->getValue( $this->multi_currency );
 	}
 }


### PR DESCRIPTION
## Summary

Caches the resolved selected multi-currency `Currency` object for the current request when no `wcpay_multi_currency_override_selected_currency` filters are active.

Large variable product pages call the WooPayments frontend price filters tens of thousands of times while building variation price data. Each conversion currently resolves the selected currency again, which repeatedly reads the WC session for anonymous frontend requests.

This keeps existing override-filter behavior by bypassing the cache whenever override filters are present, and clears the cached value when the selected currency is updated or enabled currencies are rebuilt.

## Benchmark

Local Docker benchmark against WooCommerce 10.9.1, WooPayments 10.9.0 installed in the benchmark site, PHP 8.3.31, MySQL 8.0.46, HPOS enabled, gateway stack active, 800-variation variable product page.

Regular request benchmark, 5 requests:

| Run | Median total | p95 total | Median server | p95 server | Query median |
| --- | ---: | ---: | ---: | ---: | ---: |
| Baseline | 1361.273 ms | 1445.900 ms | 1356.990 ms | 1443.370 ms | 250 |
| Candidate | 1239.675 ms | 1298.200 ms | 1237.880 ms | 1296.310 ms | 250 |

XHProf single-request sample:

| Function | Baseline | Candidate |
| --- | ---: | ---: |
| `WCPay\\MultiCurrency\\MultiCurrency::get_selected_currency` | 40,041 calls, 616.212 ms inclusive | 40,041 calls, 6.643 ms inclusive |
| `WCPay\\MultiCurrency\\MultiCurrency::get_stored_currency_code` | 40,041 calls, 542.719 ms inclusive | dropped out of hot list |
| `WCPay\\MultiCurrency\\MultiCurrency::get_price` | 40,039 calls, 662.756 ms inclusive | 40,039 calls, 50.740 ms inclusive |
| `WCPay\\MultiCurrency\\FrontendPrices::get_product_price` | 40,839 calls, 698.266 ms inclusive | 40,839 calls, 84.279 ms inclusive |

## Testing

- `php -l includes/multi-currency/MultiCurrency.php`
- `php -l tests/unit/multi-currency/test-class-multi-currency.php`
- `git diff --check`
- `./vendor/bin/phpcs --standard=phpcs.xml.dist tests/unit/multi-currency/test-class-multi-currency.php`
- Runtime benchmark above in the WooCommerce performance harness.

Not run successfully:

- `./bin/run-tests.sh --filter WCPay_Multi_Currency_Tests`
  - Local WooPayments Docker test environment failed before PHPUnit because generated bind-mounted DB/WordPress directories denied writes and the containers restarted. The app/test containers were stopped afterward.
- `./vendor/bin/phpcs --standard=phpcs.xml.dist includes/multi-currency/MultiCurrency.php`
  - Whole-file scan reports existing class-structure ordering errors in `MultiCurrency.php`; I did not auto-reorder unrelated methods in this PR.
