### PR TITLE
Display Stripe Radar early fraud warnings on the order screen

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -316,3 +316,36 @@
 .wcpay-fraud-risk-meta-blocked {
 	color: #b32d2e;
 }
+
+.wcpay-fraud-risk-efw {
+	border-bottom: 1px solid #ddd;
+	padding: 8px 12px;
+}
+
+.wcpay-fraud-risk-efw > p {
+	margin: 0 0 6px;
+}
+
+.wcpay-fraud-risk-efw > p:last-child {
+	margin-bottom: 0;
+}
+
+.wcpay-fraud-risk-efw__title {
+	font-weight: 600;
+}
+
+.wcpay-fraud-risk-efw__title img {
+	margin: 0 3px -3px 0;
+}
+
+.wcpay-fraud-risk-efw__reason {
+	color: #50575e;
+}
+
+.wcpay-fraud-risk-efw--actionable .wcpay-fraud-risk-efw__title {
+	color: #b26200;
+}
+
+.wcpay-fraud-risk-efw--resolved .wcpay-fraud-risk-efw__title {
+	color: #008a20;
+}

--- a/assets/css/admin.rtl.css
+++ b/assets/css/admin.rtl.css
@@ -316,3 +316,36 @@
 .wcpay-fraud-risk-meta-blocked {
 	color: #b32d2e;
 }
+
+.wcpay-fraud-risk-efw {
+	border-bottom: 1px solid #ddd;
+	padding: 8px 12px;
+}
+
+.wcpay-fraud-risk-efw > p {
+	margin: 0 0 6px;
+}
+
+.wcpay-fraud-risk-efw > p:last-child {
+	margin-bottom: 0;
+}
+
+.wcpay-fraud-risk-efw__title {
+	font-weight: 600;
+}
+
+.wcpay-fraud-risk-efw__title img {
+	margin: 0 0 -3px 3px;
+}
+
+.wcpay-fraud-risk-efw__reason {
+	color: #50575e;
+}
+
+.wcpay-fraud-risk-efw--actionable .wcpay-fraud-risk-efw__title {
+	color: #b26200;
+}
+
+.wcpay-fraud-risk-efw--resolved .wcpay-fraud-risk-efw__title {
+	color: #008a20;
+}

--- a/changelog/add-early-fraud-warnings-order-screen
+++ b/changelog/add-early-fraud-warnings-order-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Surface Stripe Radar early fraud warnings in order notes and the Fraud & Risk order metabox.

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -91,6 +91,32 @@ jQuery( function ( $ ) {
 		}
 	);
 
+	// The Fraud & Risk metabox "Refund to avoid a dispute" CTA: the refund is
+	// managed on this very screen, so open WooCommerce's inline refund panel
+	// instead of leaving the page. When the panel is unavailable (e.g. refunds
+	// disabled during a dispute), fall back to the payment details link.
+	$( document ).on(
+		'click',
+		'.wcpay-efw-refund-link',
+		function ( event ) {
+			const refundButton = document.querySelector(
+				'button.refund-items'
+			);
+			if ( ! refundButton || refundButton.disabled ) {
+				return;
+			}
+			event.preventDefault();
+			$( refundButton ).trigger( 'click' );
+			const refundPanel =
+				document.querySelector( '.wc-order-refund-items' ) ||
+				document.querySelector( '#woocommerce-order-items' );
+			refundPanel?.scrollIntoView( {
+				behavior: 'smooth',
+				block: 'center',
+			} );
+		}
+	);
+
 	$( 'select#order_status' ).on( 'change', function () {
 		//get the original status of the order from post or order data.
 		let originalStatus =

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -91,7 +91,7 @@ jQuery( function ( $ ) {
 		}
 	);
 
-	// The Fraud & Risk metabox "Refund to avoid a dispute" CTA: the refund is
+	// The Fraud & Risk metabox "Refund this payment" CTA: the refund is
 	// managed on this very screen, so open WooCommerce's inline refund panel
 	// instead of leaving the page. When the panel is unavailable (e.g. refunds
 	// disabled during a dispute), fall back to the payment details link.

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -95,27 +95,21 @@ jQuery( function ( $ ) {
 	// managed on this very screen, so open WooCommerce's inline refund panel
 	// instead of leaving the page. When the panel is unavailable (e.g. refunds
 	// disabled during a dispute), fall back to the payment details link.
-	$( document ).on(
-		'click',
-		'.wcpay-efw-refund-link',
-		function ( event ) {
-			const refundButton = document.querySelector(
-				'button.refund-items'
-			);
-			if ( ! refundButton || refundButton.disabled ) {
-				return;
-			}
-			event.preventDefault();
-			$( refundButton ).trigger( 'click' );
-			const refundPanel =
-				document.querySelector( '.wc-order-refund-items' ) ||
-				document.querySelector( '#woocommerce-order-items' );
-			refundPanel?.scrollIntoView( {
-				behavior: 'smooth',
-				block: 'center',
-			} );
+	$( document ).on( 'click', '.wcpay-efw-refund-link', function ( event ) {
+		const refundButton = document.querySelector( 'button.refund-items' );
+		if ( ! refundButton || refundButton.disabled ) {
+			return;
 		}
-	);
+		event.preventDefault();
+		$( refundButton ).trigger( 'click' );
+		const refundPanel =
+			document.querySelector( '.wc-order-refund-items' ) ||
+			document.querySelector( '#woocommerce-order-items' );
+		refundPanel?.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'center',
+		} );
+	} );
 
 	$( 'select#order_status' ).on( 'change', function () {
 		//get the original status of the order from post or order data.

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -704,7 +704,7 @@ class WC_Payments_Order_Service {
 	/**
 	 * Stores the latest early fraud warning on the order and adds a private note about it.
 	 *
-	 * Early fraud warnings are orthogonal to the fraud outcome: an approved charge can still
+	 * Early fraud warnings are independent of the fraud outcome: an approved charge can still
 	 * receive one. The meta always reflects the latest warning; the note is only added once
 	 * per warning state.
 	 *

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -738,7 +738,6 @@ class WC_Payments_Order_Service {
 		}
 
 		$order->add_order_note( $note );
-		$order->save();
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -725,10 +725,10 @@ class WC_Payments_Order_Service {
 		$this->set_early_fraud_warning_for_order(
 			$order,
 			[
-				'efw_id'     => $efw_id,
-				'actionable' => $actionable,
-				'fraud_type' => $fraud_type,
-				'created'    => $created,
+				'efw_id'         => $efw_id,
+				'efw_actionable' => $actionable,
+				'efw_type'       => $fraud_type,
+				'created'        => $created,
 			]
 		);
 
@@ -1282,8 +1282,8 @@ class WC_Payments_Order_Service {
 	/**
 	 * Set the early fraud warning data for an order.
 	 *
-	 * @param  mixed                                                                     $order The order.
-	 * @param  array{efw_id: string, actionable: bool, fraud_type: string, created: int} $early_fraud_warning The early fraud warning data to be set.
+	 * @param  mixed                                                                       $order The order.
+	 * @param  array{efw_id: string, efw_actionable: bool, efw_type: string, created: int} $early_fraud_warning The early fraud warning data to be set.
 	 *
 	 * @throws Order_Not_Found_Exception
 	 */
@@ -1298,7 +1298,7 @@ class WC_Payments_Order_Service {
 	 *
 	 * @param  mixed $order The order Id or order object.
 	 *
-	 * @return array{efw_id: string, actionable: bool, fraud_type: string, created: int}|null The early fraud warning data, or null when none was received.
+	 * @return array{efw_id: string, efw_actionable: bool, efw_type: string, created: int}|null The early fraud warning data, or null when none was received.
 	 *
 	 * @throws Order_Not_Found_Exception
 	 */

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -242,6 +242,13 @@ class WC_Payments_Order_Service {
 	const WCPAY_OPEN_DISPUTE_IDS_META_KEY = '_wcpay_open_dispute_ids';
 
 	/**
+	 * Meta key used to store the latest early fraud warning received for the order's charge.
+	 *
+	 * @const string
+	 */
+	const WCPAY_EARLY_FRAUD_WARNING_META_KEY = '_wcpay_early_fraud_warning';
+
+	/**
 	 * Client for making requests to the WooCommerce Payments API
 	 *
 	 * @var WC_Payments_API_Client
@@ -692,6 +699,46 @@ class WC_Payments_Order_Service {
 		remove_filter( 'woocommerce_email_enabled_customer_completed_renewal_order', '__return_false' );
 
 		$order->add_order_note( $note );
+	}
+
+	/**
+	 * Stores the latest early fraud warning on the order and adds a private note about it.
+	 *
+	 * Early fraud warnings are orthogonal to the fraud outcome: an approved charge can still
+	 * receive one. The meta always reflects the latest warning; the note is only added once
+	 * per warning state.
+	 *
+	 * @param WC_Order $order      Order object.
+	 * @param string   $charge_id  The ID of the charge the early fraud warning relates to.
+	 * @param string   $efw_id     The ID of the early fraud warning object.
+	 * @param bool     $actionable Whether the payment can still be refunded to prevent a dispute.
+	 * @param string   $fraud_type The fraud type reported by the card network.
+	 * @param int      $created    Unix timestamp of when the early fraud warning was created.
+	 *
+	 * @return void
+	 */
+	public function mark_payment_early_fraud_warning( $order, string $charge_id, string $efw_id, bool $actionable, string $fraud_type, int $created ) {
+		if ( ! is_a( $order, 'WC_Order' ) ) {
+			return;
+		}
+
+		$this->set_early_fraud_warning_for_order(
+			$order,
+			[
+				'efw_id'     => $efw_id,
+				'actionable' => $actionable,
+				'fraud_type' => $fraud_type,
+				'created'    => $created,
+			]
+		);
+
+		$note = $this->generate_early_fraud_warning_note( $charge_id, $actionable, $fraud_type );
+		if ( $this->order_note_exists( $order, $note ) ) {
+			return;
+		}
+
+		$order->add_order_note( $note );
+		$order->save();
 	}
 
 	/**
@@ -1231,6 +1278,36 @@ class WC_Payments_Order_Service {
 	public function get_fraud_meta_box_type_for_order( $order ): string {
 		$order = $this->get_order( $order );
 		return $order->get_meta( self::WCPAY_FRAUD_META_BOX_TYPE_META_KEY, true );
+	}
+
+	/**
+	 * Set the early fraud warning data for an order.
+	 *
+	 * @param  mixed $order The order.
+	 * @param  array $early_fraud_warning The early fraud warning data to be set.
+	 *
+	 * @throws Order_Not_Found_Exception
+	 */
+	public function set_early_fraud_warning_for_order( $order, array $early_fraud_warning ) {
+		$order = $this->get_order( $order );
+		$order->update_meta_data( self::WCPAY_EARLY_FRAUD_WARNING_META_KEY, $early_fraud_warning );
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Get the early fraud warning data for an order.
+	 *
+	 * @param  mixed $order The order Id or order object.
+	 *
+	 * @return array The early fraud warning data, or an empty array when none was received.
+	 *
+	 * @throws Order_Not_Found_Exception
+	 */
+	public function get_early_fraud_warning_for_order( $order ): array {
+		$order               = $this->get_order( $order );
+		$early_fraud_warning = $order->get_meta( self::WCPAY_EARLY_FRAUD_WARNING_META_KEY, true );
+
+		return is_array( $early_fraud_warning ) ? $early_fraud_warning : [];
 	}
 
 	/**
@@ -2479,6 +2556,58 @@ class WC_Payments_Order_Service {
 		}
 
 		return $note;
+	}
+
+	/**
+	 * Get content for the early fraud warning order note.
+	 *
+	 * @param string $charge_id  The ID of the charge the early fraud warning relates to.
+	 * @param bool   $actionable Whether the payment can still be refunded to prevent a dispute.
+	 * @param string $fraud_type The fraud type reported by the card network.
+	 *
+	 * @return string Note content.
+	 */
+	private function generate_early_fraud_warning_note( $charge_id, $actionable, $fraud_type ) {
+		$transaction_url = WC_Payments_Utils::compose_transaction_url( '', $charge_id );
+
+		if ( ! $actionable ) {
+			return sprintf(
+				WC_Payments_Utils::esc_interpolated_html(
+					__( 'The early fraud warning received for this payment is no longer actionable, because the payment was refunded or disputed. See <a>payment details</a> for more information.', 'woocommerce-payments' ),
+					[
+						'a' => '<a href="%1$s" target="_blank" rel="noopener noreferrer">',
+					]
+				),
+				$transaction_url
+			);
+		}
+
+		// Get merchant-friendly fraud type description.
+		$reason = WC_Payments_Utils::get_early_fraud_warning_fraud_type_description( $fraud_type );
+
+		if ( '' === $reason ) {
+			return sprintf(
+				WC_Payments_Utils::esc_interpolated_html(
+					__( 'Payment has received an early fraud warning. Refunding the payment now can prevent a dispute. See <a>payment details</a> for more information.', 'woocommerce-payments' ),
+					[
+						'a' => '<a href="%1$s" target="_blank" rel="noopener noreferrer">',
+					]
+				),
+				$transaction_url
+			);
+		}
+
+		return sprintf(
+			WC_Payments_Utils::esc_interpolated_html(
+				/* translators: %1: the early fraud warning reason, e.g. "Made with stolen card" */
+				__( 'Payment has received an early fraud warning with reason "%1$s". Refunding the payment now can prevent a dispute. See <a>payment details</a> for more information.', 'woocommerce-payments' ),
+				[
+					'a' => '<a href="%2$s" target="_blank" rel="noopener noreferrer">',
+				]
+			),
+			$reason,
+			$transaction_url
+		);
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1282,8 +1282,8 @@ class WC_Payments_Order_Service {
 	/**
 	 * Set the early fraud warning data for an order.
 	 *
-	 * @param  mixed $order The order.
-	 * @param  array $early_fraud_warning The early fraud warning data to be set.
+	 * @param  mixed                                                                     $order The order.
+	 * @param  array{efw_id: string, actionable: bool, fraud_type: string, created: int} $early_fraud_warning The early fraud warning data to be set.
 	 *
 	 * @throws Order_Not_Found_Exception
 	 */
@@ -1298,7 +1298,7 @@ class WC_Payments_Order_Service {
 	 *
 	 * @param  mixed $order The order Id or order object.
 	 *
-	 * @return array|null The early fraud warning data, or null when none was received.
+	 * @return array{efw_id: string, actionable: bool, fraud_type: string, created: int}|null The early fraud warning data, or null when none was received.
 	 *
 	 * @throws Order_Not_Found_Exception
 	 */

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1298,15 +1298,15 @@ class WC_Payments_Order_Service {
 	 *
 	 * @param  mixed $order The order Id or order object.
 	 *
-	 * @return array The early fraud warning data, or an empty array when none was received.
+	 * @return array|null The early fraud warning data, or null when none was received.
 	 *
 	 * @throws Order_Not_Found_Exception
 	 */
-	public function get_early_fraud_warning_for_order( $order ): array {
+	public function get_early_fraud_warning_for_order( $order ): ?array {
 		$order               = $this->get_order( $order );
 		$early_fraud_warning = $order->get_meta( self::WCPAY_EARLY_FRAUD_WARNING_META_KEY, true );
 
-		return is_array( $early_fraud_warning ) ? $early_fraud_warning : [];
+		return is_array( $early_fraud_warning ) ? $early_fraud_warning : null;
 	}
 
 	/**

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -2585,12 +2585,16 @@ class WC_Payments_Order_Service {
 		// Get merchant-friendly fraud type description.
 		$reason = WC_Payments_Utils::get_early_fraud_warning_fraud_type_description( $fraud_type );
 
+		// The refund phrase carries the `wcpay-efw-refund-link` class so admin
+		// order JS can open WooCommerce's inline refund panel in place (see
+		// client/order/index.js); the payment details href is its fallback.
 		if ( '' === $reason ) {
 			return sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
-					__( 'Payment has received an early fraud warning. Refunding the payment now can prevent a dispute. See <a>payment details</a> for more information.', 'woocommerce-payments' ),
+					__( 'Payment has received an early fraud warning. <refund>Refunding the payment now</refund> can prevent a dispute. See <a>payment details</a> for more information.', 'woocommerce-payments' ),
 					[
-						'a' => '<a href="%1$s" target="_blank" rel="noopener noreferrer">',
+						'refund' => '<a href="%1$s" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">',
+						'a'      => '<a href="%1$s" target="_blank" rel="noopener noreferrer">',
 					]
 				),
 				$transaction_url
@@ -2600,9 +2604,10 @@ class WC_Payments_Order_Service {
 		return sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %1: the early fraud warning reason, e.g. "Made with stolen card" */
-				__( 'Payment has received an early fraud warning with reason "%1$s". Refunding the payment now can prevent a dispute. See <a>payment details</a> for more information.', 'woocommerce-payments' ),
+				__( 'Payment has received an early fraud warning with reason "%1$s". <refund>Refunding the payment now</refund> can prevent a dispute. See <a>payment details</a> for more information.', 'woocommerce-payments' ),
 				[
-					'a' => '<a href="%2$s" target="_blank" rel="noopener noreferrer">',
+					'refund' => '<a href="%2$s" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">',
+					'a'      => '<a href="%2$s" target="_blank" rel="noopener noreferrer">',
 				]
 			),
 			$reason,

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -1315,7 +1315,7 @@ class WC_Payments_Utils {
 	/**
 	 * Returns a merchant-friendly description of an early fraud warning fraud type.
 	 *
-	 * This mapping is duplicated in client/payment-details/timeline/map-events.js.
+	 * This mapping is duplicated in client/payment-details/timeline/mappings.ts.
 	 *
 	 * @param string $fraud_type The fraud type reported by the card network.
 	 *

--- a/includes/class-wc-payments-utils.php
+++ b/includes/class-wc-payments-utils.php
@@ -1313,6 +1313,36 @@ class WC_Payments_Utils {
 	}
 
 	/**
+	 * Returns a merchant-friendly description of an early fraud warning fraud type.
+	 *
+	 * This mapping is duplicated in client/payment-details/timeline/map-events.js.
+	 *
+	 * @param string $fraud_type The fraud type reported by the card network.
+	 *
+	 * @return string The description, or an empty string for unknown fraud types.
+	 */
+	public static function get_early_fraud_warning_fraud_type_description( string $fraud_type ): string {
+		switch ( $fraud_type ) {
+			case 'card_never_received':
+				return __( 'Card never received', 'woocommerce-payments' );
+			case 'fraudulent_card_application':
+				return __( 'Fraudulent card application', 'woocommerce-payments' );
+			case 'made_with_counterfeit_card':
+				return __( 'Made with counterfeit card', 'woocommerce-payments' );
+			case 'made_with_lost_card':
+				return __( 'Made with lost card', 'woocommerce-payments' );
+			case 'made_with_stolen_card':
+				return __( 'Made with stolen card', 'woocommerce-payments' );
+			case 'misc':
+				return __( 'Other', 'woocommerce-payments' );
+			case 'unauthorized_use_of_card':
+				return __( 'Unauthorized use of card', 'woocommerce-payments' );
+			default:
+				return '';
+		}
+	}
+
+	/**
 	 * Register a style for use.
 	 *
 	 * @uses   wp_register_style()

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -198,6 +198,10 @@ class WC_Payments_Webhook_Processing_Service {
 			case 'charge.expired':
 				$this->process_webhook_expired_authorization( $event_body );
 				break;
+			case 'radar.early_fraud_warning.created':
+			case 'radar.early_fraud_warning.updated':
+				$this->process_webhook_early_fraud_warning( $event_body );
+				break;
 			case 'account.updated':
 				$this->account->refresh_account_data();
 				$this->token_service->clear_all_cached_payment_methods();
@@ -847,6 +851,49 @@ class WC_Payments_Webhook_Processing_Service {
 		// Clear dispute caches to trigger a fetch of new data. The dispute changed on
 		// Stripe's side even when its note is a duplicate of one already on the order.
 		$this->database_cache->delete_dispute_caches();
+	}
+
+	/**
+	 * Process webhook for an early fraud warning being created or updated.
+	 *
+	 * The platform only forwards `created` events for charges without a dispute, but always
+	 * forwards `updated` events so a previously stored warning can be resolved. An `updated`
+	 * event for a warning the store never saw is therefore ignored.
+	 *
+	 * @param array $event_body The event that triggered the webhook.
+	 *
+	 * @throws Invalid_Webhook_Data_Exception Required parameters not found.
+	 */
+	private function process_webhook_early_fraud_warning( $event_body ) {
+		$event_type   = $this->read_webhook_property( $event_body, 'type' );
+		$event_data   = $this->read_webhook_property( $event_body, 'data' );
+		$event_object = $this->read_webhook_property( $event_data, 'object' );
+		$charge_id    = $this->read_webhook_property( $event_object, 'charge' );
+		$efw_id       = $this->read_webhook_property( $event_object, 'id' );
+		$actionable   = $this->read_webhook_property( $event_object, 'actionable' );
+		$fraud_type   = $this->read_webhook_property( $event_object, 'fraud_type' );
+		$created      = $this->read_webhook_property( $event_object, 'created' );
+
+		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
+
+		if ( ! $order ) {
+			throw new Invalid_Webhook_Data_Exception(
+				sprintf(
+				/* translators: %1: charge ID */
+					__( 'Could not find order via charge ID: %1$s', 'woocommerce-payments' ),
+					$charge_id
+				)
+			);
+		}
+
+		// An update to a warning the store never received (e.g. its creation was skipped
+		// because the charge was already disputed) would only add a confusing "resolved"
+		// note for a warning the merchant never saw — ignore it.
+		if ( 'radar.early_fraud_warning.updated' === $event_type && [] === $this->order_service->get_early_fraud_warning_for_order( $order ) ) {
+			return;
+		}
+
+		$this->order_service->mark_payment_early_fraud_warning( $order, $charge_id, $efw_id, (bool) $actionable, (string) $fraud_type, (int) $created );
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -893,7 +893,7 @@ class WC_Payments_Webhook_Processing_Service {
 		// An update to a warning the store never received (e.g. its creation was skipped
 		// because the charge was already disputed) would only add a confusing "resolved"
 		// note for a warning the merchant never saw — ignore it.
-		if ( 'radar.early_fraud_warning.updated' === $event_type && [] === $this->order_service->get_early_fraud_warning_for_order( $order ) ) {
+		if ( 'radar.early_fraud_warning.updated' === $event_type && null === $this->order_service->get_early_fraud_warning_for_order( $order ) ) {
 			return;
 		}
 

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -871,8 +871,12 @@ class WC_Payments_Webhook_Processing_Service {
 		$charge_id    = $this->read_webhook_property( $event_object, 'charge' );
 		$efw_id       = $this->read_webhook_property( $event_object, 'id' );
 		$actionable   = $this->read_webhook_property( $event_object, 'actionable' );
-		$fraud_type   = $this->read_webhook_property( $event_object, 'fraud_type' );
 		$created      = $this->read_webhook_property( $event_object, 'created' );
+
+		// Unlike the fields above, `fraud_type` only drives a descriptive label that already
+		// degrades to an empty reason when the value is unknown, so a missing key must not
+		// abort storing the warning — read it optionally and default to an empty string.
+		$fraud_type = $event_object['fraud_type'] ?? '';
 
 		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
 

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -296,8 +296,8 @@ class Order_Fraud_And_Risk_Meta_Box {
 			return;
 		}
 
-		$actionable      = ! empty( $early_fraud_warning['actionable'] );
-		$fraud_type_text = WC_Payments_Utils::get_early_fraud_warning_fraud_type_description( $early_fraud_warning['fraud_type'] ?? '' );
+		$actionable      = ! empty( $early_fraud_warning['efw_actionable'] );
+		$fraud_type_text = WC_Payments_Utils::get_early_fraud_warning_fraud_type_description( $early_fraud_warning['efw_type'] ?? '' );
 
 		$icon = $actionable
 			? [

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -338,7 +338,7 @@ class Order_Fraud_And_Risk_Meta_Box {
 			// when the panel is unavailable (e.g. refunds locked during a dispute).
 			$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 			if ( '' !== $transaction_url ) {
-				echo '<p><a href="' . esc_url( $transaction_url ) . '" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Refund to avoid a dispute', 'woocommerce-payments' ) . '</a></p>';
+				echo '<p><a href="' . esc_url( $transaction_url ) . '" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Refund this payment', 'woocommerce-payments' ) . '</a></p>';
 			}
 		}
 

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -292,7 +292,7 @@ class Order_Fraud_And_Risk_Meta_Box {
 	private function maybe_print_early_fraud_warning_block( $order, $intent_id, $charge_id ) {
 		$early_fraud_warning = $this->order_service->get_early_fraud_warning_for_order( $order );
 
-		if ( [] === $early_fraud_warning ) {
+		if ( null === $early_fraud_warning ) {
 			return;
 		}
 

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -109,10 +109,10 @@ class Order_Fraud_And_Risk_Meta_Box {
 		$risk_filters_url              = WC_Payments_Admin_Settings::get_settings_url( [ 'anchor' => '%23fp-settings' ] );
 		$show_adjust_risk_filters_link = true;
 
-		// Early fraud warnings are orthogonal to the fraud outcome below — an approved
-		// charge can still receive one — so this renders as its own additive block. It
-		// leads the metabox because the warning postdates the checkout-time risk level:
-		// the actionable signal must not be buried under a reassuring "Normal" score.
+		// Early fraud warnings are independent of the fraud outcome below — an approved
+		// charge can still receive one — so this renders as its own additive block. The
+		// warning goes first: it arrives after the risk level was assessed at checkout,
+		// and a reassuring "Normal" score at the top could make merchants overlook it.
 		$this->maybe_print_early_fraud_warning_block( $order, $intent_id, $charge_id );
 
 		$this->maybe_print_risk_level_block( $risk_level );

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -111,6 +111,10 @@ class Order_Fraud_And_Risk_Meta_Box {
 
 		$this->maybe_print_risk_level_block( $risk_level );
 
+		// Early fraud warnings are orthogonal to the fraud outcome below — an approved
+		// charge can still receive one — so this renders as its own additive block.
+		$this->maybe_print_early_fraud_warning_block( $order, $intent_id, $charge_id );
+
 		echo '<div class="wcpay-fraud-risk-action">';
 
 		switch ( $meta_box_type ) {
@@ -271,6 +275,67 @@ class Order_Fraud_And_Risk_Meta_Box {
 		echo '<p class="wcpay-fraud-risk-level__title">' . esc_html( $titles[ $risk_level ] ) . '</p>';
 		echo '<div class="wcpay-fraud-risk-level__bar"></div>';
 		echo '<p>' . esc_html( $descriptions[ $risk_level ] ) . '</p>';
+		echo '</div>';
+	}
+
+	/**
+	 * Prints the early fraud warning block when the order's charge received one.
+	 *
+	 * @param \WC_Order $order     The order we are working with.
+	 * @param string    $intent_id The payment intent ID for the order.
+	 * @param string    $charge_id The charge ID for the order.
+	 *
+	 * @return void
+	 */
+	private function maybe_print_early_fraud_warning_block( $order, $intent_id, $charge_id ) {
+		$early_fraud_warning = $this->order_service->get_early_fraud_warning_for_order( $order );
+
+		if ( [] === $early_fraud_warning ) {
+			return;
+		}
+
+		$actionable      = ! empty( $early_fraud_warning['actionable'] );
+		$fraud_type_text = WC_Payments_Utils::get_early_fraud_warning_fraud_type_description( $early_fraud_warning['fraud_type'] ?? '' );
+
+		$icon = $actionable
+			? [
+				'url' => plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ),
+				'alt' => __( 'Orange shield outline', 'woocommerce-payments' ),
+			]
+			: [
+				'url' => plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ),
+				'alt' => __( 'Green check mark', 'woocommerce-payments' ),
+			];
+
+		$modifier = $actionable ? 'actionable' : 'resolved';
+		$title    = $actionable
+			? __( 'Early fraud warning', 'woocommerce-payments' )
+			: __( 'Early fraud warning resolved', 'woocommerce-payments' );
+
+		$description = $actionable
+			? __( 'The card issuer flagged this payment as likely fraudulent. Refunding it now can prevent a dispute.', 'woocommerce-payments' )
+			: __( 'This payment was refunded or disputed, so the warning is no longer actionable.', 'woocommerce-payments' );
+
+		echo '<div class="wcpay-fraud-risk-efw wcpay-fraud-risk-efw--' . esc_attr( $modifier ) . '">';
+		echo '<p class="wcpay-fraud-risk-efw__title"><img src="' . esc_url( $icon['url'] ) . '" alt="' . esc_attr( $icon['alt'] ) . '"> ' . esc_html( $title ) . '</p>';
+
+		if ( '' !== $fraud_type_text ) {
+			echo '<p class="wcpay-fraud-risk-efw__reason">' . sprintf(
+				/* translators: %s is the card network's reported fraud reason, e.g. "Made with stolen card" */
+				esc_html__( 'Reported reason: %s', 'woocommerce-payments' ),
+				esc_html( $fraud_type_text )
+			) . '</p>';
+		}
+
+		echo '<p>' . esc_html( $description ) . '</p>';
+
+		if ( $actionable ) {
+			$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
+			if ( '' !== $transaction_url ) {
+				echo '<p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Refund to avoid a dispute', 'woocommerce-payments' ) . '</a></p>';
+			}
+		}
+
 		echo '</div>';
 	}
 

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -330,9 +330,13 @@ class Order_Fraud_And_Risk_Meta_Box {
 		echo '<p>' . esc_html( $description ) . '</p>';
 
 		if ( $actionable ) {
+			// The refund is managed on this same screen, so admin JS intercepts the
+			// click and opens WooCommerce's inline refund panel instead (see
+			// client/order/index.js). The payment details href is the fallback for
+			// when the panel is unavailable (e.g. refunds locked during a dispute).
 			$transaction_url = WC_Payments_Utils::compose_transaction_url( $intent_id, $charge_id );
 			if ( '' !== $transaction_url ) {
-				echo '<p><a href="' . esc_url( $transaction_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Refund to avoid a dispute', 'woocommerce-payments' ) . '</a></p>';
+				echo '<p><a href="' . esc_url( $transaction_url ) . '" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Refund to avoid a dispute', 'woocommerce-payments' ) . '</a></p>';
 			}
 		}
 

--- a/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
+++ b/includes/fraud-prevention/class-order-fraud-and-risk-meta-box.php
@@ -109,11 +109,13 @@ class Order_Fraud_And_Risk_Meta_Box {
 		$risk_filters_url              = WC_Payments_Admin_Settings::get_settings_url( [ 'anchor' => '%23fp-settings' ] );
 		$show_adjust_risk_filters_link = true;
 
-		$this->maybe_print_risk_level_block( $risk_level );
-
 		// Early fraud warnings are orthogonal to the fraud outcome below — an approved
-		// charge can still receive one — so this renders as its own additive block.
+		// charge can still receive one — so this renders as its own additive block. It
+		// leads the metabox because the warning postdates the checkout-time risk level:
+		// the actionable signal must not be buried under a reassuring "Normal" score.
 		$this->maybe_print_early_fraud_warning_block( $order, $intent_id, $charge_id );
+
+		$this->maybe_print_risk_level_block( $risk_level );
 
 		echo '<div class="wcpay-fraud-risk-action">';
 

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -495,6 +495,142 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->expectOutputString( $risk_actions_block );
 	}
 
+	public function test_display_early_fraud_warning_actionable_in_order_fraud_and_risk_meta_box() {
+		// Arrange: Set the return results for the order service methods.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_id_for_order' )
+			->willReturn( 'ch_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_fraud_meta_box_type_for_order' )
+			->willReturn( Fraud_Meta_Box_Type::ALLOW );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
+
+		// Arrange: The order has an actionable early fraud warning stored.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_early_fraud_warning_for_order' )
+			->willReturn(
+				[
+					'efw_id'     => 'issfr_123',
+					'actionable' => true,
+					'fraud_type' => 'made_with_stolen_card',
+					'created'    => 1719800000,
+				]
+			);
+
+		// Act: Call the method to display the meta box.
+		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
+
+		// Assert: Check to make sure the amber block with the refund CTA has been output.
+		$efw_block          = '<div class="wcpay-fraud-risk-efw wcpay-fraud-risk-efw--actionable">'
+			. '<p class="wcpay-fraud-risk-efw__title"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Early fraud warning</p>'
+			. '<p class="wcpay-fraud-risk-efw__reason">Reported reason: Made with stolen card</p>'
+			. '<p>The card issuer flagged this payment as likely fraudulent. Refunding it now can prevent a dispute.</p>'
+			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" target="_blank" rel="noopener noreferrer">Refund to avoid a dispute</a></p>'
+			. '</div>';
+		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
+
+		$this->expectOutputString( $efw_block . $risk_actions_block );
+	}
+
+	public function test_display_early_fraud_warning_resolved_in_order_fraud_and_risk_meta_box() {
+		// Arrange: Set the return results for the order service methods.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_id_for_order' )
+			->willReturn( 'ch_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_fraud_meta_box_type_for_order' )
+			->willReturn( Fraud_Meta_Box_Type::ALLOW );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
+
+		// Arrange: The order has a resolved early fraud warning stored.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_early_fraud_warning_for_order' )
+			->willReturn(
+				[
+					'efw_id'     => 'issfr_123',
+					'actionable' => false,
+					'fraud_type' => 'made_with_stolen_card',
+					'created'    => 1719800000,
+				]
+			);
+
+		// Act: Call the method to display the meta box.
+		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
+
+		// Assert: Check to make sure the muted block without a refund CTA has been output.
+		$efw_block          = '<div class="wcpay-fraud-risk-efw wcpay-fraud-risk-efw--resolved">'
+			. '<p class="wcpay-fraud-risk-efw__title"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> Early fraud warning resolved</p>'
+			. '<p class="wcpay-fraud-risk-efw__reason">Reported reason: Made with stolen card</p>'
+			. '<p>This payment was refunded or disputed, so the warning is no longer actionable.</p>'
+			. '</div>';
+		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
+
+		$this->expectOutputString( $efw_block . $risk_actions_block );
+	}
+
+	public function test_do_not_display_early_fraud_warning_in_order_fraud_and_risk_meta_box_without_one() {
+		// Arrange: Set the return results for the order service methods.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_id_for_order' )
+			->willReturn( 'ch_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_fraud_meta_box_type_for_order' )
+			->willReturn( Fraud_Meta_Box_Type::ALLOW );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
+
+		// Arrange: The order has no early fraud warning stored.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_early_fraud_warning_for_order' )
+			->willReturn( [] );
+
+		// Act: Call the method to display the meta box.
+		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
+
+		// Assert: Check to make sure no early fraud warning markup has been output.
+		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
+
+		$this->expectOutputString( $risk_actions_block );
+	}
+
 	private function compose_fraud_and_risk_level_block( $risk_level, $title, $description ) {
 		$output  = '<div class="wcpay-fraud-risk-level wcpay-fraud-risk-level--' . $risk_level . '">';
 		$output .= '<p class="wcpay-fraud-risk-level__title">' . $title . '</p>';

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -515,7 +515,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->mock_order_service
 			->expects( $this->once() )
 			->method( 'get_charge_risk_level_for_order' )
-			->willReturn( '' );
+			->willReturn( 'normal' );
 
 		// Arrange: The order has an actionable early fraud warning stored.
 		$this->mock_order_service
@@ -533,16 +533,17 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		// Act: Call the method to display the meta box.
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
 
-		// Assert: Check to make sure the amber block with the refund CTA has been output.
+		// Assert: The amber block with the refund CTA leads the metabox, before the risk level.
 		$efw_block          = '<div class="wcpay-fraud-risk-efw wcpay-fraud-risk-efw--actionable">'
 			. '<p class="wcpay-fraud-risk-efw__title"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Early fraud warning</p>'
 			. '<p class="wcpay-fraud-risk-efw__reason">Reported reason: Made with stolen card</p>'
 			. '<p>The card issuer flagged this payment as likely fraudulent. Refunding it now can prevent a dispute.</p>'
 			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refund to avoid a dispute</a></p>'
 			. '</div>';
+		$risk_level_block   = $this->compose_fraud_and_risk_level_block( 'normal', 'Normal', 'This payment shows a lower than normal risk of fraudulent activity.' );
 		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
 
-		$this->expectOutputString( $efw_block . $risk_actions_block );
+		$this->expectOutputString( $efw_block . $risk_level_block . $risk_actions_block );
 	}
 
 	public function test_display_early_fraud_warning_with_unknown_fraud_type_omits_reason_line() {

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -670,7 +670,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->mock_order_service
 			->expects( $this->once() )
 			->method( 'get_early_fraud_warning_for_order' )
-			->willReturn( [] );
+			->willReturn( null );
 
 		// Act: Call the method to display the meta box.
 		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -538,7 +538,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			. '<p class="wcpay-fraud-risk-efw__title"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Early fraud warning</p>'
 			. '<p class="wcpay-fraud-risk-efw__reason">Reported reason: Made with stolen card</p>'
 			. '<p>The card issuer flagged this payment as likely fraudulent. Refunding it now can prevent a dispute.</p>'
-			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refund to avoid a dispute</a></p>'
+			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refund this payment</a></p>'
 			. '</div>';
 		$risk_level_block   = $this->compose_fraud_and_risk_level_block( 'normal', 'Normal', 'This payment shows a lower than normal risk of fraudulent activity.' );
 		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
@@ -588,7 +588,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$efw_block          = '<div class="wcpay-fraud-risk-efw wcpay-fraud-risk-efw--actionable">'
 			. '<p class="wcpay-fraud-risk-efw__title"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Early fraud warning</p>'
 			. '<p>The card issuer flagged this payment as likely fraudulent. Refunding it now can prevent a dispute.</p>'
-			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refund to avoid a dispute</a></p>'
+			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refund this payment</a></p>'
 			. '</div>';
 		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
 

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -523,10 +523,10 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->method( 'get_early_fraud_warning_for_order' )
 			->willReturn(
 				[
-					'efw_id'     => 'issfr_123',
-					'actionable' => true,
-					'fraud_type' => 'made_with_stolen_card',
-					'created'    => 1719800000,
+					'efw_id'         => 'issfr_123',
+					'efw_actionable' => true,
+					'efw_type'       => 'made_with_stolen_card',
+					'created'        => 1719800000,
 				]
 			);
 
@@ -574,10 +574,10 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->method( 'get_early_fraud_warning_for_order' )
 			->willReturn(
 				[
-					'efw_id'     => 'issfr_123',
-					'actionable' => true,
-					'fraud_type' => 'brand_new_stripe_enum',
-					'created'    => 1719800000,
+					'efw_id'         => 'issfr_123',
+					'efw_actionable' => true,
+					'efw_type'       => 'brand_new_stripe_enum',
+					'created'        => 1719800000,
 				]
 			);
 
@@ -623,10 +623,10 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			->method( 'get_early_fraud_warning_for_order' )
 			->willReturn(
 				[
-					'efw_id'     => 'issfr_123',
-					'actionable' => false,
-					'fraud_type' => 'made_with_stolen_card',
-					'created'    => 1719800000,
+					'efw_id'         => 'issfr_123',
+					'efw_actionable' => false,
+					'efw_type'       => 'made_with_stolen_card',
+					'created'        => 1719800000,
 				]
 			);
 

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -538,7 +538,7 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 			. '<p class="wcpay-fraud-risk-efw__title"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Early fraud warning</p>'
 			. '<p class="wcpay-fraud-risk-efw__reason">Reported reason: Made with stolen card</p>'
 			. '<p>The card issuer flagged this payment as likely fraudulent. Refunding it now can prevent a dispute.</p>'
-			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" target="_blank" rel="noopener noreferrer">Refund to avoid a dispute</a></p>'
+			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refund to avoid a dispute</a></p>'
 			. '</div>';
 		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
 

--- a/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
+++ b/tests/unit/fraud-prevention/test-class-order-fraud-and-risk-meta-box.php
@@ -545,6 +545,55 @@ class Order_Fraud_And_Risk_Meta_Box_Test extends WCPAY_UnitTestCase {
 		$this->expectOutputString( $efw_block . $risk_actions_block );
 	}
 
+	public function test_display_early_fraud_warning_with_unknown_fraud_type_omits_reason_line() {
+		// Arrange: Set the return results for the order service methods.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_intent_id_for_order' )
+			->willReturn( 'pi_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_id_for_order' )
+			->willReturn( 'ch_mock' );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_fraud_meta_box_type_for_order' )
+			->willReturn( Fraud_Meta_Box_Type::ALLOW );
+
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_charge_risk_level_for_order' )
+			->willReturn( '' );
+
+		// Arrange: The stored warning carries a fraud type we have no label for.
+		$this->mock_order_service
+			->expects( $this->once() )
+			->method( 'get_early_fraud_warning_for_order' )
+			->willReturn(
+				[
+					'efw_id'     => 'issfr_123',
+					'actionable' => true,
+					'fraud_type' => 'brand_new_stripe_enum',
+					'created'    => 1719800000,
+				]
+			);
+
+		// Act: Call the method to display the meta box.
+		$this->order_fraud_and_risk_meta_box->display_order_fraud_and_risk_meta_box_message( $this->order );
+
+		// Assert: The amber block is output without the "Reported reason" paragraph.
+		$efw_block          = '<div class="wcpay-fraud-risk-efw wcpay-fraud-risk-efw--actionable">'
+			. '<p class="wcpay-fraud-risk-efw__title"><img src="' . plugins_url( 'assets/images/icons/shield-stroke-orange.svg', WCPAY_PLUGIN_FILE ) . '" alt="Orange shield outline"> Early fraud warning</p>'
+			. '<p>The card issuer flagged this payment as likely fraudulent. Refunding it now can prevent a dispute.</p>'
+			. '<p><a href="http://example.org/wp-admin/admin.php?page=wc-admin&#038;path=%2Fpayments%2Ftransactions%2Fdetails&#038;id=pi_mock" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refund to avoid a dispute</a></p>'
+			. '</div>';
+		$risk_actions_block = $this->compose_fraud_and_risk_actions_block( '<p class="wcpay-fraud-risk-meta-allow"><img src="' . plugins_url( 'assets/images/icons/check-green.svg', WCPAY_PLUGIN_FILE ) . '" alt="Green check mark"> No action taken</p><p>The payment for this order passed your risk filtering.</p>' );
+
+		$this->expectOutputString( $efw_block . $risk_actions_block );
+	}
+
 	public function test_display_early_fraud_warning_resolved_in_order_fraud_and_risk_meta_box() {
 		// Arrange: Set the return results for the order service methods.
 		$this->mock_order_service

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1843,7 +1843,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertCount( 1, $notes );
 		$this->assertStringContainsString( 'Payment has received an early fraud warning with reason', $notes[0]->content );
 		$this->assertStringContainsString( 'Made with stolen card', $notes[0]->content );
-		$this->assertStringContainsString( 'Refunding the payment now can prevent a dispute', $notes[0]->content );
+		$this->assertStringContainsString( 'class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refunding the payment now</a> can prevent a dispute', $notes[0]->content );
 		$this->assertStringContainsString( '%2Fpayments%2Ftransactions%2Fdetails&id=ch_123" target="_blank" rel="noopener noreferrer">payment details', $notes[0]->content );
 
 		// Assert: Applying the same data multiple times does not cause duplicate notes.
@@ -1889,7 +1889,8 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 
 		// Assert: Check that the note was added without the reason clause.
 		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
-		$this->assertStringContainsString( 'Payment has received an early fraud warning. Refunding the payment now can prevent a dispute', $notes[0]->content );
+		$this->assertStringContainsString( 'Payment has received an early fraud warning. <a', $notes[0]->content );
+		$this->assertStringContainsString( '>Refunding the payment now</a> can prevent a dispute', $notes[0]->content );
 		$this->assertStringNotContainsString( 'with reason', $notes[0]->content );
 	}
 

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1821,6 +1821,95 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Tests that an actionable early fraud warning stores meta and adds a note once.
+	 */
+	public function test_mark_payment_early_fraud_warning_actionable() {
+		// Act: Mark the early fraud warning on the order.
+		$this->order_service->mark_payment_early_fraud_warning( $this->order, 'ch_123', 'issfr_123', true, 'made_with_stolen_card', 1719800000 );
+
+		// Assert: Check that the early fraud warning meta was stored.
+		$this->assertSame(
+			[
+				'efw_id'     => 'issfr_123',
+				'actionable' => true,
+				'fraud_type' => 'made_with_stolen_card',
+				'created'    => 1719800000,
+			],
+			$this->order->get_meta( '_wcpay_early_fraud_warning', true )
+		);
+
+		// Assert: Check that the note was added with the reason and a link to the payment details.
+		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+		$this->assertCount( 1, $notes );
+		$this->assertStringContainsString( 'Payment has received an early fraud warning with reason', $notes[0]->content );
+		$this->assertStringContainsString( 'Made with stolen card', $notes[0]->content );
+		$this->assertStringContainsString( 'Refunding the payment now can prevent a dispute', $notes[0]->content );
+		$this->assertStringContainsString( '%2Fpayments%2Ftransactions%2Fdetails&id=ch_123" target="_blank" rel="noopener noreferrer">payment details', $notes[0]->content );
+
+		// Assert: Applying the same data multiple times does not cause duplicate notes.
+		$this->order_service->mark_payment_early_fraud_warning( $this->order, 'ch_123', 'issfr_123', true, 'made_with_stolen_card', 1719800000 );
+		$notes_2 = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+		$this->assertCount( 1, $notes_2 );
+	}
+
+	/**
+	 * Tests that a resolved early fraud warning overwrites the meta and adds a resolved note.
+	 */
+	public function test_mark_payment_early_fraud_warning_resolved() {
+		// Arrange: Store an actionable early fraud warning first.
+		$this->order_service->mark_payment_early_fraud_warning( $this->order, 'ch_123', 'issfr_123', true, 'made_with_stolen_card', 1719800000 );
+
+		// Act: Mark the same early fraud warning as no longer actionable.
+		$this->order_service->mark_payment_early_fraud_warning( $this->order, 'ch_123', 'issfr_123', false, 'made_with_stolen_card', 1719800000 );
+
+		// Assert: Check that the early fraud warning meta was overwritten with the latest state.
+		$this->assertSame(
+			[
+				'efw_id'     => 'issfr_123',
+				'actionable' => false,
+				'fraud_type' => 'made_with_stolen_card',
+				'created'    => 1719800000,
+			],
+			$this->order->get_meta( '_wcpay_early_fraud_warning', true )
+		);
+
+		// Assert: Check that a resolved note was added on top of the actionable one.
+		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+		$this->assertCount( 2, $notes );
+		$this->assertStringContainsString( 'The early fraud warning received for this payment is no longer actionable', $notes[0]->content );
+		$this->assertStringContainsString( 'Payment has received an early fraud warning', $notes[1]->content );
+	}
+
+	/**
+	 * Tests that an unknown fraud type produces a note without a reason.
+	 */
+	public function test_mark_payment_early_fraud_warning_with_unknown_fraud_type() {
+		// Act: Mark an early fraud warning with a fraud type we have no label for.
+		$this->order_service->mark_payment_early_fraud_warning( $this->order, 'ch_123', 'issfr_123', true, 'some_future_fraud_type', 1719800000 );
+
+		// Assert: Check that the note was added without the reason clause.
+		$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+		$this->assertStringContainsString( 'Payment has received an early fraud warning. Refunding the payment now can prevent a dispute', $notes[0]->content );
+		$this->assertStringNotContainsString( 'with reason', $notes[0]->content );
+	}
+
+	/**
+	 * Tests to make sure mark_payment_early_fraud_warning exits if the order is invalid.
+	 */
+	public function test_mark_payment_early_fraud_warning_exits_if_order_invalid() {
+		// Arrange: Get current notes.
+		$expected_notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+
+		// Act: Attempt to mark the early fraud warning on an invalid order.
+		$this->order_service->mark_payment_early_fraud_warning( 'fake_order', 'ch_123', 'issfr_123', true, 'made_with_stolen_card', 1719800000 );
+
+		// Assert: Confirm no meta was stored and the notes were not updated.
+		$this->assertSame( '', $this->order->get_meta( '_wcpay_early_fraud_warning', true ) );
+		$updated_notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+		$this->assertEquals( $expected_notes, $updated_notes );
+	}
+
+	/**
 	 * Tests if the order was completed successfully.
 	 */
 	public function test_mark_terminal_payment_completed() {
@@ -2064,6 +2153,34 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->order->save_meta_data();
 		$fraud_meta_box_type_from_service = $this->order_service->get_fraud_meta_box_type_for_order( $this->order->get_id() );
 		$this->assertEquals( $fraud_meta_box_type_from_service, $fraud_meta_box_type );
+	}
+
+	public function test_set_early_fraud_warning_for_order() {
+		$early_fraud_warning = [
+			'efw_id'     => 'issfr_123',
+			'actionable' => true,
+			'fraud_type' => 'made_with_stolen_card',
+			'created'    => 1719800000,
+		];
+		$this->order_service->set_early_fraud_warning_for_order( $this->order, $early_fraud_warning );
+		$this->assertSame( $this->order->get_meta( '_wcpay_early_fraud_warning', true ), $early_fraud_warning );
+	}
+
+	public function test_get_early_fraud_warning_for_order() {
+		$early_fraud_warning = [
+			'efw_id'     => 'issfr_123',
+			'actionable' => true,
+			'fraud_type' => 'made_with_stolen_card',
+			'created'    => 1719800000,
+		];
+		$this->order->update_meta_data( '_wcpay_early_fraud_warning', $early_fraud_warning );
+		$this->order->save_meta_data();
+		$early_fraud_warning_from_service = $this->order_service->get_early_fraud_warning_for_order( $this->order->get_id() );
+		$this->assertSame( $early_fraud_warning_from_service, $early_fraud_warning );
+	}
+
+	public function test_get_early_fraud_warning_for_order_returns_empty_array_when_not_set() {
+		$this->assertSame( [], $this->order_service->get_early_fraud_warning_for_order( $this->order->get_id() ) );
 	}
 
 	public function test_set_payment_transaction_id_for_order() {

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1830,10 +1830,10 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Assert: Check that the early fraud warning meta was persisted (read back from the database).
 		$this->assertSame(
 			[
-				'efw_id'     => 'issfr_123',
-				'actionable' => true,
-				'fraud_type' => 'made_with_stolen_card',
-				'created'    => 1719800000,
+				'efw_id'         => 'issfr_123',
+				'efw_actionable' => true,
+				'efw_type'       => 'made_with_stolen_card',
+				'created'        => 1719800000,
 			],
 			wc_get_order( $this->order->get_id() )->get_meta( '_wcpay_early_fraud_warning', true )
 		);
@@ -1865,10 +1865,10 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Assert: Check that the persisted early fraud warning meta was overwritten with the latest state.
 		$this->assertSame(
 			[
-				'efw_id'     => 'issfr_123',
-				'actionable' => false,
-				'fraud_type' => 'made_with_stolen_card',
-				'created'    => 1719800000,
+				'efw_id'         => 'issfr_123',
+				'efw_actionable' => false,
+				'efw_type'       => 'made_with_stolen_card',
+				'created'        => 1719800000,
 			],
 			wc_get_order( $this->order->get_id() )->get_meta( '_wcpay_early_fraud_warning', true )
 		);
@@ -2158,10 +2158,10 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 
 	public function test_set_early_fraud_warning_for_order() {
 		$early_fraud_warning = [
-			'efw_id'     => 'issfr_123',
-			'actionable' => true,
-			'fraud_type' => 'made_with_stolen_card',
-			'created'    => 1719800000,
+			'efw_id'         => 'issfr_123',
+			'efw_actionable' => true,
+			'efw_type'       => 'made_with_stolen_card',
+			'created'        => 1719800000,
 		];
 		$this->order_service->set_early_fraud_warning_for_order( $this->order, $early_fraud_warning );
 		$this->assertSame( $this->order->get_meta( '_wcpay_early_fraud_warning', true ), $early_fraud_warning );
@@ -2169,10 +2169,10 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 
 	public function test_get_early_fraud_warning_for_order() {
 		$early_fraud_warning = [
-			'efw_id'     => 'issfr_123',
-			'actionable' => true,
-			'fraud_type' => 'made_with_stolen_card',
-			'created'    => 1719800000,
+			'efw_id'         => 'issfr_123',
+			'efw_actionable' => true,
+			'efw_type'       => 'made_with_stolen_card',
+			'created'        => 1719800000,
 		];
 		$this->order->update_meta_data( '_wcpay_early_fraud_warning', $early_fraud_warning );
 		$this->order->save_meta_data();

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1827,7 +1827,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Act: Mark the early fraud warning on the order.
 		$this->order_service->mark_payment_early_fraud_warning( $this->order, 'ch_123', 'issfr_123', true, 'made_with_stolen_card', 1719800000 );
 
-		// Assert: Check that the early fraud warning meta was stored.
+		// Assert: Check that the early fraud warning meta was persisted (read back from the database).
 		$this->assertSame(
 			[
 				'efw_id'     => 'issfr_123',
@@ -1835,7 +1835,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 				'fraud_type' => 'made_with_stolen_card',
 				'created'    => 1719800000,
 			],
-			$this->order->get_meta( '_wcpay_early_fraud_warning', true )
+			wc_get_order( $this->order->get_id() )->get_meta( '_wcpay_early_fraud_warning', true )
 		);
 
 		// Assert: Check that the note was added with the reason and a link to the payment details.
@@ -1843,7 +1843,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertCount( 1, $notes );
 		$this->assertStringContainsString( 'Payment has received an early fraud warning with reason', $notes[0]->content );
 		$this->assertStringContainsString( 'Made with stolen card', $notes[0]->content );
-		$this->assertStringContainsString( 'class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refunding the payment now</a> can prevent a dispute', $notes[0]->content );
+		$this->assertStringContainsString( '%2Fpayments%2Ftransactions%2Fdetails&id=ch_123" class="wcpay-efw-refund-link" target="_blank" rel="noopener noreferrer">Refunding the payment now</a> can prevent a dispute', $notes[0]->content );
 		$this->assertStringContainsString( '%2Fpayments%2Ftransactions%2Fdetails&id=ch_123" target="_blank" rel="noopener noreferrer">payment details', $notes[0]->content );
 
 		// Assert: Applying the same data multiple times does not cause duplicate notes.
@@ -1862,7 +1862,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		// Act: Mark the same early fraud warning as no longer actionable.
 		$this->order_service->mark_payment_early_fraud_warning( $this->order, 'ch_123', 'issfr_123', false, 'made_with_stolen_card', 1719800000 );
 
-		// Assert: Check that the early fraud warning meta was overwritten with the latest state.
+		// Assert: Check that the persisted early fraud warning meta was overwritten with the latest state.
 		$this->assertSame(
 			[
 				'efw_id'     => 'issfr_123',
@@ -1870,7 +1870,7 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 				'fraud_type' => 'made_with_stolen_card',
 				'created'    => 1719800000,
 			],
-			$this->order->get_meta( '_wcpay_early_fraud_warning', true )
+			wc_get_order( $this->order->get_id() )->get_meta( '_wcpay_early_fraud_warning', true )
 		);
 
 		// Assert: Check that a resolved note was added on top of the actionable one.

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -2180,8 +2180,8 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( $early_fraud_warning_from_service, $early_fraud_warning );
 	}
 
-	public function test_get_early_fraud_warning_for_order_returns_empty_array_when_not_set() {
-		$this->assertSame( [], $this->order_service->get_early_fraud_warning_for_order( $this->order->get_id() ) );
+	public function test_get_early_fraud_warning_for_order_returns_null_when_not_set() {
+		$this->assertNull( $this->order_service->get_early_fraud_warning_for_order( $this->order->get_id() ) );
 	}
 
 	public function test_set_payment_transaction_id_for_order() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -2337,6 +2337,180 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		$this->webhook_processing_service->process( $this->event_body );
 	}
 
+	/**
+	 * Tests that an early fraud warning created event stores the meta and adds an order note.
+	 */
+	public function test_early_fraud_warning_created_order_note() {
+		// Setup test request data.
+		$this->event_body['type']           = 'radar.early_fraud_warning.created';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'             => 'issfr_123',
+			'charge'         => 'test_charge_id',
+			'payment_intent' => 'pi_123',
+			'actionable'     => true,
+			'fraud_type'     => 'made_with_stolen_card',
+			'created'        => 1719800000,
+		];
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'update_meta_data' )
+			->with(
+				'_wcpay_early_fraud_warning',
+				[
+					'efw_id'     => 'issfr_123',
+					'actionable' => true,
+					'fraud_type' => 'made_with_stolen_card',
+					'created'    => 1719800000,
+				]
+			);
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'/Payment has received an early fraud warning with reason &quot;Made with stolen card&quot;/'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $this->mock_order );
+
+		// Run the test.
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
+	 * Tests that an early fraud warning updated event resolves a previously stored warning.
+	 */
+	public function test_early_fraud_warning_updated_resolves_existing_warning() {
+		// Setup test request data.
+		$this->event_body['type']           = 'radar.early_fraud_warning.updated';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'             => 'issfr_123',
+			'charge'         => 'test_charge_id',
+			'payment_intent' => 'pi_123',
+			'actionable'     => false,
+			'fraud_type'     => 'made_with_stolen_card',
+			'created'        => 1719800000,
+		];
+
+		// Arrange: The order has a previously stored, actionable warning.
+		$this->mock_order
+			->method( 'get_meta' )
+			->with( '_wcpay_early_fraud_warning', true )
+			->willReturn(
+				[
+					'efw_id'     => 'issfr_123',
+					'actionable' => true,
+					'fraud_type' => 'made_with_stolen_card',
+					'created'    => 1719800000,
+				]
+			);
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'update_meta_data' )
+			->with(
+				'_wcpay_early_fraud_warning',
+				[
+					'efw_id'     => 'issfr_123',
+					'actionable' => false,
+					'fraud_type' => 'made_with_stolen_card',
+					'created'    => 1719800000,
+				]
+			);
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'/The early fraud warning received for this payment is no longer actionable/'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $this->mock_order );
+
+		// Run the test.
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
+	 * Tests that an early fraud warning updated event is ignored when the store never
+	 * received the corresponding created event (e.g. it was skipped because the charge
+	 * was already disputed).
+	 */
+	public function test_early_fraud_warning_updated_is_ignored_without_existing_warning() {
+		// Setup test request data.
+		$this->event_body['type']           = 'radar.early_fraud_warning.updated';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'             => 'issfr_123',
+			'charge'         => 'test_charge_id',
+			'payment_intent' => 'pi_123',
+			'actionable'     => false,
+			'fraud_type'     => 'made_with_stolen_card',
+			'created'        => 1719800000,
+		];
+
+		$this->mock_order
+			->expects( $this->never() )
+			->method( 'update_meta_data' );
+
+		$this->mock_order
+			->expects( $this->never() )
+			->method( 'add_order_note' );
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $this->mock_order );
+
+		// Run the test.
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
+	 * Tests that an early fraud warning event for an unknown charge throws.
+	 */
+	public function test_early_fraud_warning_throws_exception_when_order_not_found() {
+		// Setup test request data.
+		$this->event_body['type']           = 'radar.early_fraud_warning.created';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'             => 'issfr_123',
+			'charge'         => 'unknown_charge_id',
+			'payment_intent' => 'pi_123',
+			'actionable'     => true,
+			'fraud_type'     => 'made_with_stolen_card',
+			'created'        => 1719800000,
+		];
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'unknown_charge_id' )
+			->willReturn( false );
+
+		$this->expectException( Invalid_Webhook_Data_Exception::class );
+		$this->expectExceptionMessage( 'Could not find order via charge ID: unknown_charge_id' );
+
+		// Run the test.
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
 	public function test_process_full_refund_succeeded(): void {
 		$this->event_body['type']           = 'charge.refunded';
 		$this->event_body['livemode']       = true;

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -2560,6 +2560,34 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 		$this->webhook_processing_service->process( $this->event_body );
 	}
 
+	/**
+	 * Tests that an early fraud warning payload missing a required field throws. Unlike the
+	 * optional `fraud_type`, the `charge` reference is load-bearing — without it the order
+	 * cannot be resolved, so processing must abort with the standard exception.
+	 */
+	public function test_early_fraud_warning_throws_exception_when_charge_missing() {
+		// Setup test request data — note the absent `charge` key.
+		$this->event_body['type']           = 'radar.early_fraud_warning.created';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'             => 'issfr_123',
+			'payment_intent' => 'pi_123',
+			'actionable'     => true,
+			'fraud_type'     => 'made_with_stolen_card',
+			'created'        => 1719800000,
+		];
+
+		$this->mock_db_wrapper
+			->expects( $this->never() )
+			->method( 'order_from_charge_id' );
+
+		$this->expectException( Invalid_Webhook_Data_Exception::class );
+		$this->expectExceptionMessage( 'charge not found in array' );
+
+		// Run the test.
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
 	public function test_process_full_refund_succeeded(): void {
 		$this->event_body['type']           = 'charge.refunded';
 		$this->event_body['livemode']       = true;

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -2386,6 +2386,55 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a created event with no `fraud_type` key still stores the warning and adds a
+	 * note (without a reason line), rather than aborting webhook processing. `fraud_type` only
+	 * drives a descriptive label, so a missing value must degrade gracefully.
+	 */
+	public function test_early_fraud_warning_created_stores_warning_when_fraud_type_missing() {
+		// Setup test request data — note the absent `fraud_type` key.
+		$this->event_body['type']           = 'radar.early_fraud_warning.created';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'             => 'issfr_123',
+			'charge'         => 'test_charge_id',
+			'payment_intent' => 'pi_123',
+			'actionable'     => true,
+			'created'        => 1719800000,
+		];
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'update_meta_data' )
+			->with(
+				'_wcpay_early_fraud_warning',
+				[
+					'efw_id'     => 'issfr_123',
+					'actionable' => true,
+					'fraud_type' => '',
+					'created'    => 1719800000,
+				]
+			);
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->matchesRegularExpression(
+					'/Payment has received an early fraud warning\. Refunding/'
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $this->mock_order );
+
+		// Run the test.
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
 	 * Tests that an early fraud warning updated event resolves a previously stored warning.
 	 */
 	public function test_early_fraud_warning_updated_resolves_existing_warning() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -2359,10 +2359,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->with(
 				'_wcpay_early_fraud_warning',
 				[
-					'efw_id'     => 'issfr_123',
-					'actionable' => true,
-					'fraud_type' => 'made_with_stolen_card',
-					'created'    => 1719800000,
+					'efw_id'         => 'issfr_123',
+					'efw_actionable' => true,
+					'efw_type'       => 'made_with_stolen_card',
+					'created'        => 1719800000,
 				]
 			);
 
@@ -2408,10 +2408,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->with(
 				'_wcpay_early_fraud_warning',
 				[
-					'efw_id'     => 'issfr_123',
-					'actionable' => true,
-					'fraud_type' => '',
-					'created'    => 1719800000,
+					'efw_id'         => 'issfr_123',
+					'efw_actionable' => true,
+					'efw_type'       => '',
+					'created'        => 1719800000,
 				]
 			);
 
@@ -2456,10 +2456,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->with( '_wcpay_early_fraud_warning', true )
 			->willReturn(
 				[
-					'efw_id'     => 'issfr_123',
-					'actionable' => true,
-					'fraud_type' => 'made_with_stolen_card',
-					'created'    => 1719800000,
+					'efw_id'         => 'issfr_123',
+					'efw_actionable' => true,
+					'efw_type'       => 'made_with_stolen_card',
+					'created'        => 1719800000,
 				]
 			);
 
@@ -2469,10 +2469,10 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->with(
 				'_wcpay_early_fraud_warning',
 				[
-					'efw_id'     => 'issfr_123',
-					'actionable' => false,
-					'fraud_type' => 'made_with_stolen_card',
-					'created'    => 1719800000,
+					'efw_id'         => 'issfr_123',
+					'efw_actionable' => false,
+					'efw_type'       => 'made_with_stolen_card',
+					'created'        => 1719800000,
 				]
 			);
 

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -2420,7 +2420,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->method( 'add_order_note' )
 			->with(
 				$this->matchesRegularExpression(
-					'/Payment has received an early fraud warning\. Refunding/'
+					'/Payment has received an early fraud warning\. <a [^>]+>Refunding/'
 				)
 			);
 


### PR DESCRIPTION
Fixes WOOPMNT-191

#### Changes proposed in this Pull Request

Stripe Radar delivers **early fraud warnings** (EFWs) when a card network reports a charge as likely fraudulent — often days before a formal dispute, while a proactive refund can still prevent it (and its fee). WooPayments currently surfaces nothing for them.

This PR adds the **order-screen half** of the feature: the `radar.early_fraud_warning.created`/`.updated` webhooks are stored as order meta and surfaced on two order-screen surfaces, each with a refund CTA that starts the refund flow native to that screen:

1. **Order note** — private notes on warning arrival and resolution; the "Refunding the payment now" phrase opens WooCommerce's inline refund panel on the order screen.
2. **Fraud & Risk metabox** — amber block with the reported reason and a "Refund to avoid a dispute" CTA (same inline refund panel; falls back to the payment details page when refunds are locked), green "resolved" once refunded or disputed.

**Server dependency:** the Transact Platform must forward these webhooks — companion server-side PR under internal review ([#226081](https://github.a8c.com/Automattic/wpcom/pull/226081)). 

**Backward compatibility:** fully additive, no BC risk — new public methods on `WC_Payments_Order_Service`, a new order meta key (`_wcpay_early_fraud_warning`), a new `WC_Payments_Utils` helper, and two new cases in the existing webhook `switch`. No existing signature, hook, meta key, or behavior changes; the order-screen refund-link JS handler is new and bundled (no external consumers).

#### Screenshots

| Surface | Actionable | Resolved |
|---|---|---|
| Order note |<img width="281" height="167" alt="Order note: early fraud warning received, with refund and payment details links" src="https://github.com/user-attachments/assets/44b7560b-dd8b-42d0-ba96-2cdcef21a51c" />|<img width="282" height="160" alt="Order note: early fraud warning resolved" src="https://github.com/user-attachments/assets/2024a286-592e-4bd1-b901-bfc28be584a5" />|
| Fraud & Risk metabox |<img width="286" height="405" alt="Fraud &amp; Risk metabox: amber early fraud warning block with refund CTA" src="https://github.com/user-attachments/assets/d17e9189-9c12-4918-9e91-ac55f6607acf" />|<img width="288" height="359" alt="Fraud &amp; Risk metabox: green early fraud warning resolved block" src="https://github.com/user-attachments/assets/d17bb03e-8c22-4664-b08c-69043dbc9ccf" />|

#### Testing instructions

Test this PR end-to-end together with the companion server-side PR (internal ref: wpcom #226081), which forwards the Stripe webhooks.

1. Place an order paying with Stripe's early-fraud-warning test card `4000 0000 0000 5423` (any future expiry/CVC). Stripe emits a real `radar.early_fraud_warning.created` webhook, which the server forwards to the store — the surfaces below populate within seconds of checkout.
2. Open the order in wp-admin and verify the two order-screen surfaces:
   - **Order notes**: a private note "Payment has received an early fraud warning with reason…". Its **"Refunding the payment now"** link opens WooCommerce's inline refund panel on this same screen (no navigation) and scrolls to it — hit Cancel to close without refunding. The separate **"payment details"** link navigates to the payment details page.
   - **Fraud & Risk metabox**: the amber **Early fraud warning** block with "Reported reason: Made with stolen card". Its **"Refund to avoid a dispute"** CTA opens the same inline refund panel in place.
3. Refund the payment from the inline panel. Stripe emits `radar.early_fraud_warning.updated` with `actionable=false`: the metabox flips to the green **Early fraud warning resolved** state (refund CTA gone) and a resolution note is added.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times. 
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
