### PR TITLE
dev: guard changelog.txt and readme.txt drift between trunk and develop

### DIFF
--- a/.github/actions/compare-release-files/action.yml
+++ b/.github/actions/compare-release-files/action.yml
@@ -1,0 +1,102 @@
+name: "Compare release files between trunk and develop"
+description: "Diffs changelog.txt and readme.txt between trunk and develop. Posts a Step Summary and sends a Slack notification when drift is detected."
+
+inputs:
+  slack-webhook:
+    description: "Slack incoming-webhook URL. When empty, the Slack step is skipped."
+    required: false
+    default: ""
+
+outputs:
+  has-drift:
+    description: "'true' if changelog.txt or readme.txt differ between trunk and develop."
+    value: ${{ steps.compare.outputs.has-drift }}
+
+runs:
+  using: composite
+  steps:
+    - name: "Checkout trunk"
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        ref: trunk
+        path: _trunk
+        fetch-depth: 1
+
+    - name: "Checkout develop"
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        ref: develop
+        path: _develop
+        fetch-depth: 1
+
+    - name: "Diff release files"
+      id: compare
+      shell: bash
+      run: |
+        set -euo pipefail
+        HAS_DRIFT=false
+        SUMMARY=""
+
+        for FILE in changelog.txt readme.txt; do
+          DIFF=$(diff "_trunk/$FILE" "_develop/$FILE" || true)
+          if [ -n "$DIFF" ]; then
+            HAS_DRIFT=true
+            SUMMARY+="### \`$FILE\`"$'\n'
+            SUMMARY+="\`\`\`diff"$'\n'
+            SUMMARY+="$DIFF"$'\n'
+            SUMMARY+="\`\`\`"$'\n\n'
+          fi
+        done
+
+        echo "has-drift=$HAS_DRIFT" >> "$GITHUB_OUTPUT"
+
+        if [ "$HAS_DRIFT" = "true" ]; then
+          {
+            echo "## :warning: Release file drift detected between \`trunk\` and \`develop\`"
+            echo ""
+            printf '%s' "$SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo ":white_check_mark: \`changelog.txt\` and \`readme.txt\` are in sync between \`trunk\` and \`develop\`." >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: "Slack notification"
+      if: ${{ steps.compare.outputs.has-drift == 'true' && inputs.slack-webhook != '' }}
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+      with:
+        webhook: ${{ inputs.slack-webhook }}
+        webhook-type: incoming-webhook
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":warning: Release file drift: trunk vs develop",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "`changelog.txt` or `readme.txt` differ between `trunk` and `develop`. The release lead should review and manually sync them."
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  { "type": "mrkdwn", "text": "*Repository:*\n${{ github.repository }}" },
+                  { "type": "mrkdwn", "text": "*Triggered by:*\n${{ github.workflow }}" }
+                ]
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View diff in Step Summary> | <https://github.com/${{ github.repository }}/compare/develop...trunk|Compare branches>"
+                }
+              }
+            ]
+          }

--- a/.github/actions/compare-release-files/action.yml
+++ b/.github/actions/compare-release-files/action.yml
@@ -3,9 +3,8 @@ description: "Diffs changelog.txt and readme.txt between trunk and develop. Post
 
 inputs:
   slack-webhook:
-    description: "Slack incoming-webhook URL. When empty, the Slack step is skipped."
-    required: false
-    default: ""
+    description: "Slack incoming-webhook URL."
+    required: true
 
 outputs:
   has-drift:
@@ -61,7 +60,7 @@ runs:
         fi
 
     - name: "Slack notification"
-      if: ${{ steps.compare.outputs.has-drift == 'true' && inputs.slack-webhook != '' }}
+      if: ${{ steps.compare.outputs.has-drift == 'true' }}
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       with:
         webhook: ${{ inputs.slack-webhook }}

--- a/.github/actions/compare-release-files/action.yml
+++ b/.github/actions/compare-release-files/action.yml
@@ -14,19 +14,9 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: "Checkout trunk"
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        ref: trunk
-        path: _trunk
-        fetch-depth: 1
-
-    - name: "Checkout develop"
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        ref: develop
-        path: _develop
-        fetch-depth: 1
+    - name: "Fetch trunk and develop"
+      shell: bash
+      run: git fetch origin trunk develop
 
     - name: "Diff release files"
       id: compare
@@ -37,7 +27,7 @@ runs:
         SUMMARY=""
 
         for FILE in changelog.txt readme.txt; do
-          DIFF=$(diff "_trunk/$FILE" "_develop/$FILE" || true)
+          DIFF=$(git diff origin/trunk origin/develop -- "$FILE" || true)
           if [ -n "$DIFF" ]; then
             HAS_DRIFT=true
             SUMMARY+="### \`$FILE\`"$'\n'

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -208,7 +208,7 @@ jobs:
       - name: "Compare release files"
         uses: ./.github/actions/compare-release-files
         with:
-          slack-webhook: ${{ secrets.RELEASE_FILES_DRIFT_SLACK_WEBHOOK_URL }}
+          slack-webhook: ${{ secrets.CODE_FREEZE_SLACK_WEBHOOK_URL }}
 
   update-wiki:
     name: "Update the wiki for the next release"

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -194,6 +194,22 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Cleanup summary for \`$RELEASE_VERSION\`: $DELETED deleted, $SKIPPED skipped." >> $GITHUB_STEP_SUMMARY
 
+  compare-release-files:
+    name: "Check changelog.txt and readme.txt drift between trunk and develop"
+    needs: get-last-released-version
+    runs-on: ubuntu-latest
+    # Never let a drift alert block the rest of the release.
+    continue-on-error: true
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: "Compare release files"
+        uses: ./.github/actions/compare-release-files
+        with:
+          slack-webhook: ${{ secrets.RELEASE_FILES_DRIFT_SLACK_WEBHOOK_URL }}
+
   update-wiki:
     name: "Update the wiki for the next release"
     needs: get-last-released-version

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -78,33 +78,6 @@ jobs:
             gh release create "$RELEASE_VERSION" --notes "$RELEASE_NOTES" --title "$TAG_MESSAGE" "$FILENAME"
           fi
 
-  merge-trunk-into-develop:
-    name: "Merge trunk back into develop"
-    needs: get-last-released-version
-    runs-on: ubuntu-latest
-    env:
-      RELEASE_VERSION: ${{ needs.get-last-released-version.outputs.releaseVersion }}
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: 'trunk'
-          fetch-depth: 0
-          token: ${{ SECRETS.BOTWOO_TOKEN }}
-
-      - name: "Merge trunk back into develop"
-        run: |
-          git config user.name "botwoo"
-          git config user.email "botwoo@users.noreply.github.com"
-          git checkout develop && git pull
-          if git merge-base --is-ancestor trunk develop; then
-            echo ":information_source: develop already contains trunk v$RELEASE_VERSION; skipping merge." >> $GITHUB_STEP_SUMMARY
-          else
-            git merge trunk --no-ff -m "Merge trunk v$RELEASE_VERSION into develop"
-            git push
-          fi
-
   trigger-translations:
     name: "Trigger translations update for the release"
     needs: [ get-last-released-version, create-gh-release ]

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -167,22 +167,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Cleanup summary for \`$RELEASE_VERSION\`: $DELETED deleted, $SKIPPED skipped." >> $GITHUB_STEP_SUMMARY
 
-  compare-release-files:
-    name: "Check changelog.txt and readme.txt drift between trunk and develop"
-    needs: get-last-released-version
-    runs-on: ubuntu-latest
-    # Never let a drift alert block the rest of the release.
-    continue-on-error: true
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: "Compare release files"
-        uses: ./.github/actions/compare-release-files
-        with:
-          slack-webhook: ${{ secrets.CODE_FREEZE_SLACK_WEBHOOK_URL }}
-
   update-wiki:
     name: "Update the wiki for the next release"
     needs: get-last-released-version
@@ -246,3 +230,19 @@ jobs:
             echo ":information_source: No changes to push." >> $GITHUB_STEP_SUMMARY
             exit 0 # Exit with success anyway
           fi
+
+  compare-release-files:
+    name: "Check changelog.txt and readme.txt drift between trunk and develop"
+    needs: [ create-gh-release, trigger-translations, cleanup-testing-branches, update-wiki ]
+    runs-on: ubuntu-latest
+    # Run even if earlier jobs failed so drift is always checked after a release attempt.
+    if: always()
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: "Compare release files"
+        uses: ./.github/actions/compare-release-files
+        with:
+          slack-webhook: ${{ secrets.CODE_FREEZE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release-files-drift-check.yml
+++ b/.github/workflows/release-files-drift-check.yml
@@ -1,0 +1,28 @@
+name: "Weekly release file drift check"
+
+# Runs every Monday at 09:00 UTC as a safety net to catch any
+# changelog.txt / readme.txt drift between trunk and develop that
+# wasn't caught by the post-release-updates workflow.
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  compare-release-files:
+    name: "Compare changelog.txt and readme.txt between trunk and develop"
+    # Only the upstream repo carries the webhook secret; skip on forks.
+    if: github.repository == 'Automattic/woocommerce-payments'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: "Compare release files"
+        uses: ./.github/actions/compare-release-files
+        with:
+          slack-webhook: ${{ secrets.RELEASE_FILES_DRIFT_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release-files-drift-check.yml
+++ b/.github/workflows/release-files-drift-check.yml
@@ -25,4 +25,4 @@ jobs:
       - name: "Compare release files"
         uses: ./.github/actions/compare-release-files
         with:
-          slack-webhook: ${{ secrets.RELEASE_FILES_DRIFT_SLACK_WEBHOOK_URL }}
+          slack-webhook: ${{ secrets.CODE_FREEZE_SLACK_WEBHOOK_URL }}

--- a/changelog/woopmnt-6282-guard-compare-changelogtxt-and-readmetxt-between-trunk-and
+++ b/changelog/woopmnt-6282-guard-compare-changelogtxt-and-readmetxt-between-trunk-and
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Guard: compare changelog.txt and readme.txt between trunk and develop after each release
+Remove trunk→develop auto-merge from post-release workflow; add a composite action and weekly scheduled job to detect changelog.txt and readme.txt drift between trunk and develop.

--- a/changelog/woopmnt-6282-guard-compare-changelogtxt-and-readmetxt-between-trunk-and
+++ b/changelog/woopmnt-6282-guard-compare-changelogtxt-and-readmetxt-between-trunk-and
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Guard: compare changelog.txt and readme.txt between trunk and develop after each release


### PR DESCRIPTION
Fixes WOOPMNT-6282

#### Changes proposed in this Pull Request

As part of the branch protection / release flow changes, the `trunk → develop` auto-merge is being removed from the post-release workflow. Without it, `changelog.txt` and `readme.txt` can silently drift between the two branches over time.

This PR:
- **Removes** the `merge-trunk-into-develop` job from `post-release-updates.yml`
- **Adds** a reusable composite action (`.github/actions/compare-release-files`) that fetches both branches and diffs the two files via `git diff origin/trunk origin/develop`
- **Adds** a `compare-release-files` job to `post-release-updates.yml` that runs last (after all other jobs) and notifies via Slack if drift is detected
- **Adds** a new weekly scheduled workflow (`release-files-drift-check.yml`) that runs every Monday at 09:00 UTC as a safety net, using the same composite action

The Slack notification fires only when drift is found; both callers share a single checkout + `git fetch` rather than spinning up separate worktrees per branch.

#### Testing instructions

This is a bit tricky to test for now, but we can test it after the merge.

1. Trigger `release-files-drift-check` via `workflow_dispatch` and confirm green checkmark in the Step Summary.
2. Create a new PR to make change to a difference between `trunk` and `develop` in `changelog.txt` or `readme.txt`
3. Verify the drift path: temporarily introduce a difference between `trunk` and `develop` in `changelog.txt`, re-run — confirm the diff appears in Step Summary and a Slack message is sent to the `CODE_FREEZE_SLACK_WEBHOOK_URL` channel.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — CI workflow changes, no unit tests applicable
- [x] Tested on mobile (or does not apply) — does not apply

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.