### PR TITLE
Changelog for develop from version 0.1.96

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,55 @@
 *** WooPayments Changelog ***
 
+= 0.1.96 - 2026-07-15 =
+* Add - Add A/B/C design variants to the in-app review prompt, assigned per-store via ExPlat (prompt remains disabled pending eligibility criteria)
+* Add - Add a client-side origin assertion that blocks checkout when Stripe.js is loaded from an unexpected origin, as defense-in-depth against skimmers that repoint the script handle to a look-alike domain.
+* Add - Multi-Currency: add the `wcpay_multi_currency_should_output_explicit_price` filter so merchants can force the currency code suffix on totals (e.g. "765 Kč CZK") on or off.
+* Add - Multi-Currency: auto-detect page caching to enable or recommend the cache-optimized rendering mode
+* Fix - Add direct file access protection to PHP files flagged by Plugin Check.
+* Fix - Attach WooPayments subscription tokens when webhook payment completion runs without checkout AJAX finalization.
+* Fix - Avoid invalidating multi-currency rate cache for visitor-filtered currencies
+* Fix - Display transaction detail timeline dates in the site timezone.
+* Fix - fix: adding scope to checkout style extraction
+* Fix - fix: ensure file purpose cache key value is consistent
+* Fix - fix: redact the address autocomplete token from API response logs.
+* Fix - Fix Affirm BNPL name validation checking wrong field path, which caused billing address to be stripped on order-pay pages
+* Fix - Fix changelog formatter PCRE JIT stack exhaustion causing changelogger --amend to wipe all existing entries
+* Fix - Fix doubled spacing between express checkout buttons on the Cart block with WooCommerce 10.8+
+* Fix - Fixed the one-and-done and test-to-live notice eligibility checks running a slow, unbounded order query that could block admin order pages on large stores.
+* Fix - Fix inconsistent card brand SVG styling: add missing rounded corners to Mastercard, correct Discover rendered width from 61px to 64px, and add explicit white background fill to Discover.
+* Fix - Fix PHP 8.5 deprecation notice when selecting a currency before any currency is stored for the user or session
+* Fix - Fix REST API routes not being registered for internal REST requests made from admin pages
+* Fix - Fix the dispute notification "View and respond to dispute" link intermittently landing on an error or broken page by redirecting to the disputes list when the dispute's transaction details cannot be resolved.
+* Fix - Fix WooPay express checkout button showing an infinite spinner on classic variable product pages
+* Fix - Forward structured error details (error code, type, and HTTP status) in the test drive account init REST error response, so consumers can distinguish non-recoverable errors.
+* Fix - Hide optional business structure selection during onboarding
+* Fix - Hide WooPay and Apple Pay / Google Pay express checkout buttons on the product page when the product cannot be added to the cart
+* Fix - Preserve decimal product quantities when adding to cart via Express Checkout
+* Fix - Preserve the express checkouts a merchant enabled in a sandbox account (such as Link by Stripe) when transitioning to a live account, instead of resetting them, while keeping Link and WooPay mutually exclusive.
+* Fix - Record the correct failure reason and avoid a PHP warning when a refund fails because of insufficient account balance.
+* Fix - Redact data from GET request URL in API log context
+* Fix - Remove giropay and sofort from payment method registry to prevent incompatible block checkout warnings
+* Fix - Request unrequested payment method capabilities (e.g. BNPL) on settings save when the capability is absent from cached account data
+* Fix - Reuse the React root for the WooPay save-user section on Blocks checkout so its state is no longer reset on cart/checkout updates.
+* Fix - Show all disputes on a transaction that has more than one, instead of only the first
+* Fix - Soften and clarify the VAT registration warning in the tax details modal; link to documentation instead of stating region-specific legal requirements.
+* Fix - Store the payment intent ID on orders when a payment fails, improving transaction traceability and webhook matching.
+* Fix - update: ECE to allow pay-for-order flow when customer billing email is missing
+* Update - Harden the client-side Stripe.js origin assertion: ignore non-script elements sharing the Stripe.js script id, and make the blocked-payment error message translatable.
+* Update - refactor: make the iti tel input lazy-loaded, so that bundles are more optimized for the majority of scenarios
+* Dev - Add job to open a release sync PR against develop at code freeze time
+* Dev - Fix flaky shopper-multi-currency-widget E2E test by verifying the currency switcher widget is assigned to the sidebar before the test runs
+* Dev - Fix multi-currency widget E2E test timing out on WP nightly by waiting for the block editor canvas to mount before inserting the currency switcher block.
+* Dev - Look up webhook IDs in WooPay order status sync tests instead of hardcoding them, fixing order-dependent failures in full suite runs
+* Dev - Make the shopper free-trial subscription E2E tests (standard and QIT suites) resilient to WooCommerce Subscriptions price-string copy/layout changes (fixes the 9.0.0 "Free trial: 14 days" rendering).
+* Dev - Pass agent-pipeline workflow inputs through environment variables instead of interpolating them directly into shell steps.
+* Dev - Resolve repeated Database_Cache::get_or_add() calls from memory within a request, skipping redundant validation of hot keys like account data
+* Dev - Restore $_SERVER['REQUEST_URI'] after WC_Payments_Utils tests so leaked wp-json URIs don't send later tests down REST-only WooCommerce code paths
+* Dev - Retry transient QIT E2E environment-provisioning failures (corrupt downloads, network blips) so CI flakes no longer fail the run
+* Dev - Skip express checkout button handler construction on cron and XML-RPC requests, where the handlers' hooks can never fire
+* Dev - tweak: added a `should_convert_shipping_amount` filter to MCCY
+* Dev - Update Node support and WooCommerce package dependencies.
+
 = 10.9.0 - 2026-06-24 =
 * Add - Add a Balance reconciliation report to the WooPayments Reports area (behind a feature flag)
 * Add - Add a CSV Export button to the Fees report

--- a/changelog/WOOPMNT-4219-soften-vat-modal-warning
+++ b/changelog/WOOPMNT-4219-soften-vat-modal-warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Soften and clarify the VAT registration warning in the tax details modal; link to documentation instead of stating region-specific legal requirements.

--- a/changelog/WOOPMNT-5973
+++ b/changelog/WOOPMNT-5973
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix Affirm BNPL name validation checking wrong field path, which caused billing address to be stripped on order-pay pages

--- a/changelog/WOOPMNT-6238-fix-null-array-offset-selected-currency
+++ b/changelog/WOOPMNT-6238-fix-null-array-offset-selected-currency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix PHP 8.5 deprecation notice when selecting a currency before any currency is stored for the user or session

--- a/changelog/WOOPMNT-6240-fix-one-and-done-notice-eligibility-query
+++ b/changelog/WOOPMNT-6240-fix-one-and-done-notice-eligibility-query
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed the one-and-done and test-to-live notice eligibility checks running a slow, unbounded order query that could block admin order pages on large stores.

--- a/changelog/WOOPMNT-6277-giropay-shows-as-incompatible-with-block-checkout
+++ b/changelog/WOOPMNT-6277-giropay-shows-as-incompatible-with-block-checkout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Remove giropay and sofort from payment method registry to prevent incompatible block checkout warnings

--- a/changelog/add-woopmnt-4446-add-intent-id-to-failed-transactions
+++ b/changelog/add-woopmnt-4446-add-intent-id-to-failed-transactions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Store the payment intent ID on orders when a payment fails, improving transaction traceability and webhook matching.

--- a/changelog/add-woopmnt-4898-explicit-price-filter
+++ b/changelog/add-woopmnt-4898-explicit-price-filter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Multi-Currency: add the `wcpay_multi_currency_should_output_explicit_price` filter so merchants can force the currency code suffix on totals (e.g. "765 Kč CZK") on or off.

--- a/changelog/add-woopmnt-6025-auto-detect-caching-rendering-mode
+++ b/changelog/add-woopmnt-6025-auto-detect-caching-rendering-mode
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Multi-Currency: auto-detect page caching to enable or recommend the cache-optimized rendering mode

--- a/changelog/add-woopmnt-6080-review-prompt-experiment
+++ b/changelog/add-woopmnt-6080-review-prompt-experiment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add A/B/C design variants to the in-app review prompt, assigned per-store via ExPlat (prompt remains disabled pending eligibility criteria)

--- a/changelog/add-woopmnt-6210-stripe-origin-assertion
+++ b/changelog/add-woopmnt-6210-stripe-origin-assertion
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add a client-side origin assertion that blocks checkout when Stripe.js is loaded from an unexpected origin, as defense-in-depth against skimmers that repoint the script handle to a look-alike domain.

--- a/changelog/add-woopmnt-6229-branch-protection
+++ b/changelog/add-woopmnt-6229-branch-protection
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Scope WooPayments repo access with branch protection: add CODEOWNERS and a branch-protection-change Slack alert workflow. CI/governance only, not user-facing. Refs WOOPMNT-6229.
-
-

--- a/changelog/agent-woopmnt-6235
+++ b/changelog/agent-woopmnt-6235
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Security hardening for dispute evidence abilities and fraud prevention token handling

--- a/changelog/bump-jetpack-changelogger-6.0.17
+++ b/changelog/bump-jetpack-changelogger-6.0.17
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Bump automattic/jetpack-changelogger from 6.0.14 to 6.0.17.

--- a/changelog/chore-10305-test-docs-reorg
+++ b/changelog/chore-10305-test-docs-reorg
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: chore: reorganize testing docs

--- a/changelog/chore-upgrade-ts-to-5.9
+++ b/changelog/chore-upgrade-ts-to-5.9
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: chore: upgrade TypeScript from 4.9.5 to 5.9.3

--- a/changelog/codex-fix-mc-cache-base-currency
+++ b/changelog/codex-fix-mc-cache-base-currency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Avoid invalidating multi-currency rate cache for visitor-filtered currencies

--- a/changelog/e2e-WOOPMNT-6249
+++ b/changelog/e2e-WOOPMNT-6249
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix multi-currency widget E2E test timing out on WP nightly by waiting for the block editor canvas to mount before inserting the currency switcher block.

--- a/changelog/experiment-iti-lazy
+++ b/changelog/experiment-iti-lazy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-refactor: make the iti tel input lazy-loaded, so that bundles are more optimized for the majority of scenarios

--- a/changelog/fix-6252-e2e-subscription-free-trial-price-display
+++ b/changelog/fix-6252-e2e-subscription-free-trial-price-display
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Make the shopper free-trial subscription E2E tests (standard and QIT suites) resilient to WooCommerce Subscriptions price-string copy/layout changes (fixes the 9.0.0 "Free trial: 14 days" rendering).

--- a/changelog/fix-8090-eager-loading-quick-wins
+++ b/changelog/fix-8090-eager-loading-quick-wins
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Skip express checkout button handler construction on cron and XML-RPC requests, where the handlers' hooks can never fire

--- a/changelog/fix-8090-eager-loading-quick-wins#2
+++ b/changelog/fix-8090-eager-loading-quick-wins#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Resolve repeated Database_Cache::get_or_add() calls from memory within a request, skipping redundant validation of hot keys like account data

--- a/changelog/fix-8090-eager-loading-quick-wins#3
+++ b/changelog/fix-8090-eager-loading-quick-wins#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Look up webhook IDs in WooPay order status sync tests instead of hardcoding them, fixing order-dependent failures in full suite runs

--- a/changelog/fix-8654-unused-variable-sniffs-includes
+++ b/changelog/fix-8654-unused-variable-sniffs-includes
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: fix: enable VariableAnalysis UnusedVariable phpcs sniff for includes/ and src/ files (#8654)

--- a/changelog/fix-8655-unused-variable-sniffs-multicurrency
+++ b/changelog/fix-8655-unused-variable-sniffs-multicurrency
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: fix: enable VariableAnalysis UnusedVariable phpcs sniff for multi-currency files (#8655)

--- a/changelog/fix-WOOPMNT-5956
+++ b/changelog/fix-WOOPMNT-5956
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fix: adding scope to checkout style extraction

--- a/changelog/fix-bump-qit-cli-to-1-3-0
+++ b/changelog/fix-bump-qit-cli-to-1-3-0
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Bump QIT CLI in E2E CI to 1.3.0.

--- a/changelog/fix-changelog-formatter-pcre-jit
+++ b/changelog/fix-changelog-formatter-pcre-jit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix changelog formatter PCRE JIT stack exhaustion causing changelogger --amend to wipe all existing entries

--- a/changelog/fix-e2e-multi-currency-widget-setup-flake
+++ b/changelog/fix-e2e-multi-currency-widget-setup-flake
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix flaky shopper-multi-currency-widget E2E test by verifying the currency switcher widget is assigned to the sidebar before the test runs

--- a/changelog/fix-e2e-setup-network-retries
+++ b/changelog/fix-e2e-setup-network-retries
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Retry transient network operations (Docker image pulls, wordpress.org plugin/theme installs, GitHub release downloads) in the E2E environment setup script. CI/test-infra only, not user-facing.

--- a/changelog/fix-ece-block-cart-button-spacing
+++ b/changelog/fix-ece-block-cart-button-spacing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix doubled spacing between express checkout buttons on the Cart block with WooCommerce 10.8+

--- a/changelog/fix-ece-decimal-quantity
+++ b/changelog/fix-ece-decimal-quantity
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Preserve decimal product quantities when adding to cart via Express Checkout

--- a/changelog/fix-express-pay-for-order-wallet-billing-email
+++ b/changelog/fix-express-pay-for-order-wallet-billing-email
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-update: ECE to allow pay-for-order flow when customer billing email is missing

--- a/changelog/fix-forward-test-drive-init-error-details
+++ b/changelog/fix-forward-test-drive-init-error-details
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Forward structured error details (error code, type, and HTTP status) in the test drive account init REST error response, so consumers can distinguish non-recoverable errors.

--- a/changelog/fix-link-woopay-mutual-exclusion
+++ b/changelog/fix-link-woopay-mutual-exclusion
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Preserve the express checkouts a merchant enabled in a sandbox account (such as Link by Stripe) when transitioning to a live account, instead of resetting them, while keeping Link and WooPay mutually exclusive.

--- a/changelog/fix-onboarding-optional-business-structure
+++ b/changelog/fix-onboarding-optional-business-structure
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Hide optional business structure selection during onboarding

--- a/changelog/fix-payment-timeline-site-timezone
+++ b/changelog/fix-payment-timeline-site-timezone
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Display transaction detail timeline dates in the site timezone.

--- a/changelog/fix-plugincheck-direct-file-access-protection
+++ b/changelog/fix-plugincheck-direct-file-access-protection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add direct file access protection to PHP files flagged by Plugin Check.

--- a/changelog/fix-qit-e2e-env-provisioning-retry
+++ b/changelog/fix-qit-e2e-env-provisioning-retry
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Retry transient QIT E2E environment-provisioning failures (corrupt downloads, network blips) so CI flakes no longer fail the run

--- a/changelog/fix-reports-date-filter-default-between
+++ b/changelog/fix-reports-date-filter-default-between
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Default the payments reports date filter to the Between operator so its date range presets are offered by default.

--- a/changelog/fix-request-absent-bnpl-capabilities-on-settings-save
+++ b/changelog/fix-request-absent-bnpl-capabilities-on-settings-save
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Request unrequested payment method capabilities (e.g. BNPL) on settings save when the capability is absent from cached account data

--- a/changelog/fix-rest-api-init-admin-context
+++ b/changelog/fix-rest-api-init-admin-context
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix REST API routes not being registered for internal REST requests made from admin pages

--- a/changelog/fix-shell-quote-cve-2026-9277
+++ b/changelog/fix-shell-quote-cve-2026-9277
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Bump shell-quote dev dependency (webpack-dev-server → launch-editor) from 1.8.3 to 1.9.0 to clear CVE-2026-9277. Dev-only, not user-facing.
-
-

--- a/changelog/fix-test-request-uri-pollution
+++ b/changelog/fix-test-request-uri-pollution
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Restore $_SERVER['REQUEST_URI'] after WC_Payments_Utils tests so leaked wp-json URIs don't send later tests down REST-only WooCommerce code paths

--- a/changelog/fix-unused-variable-sniffs-poc-configs
+++ b/changelog/fix-unused-variable-sniffs-poc-configs
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: fix: enable VariableAnalysis UnusedVariable phpcs sniff on payment-method Configs (closes #8436)

--- a/changelog/fix-unused-variable-sniffs-remaining-includes
+++ b/changelog/fix-unused-variable-sniffs-remaining-includes
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: fix: enable VariableAnalysis UnusedVariable sniff on remaining includes/ and src/ files (part of #8436)

--- a/changelog/fix-unused-variable-sniffs-remaining-tests
+++ b/changelog/fix-unused-variable-sniffs-remaining-tests
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: fix: enable VariableAnalysis UnusedVariable phpcs sniff on remaining test files (part of #8436)

--- a/changelog/fix-wc-commenting-stragglers-prod
+++ b/changelog/fix-wc-commenting-stragglers-prod
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: fix: resolve the remaining WooCommerce.Commenting phpcs hook comment errors (production files added after the #8437 sweep) and remove the now-unneeded CommentHooks excludes from phpcs.xml.dist (not user-facing).
-
-

--- a/changelog/fix-woopay-express-button-variable-product-spinner
+++ b/changelog/fix-woopay-express-button-variable-product-spinner
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix WooPay express checkout button showing an infinite spinner on classic variable product pages

--- a/changelog/fix-woopay-file-purpose-cache
+++ b/changelog/fix-woopay-file-purpose-cache
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fix: ensure file purpose cache key value is consistent

--- a/changelog/fix-woopmnt-11570-card-brand-svg-consistency
+++ b/changelog/fix-woopmnt-11570-card-brand-svg-consistency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix inconsistent card brand SVG styling: add missing rounded corners to Mastercard, correct Discover rendered width from 61px to 64px, and add explicit white background fill to Discover.

--- a/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
+++ b/changelog/fix-woopmnt-4183-show-all-disputes-on-transaction
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Show all disputes on a transaction that has more than one, instead of only the first

--- a/changelog/fix-woopmnt-4231-express-buttons
+++ b/changelog/fix-woopmnt-4231-express-buttons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Hide WooPay and Apple Pay / Google Pay express checkout buttons on the product page when the product cannot be added to the cart

--- a/changelog/fix-woopmnt-5946-agent-workflow-input-interpolation
+++ b/changelog/fix-woopmnt-5946-agent-workflow-input-interpolation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Pass agent-pipeline workflow inputs through environment variables instead of interpolating them directly into shell steps.

--- a/changelog/fix-woopmnt-5951-woopay-save-user-root-reuse
+++ b/changelog/fix-woopmnt-5951-woopay-save-user-root-reuse
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Reuse the React root for the WooPay save-user section on Blocks checkout so its state is no longer reset on cart/checkout updates.

--- a/changelog/fix-woopmnt-5952-redact-autocomplete-token
+++ b/changelog/fix-woopmnt-5952-redact-autocomplete-token
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fix: redact the address autocomplete token from API response logs.

--- a/changelog/fix-woopmnt-5954-redact-get-url-log-context
+++ b/changelog/fix-woopmnt-5954-redact-get-url-log-context
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Redact data from GET request URL in API log context

--- a/changelog/fix-woopmnt-5977-refund-failure-note
+++ b/changelog/fix-woopmnt-5977-refund-failure-note
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Record the correct failure reason and avoid a PHP warning when a refund fails because of insufficient account balance.

--- a/changelog/fix-woopmnt-6259-webhook-subscription-token
+++ b/changelog/fix-woopmnt-6259-webhook-subscription-token
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Attach WooPayments subscription tokens when webhook payment completion runs without checkout AJAX finalization.

--- a/changelog/tweak-add-mccy-filter-on-shipping-prices
+++ b/changelog/tweak-add-mccy-filter-on-shipping-prices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-tweak: added a `should_convert_shipping_amount` filter to MCCY

--- a/changelog/update-node24-woocommerce-packages
+++ b/changelog/update-node24-woocommerce-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update Node support and WooCommerce package dependencies.

--- a/changelog/update-woopmnt-6210-stripe-origin-hardening
+++ b/changelog/update-woopmnt-6210-stripe-origin-hardening
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Harden the client-side Stripe.js origin assertion: ignore non-script elements sharing the Stripe.js script id, and make the blocked-payment error message translatable.

--- a/changelog/update-woopmnt-6229-codeowners-pci-guardians
+++ b/changelog/update-woopmnt-6229-codeowners-pci-guardians
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Point CODEOWNERS at the PCI Guardians team (single trained reviewer group) for protected-branch reviews. CI/governance only, not user-facing. Refs WOOPMNT-6229.

--- a/changelog/woopmnt-6213-view-and-respond-to-dispute-cta-in-dispute-notification
+++ b/changelog/woopmnt-6213-view-and-respond-to-dispute-cta-in-dispute-notification
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the dispute notification "View and respond to dispute" link intermittently landing on an error or broken page by redirecting to the disputes list when the dispute's transaction details cannot be resolved.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce-payments",
-	"version": "10.9.0",
+	"version": "0.1.96",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "woocommerce-payments",
-			"version": "10.9.0",
+			"version": "0.1.96",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-payments",
-	"version": "10.9.0",
+	"version": "0.1.96",
 	"main": "webpack.config.js",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 7.3
-Stable tag: 10.9.0
+Stable tag: 0.1.96
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -86,6 +86,56 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 4. Manage Disputes
 
 == Changelog ==
+
+= 0.1.96 - 2026-07-15 =
+* Add - Add A/B/C design variants to the in-app review prompt, assigned per-store via ExPlat (prompt remains disabled pending eligibility criteria)
+* Add - Add a client-side origin assertion that blocks checkout when Stripe.js is loaded from an unexpected origin, as defense-in-depth against skimmers that repoint the script handle to a look-alike domain.
+* Add - Multi-Currency: add the `wcpay_multi_currency_should_output_explicit_price` filter so merchants can force the currency code suffix on totals (e.g. "765 Kč CZK") on or off.
+* Add - Multi-Currency: auto-detect page caching to enable or recommend the cache-optimized rendering mode
+* Fix - Add direct file access protection to PHP files flagged by Plugin Check.
+* Fix - Attach WooPayments subscription tokens when webhook payment completion runs without checkout AJAX finalization.
+* Fix - Avoid invalidating multi-currency rate cache for visitor-filtered currencies
+* Fix - Display transaction detail timeline dates in the site timezone.
+* Fix - fix: adding scope to checkout style extraction
+* Fix - fix: ensure file purpose cache key value is consistent
+* Fix - fix: redact the address autocomplete token from API response logs.
+* Fix - Fix Affirm BNPL name validation checking wrong field path, which caused billing address to be stripped on order-pay pages
+* Fix - Fix changelog formatter PCRE JIT stack exhaustion causing changelogger --amend to wipe all existing entries
+* Fix - Fix doubled spacing between express checkout buttons on the Cart block with WooCommerce 10.8+
+* Fix - Fixed the one-and-done and test-to-live notice eligibility checks running a slow, unbounded order query that could block admin order pages on large stores.
+* Fix - Fix inconsistent card brand SVG styling: add missing rounded corners to Mastercard, correct Discover rendered width from 61px to 64px, and add explicit white background fill to Discover.
+* Fix - Fix PHP 8.5 deprecation notice when selecting a currency before any currency is stored for the user or session
+* Fix - Fix REST API routes not being registered for internal REST requests made from admin pages
+* Fix - Fix the dispute notification "View and respond to dispute" link intermittently landing on an error or broken page by redirecting to the disputes list when the dispute's transaction details cannot be resolved.
+* Fix - Fix WooPay express checkout button showing an infinite spinner on classic variable product pages
+* Fix - Forward structured error details (error code, type, and HTTP status) in the test drive account init REST error response, so consumers can distinguish non-recoverable errors.
+* Fix - Hide optional business structure selection during onboarding
+* Fix - Hide WooPay and Apple Pay / Google Pay express checkout buttons on the product page when the product cannot be added to the cart
+* Fix - Preserve decimal product quantities when adding to cart via Express Checkout
+* Fix - Preserve the express checkouts a merchant enabled in a sandbox account (such as Link by Stripe) when transitioning to a live account, instead of resetting them, while keeping Link and WooPay mutually exclusive.
+* Fix - Record the correct failure reason and avoid a PHP warning when a refund fails because of insufficient account balance.
+* Fix - Redact data from GET request URL in API log context
+* Fix - Remove giropay and sofort from payment method registry to prevent incompatible block checkout warnings
+* Fix - Request unrequested payment method capabilities (e.g. BNPL) on settings save when the capability is absent from cached account data
+* Fix - Reuse the React root for the WooPay save-user section on Blocks checkout so its state is no longer reset on cart/checkout updates.
+* Fix - Show all disputes on a transaction that has more than one, instead of only the first
+* Fix - Soften and clarify the VAT registration warning in the tax details modal; link to documentation instead of stating region-specific legal requirements.
+* Fix - Store the payment intent ID on orders when a payment fails, improving transaction traceability and webhook matching.
+* Fix - update: ECE to allow pay-for-order flow when customer billing email is missing
+* Update - Harden the client-side Stripe.js origin assertion: ignore non-script elements sharing the Stripe.js script id, and make the blocked-payment error message translatable.
+* Update - refactor: make the iti tel input lazy-loaded, so that bundles are more optimized for the majority of scenarios
+* Dev - Add job to open a release sync PR against develop at code freeze time
+* Dev - Fix flaky shopper-multi-currency-widget E2E test by verifying the currency switcher widget is assigned to the sidebar before the test runs
+* Dev - Fix multi-currency widget E2E test timing out on WP nightly by waiting for the block editor canvas to mount before inserting the currency switcher block.
+* Dev - Look up webhook IDs in WooPay order status sync tests instead of hardcoding them, fixing order-dependent failures in full suite runs
+* Dev - Make the shopper free-trial subscription E2E tests (standard and QIT suites) resilient to WooCommerce Subscriptions price-string copy/layout changes (fixes the 9.0.0 "Free trial: 14 days" rendering).
+* Dev - Pass agent-pipeline workflow inputs through environment variables instead of interpolating them directly into shell steps.
+* Dev - Resolve repeated Database_Cache::get_or_add() calls from memory within a request, skipping redundant validation of hot keys like account data
+* Dev - Restore $_SERVER['REQUEST_URI'] after WC_Payments_Utils tests so leaked wp-json URIs don't send later tests down REST-only WooCommerce code paths
+* Dev - Retry transient QIT E2E environment-provisioning failures (corrupt downloads, network blips) so CI flakes no longer fail the run
+* Dev - Skip express checkout button handler construction on cron and XML-RPC requests, where the handlers' hooks can never fire
+* Dev - tweak: added a `should_convert_shipping_amount` filter to MCCY
+* Dev - Update Node support and WooCommerce package dependencies.
 
 = 10.9.0 - 2026-06-24 =
 * Add - Add a Balance reconciliation report to the WooPayments Reports area (behind a feature flag)

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC tested up to: 10.9.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
- * Version: 10.9.0
+ * Version: 0.1.96
  * Requires Plugins: woocommerce
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
> [!NOTE]
> As the release lead, please approve and merge this PR after the code freeze process is done successfully.

Applies the changelog entries from `release/0.1.96` to `develop` so that `develop` stays in sync without a `trunk → develop` merge.

Related release PR: #11951