### PR TITLE
fix: bump shell-quote dev dependency to 1.9.0 (CVE-2026-9277)

### DIFF
--- a/changelog/fix-shell-quote-cve-2026-9277
+++ b/changelog/fix-shell-quote-cve-2026-9277
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Bump shell-quote dev dependency (webpack-dev-server → launch-editor) from 1.8.3 to 1.9.0 to clear CVE-2026-9277. Dev-only, not user-facing.
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -45623,10 +45623,11 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+			"integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Dependabot alert [#323](https://github.com/Automattic/woocommerce-payments/security/dependabot/323) (CVE-2026-9277, critical) flagged `shell-quote`.

Bumping it to `1.9.0` in the lockfile.

#### Testing instructions

Dev-only dependency bump — no user-facing behavior change.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — lockfile-only dev-dependency bump, no code to test.
- [x] Tested on mobile (or does not apply) — does not apply.

**Post merge**

- [ ] QA Testing Not Applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
