### PR TITLE
feat: open release sync PR against develop at code freeze

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -14,6 +14,7 @@ jobs:
   check-changelog:
     name:    Check changelog
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'changelog-for-develop/') }}
     steps:
       # clone the repository
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -149,7 +149,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.create_branch.outputs.trimmed-version }}
           RELEASE_PR_ID: ${{ steps.create-pr-to-trunk.outputs.RELEASE_PR_ID }}
         run: |
-          PR_BODY=$(echo -e "Applies the changelog entries from \`release/$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.\n\nRelated release PR: #${RELEASE_PR_ID}")
+          PR_BODY=$(echo -e "> [!NOTE]\n> As the release lead, please approve and merge this PR after the code freeze process is done successfully.\n\nApplies the changelog entries from \`release/$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.\n\nRelated release PR: #${RELEASE_PR_ID}")
           DEVELOP_PR_URL=$(gh pr create \
             --title "Changelog for $RELEASE_VERSION → develop" \
             --body "$PR_BODY" \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -198,11 +198,12 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.branch }}
           RELEASE_PR_ID: ${{ needs.prepare-release.outputs.release-pr-id }}
         run: |
+          PR_BODY="Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.
+
+Related release PR: #${RELEASE_PR_ID}"
           gh pr create \
             --title "Changelog for ${RELEASE_VERSION#release/} → develop" \
-            --body "Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.
-
-Related release PR: #${RELEASE_PR_ID}" \
+            --body "$PR_BODY" \
             --base develop \
             --head "$DEVELOP_BRANCH"
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -166,6 +166,43 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+  create-develop-release-pr:
+    name: "Open release PR against develop"
+    needs: prepare-release
+    if: ${{ ! inputs.dry-run }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.BOTWOO_TOKEN }}
+
+      - name: "Cherry-pick changelog commit from release branch"
+        env:
+          RELEASE_BRANCH: ${{ needs.prepare-release.outputs.branch }}
+        run: |
+          git fetch origin "$RELEASE_BRANCH"
+          CHANGELOG_COMMIT=$(git rev-parse origin/"$RELEASE_BRANCH")
+          DEVELOP_BRANCH="changelog-for-develop/${RELEASE_BRANCH#release/}"
+          git checkout -b "$DEVELOP_BRANCH"
+          git cherry-pick "$CHANGELOG_COMMIT"
+          git push origin "$DEVELOP_BRANCH"
+          echo "DEVELOP_BRANCH=$DEVELOP_BRANCH" >> "$GITHUB_ENV"
+
+      - name: "Open PR against develop"
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.branch }}
+        run: |
+          gh pr create \
+            --title "Changelog for ${RELEASE_VERSION#release/} → develop" \
+            --body "Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge." \
+            --base develop \
+            --head "$DEVELOP_BRANCH"
+
   build-zip-and-run-smoke-tests:
     name: "Build zip & Run smoke tests"
     needs: prepare-release

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           PR_BODY=$(echo -e "> [!NOTE]\n> As the release lead, please approve and merge this PR after the code freeze process is done successfully.\n\nApplies the changelog entries from \`release/$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.\n\nRelated release PR: #${RELEASE_PR_ID}")
           DEVELOP_PR_URL=$(gh pr create \
-            --title "Changelog for $RELEASE_VERSION → develop" \
+            --title "Changelog for develop from version $RELEASE_VERSION" \
             --body "$PR_BODY" \
             --base develop \
             --head "$DEVELOP_BRANCH")

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -196,10 +196,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.branch }}
+          RELEASE_PR_ID: ${{ needs.prepare-release.outputs.release-pr-id }}
         run: |
           gh pr create \
             --title "Changelog for ${RELEASE_VERSION#release/} → develop" \
-            --body "Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge." \
+            --body "Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.
+
+Related release PR: #${RELEASE_PR_ID}" \
             --base develop \
             --head "$DEVELOP_BRANCH"
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -198,9 +198,7 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.branch }}
           RELEASE_PR_ID: ${{ needs.prepare-release.outputs.release-pr-id }}
         run: |
-          PR_BODY="Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.
-
-Related release PR: #${RELEASE_PR_ID}"
+          PR_BODY=$(echo -e "Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.\n\nRelated release PR: #${RELEASE_PR_ID}")
           gh pr create \
             --title "Changelog for ${RELEASE_VERSION#release/} → develop" \
             --body "$PR_BODY" \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -129,7 +129,35 @@ jobs:
             echo "RELEASE_PR_ID=$PR_ID" >> $GITHUB_OUTPUT
           fi
 
-      - name: Add comment to PR
+      - name: "Cherry-pick changelog commit onto develop branch"
+        if: ${{ ! inputs.dry-run }}
+        env:
+          RELEASE_BRANCH: ${{ steps.create_branch.outputs.branch-name }}
+        run: |
+          git fetch origin develop "$RELEASE_BRANCH"
+          CHANGELOG_COMMIT=$(git rev-parse origin/"$RELEASE_BRANCH")
+          DEVELOP_BRANCH="changelog-for-develop/${RELEASE_BRANCH#release/}"
+          git checkout -b "$DEVELOP_BRANCH" origin/develop
+          git cherry-pick "$CHANGELOG_COMMIT"
+          git push origin "$DEVELOP_BRANCH"
+          echo "DEVELOP_BRANCH=$DEVELOP_BRANCH" >> "$GITHUB_ENV"
+
+      - name: "Open PR against develop"
+        if: ${{ ! inputs.dry-run }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
+          RELEASE_VERSION: ${{ steps.create_branch.outputs.trimmed-version }}
+          RELEASE_PR_ID: ${{ steps.create-pr-to-trunk.outputs.RELEASE_PR_ID }}
+        run: |
+          PR_BODY=$(echo -e "Applies the changelog entries from \`release/$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.\n\nRelated release PR: #${RELEASE_PR_ID}")
+          DEVELOP_PR_URL=$(gh pr create \
+            --title "Changelog for $RELEASE_VERSION → develop" \
+            --body "$PR_BODY" \
+            --base develop \
+            --head "$DEVELOP_BRANCH")
+          echo "DEVELOP_PR_URL=$DEVELOP_PR_URL" >> "$GITHUB_ENV"
+
+      - name: "Add comment to PR to trunk"
         if: ${{ ! inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -137,7 +165,9 @@ jobs:
         run: |
           gh pr comment https://github.com/Automattic/woocommerce-payments/pull/$RELEASE_PR_ID --body="### Release zip build & Smoke tests
 
-          Check status of zip file build & smoke tests at https://github.com/Automattic/woocommerce-payments/actions/runs/${GITHUB_RUN_ID}"
+          Check status of zip file build & smoke tests at https://github.com/Automattic/woocommerce-payments/actions/runs/${GITHUB_RUN_ID}
+
+          Related develop sync PR: $DEVELOP_PR_URL"
 
       - name: "Dry-run summary"
         # Run even if an earlier step failed, so the diff is always reported
@@ -165,46 +195,6 @@ jobs:
             git status --short
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-
-  create-develop-release-pr:
-    name: "Open release PR against develop"
-    needs: prepare-release
-    if: ${{ ! inputs.dry-run }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: develop
-          fetch-depth: 0
-          token: ${{ secrets.BOTWOO_TOKEN }}
-
-      - name: "Cherry-pick changelog commit from release branch"
-        env:
-          RELEASE_BRANCH: ${{ needs.prepare-release.outputs.branch }}
-        run: |
-          git fetch origin "$RELEASE_BRANCH"
-          CHANGELOG_COMMIT=$(git rev-parse origin/"$RELEASE_BRANCH")
-          DEVELOP_BRANCH="changelog-for-develop/${RELEASE_BRANCH#release/}"
-          git checkout -b "$DEVELOP_BRANCH"
-          git cherry-pick "$CHANGELOG_COMMIT"
-          git push origin "$DEVELOP_BRANCH"
-          echo "DEVELOP_BRANCH=$DEVELOP_BRANCH" >> "$GITHUB_ENV"
-
-      - name: "Open PR against develop"
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
-          RELEASE_VERSION: ${{ needs.prepare-release.outputs.branch }}
-          RELEASE_PR_ID: ${{ needs.prepare-release.outputs.release-pr-id }}
-        run: |
-          PR_BODY=$(echo -e "Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.\n\nRelated release PR: #${RELEASE_PR_ID}")
-          DEVELOP_PR_URL=$(gh pr create \
-            --title "Changelog for ${RELEASE_VERSION#release/} → develop" \
-            --body "$PR_BODY" \
-            --base develop \
-            --head "$DEVELOP_BRANCH")
-          gh pr comment "$RELEASE_PR_ID" --body "Related develop sync PR: $DEVELOP_PR_URL"
 
   build-zip-and-run-smoke-tests:
     name: "Build zip & Run smoke tests"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,4 +1,4 @@
-name: "Release - Create PR to trunk"
+name: "Release - Create release PRs"
 
 # This action will run inside the release code freeze workflow or when it is triggered manually
 on:
@@ -199,11 +199,12 @@ jobs:
           RELEASE_PR_ID: ${{ needs.prepare-release.outputs.release-pr-id }}
         run: |
           PR_BODY=$(echo -e "Applies the changelog entries from \`$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.\n\nRelated release PR: #${RELEASE_PR_ID}")
-          gh pr create \
+          DEVELOP_PR_URL=$(gh pr create \
             --title "Changelog for ${RELEASE_VERSION#release/} → develop" \
             --body "$PR_BODY" \
             --base develop \
-            --head "$DEVELOP_BRANCH"
+            --head "$DEVELOP_BRANCH")
+          gh pr comment "$RELEASE_PR_ID" --body "Related develop sync PR: $DEVELOP_PR_URL"
 
   build-zip-and-run-smoke-tests:
     name: "Build zip & Run smoke tests"

--- a/changelog/woopmnt-6285-code-freeze-open-a-changelog-sync-pr-against-develop-at
+++ b/changelog/woopmnt-6285-code-freeze-open-a-changelog-sync-pr-against-develop-at
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add job to open a release sync PR against develop at code freeze time


### PR DESCRIPTION
Fixes WOOPMNT-6285

#### Changes proposed in this Pull Request

As part of the branch-protection / release-flow changes, the `trunk → develop` post-release merge is being removed. This means changelog and version-bump changes committed at code freeze (on `release/X.Y.Z`) would never reach `develop`.

This PR adds automation so that at code freeze time, in addition to the existing `release/X.Y.Z → trunk` PR, a second PR (`changelog-for-develop/X.Y.Z → develop`) is automatically opened with the same changes.

**How it works:**

After the `prepare-release` job creates and pushes the release branch, three new inline steps run:

1. **Cherry-pick changelog commit onto develop branch** — fetches `develop` and the release branch, creates `changelog-for-develop/X.Y.Z` from `origin/develop`, cherry-picks the version-bump + changelog commit from the release branch, and pushes the new branch.
2. **Open PR against develop** — opens `changelog-for-develop/X.Y.Z → develop` via `gh pr create` using `BOTWOO_TOKEN`. The PR body includes a note for the release lead and a reference back to the trunk PR.
3. **Add comment to PR to trunk** (renamed from "Add comment to PR") — posts the smoke test status link to the trunk PR and also includes a link to the new develop sync PR.

**Also changed:**
- Workflow renamed from `"Release - Create PR to trunk"` to `"Release - Create release PRs"` to reflect that it now opens PRs against both `trunk` and `develop`.
- `check-changelog.yml` skips the changelog check for PRs whose head branch starts with `changelog-for-develop/` — these PRs are auto-generated cherry-picks and don't need their own changelog entry.
- Dry-run mode skips all three new steps (guarded by `if: ${{ ! inputs.dry-run }}`).

#### Testing instructions

- Trigger `release-pr.yml` manually (workflow_dispatch) for a test version with `dry-run: false`
- Verify a PR `changelog-for-develop/X.Y.Z → develop` is opened automatically with the release lead note and a reference to the trunk PR
- Verify the trunk PR comment includes a link to the develop sync PR

I manually tested with this run https://github.com/Automattic/woocommerce-payments/actions/runs/29309071618, which results into: 

- http://github.com/Automattic/woocommerce-payments/pull/11951
- http://github.com/Automattic/woocommerce-payments/pull/11952

Note: 
- `check-changelog.yml` is skipped on the `changelog-for-develop/*` PR - however, it's not applied until this PR is merged into develop. 

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
