### PR TITLE
fix: bump QIT CLI in E2E CI to 1.3.0

### DIFF
--- a/.github/workflows/qit-e2e-run.yml
+++ b/.github/workflows/qit-e2e-run.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install QIT CLI
         # Pin to a stable release to avoid regressions from dev-trunk.
         # Test packages feature is available since 1.1.0.
-        run: composer global require woocommerce/qit-cli:1.1.8
+        run: composer global require woocommerce/qit-cli:1.3.0
 
       - name: Authenticate QIT
         run: qit partner:add --user='${{ secrets.QIT_CI_USER }}' --application_password='${{ secrets.QIT_CI_SECRET }}'

--- a/changelog/fix-bump-qit-cli-to-1-3-0
+++ b/changelog/fix-bump-qit-cli-to-1-3-0
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Bump QIT CLI in E2E CI to 1.3.0.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Our pre-release QIT E2E runs against WooCommerce `11.0.0-dev` were dying at env setup with a misleading `invalid zip` error. The pinned qit-cli (`1.1.8`) mis-reported failed downloads and reused stale-cached `-dev` builds; `1.3.0` fixes both. Bumping the pin.

#### Testing instructions

* Confirm the QIT E2E workflows run/execute fine with the bumped CLI: [pre-release run](https://github.com/Automattic/woocommerce-payments/actions/runs/28928825485).
* The QIT E2E Tests - Pull Request checks on this PR run fine

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️): CI-only config change, no code paths to test.
- [x] Tested on mobile (or does not apply): does not apply.
