### PR TITLE
chore: reorganize testing documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,7 +336,7 @@ npm run tube:stop
 |-----|---------|
 | `README.md` | Main setup and overview |
 | `CONTRIBUTING.md` | Contribution guidelines |
-| `tests/README.md` | Testing guide |
+| `tests/README.md` | Testing overview & index of suites (unit, JS, E2E, QIT) |
 | `docker/README.md` | Docker setup |
 | `includes/core/README.md` | Extensibility docs |
 | `docs/` | Additional documentation |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,15 @@ You can also set up linting hints in your editor. Here are some useful instructi
 
 ## Running the tests
 
-Follow the instructions in the [tests readme](tests/README.md).
+WooPayments has several test suites. Once your [Docker environment](docker/README.md) is running:
+
+```bash
+npm test          # Run JS and PHP unit tests
+npm run test:js   # JavaScript unit tests only
+npm run test:php  # PHP unit tests only
+```
+
+See the [tests README](tests/README.md) for an overview of all suites, and the per-suite guides for setup and details: [PHP unit](tests/unit/README.md), [JavaScript unit](tests/js/README.md), [E2E](tests/e2e/README.md), and [QIT](tests/qit/README.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ You will need an externally accessible URL to set up the plugin. You can use ngr
 
 See: [CONTRIBUTING.md](CONTRIBUTING.md) for more development details.
 
+## Testing
+
+WooPayments has PHP unit, JavaScript unit, E2E, and QIT test suites. Once your [Docker environment](docker/README.md) is running:
+
+```bash
+npm test          # Run JS and PHP unit tests
+```
+
+See [tests/README.md](tests/README.md) for how to run each suite, and [docs/test-matrix.md](docs/test-matrix.md) for the full inventory of suites and what they gate.
+
 ## Debugging
 
 If you are following the [Docker setup](docker/README.md), Xdebug is ready to use for debugging.

--- a/changelog/chore-10305-test-docs-reorg
+++ b/changelog/chore-10305-test-docs-reorg
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: chore: reorganize testing docs

--- a/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
+++ b/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show all disputes on a transaction that has more than one, instead of only the first

--- a/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
+++ b/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Show all disputes on a transaction that has more than one, instead of only the first

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,37 +1,26 @@
-# WooPayments Unit Tests
+# WooPayments Tests
 
-This guide follows the [WooCommerce guide to unit tests](https://github.com/woocommerce/woocommerce/tree/master/tests).
+WooPayments has several test suites, each documented alongside the tests it covers. Use this page to find the right one.
 
-## Setup for running tests in the docker containers
+| Suite | Location | What it covers | Guide |
+|-------|----------|----------------|-------|
+| **PHP unit** | `tests/unit/` | PHPUnit tests for backend PHP code (`includes/`, `src/`) | [tests/unit/README.md](unit/README.md) |
+| **JavaScript unit** | `tests/js/` | Jest + React Testing Library tests for the `client/` frontend | [tests/js/README.md](js/README.md) |
+| **End-to-end (E2E)** | `tests/e2e/` | Playwright tests exercising full flows in a real WordPress environment | [tests/e2e/README.md](e2e/README.md) |
+| **QIT** | `tests/qit/` | WooCommerce Quality Insights Toolkit suites (E2E, security, malware, PHPStan) for marketplace certification | [tests/qit/README.md](qit/README.md) |
 
-1. Start the WordPress container: `npm run up` (or `npm run up:recreate` for first-time setup)
-   - This auto-starts shared infrastructure (database, phpMyAdmin) if not already running
-2. Once the containers are up, run tests from the plugin root directory:
-   - `npm run test:php` - Run PHP unit tests only
-   - `npm run test:js` - Run JavaScript unit tests only
-   - `npm test` - Run both JS and PHP tests
-3. Watch mode for iterative development:
-   - `npm run test:php-watch` - PHP tests in watch mode
-   - `npm run test:watch` - JavaScript tests in watch mode
+## Quick start
 
-## Initial Setup for running tests locally
+Once your [Docker environment](../docker/README.md) is running:
 
-1. From the plugin directory, run `composer install` if you have not already:
-
-```
-$ composer install
+```bash
+npm test          # Run JS and PHP unit tests
+npm run test:js   # JavaScript unit tests only
+npm run test:php  # PHP unit tests only
 ```
 
-2. Install WordPress and the WP Unit Test lib using the `bin/install-wp-tests.sh` script. From the plugin root directory type:
+See the per-suite guides above for setup, watch mode, coverage, and how to run a single test.
 
-```
-$ bin/install-wp-tests.sh <db-name> <db-user> <db-password> [db-host]
-```
+## Deep reference
 
-Tip: try using `127.0.0.1` for the DB host if the default `localhost` isn't working.
-
-3. Run the tests from the plugin root directory using
-
-```
-$ ./vendor/bin/phpunit
-```
+[`docs/test-matrix.md`](../docs/test-matrix.md) is the authoritative inventory of every suite — including which run in CI, which gate a release, and their reliability notes.

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -1,0 +1,23 @@
+# WooPayments JavaScript Unit Tests
+
+Jest + React Testing Library tests for the `client/` frontend. Tests are co-located with the source they cover, in `__tests__/` directories. Configuration lives in [`tests/js/jest.config.js`](jest.config.js).
+
+For PHP unit tests, see [tests/unit/README.md](../unit/README.md). For an overview of all test suites, see [tests/README.md](../README.md).
+
+## Running the tests
+
+From the plugin root directory:
+
+```bash
+npm run test:js                 # Run all JS unit tests
+npm run test:watch              # Watch mode (re-runs on change)
+npm run test:debug              # Debug mode (attach an inspector)
+npm run test:update-snapshots   # Update Jest snapshots
+```
+
+To run a single file or match tests by name, pass Jest arguments through:
+
+```bash
+npm run test:js -- path/to/file.test.tsx
+npm run test:js -- -t "renders the deposit schedule"
+```

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,43 @@
+# WooPayments PHP Unit Tests
+
+PHPUnit tests for the backend PHP code in `includes/` and `src/`. This guide follows the [WooCommerce guide to unit tests](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests).
+
+For JavaScript unit tests, see [tests/js/README.md](../js/README.md). For an overview of all test suites, see [tests/README.md](../README.md).
+
+## Running tests in the Docker containers
+
+1. Start the WordPress container: `npm run up` (or `npm run up:recreate` for first-time setup)
+   - This auto-starts shared infrastructure (database, phpMyAdmin) if not already running
+2. Once the containers are up, run tests from the plugin root directory:
+   - `npm run test:php` - Run PHP unit tests
+   - `npm run test:php-watch` - PHP tests in watch mode
+   - `npm run test:php-coverage` - PHP tests with coverage
+3. Run a single test class or method:
+
+```
+docker compose exec -u www-data wordpress bash -c \
+  "cd /var/www/html/wp-content/plugins/woocommerce-payments && \
+  vendor/bin/phpunit --configuration phpunit.xml.dist --filter 'TestClassName::test_method_name'"
+```
+
+## Running tests locally (without Docker)
+
+1. From the plugin directory, run `composer install` if you have not already:
+
+```
+$ composer install
+```
+
+2. Install WordPress and the WP Unit Test lib using the `bin/install-wp-tests.sh` script. From the plugin root directory type:
+
+```
+$ bin/install-wp-tests.sh <db-name> <db-user> <db-password> [db-host]
+```
+
+Tip: try using `127.0.0.1` for the DB host if the default `localhost` isn't working.
+
+3. Run the tests from the plugin root directory using
+
+```
+$ ./vendor/bin/phpunit
+```


### PR DESCRIPTION
Closes #10305

Reorganing the testing docs to follow the layout WooCommerce core uses.

- `tests/README.md` is now an index of the test suites (unit, JS, E2E, QIT), each linking to its own guide.
- The unit-test setup moved into `tests/unit/README.md`, and the JS test commands into a new `tests/js/README.md`, so each suite is documented next to its code.
- Added a short Testing section to the main README and pointed `CONTRIBUTING.md` at the new index.

The old `tests/README.md` was titled "Unit Tests" but lived above the e2e, qit, and js suites, so it was easy to miss. Colocating each suite's docs and keeping an index at the top matches how WooCommerce core organizes this.
