### PR TITLE
tweak: add a Multi-Currency filter to opt shipping costs out of conversion

### DIFF
--- a/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
+++ b/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show all disputes on a transaction that has more than one, instead of only the first

--- a/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
+++ b/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Show all disputes on a transaction that has more than one, instead of only the first

--- a/changelog/tweak-add-mccy-filter-on-shipping-prices
+++ b/changelog/tweak-add-mccy-filter-on-shipping-prices
@@ -1,0 +1,4 @@
+Sub Significance: patch
+Type: dev
+
+tweak: added a `should_convert_shipping_amount` filter to MCCY

--- a/changelog/tweak-add-mccy-filter-on-shipping-prices
+++ b/changelog/tweak-add-mccy-filter-on-shipping-prices
@@ -1,4 +1,4 @@
-Sub Significance: patch
+Significance: patch
 Type: dev
 
 tweak: added a `should_convert_shipping_amount` filter to MCCY

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -209,7 +209,7 @@ class Compatibility extends BaseCompatibility {
 		 * Some shipping methods (such as live-rate plugins) return costs that are already
 		 * converted to the customer's currency. Converting again would double-convert the cost.
 		 *
-		 * @since 10.9.0
+		 * @since 10.10.0
 		 *
 		 * @param bool   $convert         Whether the shipping cost should be converted. Default true.
 		 * @param object $shipping_method The shipping method object adding the rate.

--- a/includes/multi-currency/Compatibility.php
+++ b/includes/multi-currency/Compatibility.php
@@ -192,6 +192,32 @@ class Compatibility extends BaseCompatibility {
 	}
 
 	/**
+	 * Checks to see if the shipping cost should be converted.
+	 *
+	 * @param object $shipping_method Shipping method object to test.
+	 *
+	 * @return bool True if it should be converted.
+	 */
+	public function should_convert_shipping_amount( $shipping_method = null ): bool {
+		if ( ! $shipping_method ) {
+			return true;
+		}
+
+		/**
+		 * Filters whether a shipping rate's cost should be converted to the selected currency.
+		 *
+		 * Some shipping methods (such as live-rate plugins) return costs that are already
+		 * converted to the customer's currency. Converting again would double-convert the cost.
+		 *
+		 * @since 10.9.0
+		 *
+		 * @param bool   $convert         Whether the shipping cost should be converted. Default true.
+		 * @param object $shipping_method The shipping method object adding the rate.
+		 */
+		return apply_filters( MultiCurrency::FILTER_PREFIX . 'should_convert_shipping_amount', true, $shipping_method );
+	}
+
+	/**
 	 * Determines if the store currency should be returned or not.
 	 *
 	 * @return bool

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -66,7 +66,7 @@ class FrontendPrices {
 
 		// Shipping methods hooks.
 		add_filter( 'woocommerce_shipping_zone_shipping_methods', [ $this, 'convert_free_shipping_method_min_amount' ], 99 );
-		add_filter( 'woocommerce_shipping_method_add_rate_args', [ $this, 'convert_shipping_method_rate_cost' ], 99 );
+		add_filter( 'woocommerce_shipping_method_add_rate_args', [ $this, 'convert_shipping_method_rate_cost' ], 99, 2 );
 
 		// Coupon hooks.
 		add_filter( 'woocommerce_coupon_get_amount', [ $this, 'get_coupon_amount' ], 99, 2 );
@@ -272,12 +272,13 @@ class FrontendPrices {
 	/**
 	 * Returns the shipping add rate args with cost converted.
 	 *
-	 * @param array $args Shipping rate args.
+	 * @param array $args   Shipping rate args.
+	 * @param mixed $method The shipping method object adding the rate.
 	 *
 	 * @return array Shipping rate args with converted cost.
 	 */
-	public function convert_shipping_method_rate_cost( $args ) {
-		if ( isset( $args['cost'] ) ) {
+	public function convert_shipping_method_rate_cost( $args, $method = null ) {
+		if ( isset( $args['cost'] ) && $this->compatibility->should_convert_shipping_amount( $method ) ) {
 			/**
 			 * We need to keep the `cost` structure intact when applying
 			 * multi-currency conversions, because downstream it is important

--- a/includes/multi-currency/FrontendPrices.php
+++ b/includes/multi-currency/FrontendPrices.php
@@ -8,6 +8,7 @@
 namespace WCPay\MultiCurrency;
 
 use WC_Order;
+use WC_Shipping_Method;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -272,12 +273,12 @@ class FrontendPrices {
 	/**
 	 * Returns the shipping add rate args with cost converted.
 	 *
-	 * @param array $args   Shipping rate args.
-	 * @param mixed $method The shipping method object adding the rate.
+	 * @param array              $args   Shipping rate args.
+	 * @param WC_Shipping_Method $method The shipping method adding the rate.
 	 *
 	 * @return array Shipping rate args with converted cost.
 	 */
-	public function convert_shipping_method_rate_cost( $args, $method = null ) {
+	public function convert_shipping_method_rate_cost( $args, $method ) {
 		if ( isset( $args['cost'] ) && $this->compatibility->should_convert_shipping_amount( $method ) ) {
 			/**
 			 * We need to keep the `cost` structure intact when applying

--- a/tests/unit/multi-currency/test-class-compatibility.php
+++ b/tests/unit/multi-currency/test-class-compatibility.php
@@ -86,6 +86,10 @@ class WCPay_Multi_Currency_Compatibility_Tests extends WCPAY_UnitTestCase {
 		$this->assertTrue( $this->compatibility->should_convert_product_price( null ) );
 	}
 
+	public function test_should_convert_shipping_amount_return_true_on_null_method() {
+		$this->assertTrue( $this->compatibility->should_convert_shipping_amount( null ) );
+	}
+
 	public function test_filter_woocommerce_order_query_with_call_not_in_backtrace() {
 		$order = wc_create_order();
 		$order->set_total( 1000 );

--- a/tests/unit/multi-currency/test-class-frontend-prices.php
+++ b/tests/unit/multi-currency/test-class-frontend-prices.php
@@ -210,6 +210,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_convert_shipping_method_rate_cost_for_string_cost() {
+		$this->mock_compatibility->method( 'should_convert_shipping_amount' )->willReturn( true );
 		$this->mock_multi_currency
 			->expects( $this->once() )
 			->method( 'get_price' )
@@ -254,6 +255,7 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 	}
 
 	public function test_convert_shipping_method_rate_cost_for_array_cost() {
+		$this->mock_compatibility->method( 'should_convert_shipping_amount' )->willReturn( true );
 		$matcher = $this->exactly( 2 );
 		$this->mock_multi_currency
 			->expects( $matcher )
@@ -307,6 +309,19 @@ class WCPay_Multi_Currency_Frontend_Prices_Tests extends WCPAY_UnitTestCase {
 		// Cost gets converted and taxes properly calculated based on it.
 		$this->assertSame( '11.00', $shipping_rate->cost );
 		$this->assertSame( 1.1, $shipping_rate->taxes[1] );
+	}
+
+	public function test_convert_shipping_method_rate_cost_skips_conversion_on_compatibility() {
+		$shipping_method = new \WC_Shipping_Flat_Rate();
+		$this->mock_compatibility
+			->method( 'should_convert_shipping_amount' )
+			->with( $shipping_method )
+			->willReturn( false );
+		$this->mock_multi_currency->expects( $this->never() )->method( 'get_price' );
+
+		$args = $this->frontend_prices->convert_shipping_method_rate_cost( [ 'cost' => '10' ], $shipping_method );
+
+		$this->assertSame( '10', $args['cost'] );
 	}
 
 	public function test_get_coupon_amount_returns_empty_amount() {


### PR DESCRIPTION
Fixes #11932
[WOOPMNT-6276](https://linear.app/a8c/issue/WOOPMNT-6276)

#### Changes proposed in this Pull Request

Adding a `wcpay_multi_currency_should_convert_shipping_amount` filter to MCCY.

By default nothing changes. But shipping methods that already return a currency-converted cost (e.g. live-rate plugins like Gelato) can now opt out, avoiding the double conversion reported in the linked issue.

#### Testing instructions

> [!IMPORTANT]
> Please note: you'll need to enable "Debug mode" while testing this, otherwise shipping calculations will be cached. Go to WooCommerce > Settings > Shipping > Shipping settings 

<img width="904" height="111" alt="Screenshot 2026-07-08 at 3 55 21 PM" src="https://github.com/user-attachments/assets/e612013e-739d-4bc4-8b72-4bfb81db5db6" />

1. Enable WooPayments Multi-Currency with at least one currency besides the store base currency.
2. Add a product to the cart and view shipping at checkout in the non-base currency, confirm the shipping cost is converted
3. Add the following snippet, you can use the [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/) plugin:
   ```php
   add_filter( 'wcpay_multi_currency_should_convert_shipping_amount', '__return_false' );
   ```
4. Reload checkout in the non-base currency and confirm the shipping cost is no longer converted

Store with USD base currency:
<img width="471" height="588" alt="Screenshot 2026-07-08 at 3 51 03 PM" src="https://github.com/user-attachments/assets/90945e31-ddac-4c0d-9750-40e7c2cf9a5f" />

With PLN conversion:
<img width="460" height="574" alt="Screenshot 2026-07-08 at 3 51 25 PM" src="https://github.com/user-attachments/assets/42e9d4a6-cfa2-4f2b-a05f-641f144e5fc0" />

With PLN conversion & filter applied:
<img width="489" height="584" alt="Screenshot 2026-07-08 at 3 53 34 PM" src="https://github.com/user-attachments/assets/fa88b885-bada-4677-ac1f-fedfa28b6dce" />


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
