### PR TITLE
fix: forward error details from test drive account init errors

### DIFF
--- a/changelog/fix-forward-test-drive-init-error-details
+++ b/changelog/fix-forward-test-drive-init-error-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Forward structured error details (error code and type) in the test drive account init REST error response, so consumers can distinguish non-recoverable errors.

--- a/changelog/fix-forward-test-drive-init-error-details
+++ b/changelog/fix-forward-test-drive-init-error-details
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Forward structured error details (error code and type) in the test drive account init REST error response, so consumers can distinguish non-recoverable errors.
+Forward structured error details (error code, type, and HTTP status) in the test drive account init REST error response, so consumers can distinguish non-recoverable errors.

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -372,11 +372,12 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 		} catch ( API_Exception $e ) {
 			// Forward the structured error details so consumers (e.g. the WooCommerce NOX onboarding)
 			// can distinguish non-recoverable errors from transient ones.
+			$http_code = $e->get_http_code();
 			return new WP_Error(
 				self::RESULT_BAD_REQUEST,
 				$e->getMessage(),
 				[
-					'status'     => 400,
+					'status'     => 0 !== $http_code ? $http_code : 400,
 					'error_code' => $e->get_error_code(),
 					'error_type' => $e->get_error_type(),
 				]

--- a/includes/admin/class-wc-rest-payments-onboarding-controller.php
+++ b/includes/admin/class-wc-rest-payments-onboarding-controller.php
@@ -7,6 +7,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use WCPay\Exceptions\API_Exception;
 use WCPay\Logger;
 
 /**
@@ -368,6 +369,18 @@ class WC_REST_Payments_Onboarding_Controller extends WC_Payments_REST_Controller
 
 		try {
 			$success = $this->onboarding_service->init_test_drive_account( $country, $request->get_param( 'capabilities' ) ?? [], $request->get_param( 'account_data' ) ?? [] );
+		} catch ( API_Exception $e ) {
+			// Forward the structured error details so consumers (e.g. the WooCommerce NOX onboarding)
+			// can distinguish non-recoverable errors from transient ones.
+			return new WP_Error(
+				self::RESULT_BAD_REQUEST,
+				$e->getMessage(),
+				[
+					'status'     => 400,
+					'error_code' => $e->get_error_code(),
+					'error_type' => $e->get_error_type(),
+				]
+			);
 		} catch ( Exception $e ) {
 			return new WP_Error( self::RESULT_BAD_REQUEST, $e->getMessage(), [ 'status' => 400 ] );
 		}

--- a/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
@@ -162,7 +162,7 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 				new API_Exception(
 					"Error: The statement descriptor matches a common term or website URL, and can't be used.",
 					'invalid_request_error',
-					400,
+					409,
 					'invalid_request_error'
 				)
 			);
@@ -175,9 +175,32 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'bad_request', $response->get_error_code() );
 
 		$error_data = $response->get_error_data();
-		$this->assertSame( 400, $error_data['status'] );
+		$this->assertSame( 409, $error_data['status'] );
 		$this->assertSame( 'invalid_request_error', $error_data['error_code'] );
 		$this->assertSame( 'invalid_request_error', $error_data['error_type'] );
+	}
+
+	public function test_init_test_drive_account_falls_back_to_400_when_api_exception_has_no_http_code() {
+		$this->mock_onboarding_service
+			->expects( $this->once() )
+			->method( 'init_test_drive_account' )
+			->willThrowException(
+				new API_Exception(
+					'Something went wrong',
+					'wcpay_account_creation_failed',
+					0,
+					'api_error'
+				)
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params( [ 'country' => 'US' ] );
+
+		$response = $this->controller->init_test_drive_account( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+
+		$error_data = $response->get_error_data();
+		$this->assertSame( 400, $error_data['status'] );
 	}
 
 	public function test_finalize_embedded_kyc() {

--- a/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
@@ -7,6 +7,7 @@
 
 use PHPUnit\Framework\MockObject\MockObject;
 use WCPay\Constants\Country_Code;
+use WCPay\Exceptions\API_Exception;
 
 /**
  * WC_REST_Payments_Onboarding_Controller unit tests.
@@ -151,6 +152,32 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'bad_request', $response->get_error_code() );
 		$this->assertSame( 'Something went wrong', $response->get_error_message() );
+	}
+
+	public function test_init_test_drive_account_forwards_error_details_on_api_exception() {
+		$this->mock_onboarding_service
+			->expects( $this->once() )
+			->method( 'init_test_drive_account' )
+			->willThrowException(
+				new API_Exception(
+					"Error: The statement descriptor matches a common term or website URL, and can't be used.",
+					'invalid_request_error',
+					400,
+					'invalid_request_error'
+				)
+			);
+
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params( [ 'country' => 'US' ] );
+
+		$response = $this->controller->init_test_drive_account( $request );
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'bad_request', $response->get_error_code() );
+
+		$error_data = $response->get_error_data();
+		$this->assertSame( 400, $error_data['status'] );
+		$this->assertSame( 'invalid_request_error', $error_data['error_code'] );
+		$this->assertSame( 'invalid_request_error', $error_data['error_type'] );
 	}
 
 	public function test_finalize_embedded_kyc() {

--- a/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
+++ b/tests/unit/admin/test-class-wc-rest-payments-onboarding-controller.php
@@ -161,7 +161,7 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 			->willThrowException(
 				new API_Exception(
 					"Error: The statement descriptor matches a common term or website URL, and can't be used.",
-					'invalid_request_error',
+					'account_country_invalid',
 					409,
 					'invalid_request_error'
 				)
@@ -176,7 +176,7 @@ class WC_REST_Payments_Onboarding_Controller_Test extends WCPAY_UnitTestCase {
 
 		$error_data = $response->get_error_data();
 		$this->assertSame( 409, $error_data['status'] );
-		$this->assertSame( 'invalid_request_error', $error_data['error_code'] );
+		$this->assertSame( 'account_country_invalid', $error_data['error_code'] );
 		$this->assertSame( 'invalid_request_error', $error_data['error_type'] );
 	}
 


### PR DESCRIPTION
Part of woocommerce/woocommerce#59437

#### Changes proposed in this Pull Request

The test drive account init endpoint (`/wc/v3/payments/onboarding/test_drive_account/init`) catches all exceptions generically and returns a `WP_Error` carrying only the message. The structured error details available on `API_Exception` — the error code and type, e.g. Stripe's `invalid_request_error` — are discarded.

Consumers such as the WooCommerce NOX onboarding need those details to distinguish non-recoverable errors (e.g. Stripe rejecting the auto-generated statement descriptor, which the merchant cannot fix) from transient ones, so they can move merchants forward instead of trapping them in a retry loop. See woocommerce/woocommerce#59437 and the companion WooCommerce core PR that consumes these fields: woocommerce/woocommerce#66356.

This PR catches `API_Exception` separately in `init_test_drive_account()` and includes `error_code` and `error_type` in the `WP_Error` data. All other exceptions keep the existing behavior. This is a purely additive change to the error response shape.

#### Testing instructions

* Run the unit tests: `npm run test:php -- --filter test_init_test_drive_account` — the new `test_init_test_drive_account_forwards_error_details_on_api_exception` covers the added behavior, and the existing tests confirm the generic exception path is unchanged.
* Manual (optional): on a dev site connected to a server that fails test drive account creation, trigger the NOX test account step and inspect the `test_drive_account/init` REST response — the error `data` should now include `error_code` and `error_type` when the failure originates from an `API_Exception`.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

