### PR TITLE
Fix REQUEST_URI pollution from WC_Payments_Utils tests breaking later suite runs

### DIFF
--- a/changelog/fix-test-request-uri-pollution
+++ b/changelog/fix-test-request-uri-pollution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Restore $_SERVER['REQUEST_URI'] after WC_Payments_Utils tests so leaked wp-json URIs don't send later tests down REST-only WooCommerce code paths

--- a/tests/unit/test-class-wc-payments-utils.php
+++ b/tests/unit/test-class-wc-payments-utils.php
@@ -13,6 +13,34 @@ use WCPay\Exceptions\API_Exception;
  * WC_Payments_Utils unit tests.
  */
 class WC_Payments_Utils_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * The value of $_SERVER['REQUEST_URI'] before the test, so tests that
+	 * simulate request URLs don't leak them into later tests. A leaked
+	 * /wp-json/ URI makes WC()->is_rest_api_request() return true suite-wide,
+	 * which sends product creation down REST-only code paths.
+	 *
+	 * @var string|null
+	 */
+	private $original_request_uri;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_request_uri = $_SERVER['REQUEST_URI'] ?? null;
+	}
+
+	public function tear_down() {
+		if ( null === $this->original_request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		}
+		unset( $_REQUEST['rest_route'] );
+
+		parent::tear_down();
+	}
+
 	public function test_esc_interpolated_html_returns_raw_string() {
 		$result = WC_Payments_Utils::esc_interpolated_html(
 			'hello world',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Running the full local PHP suite deterministically fails with two errors:

```
WC_Payments_Test::test_fit_card_brand_icon_for_printable_order_receipt_updates_wcpay_receipt_css
Exception: The product with SKU (DUMMY SKU) you are trying to insert is already present in the lookup table
```

The SKU error is a red herring. The actual cause: the `is_store_api_request()` tests in `WC_Payments_Utils_Test` set `$_SERVER['REQUEST_URI']` to various `/wp-json/…` URLs and never restore it. The last value leaks into every test class that runs afterwards, so `WC()->is_rest_api_request()` returns true for the rest of the suite. That sends product creation in later tests down WooCommerce's REST-only concurrent-SKU-lock path (`WC_Product_Data_Store_CPT::create()` only takes it when `is_rest_api_request()` is true), which fails on the shared `DUMMY SKU` fixture. First victims are the `fit_card_brand_icon` tests in `WC_Payments_Test` — the next class in suite order.

The fix captures the original `REQUEST_URI` in `set_up()` and restores it in `tear_down()`, along with the `rest_route` request var some of the same tests set.

There's one more pre-existing order-dependent failure in full-suite runs (`WooPay_Order_Status_Sync_Test::test_woopay_specific_webhook_payload_is_updated`) with a different cause — not addressed here.

#### Testing instructions

* On `develop`, run the two classes together and watch them fail:
  `vendor/bin/phpunit --configuration phpunit.xml.dist --filter 'WC_Payments_Utils_Test|WC_Payments_Test'` → 2 errors.
* On this branch, the same command is green (127 tests), and a full suite run goes from 2 errors + 1 failure to just the unrelated pre-existing failure (3,818 tests).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — this is itself a test-only fix, verified by the previously failing suite.
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
