### PR TITLE
fix: silence false-positive PluginCheck UnescapedDBParameter signals

### DIFF
--- a/changelog/fix-plugincheck-unescaped-db-parameter
+++ b/changelog/fix-plugincheck-unescaped-db-parameter
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Silence false-positive PluginCheck UnescapedDBParameter signals on prepared queries whose only interpolated identifiers are $wpdb-provided table names.

--- a/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
+++ b/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show all disputes on a transaction that has more than one, instead of only the first

--- a/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
+++ b/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Show all disputes on a transaction that has more than one, instead of only the first

--- a/includes/class-wc-payments-payment-request-session-handler.php
+++ b/includes/class-wc-payments-payment-request-session-handler.php
@@ -169,6 +169,7 @@ final class WC_Payments_Payment_Request_Session_Handler extends WC_Session_Handl
 		if ( $this->_dirty ) {
 			global $wpdb;
 
+			// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- $this->_table is set by WC_Session_Handler to $wpdb->prefix . 'woocommerce_sessions', never user input.
 			$wpdb->query(
 				$wpdb->prepare(
 					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/includes/migrations/class-wc-payments-remediate-canceled-auth-fees.php
+++ b/includes/migrations/class-wc-payments-remediate-canceled-auth-fees.php
@@ -340,7 +340,7 @@ class WC_Payments_Remediate_Canceled_Auth_Fees {
 		$sql     .= ' ORDER BY orders.id ASC LIMIT %d';
 		$params[] = $limit;
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- $sql interpolates only $wpdb-provided table names; all dynamic values are bound via placeholders in $wpdb->prepare().
 		$order_ids = $wpdb->get_col( $wpdb->prepare( $sql, $params ) );
 
 		return $this->convert_ids_to_orders( $order_ids );
@@ -390,7 +390,7 @@ class WC_Payments_Remediate_Canceled_Auth_Fees {
 		$sql     .= ' ORDER BY orders.ID ASC LIMIT %d';
 		$params[] = $limit;
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- $sql interpolates only $wpdb-provided table names; all dynamic values are bound via placeholders in $wpdb->prepare().
 		$order_ids = $wpdb->get_col( $wpdb->prepare( $sql, $params ) );
 
 		return $this->convert_ids_to_orders( $order_ids );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

[Plugin Check](https://wordpress.org/plugins/plugin-check/) reports three `PluginCheck.Security.DirectDB.UnescapedDBParameter` signals against direct-DB call sites:

All three are false positives:

- The only interpolated identifiers are values WordPress/WooCommerce control — the WC core sessions table (`$wpdb->prefix . 'woocommerce_sessions'`, set by `WC_Session_Handler`) and `$wpdb->posts` / `$wpdb->postmeta`. None of them are user input.
- Every dynamic value (session id/value/expiry, intent status, dates, order id, limit) is bound through `$wpdb->prepare()` placeholders.

The `%i` identifier placeholder would let us prepare the table name too, but it requires WP 6.2+ and the plugin still supports WP 6.0, so it isn't available here.

Each site already carries a scoped `phpcs:ignore` for the sibling `WordPress.DB.PreparedSQL.*` sniff. This PR extends those with `PluginCheck.Security.DirectDB.UnescapedDBParameter` and a short justification comment, keeping the suppression narrow and documented.

#### Testing instructions

* Run the Plugin Check tool (or the CI report that produced these signals) against the branch and confirm the three `UnescapedDBParameter` signals are gone.
* `npm run lint:php` passes for both files.
* No runtime behavior changes — the queries are byte-for-byte identical; only comments were added.


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [ ] Covered with tests (comment-only change; no behavior to test)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] QA Testing Not Applicable
