### PR TITLE
dev: guard version drift of woocommerce-payments.php, package.json, and package-lock.json between trunk and develop

### DIFF
--- a/.github/actions/compare-release-files/action.yml
+++ b/.github/actions/compare-release-files/action.yml
@@ -1,5 +1,5 @@
 name: "Compare release files between trunk and develop"
-description: "Diffs changelog.txt and readme.txt between trunk and develop. Posts a Step Summary and sends a Slack notification when drift is detected."
+description: "Checks changelog.txt, readme.txt, and version fields (woocommerce-payments.php, package.json, package-lock.json) between trunk and develop. Posts a Step Summary and sends a Slack notification when drift is detected."
 
 inputs:
   slack-webhook:
@@ -8,7 +8,7 @@ inputs:
 
 outputs:
   has-drift:
-    description: "'true' if changelog.txt or readme.txt differ between trunk and develop."
+    description: "'true' if changelog.txt, readme.txt, or version fields differ between trunk and develop."
     value: ${{ steps.compare.outputs.has-drift }}
 
 runs:
@@ -37,6 +37,47 @@ runs:
           fi
         done
 
+        # Check version fields between trunk and develop.
+        # Extract the plugin header version from woocommerce-payments.php.
+        PHP_TRUNK=$(git show origin/trunk:woocommerce-payments.php \
+          | grep -E '^\s*\*\s*Version:' | head -n1 \
+          | sed -E 's/^[[:space:]]*\*[[:space:]]*Version:[[:space:]]*//')
+        PHP_DEV=$(git show origin/develop:woocommerce-payments.php \
+          | grep -E '^\s*\*\s*Version:' | head -n1 \
+          | sed -E 's/^[[:space:]]*\*[[:space:]]*Version:[[:space:]]*//')
+        if [ "$PHP_TRUNK" != "$PHP_DEV" ]; then
+          HAS_DRIFT=true
+          SUMMARY+="### \`woocommerce-payments.php\` (plugin header version)"$'\n'
+          SUMMARY+="- trunk: \`$PHP_TRUNK\`"$'\n'
+          SUMMARY+="- develop: \`$PHP_DEV\`"$'\n\n'
+        fi
+
+        # Check package.json version.
+        PKG_TRUNK=$(git show origin/trunk:package.json | jq -r .version)
+        PKG_DEV=$(git show origin/develop:package.json | jq -r .version)
+        if [ "$PKG_TRUNK" != "$PKG_DEV" ]; then
+          HAS_DRIFT=true
+          SUMMARY+="### \`package.json\` (version)"$'\n'
+          SUMMARY+="- trunk: \`$PKG_TRUNK\`"$'\n'
+          SUMMARY+="- develop: \`$PKG_DEV\`"$'\n\n'
+        fi
+
+        # Check package-lock.json — both the top-level .version field and the
+        # .packages[""].version entry (both are written by npm and bump-version.sh).
+        # Check each independently so a partial-update is also caught.
+        for LOCK_FIELD in '.version' '.packages[""].version'; do
+          LOCK_TRUNK=$(git show origin/trunk:package-lock.json 2>/dev/null \
+            | jq -r "$LOCK_FIELD // \"\"" || true)
+          LOCK_DEV=$(git show origin/develop:package-lock.json 2>/dev/null \
+            | jq -r "$LOCK_FIELD // \"\"" || true)
+          if [ -n "$LOCK_TRUNK" ] && [ -n "$LOCK_DEV" ] && [ "$LOCK_TRUNK" != "$LOCK_DEV" ]; then
+            HAS_DRIFT=true
+            SUMMARY+="### \`package-lock.json\` (\`$LOCK_FIELD\`)"$'\n'
+            SUMMARY+="- trunk: \`$LOCK_TRUNK\`"$'\n'
+            SUMMARY+="- develop: \`$LOCK_DEV\`"$'\n\n'
+          fi
+        done
+
         echo "has-drift=$HAS_DRIFT" >> "$GITHUB_OUTPUT"
 
         if [ "$HAS_DRIFT" = "true" ]; then
@@ -46,7 +87,7 @@ runs:
             printf '%s' "$SUMMARY"
           } >> "$GITHUB_STEP_SUMMARY"
         else
-          echo ":white_check_mark: \`changelog.txt\` and \`readme.txt\` are in sync between \`trunk\` and \`develop\`." >> "$GITHUB_STEP_SUMMARY"
+          echo ":white_check_mark: \`changelog.txt\`, \`readme.txt\`, and version fields are in sync between \`trunk\` and \`develop\`." >> "$GITHUB_STEP_SUMMARY"
         fi
 
     - name: "Slack notification"
@@ -70,7 +111,7 @@ runs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "`changelog.txt` or `readme.txt` differ between `trunk` and `develop`. The release lead should review and manually sync them."
+                  "text": "`changelog.txt`, `readme.txt`, or version fields (`woocommerce-payments.php`, `package.json`, `package-lock.json`) differ between `trunk` and `develop`. The release lead should review and manually sync them."
                 }
               },
               {

--- a/.github/workflows/post-release-updates.yml
+++ b/.github/workflows/post-release-updates.yml
@@ -232,7 +232,7 @@ jobs:
           fi
 
   compare-release-files:
-    name: "Check changelog.txt and readme.txt drift between trunk and develop"
+    name: "Check release files and version fields drift between trunk and develop"
     needs: [ create-gh-release, trigger-translations, cleanup-testing-branches, update-wiki ]
     runs-on: ubuntu-latest
     # Run even if earlier jobs failed so drift is always checked after a release attempt.

--- a/.github/workflows/release-files-drift-check.yml
+++ b/.github/workflows/release-files-drift-check.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   compare-release-files:
-    name: "Compare changelog.txt and readme.txt between trunk and develop"
+    name: "Compare release files and version fields between trunk and develop"
     # Only the upstream repo carries the webhook secret; skip on forks.
     if: github.repository == 'Automattic/woocommerce-payments'
     runs-on: ubuntu-latest

--- a/changelog/feat-version-drift-check-trunk-develop
+++ b/changelog/feat-version-drift-check-trunk-develop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Guard version drift of woocommerce-payments.php, package.json, and package-lock.json between trunk and develop


### PR DESCRIPTION
Fixes: WOOPMNT-6286

#### Changes proposed in this Pull Request

Extends the `compare-release-files` action to also detect version drift between `trunk` and `develop` for three additional files, on top of the existing `changelog.txt` / `readme.txt` checks added in #11944.

The new checks extract and compare the version value (not the full file diff) from:
- `woocommerce-payments.php` — `* Version:` plugin header
- `package.json` — `.version` field
- `package-lock.json` — both `.version` and `.packages[""].version` fields (checked independently so a partial-update is caught)

When any mismatch is found, the existing Step Summary and Slack notification are triggered.

#### Testing instructions

1. Trigger the **Weekly release file drift check** workflow manually (`workflow_dispatch`) with this branch `feat/version-drift-check-trunk-develop` branches in sync
    - Expect a green check mark reporting all files in sync with. 
    - ✅ Did it: https://github.com/Automattic/woocommerce-payments/actions/runs/29305518956 
3. Trigger the **Weekly release file drift check** workflow manually** for `feat/version-drift-check-trunk-develop___testing` that I added some drifts and modify the hard-coded `develop` - [diff ref between these two branches](https://github.com/Automattic/woocommerce-payments/compare/feat/version-drift-check-trunk-develop...feat/version-drift-check-trunk-develop___testing?expand=1): 
   - Expect: the warning and Slack message. 
   - ✅ Did it: https://github.com/Automattic/woocommerce-payments/actions/runs/29305745282 
   - ✅ Slack: p1784002860813559-slack-CGGCLBN58


-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-instructions) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.