### PR TITLE
fix: bind the order-status update nonce to its order

### DIFF
--- a/changelog/fix-update-order-status-nonce
+++ b/changelog/fix-update-order-status-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Bind the order-status update nonce to its order and avoid modifying the order before validation

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2086,7 +2086,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 						$payment_needed ? 'pi' : 'si',
 						$order_id,
 						$client_secret,
-						wp_create_nonce( 'wcpay_update_order_status_nonce' ),
+						wp_create_nonce( $this->get_update_order_status_nonce_action( $order ) ),
 					];
 
 					// For ECE SetupIntents, include the confirmation token so the frontend can
@@ -2385,7 +2385,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 							$payment_needed ? 'pi' : 'si',
 							$order_id,
 							$client_secret,
-							wp_create_nonce( 'wcpay_update_order_status_nonce' )
+							wp_create_nonce( $this->get_update_order_status_nonce_action( $order ) )
 						);
 						wp_safe_redirect( $redirect_url );
 						exit;
@@ -4043,6 +4043,20 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Build the nonce action for the update_order_status AJAX endpoint, bound to a single order.
+	 *
+	 * The order id and key are folded into the action string so a nonce minted for one order
+	 * cannot be replayed against a different one — the verifier rebuilds the same action from
+	 * the order it resolved and the tokens won't match otherwise.
+	 *
+	 * @param WC_Order $order The order the nonce is scoped to.
+	 * @return string The order-scoped nonce action.
+	 */
+	public function get_update_order_status_nonce_action( $order ) {
+		return 'wcpay_update_order_status_nonce_' . $order->get_id() . '_' . $order->get_order_key();
+	}
+
+	/**
 	 * Handle AJAX request after authenticating payment at checkout.
 	 *
 	 * This function is used to update the order status after the user has
@@ -4055,23 +4069,23 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * @throws Exception - If nonce is invalid.
 	 */
 	public function update_order_status() {
-		$intent_id_received = null;
-		$order              = null;
 		try {
-			$is_nonce_valid = check_ajax_referer( 'wcpay_update_order_status_nonce', false, false );
-			if ( ! $is_nonce_valid ) {
-				throw new Process_Payment_Exception(
-					__( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-payments' ),
-					'invalid_referrer'
-				);
-			}
-
-			$order_id = isset( $_POST['order_id'] ) ? absint( $_POST['order_id'] ) : false;
+			$order_id = isset( $_POST['order_id'] ) ? absint( $_POST['order_id'] ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$order    = wc_get_order( $order_id );
 			if ( ! $order ) {
 				throw new Process_Payment_Exception(
 					__( "We're not able to process this payment. Please try again later.", 'woocommerce-payments' ),
 					'order_not_found'
+				);
+			}
+
+			// Resolve the order first so the nonce can be checked against its order-scoped action.
+			// wc_get_order() is a read; the order is not modified until every check below passes.
+			$is_nonce_valid = check_ajax_referer( $this->get_update_order_status_nonce_action( $order ), false, false );
+			if ( ! $is_nonce_valid ) {
+				throw new Process_Payment_Exception(
+					__( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-payments' ),
+					'invalid_referrer'
 				);
 			}
 
@@ -4259,24 +4273,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 				wp_die();
 			}
 		} catch ( Intent_Authentication_Exception $e ) {
-			$error_code = $e->get_error_code();
-
-			switch ( $error_code ) {
-				case 'intent_id_mismatch':
-				case 'empty_intent_id': // The empty_intent_id case needs the same handling.
-					$note = sprintf(
-						WC_Payments_Utils::esc_interpolated_html(
-							/* translators: %1: transaction ID of the payment or a translated string indicating an unknown ID. */
-							__( 'A payment with ID <code>%1$s</code> was used in an attempt to pay for this order. This payment intent ID does not match any payments for this order, so it was ignored and the order was not updated.', 'woocommerce-payments' ),
-							[
-								'code' => '<code>',
-							]
-						),
-						$intent_id_received
-					);
-					$order->add_order_note( $note );
-					break;
-			}
+			// An empty or mismatched intent id is an untrusted-input path: the submitted intent
+			// doesn't match the one stored on the order, so the order is left unchanged and only
+			// the error is returned to the caller.
 
 			// Send back error so it can be displayed to the customer.
 			echo wp_json_encode(

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-process-payment.php
@@ -1062,7 +1062,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
 		$this->assertEquals(
-			'#wcpay-confirm-pi:' . $order_id . ':' . $secret . ':' . wp_create_nonce( 'wcpay_update_order_status_nonce' ),
+			'#wcpay-confirm-pi:' . $order_id . ':' . $secret . ':' . wp_create_nonce( $this->mock_wcpay_gateway->get_update_order_status_nonce_action( $mock_order ) ),
 			$result['redirect']
 		);
 	}
@@ -1293,7 +1293,7 @@ class WC_Payment_Gateway_WCPay_Process_Payment_Test extends WCPAY_UnitTestCase {
 		// Assert: Returning correct array.
 		$this->assertEquals( 'success', $result['result'] );
 		$this->assertEquals(
-			'#wcpay-confirm-si:' . $order_id . ':' . $secret . ':' . wp_create_nonce( 'wcpay_update_order_status_nonce' ),
+			'#wcpay-confirm-si:' . $order_id . ':' . $secret . ':' . wp_create_nonce( $this->mock_wcpay_gateway->get_update_order_status_nonce_action( $mock_order ) ),
 			$result['redirect']
 		);
 	}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -5292,7 +5292,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$intent_id = 'seti_mock_pm_change';
 		$this->order_service->set_intent_id_for_order( $order, $intent_id );
 
-		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order ) );
 		$_POST                = [
 			'action'              => 'update_order_status',
 			'order_id'            => $order->get_id(),
@@ -5347,7 +5347,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$intent_id = 'pi_mock_3ds_renewal';
 		$this->order_service->set_intent_id_for_order( $order, $intent_id );
 
-		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order ) );
 		$_POST                = [
 			'action'                     => 'update_order_status',
 			'order_id'                   => $order->get_id(),
@@ -5409,7 +5409,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$intent_id = 'pi_mock_3ds_renewal_meta';
 		$this->order_service->set_intent_id_for_order( $order, $intent_id );
 
-		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order ) );
 		$_POST                = [
 			'action'                     => 'update_order_status',
 			'order_id'                   => $order->get_id(),
@@ -5474,7 +5474,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$intent_id = 'pi_mock_3ds_renewal_email';
 		$this->order_service->set_intent_id_for_order( $order, $intent_id );
 
-		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order ) );
 		$_POST                = [
 			'action'                     => 'update_order_status',
 			'order_id'                   => $order->get_id(),
@@ -5551,7 +5551,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$intent_id = 'pi_mock_3ds_no_save';
 		$this->order_service->set_intent_id_for_order( $order, $intent_id );
 
-		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order ) );
 		$_POST                = [
 			'action'                     => 'update_order_status',
 			'order_id'                   => $order->get_id(),
@@ -5639,7 +5639,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$intent_id = 'seti_mock_free_trial';
 		$this->order_service->set_intent_id_for_order( $order, $intent_id );
 
-		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order ) );
 		$_POST                = [
 			'action'                     => 'update_order_status',
 			'order_id'                   => $order->get_id(),
@@ -5715,7 +5715,7 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$intent_id = 'seti_mock_link_free_trial';
 		$this->order_service->set_intent_id_for_order( $order, $intent_id );
 
-		$nonce                = wp_create_nonce( 'wcpay_update_order_status_nonce' );
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order ) );
 		$_POST                = [
 			'action'                     => 'update_order_status',
 			'order_id'                   => $order->get_id(),
@@ -5756,6 +5756,74 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertNotSame( 'Visa credit card', $saved->get_payment_method_title(), 'A Link payment must not be titled as a branded card.' );
 	}
 
+	public function test_update_order_status_rejects_nonce_minted_for_another_order() {
+		$order_a = WC_Helper_Order::create_order();
+		$order_b = WC_Helper_Order::create_order();
+
+		$intent_id = 'pi_mock_cross_order';
+		$this->order_service->set_intent_id_for_order( $order_b, $intent_id );
+
+		// The nonce is scoped to order A, but the request submits order B's id.
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order_a ) );
+		$_POST                = [
+			'action'    => 'update_order_status',
+			'order_id'  => $order_b->get_id(),
+			'intent_id' => $intent_id,
+			'_wpnonce'  => $nonce,
+		];
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+
+		try {
+			ob_start();
+			$this->card_gateway->update_order_status();
+			$output = ob_get_clean();
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+		}
+
+		$response = json_decode( $output, true );
+
+		$this->assertArrayHasKey( 'error', $response );
+
+		$this->assertCount( 0, $this->get_payment_attempt_notes( $order_b->get_id() ) );
+	}
+
+	public function test_update_order_status_adds_no_note_on_intent_mismatch() {
+		$order = WC_Helper_Order::create_order();
+		$this->order_service->set_intent_id_for_order( $order, 'pi_mock_stored' );
+
+		$nonce                = wp_create_nonce( $this->card_gateway->get_update_order_status_nonce_action( $order ) );
+		$_POST                = [
+			'action'    => 'update_order_status',
+			'order_id'  => $order->get_id(),
+			'intent_id' => 'pi_mock_submitted',
+			'_wpnonce'  => $nonce,
+		];
+		$_REQUEST['_wpnonce'] = $nonce;
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+
+		try {
+			ob_start();
+			$this->card_gateway->update_order_status();
+			$output = ob_get_clean();
+		} finally {
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', [ $this, 'return_ajax_wp_die_handler' ] );
+		}
+
+		$response = json_decode( $output, true );
+
+		$this->assertArrayHasKey( 'error', $response );
+
+		$this->assertCount( 0, $this->get_payment_attempt_notes( $order->get_id() ) );
+	}
+
 	public function return_ajax_wp_die_handler() {
 		return [ $this, 'ajax_wp_die_handler' ];
 	}
@@ -5771,5 +5839,16 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$product->save();
 
 		return wc_get_product( $product->get_id() );
+	}
+
+	private function get_payment_attempt_notes( int $order_id ): array {
+		$notes = wc_get_order_notes( [ 'order_id' => $order_id ] );
+
+		return array_filter(
+			$notes,
+			static function ( $note ) {
+				return false !== strpos( $note->content, 'was used in an attempt to pay for this order' );
+			}
+		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Mirrors a change from the WooCommerce Stripe Gateway that tightens input validation on the `update_order_status` AJAX endpoint. Today it uses a single shared nonce that isn't tied to any particular order, and on the intent-mismatch branch it writes an order note straight from the request before the request is validated.

Two changes:
- Bind the nonce to the specific order (folding in the order id + order key), so a nonce minted for one order can't be reused against another. All three touch-points — both mint sites in the redirect / Express Checkout flow and the verify site — build the same action string, and the frontend just relays the server-minted value, so the legitimate order-received flow is unchanged.
- Resolve the order first and stop writing an order note on the unvalidated mismatch branch, so the endpoint doesn't modify an order before the nonce checks out.

#### Testing instructions

1. Run a normal card payment that goes through 3DS / the redirect confirmation and confirm the order completes as before.
2. Run a normal Express Checkout (Apple Pay / Google Pay) payment and confirm it completes.
3. Confirm order notes and status transitions look the same as before on the happy path.

*
