### PR TITLE
Load-time quick wins: request-type gating and per-request cache memoization

### DIFF
--- a/changelog/fix-8090-eager-loading-quick-wins
+++ b/changelog/fix-8090-eager-loading-quick-wins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skip express checkout button handler construction on cron and XML-RPC requests, where the handlers' hooks can never fire

--- a/changelog/fix-8090-eager-loading-quick-wins#2
+++ b/changelog/fix-8090-eager-loading-quick-wins#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Resolve repeated Database_Cache::get_or_add() calls from memory within a request, skipping redundant validation of hot keys like account data

--- a/changelog/fix-8090-eager-loading-quick-wins#3
+++ b/changelog/fix-8090-eager-loading-quick-wins#3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Look up webhook IDs in WooPay order status sync tests instead of hardcoding them, fixing order-dependent failures in full suite runs

--- a/changelog/fix-test-request-uri-pollution
+++ b/changelog/fix-test-request-uri-pollution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Restore $_SERVER['REQUEST_URI'] after WC_Payments_Utils tests so leaked wp-json URIs don't send later tests down REST-only WooCommerce code paths

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -109,6 +109,19 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	private $in_memory_cache = [];
 
 	/**
+	 * Values already resolved by get_or_add() during this request, keyed by cache key.
+	 *
+	 * Once a key has been resolved (validated and refreshed if needed), repeated
+	 * get_or_add() calls for it within the same request return this value directly,
+	 * skipping the validation and refresh-decision work. Hot keys like the account
+	 * data are read dozens of times per request (once per gateway availability check).
+	 * Entries are cleared whenever the key is written or deleted.
+	 *
+	 * @var array
+	 */
+	private $resolved_values = [];
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -136,6 +149,11 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	 * @return mixed|null The cached value. NULL on failure to regenerate or validate the data.
 	 */
 	public function get_or_add( string $key, callable $generator, callable $validate_data, bool $force_refresh = false, bool &$refreshed = false ) {
+		if ( ! $force_refresh && array_key_exists( $key, $this->resolved_values ) ) {
+			$refreshed = false;
+			return $this->resolved_values[ $key ];
+		}
+
 		$cache_contents = $this->get_from_cache( $key );
 		$data           = null;
 		$old_data       = null;
@@ -164,6 +182,8 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 
 			$this->write_to_cache( $key, $data, $errored );
 		}
+
+		$this->resolved_values[ $key ] = $data;
 
 		return $data;
 	}
@@ -198,6 +218,7 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	 * @return void
 	 */
 	public function add( string $key, $data ) {
+		unset( $this->resolved_values[ $key ] );
 		$this->write_to_cache( $key, $data, false );
 	}
 
@@ -209,8 +230,9 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	 * @return void
 	 */
 	public function delete( string $key ) {
-		// Remove from the in-memory cache.
+		// Remove from the in-memory caches.
 		unset( $this->in_memory_cache[ $key ] );
+		unset( $this->resolved_values[ $key ] );
 
 		// Remove from the DB cache.
 		delete_option( $key );

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -112,10 +112,14 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	 * Values already resolved by get_or_add() during this request, keyed by cache key.
 	 *
 	 * Once a key has been resolved (validated and refreshed if needed), repeated
-	 * get_or_add() calls for it within the same request return this value directly,
-	 * skipping the validation and refresh-decision work. Hot keys like the account
-	 * data are read dozens of times per request (once per gateway availability check).
-	 * Entries are cleared whenever the key is written or deleted.
+	 * get_or_add() calls for it within the same request return this value after
+	 * revalidating it with the caller's own validate_data callback, skipping the
+	 * redundant second validation and refresh-decision work. Hot keys like the
+	 * account data are read dozens of times per request (once per gateway
+	 * availability check). If the caller's validator rejects the resolved value
+	 * (different caller, or a validator whose verdict changed mid-request), the
+	 * call falls through to the full read/refresh path. Entries are cleared
+	 * whenever the key is written or deleted.
 	 *
 	 * @var array
 	 */
@@ -149,7 +153,7 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	 * @return mixed|null The cached value. NULL on failure to regenerate or validate the data.
 	 */
 	public function get_or_add( string $key, callable $generator, callable $validate_data, bool $force_refresh = false, bool &$refreshed = false ) {
-		if ( ! $force_refresh && array_key_exists( $key, $this->resolved_values ) ) {
+		if ( ! $force_refresh && array_key_exists( $key, $this->resolved_values ) && $validate_data( $this->resolved_values[ $key ] ) ) {
 			$refreshed = false;
 			return $this->resolved_values[ $key ];
 		}

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -109,17 +109,11 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	private $in_memory_cache = [];
 
 	/**
-	 * Values already resolved by get_or_add() during this request, keyed by cache key.
+	 * Values resolved by get_or_add() during this request, keyed by cache key.
 	 *
-	 * Once a key has been resolved (validated and refreshed if needed), repeated
-	 * get_or_add() calls for it within the same request return this value after
-	 * revalidating it with the caller's own validate_data callback, skipping the
-	 * redundant second validation and refresh-decision work. Hot keys like the
-	 * account data are read dozens of times per request (once per gateway
-	 * availability check). If the caller's validator rejects the resolved value
-	 * (different caller, or a validator whose verdict changed mid-request), the
-	 * call falls through to the full read/refresh path. Entries are cleared
-	 * whenever the key is written or deleted.
+	 * Repeated calls are served from here once the caller's validate_data
+	 * callback approves the value; rejected values fall through to the full
+	 * read/refresh path. Cleared by add() and delete().
 	 *
 	 * @var array
 	 */

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1982,6 +1982,13 @@ class WC_Payments {
 	 * @return void
 	 */
 	public static function maybe_display_express_checkout_buttons() {
+		// Cron and XML-RPC requests never render express checkout buttons, serve
+		// their wc-ajax endpoints, or fire any hook the handlers register, so the
+		// construction cost is pure overhead there.
+		if ( wp_doing_cron() || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
+			return;
+		}
+
 		if ( WC_Payments_Features::are_payments_enabled() ) {
 			$woopay_button_handler = new WC_Payments_WooPay_Button_Handler( self::$account, self::get_gateway(), self::$woopay_util, self::get_express_checkout_helper() );
 

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -1982,9 +1982,7 @@ class WC_Payments {
 	 * @return void
 	 */
 	public static function maybe_display_express_checkout_buttons() {
-		// Cron and XML-RPC requests never render express checkout buttons, serve
-		// their wc-ajax endpoints, or fire any hook the handlers register, so the
-		// construction cost is pure overhead there.
+		// None of the handlers' hooks can fire on cron or XML-RPC requests.
 		if ( wp_doing_cron() || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
 			return;
 		}

--- a/tests/unit/test-class-database-cache.php
+++ b/tests/unit/test-class-database-cache.php
@@ -118,8 +118,47 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 
 		$this->assertEquals( $value, $first );
 		$this->assertEquals( $value, $second );
-		$this->assertSame( $validations_for_first_call, $validation_count, 'A repeated call should not validate the cached data again.' );
+		// A repeated call revalidates the resolved value exactly once (the caller's
+		// own validator still applies) instead of the two validations plus
+		// refresh-decision checks of a full read.
+		$this->assertSame( $validations_for_first_call + 1, $validation_count );
 		$this->assertFalse( $refreshed );
+	}
+
+	public function test_get_or_add_does_not_serve_resolved_value_rejected_by_the_callers_validator() {
+		$refreshed = false;
+		$old_value = [ 'old' => true ];
+		$new_value = [ 'new' => true ];
+
+		$this->write_mock_cache( $old_value );
+
+		$first = $this->database_cache->get_or_add(
+			self::MOCK_KEY,
+			function () {
+				$this->fail( 'Should not call the generator.' );
+			},
+			'__return_true',
+			false,
+			$refreshed
+		);
+
+		// A caller whose validator rejects the resolved value must not be served
+		// from the in-request memo: it falls through to the full path, which
+		// treats the data as invalid and refreshes it.
+		$second = $this->database_cache->get_or_add(
+			self::MOCK_KEY,
+			function () use ( $new_value ) {
+				return $new_value;
+			},
+			'__return_false',
+			false,
+			$refreshed
+		);
+
+		$this->assertEquals( $old_value, $first );
+		$this->assertEquals( $new_value, $second );
+		$this->assertTrue( $refreshed );
+		$this->assert_cache_contains( $new_value );
 	}
 
 	public function test_get_or_add_force_refresh_bypasses_resolved_values() {

--- a/tests/unit/test-class-database-cache.php
+++ b/tests/unit/test-class-database-cache.php
@@ -118,10 +118,7 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 
 		$this->assertEquals( $value, $first );
 		$this->assertEquals( $value, $second );
-		// A repeated call revalidates the resolved value exactly once (the caller's
-		// own validator still applies) instead of the two validations plus
-		// refresh-decision checks of a full read.
-		$this->assertSame( $validations_for_first_call + 1, $validation_count );
+		$this->assertSame( $validations_for_first_call + 1, $validation_count, 'The repeated call should revalidate once instead of performing a full read.' );
 		$this->assertFalse( $refreshed );
 	}
 
@@ -142,9 +139,6 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 			$refreshed
 		);
 
-		// A caller whose validator rejects the resolved value must not be served
-		// from the in-request memo: it falls through to the full path, which
-		// treats the data as invalid and refreshes it.
 		$second = $this->database_cache->get_or_add(
 			self::MOCK_KEY,
 			function () use ( $new_value ) {

--- a/tests/unit/test-class-database-cache.php
+++ b/tests/unit/test-class-database-cache.php
@@ -97,6 +97,113 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 		$this->assert_cache_contains( $value );
 	}
 
+	public function test_get_or_add_resolves_repeated_calls_in_memory() {
+		$refreshed        = false;
+		$value            = [ 'mock' => true ];
+		$validation_count = 0;
+
+		$this->write_mock_cache( $value );
+
+		$validator = function () use ( &$validation_count ) {
+			++$validation_count;
+			return true;
+		};
+		$generator = function () {
+			$this->fail( 'Should not call the generator.' );
+		};
+
+		$first                      = $this->database_cache->get_or_add( self::MOCK_KEY, $generator, $validator, false, $refreshed );
+		$validations_for_first_call = $validation_count;
+		$second                     = $this->database_cache->get_or_add( self::MOCK_KEY, $generator, $validator, false, $refreshed );
+
+		$this->assertEquals( $value, $first );
+		$this->assertEquals( $value, $second );
+		$this->assertSame( $validations_for_first_call, $validation_count, 'A repeated call should not validate the cached data again.' );
+		$this->assertFalse( $refreshed );
+	}
+
+	public function test_get_or_add_force_refresh_bypasses_resolved_values() {
+		$refreshed = false;
+		$old_value = [ 'old' => true ];
+		$new_value = [ 'new' => true ];
+
+		$this->write_mock_cache( $old_value );
+
+		$first = $this->database_cache->get_or_add(
+			self::MOCK_KEY,
+			function () {
+				$this->fail( 'Should not call the generator.' );
+			},
+			'__return_true',
+			false,
+			$refreshed
+		);
+
+		$second = $this->database_cache->get_or_add(
+			self::MOCK_KEY,
+			function () use ( $new_value ) {
+				return $new_value;
+			},
+			'__return_true',
+			true,
+			$refreshed
+		);
+
+		$this->assertEquals( $old_value, $first );
+		$this->assertEquals( $new_value, $second );
+		$this->assertTrue( $refreshed );
+		$this->assert_cache_contains( $new_value );
+	}
+
+	public function test_get_or_add_regenerates_after_delete_despite_resolved_values() {
+		$refreshed = false;
+		$old_value = [ 'old' => true ];
+		$new_value = [ 'new' => true ];
+
+		$this->write_mock_cache( $old_value );
+
+		$this->database_cache->get_or_add( self::MOCK_KEY, '__return_false', '__return_true', false, $refreshed );
+
+		$this->database_cache->delete( self::MOCK_KEY );
+
+		$res = $this->database_cache->get_or_add(
+			self::MOCK_KEY,
+			function () use ( $new_value ) {
+				return $new_value;
+			},
+			'__return_true',
+			false,
+			$refreshed
+		);
+
+		$this->assertEquals( $new_value, $res );
+		$this->assertTrue( $refreshed );
+	}
+
+	public function test_get_or_add_returns_value_written_by_add_despite_resolved_values() {
+		$refreshed = false;
+		$old_value = [ 'old' => true ];
+		$new_value = [ 'new' => true ];
+
+		$this->write_mock_cache( $old_value );
+
+		$this->database_cache->get_or_add( self::MOCK_KEY, '__return_false', '__return_true', false, $refreshed );
+
+		$this->database_cache->add( self::MOCK_KEY, $new_value );
+
+		$res = $this->database_cache->get_or_add(
+			self::MOCK_KEY,
+			function () {
+				$this->fail( 'Should not call the generator.' );
+			},
+			'__return_true',
+			false,
+			$refreshed
+		);
+
+		$this->assertEquals( $new_value, $res );
+	}
+
 	public function test_get_or_add_forces_refresh() {
 		$refreshed = false;
 		$value     = [ 'mock' => true ];

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -15,7 +15,7 @@ use WCPay\Exceptions\API_Exception;
 class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 
 	/**
-	 * Restored after each test — a leaked /wp-json/ REQUEST_URI makes
+	 * Restored after each test. A leaked /wp-json/ REQUEST_URI makes
 	 * WC()->is_rest_api_request() return true for all later tests.
 	 *
 	 * @var string|null

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -15,10 +15,8 @@ use WCPay\Exceptions\API_Exception;
 class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
 
 	/**
-	 * The value of $_SERVER['REQUEST_URI'] before the test, so tests that
-	 * simulate request URLs don't leak them into later tests. A leaked
-	 * /wp-json/ URI makes WC()->is_rest_api_request() return true suite-wide,
-	 * which sends product creation down REST-only code paths.
+	 * Restored after each test — a leaked /wp-json/ REQUEST_URI makes
+	 * WC()->is_rest_api_request() return true for all later tests.
 	 *
 	 * @var string|null
 	 */

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -13,6 +13,34 @@ use WCPay\Exceptions\API_Exception;
  * WC_Payments_Utils unit tests.
  */
 class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * The value of $_SERVER['REQUEST_URI'] before the test, so tests that
+	 * simulate request URLs don't leak them into later tests. A leaked
+	 * /wp-json/ URI makes WC()->is_rest_api_request() return true suite-wide,
+	 * which sends product creation down REST-only code paths.
+	 *
+	 * @var string|null
+	 */
+	private $original_request_uri;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_request_uri = $_SERVER['REQUEST_URI'] ?? null;
+	}
+
+	public function tear_down() {
+		if ( null === $this->original_request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		}
+		unset( $_REQUEST['rest_route'] );
+
+		parent::tear_down();
+	}
+
 	public function test_esc_interpolated_html_returns_raw_string() {
 		$result = WC_Payments_Utils::esc_interpolated_html(
 			'hello world',

--- a/tests/unit/test-class-wc-payments.php
+++ b/tests/unit/test-class-wc-payments.php
@@ -77,6 +77,23 @@ class WC_Payments_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_maybe_display_express_checkout_buttons_bails_during_cron_requests() {
+		$this->mock_cache->expects( $this->never() )->method( 'get' );
+
+		add_filter( 'wp_doing_cron', '__return_true' );
+		WC_Payments::maybe_display_express_checkout_buttons();
+		remove_filter( 'wp_doing_cron', '__return_true' );
+	}
+
+	public function test_maybe_display_express_checkout_buttons_checks_account_on_regular_requests() {
+		$this->mock_cache->expects( $this->once() )
+			->method( 'get' )
+			->with( 'wcpay_account_data', true )
+			->willReturn( null );
+
+		WC_Payments::maybe_display_express_checkout_buttons();
+	}
+
 	public function test_it_skips_stripe_link_gateway_registration() {
 		$all_gateways_before_registration = count( WC_Payments::get_payment_method_map() );
 		$card_gateway_mock                = $this->createMock( WC_Payment_Gateway_WCPay::class );

--- a/tests/unit/woopay/test-class-woopay-order-status-sync.php
+++ b/tests/unit/woopay/test-class-woopay-order-status-sync.php
@@ -103,7 +103,7 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 		// Create the WebHook with WooPay specific delivery URL.
 		$this->webhook_sync_mock->maybe_create_woopay_order_webhook();
 
-		// The webhook ID can't be hardcoded — auto-increment counters survive the per-test rollback.
+		// Look up the webhook ID rather than hardcoding it. Auto-increment counters survive the per-test rollback.
 		$webhook_id = current( WooPay_Order_Status_Sync::get_webhook() );
 
 		$post_processing_payload = $this->webhook_sync_mock->create_payload( $pre_processing_payload, 'product', 1, $webhook_id );

--- a/tests/unit/woopay/test-class-woopay-order-status-sync.php
+++ b/tests/unit/woopay/test-class-woopay-order-status-sync.php
@@ -103,9 +103,7 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 		// Create the WebHook with WooPay specific delivery URL.
 		$this->webhook_sync_mock->maybe_create_woopay_order_webhook();
 
-		// Look the webhook ID up instead of hardcoding it: auto-increment counters
-		// survive the per-test transaction rollback, so the ID depends on how many
-		// webhooks earlier tests in the run have created.
+		// The webhook ID can't be hardcoded — auto-increment counters survive the per-test rollback.
 		$webhook_id = current( WooPay_Order_Status_Sync::get_webhook() );
 
 		$post_processing_payload = $this->webhook_sync_mock->create_payload( $pre_processing_payload, 'product', 1, $webhook_id );

--- a/tests/unit/woopay/test-class-woopay-order-status-sync.php
+++ b/tests/unit/woopay/test-class-woopay-order-status-sync.php
@@ -103,7 +103,12 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 		// Create the WebHook with WooPay specific delivery URL.
 		$this->webhook_sync_mock->maybe_create_woopay_order_webhook();
 
-		$post_processing_payload = $this->webhook_sync_mock->create_payload( $pre_processing_payload, 'product', 1, 1 );
+		// Look the webhook ID up instead of hardcoding it: auto-increment counters
+		// survive the per-test transaction rollback, so the ID depends on how many
+		// webhooks earlier tests in the run have created.
+		$webhook_id = current( WooPay_Order_Status_Sync::get_webhook() );
+
+		$post_processing_payload = $this->webhook_sync_mock->create_payload( $pre_processing_payload, 'product', 1, $webhook_id );
 		$this->assertNotEquals( $pre_processing_payload, $post_processing_payload );
 		$this->assertEquals( $post_processing_payload, $woopay_specific_payload );
 
@@ -129,9 +134,9 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 			],
 		];
 
-		$this->create_non_woopay_specific_webhook();
+		$webhook_id = $this->create_non_woopay_specific_webhook();
 
-		$post_processing_payload = $this->webhook_sync_mock->create_payload( $pre_processing_payload, 'product', 1, 2 );
+		$post_processing_payload = $this->webhook_sync_mock->create_payload( $pre_processing_payload, 'product', 1, $webhook_id );
 		$this->assertEquals( $pre_processing_payload, $post_processing_payload );
 
 		$this->webhook_sync_mock->remove_webhook();
@@ -226,5 +231,7 @@ class WooPay_Order_Status_Sync_Test extends WP_UnitTestCase {
 		$webhook->set_delivery_url( $delivery_url_non_specific_for_woopay );
 		$webhook->set_status( 'active' );
 		$webhook->save();
+
+		return $webhook->get_id();
 	}
 }


### PR DESCRIPTION
Refs #8090

#### Changes proposed in this Pull Request

Two performance wins from re-profiling #8090, plus two test fixes found while verifying against the full suite.

- Skip express checkout handler construction on cron and XML-RPC requests. `maybe_display_express_checkout_buttons()` builds four handler objects on every request, and none of their hooks can fire in those contexts. REST, admin and wc-ajax are untouched (Store API checkout, block editor data, and the handlers' own endpoints live there).
- Serve repeated `Database_Cache::get_or_add()` calls from an in-request memo. Account data is read dozens of times per request, once per gateway `is_available()` chain. Each repeated call still runs the caller's `validate_data`, and a rejected value falls back to the full path, so validation and refresh behaviour are unchanged. `force_refresh` bypasses the memo, `add()`/`delete()` clear it. Measured against develop (median TTFB over 25 requests, warm opcache, local Docker): checkout −21ms (~8%), Payments settings tab −21 to −27ms, orders list −10ms. Pages that only read the account once (product, homepage) don't change.
- Fix `$_SERVER['REQUEST_URI']` leaking from `WC_Payments_Utils_Test`. The is_store_api_request tests left a `/wp-json/...` value behind, which made `WC()->is_rest_api_request()` true for the rest of the suite and broke product creation in later tests ("DUMMY SKU already present in the lookup table").
- Fix hardcoded webhook IDs in `WooPay_Order_Status_Sync_Test`. IDs 1 and 2 only hold on a fresh `wc_webhooks` table because auto-increment counters survive the per-test rollback.

#### Testing instructions

Needs a dev store with a WooPayments test account connected. Local Docker env assumed (`npm run up`, store at `http://localhost:8082`).

**Unit tests**

1. Run `npm run test:php -- --filter Database_Cache_Test`. The new tests cover memo hits on repeated `get_or_add()` calls, validator rejection falling back to the full path, `force_refresh` bypassing the memo, and `add()`/`delete()` clearing it. All should pass.
2. Run `npm run test:php -- --filter WC_Payments_Test`. Includes the new cron/XML-RPC gate tests. All should pass.

**Regression: express checkout still loads**

The visible Apple Pay / Google Pay buttons won't show on a localhost store (they need an HTTPS site and a browser with a wallet available), so verify the handlers still run at the DOM level:

1. Go to Payments > Settings and enable Apple Pay / Google Pay under Express checkouts, for product, cart and checkout pages.
2. Visit a product page, the cart, and checkout.
3. On each page, run `document.querySelector( '#wcpay-express-checkout-element' )` in the browser console. It should return the wrapper element (it stays hidden until a wallet is available; that part is unchanged).
4. Optional, to see the real buttons: test on an HTTPS site (e.g. a Jurassic Ninja site with this build) in Chrome signed into a Google account with a saved card, or Safari with an Apple Pay card.

**Regression: payments and admin screens**

1. Place an order with test card `4242 4242 4242 4242`. It should succeed.
2. Open the order in wp-admin and refund it. The refund should complete.
3. Load Payments > Overview, Transactions, and Payouts. All three should show data with no errors in the browser console.
4. In Payments > Settings, change a setting (e.g. the statement descriptor), save, reload. The new value should persist.

**Cron and XML-RPC gate**

1. Add `error_log( 'EC handlers constructed' );` immediately after the cron/XML-RPC guard at the top of `maybe_display_express_checkout_buttons()` in `includes/class-wc-payments.php`.
2. Watch the PHP error log: `docker compose logs -f wordpress`.
3. Run `curl http://localhost:8082/wp-cron.php`. The line must not appear.
4. Run `curl http://localhost:8082/xmlrpc.php`. The line must not appear.
5. Load the shop page in a browser. The line appears once.
6. Remove the log line when done.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
