### PR TITLE
fix(reports): standard currency formatting in the Balance report + CSV export, and a white Reports header

### DIFF
--- a/changelog/fix-woopmnt-6272-balance-export-cents
+++ b/changelog/fix-woopmnt-6272-balance-export-cents
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Balance report: export CSV amounts in major units instead of cents.

--- a/changelog/fix-woopmnt-6272-balance-payout-csv-sign
+++ b/changelog/fix-woopmnt-6272-balance-payout-csv-sign
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Balance report: export the Payouts CSV amount with the same negative sign shown on screen.

--- a/changelog/fix-woopmnt-6274-balance-amount-formatting
+++ b/changelog/fix-woopmnt-6274-balance-amount-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Balance report: display amounts using the standard WooPayments currency formatting.

--- a/changelog/fix-woopmnt-6275-reports-header-white
+++ b/changelog/fix-woopmnt-6275-reports-header-white
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reports: keep the page header background white.

--- a/client/reports/__tests__/style.test.js
+++ b/client/reports/__tests__/style.test.js
@@ -10,9 +10,11 @@ describe( 'Reports styles', () => {
 			'utf8'
 		);
 
-	// WooCommerce core paints `.woocommerce-layout__header` #f0f0f1. Reports
-	// keeps it white, and the override has been lost once before — guard it.
-	it( 'keeps the Reports page header white over the WooCommerce core gray', () => {
+	// WooCommerce core paints `.woocommerce-layout__header` #f0f0f1; the Reports
+	// stylesheet overrides it to #fff. This only matches the SCSS source — it's a
+	// tripwire against the override being silently dropped in a refactor, not a
+	// check of the rendered cascade.
+	it( 'ships a `.woocommerce-layout__header` background override in the Reports stylesheet', () => {
 		const styles = readReportsStyles();
 
 		expect( styles ).toMatch(

--- a/client/reports/__tests__/style.test.js
+++ b/client/reports/__tests__/style.test.js
@@ -4,11 +4,24 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 
 describe( 'Reports styles', () => {
-	it( 'ships Balance loading skeleton fallback styles with the Reports entry stylesheet', () => {
-		const styles = fs.readFileSync(
+	const readReportsStyles = () =>
+		fs.readFileSync(
 			path.resolve( process.cwd(), 'client/reports/style.scss' ),
 			'utf8'
 		);
+
+	// WooCommerce core paints `.woocommerce-layout__header` #f0f0f1. Reports
+	// keeps it white, and the override has been lost once before — guard it.
+	it( 'keeps the Reports page header white over the WooCommerce core gray', () => {
+		const styles = readReportsStyles();
+
+		expect( styles ).toMatch(
+			/\.woocommerce-layout__header\s*{\s*background:\s*#fff;/
+		);
+	} );
+
+	it( 'ships Balance loading skeleton fallback styles with the Reports entry stylesheet', () => {
+		const styles = readReportsStyles();
 
 		expect( styles ).toContain( '.wcpay-reports-balance__skeleton' );
 		expect( styles ).toContain( 'filter: blur( 4px );' );

--- a/client/reports/balance/__tests__/actions.test.tsx
+++ b/client/reports/balance/__tests__/actions.test.tsx
@@ -141,6 +141,12 @@ describe( 'BalanceActions Tracks', () => {
 			expectedPayload
 		);
 		expect( mockDownloadCSVFile ).toHaveBeenCalledTimes( 1 );
+
+		// The export path runs `getBalanceCSV`, which rescales minor units to
+		// major units via `formatExportAmount`. Assert the exported cell so the
+		// stub earns its place instead of only proving that a download fired.
+		const csv = mockDownloadCSVFile.mock.calls[ 0 ][ 1 ] as string;
+		expect( csv ).toContain( ',"Total charges captured",1626.72,' );
 	} );
 
 	it( 'records export errors with the failure message and preserves notice behavior', async () => {

--- a/client/reports/balance/__tests__/actions.test.tsx
+++ b/client/reports/balance/__tests__/actions.test.tsx
@@ -55,6 +55,8 @@ jest.mock( 'multi-currency/interface/functions', () => ( {
 		skipSymbol?: boolean
 	) =>
 		skipSymbol ? `${ amount } ${ currency }` : `${ currency } ${ amount }`,
+	// The production helper converts minor units to major units for CSV export.
+	formatExportAmount: ( amount: number ) => amount / 100,
 } ) );
 
 jest.mock( 'wcpay/utils/date-time', () => ( {

--- a/client/reports/balance/__tests__/actions.test.tsx
+++ b/client/reports/balance/__tests__/actions.test.tsx
@@ -49,13 +49,10 @@ jest.mock( '../use-balance-date-filter', () => {
 // Mirror the existing Balance report tests so Balance amount formatting remains
 // deterministic when CSV generation touches row labels/values.
 jest.mock( 'multi-currency/interface/functions', () => ( {
-	formatExplicitCurrency: (
-		amount: number,
-		currency: string,
-		skipSymbol?: boolean
-	) =>
-		skipSymbol ? `${ amount } ${ currency }` : `${ currency } ${ amount }`,
-	// The production helper converts minor units to major units for CSV export.
+	formatExplicitCurrency: ( amount: number, currency: string ) =>
+		`${ amount < 0 ? '-' : '' }$${ Math.abs( amount / 100 ).toFixed(
+			2
+		) } ${ currency.toUpperCase() }`,
 	formatExportAmount: ( amount: number ) => amount / 100,
 } ) );
 

--- a/client/reports/balance/__tests__/format.test.ts
+++ b/client/reports/balance/__tests__/format.test.ts
@@ -1,0 +1,72 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { formatBalanceAmount } from '../format';
+
+// The Balance report's other suites mock `multi-currency/interface/functions`
+// to keep their assertions readable. This suite deliberately does not: it runs
+// `formatBalanceAmount` through the real currency utility so the rendered
+// strings are pinned to the Balance report design rather than to a stand-in.
+
+declare const global: {
+	wcpaySettings?: typeof wcpaySettings;
+};
+
+describe( 'formatBalanceAmount', () => {
+	beforeEach( () => {
+		global.wcpaySettings = {
+			...( global.wcpaySettings ?? {} ),
+			shouldUseExplicitPrice: true,
+			zeroDecimalCurrencies: [ 'vnd', 'jpy', 'xpf' ],
+			connect: { country: 'US' },
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
+		} as unknown as typeof wcpaySettings;
+	} );
+
+	// Every row of the Balance report design, in report order.
+	it.each( [
+		[ 'Starting balance', -123400, '-$1,234.00 USD' ],
+		[ 'Total charges captured', 34514376, '+$345,143.76 USD' ],
+		[ 'Fees', -1783357, '-$17,833.57 USD' ],
+		[ 'Charge fees', -1723025, '-$17,230.25 USD' ],
+		[ 'Deposit fees', -52332, '-$523.32 USD' ],
+		[ 'Disputes fees', -8000, '-$80.00 USD' ],
+		[ 'Refunds', -3203311, '-$32,033.11 USD' ],
+		[ 'Disputes', -87598, '-$875.98 USD' ],
+		[ 'Net balance change', 29340110, '+$293,401.10 USD' ],
+		[ 'Payouts', -28267288, '-$282,672.88 USD' ],
+		[ 'Ending balance', -1072822, '-$10,728.22 USD' ],
+	] )( 'renders the %s row as %s', ( label, amount, expected ) => {
+		expect( formatBalanceAmount( amount as number, 'usd' ) ).toBe(
+			expected
+		);
+	} );
+
+	it( 'renders zero without a sign, so an empty line implies no direction', () => {
+		expect( formatBalanceAmount( 0, 'usd' ) ).toBe( '$0.00 USD' );
+	} );
+
+	it( 'does not add a decimal part to zero-decimal currencies', () => {
+		expect( formatBalanceAmount( 3450, 'jpy' ) ).toBe( '+¥3,450 JPY' );
+	} );
+
+	it( 'omits the ISO code when the store has explicit pricing turned off', () => {
+		global.wcpaySettings = {
+			...global.wcpaySettings,
+			shouldUseExplicitPrice: false,
+		} as unknown as typeof wcpaySettings;
+
+		expect( formatBalanceAmount( 123400, 'usd' ) ).toBe( '+$1,234.00' );
+	} );
+} );

--- a/client/reports/balance/__tests__/format.test.ts
+++ b/client/reports/balance/__tests__/format.test.ts
@@ -3,54 +3,69 @@
 /**
  * Internal dependencies
  */
-import { formatBalanceAmount } from '../format';
+import { formatBalanceAmount, getBalanceCSV } from '../format';
+import type { BalanceRow } from '../rows';
 
 // The Balance report's other suites mock `multi-currency/interface/functions`
 // to keep their assertions readable. This suite deliberately does not: it runs
-// `formatBalanceAmount` through the real currency utility so the rendered
+// the formatting helpers through the real currency utility so the rendered
 // strings are pinned to the Balance report design rather than to a stand-in.
 
 declare const global: {
 	wcpaySettings?: typeof wcpaySettings;
 };
 
-describe( 'formatBalanceAmount', () => {
-	beforeEach( () => {
-		global.wcpaySettings = {
-			...( global.wcpaySettings ?? {} ),
-			shouldUseExplicitPrice: true,
-			zeroDecimalCurrencies: [ 'vnd', 'jpy', 'xpf' ],
-			connect: { country: 'US' },
-			currencyData: {
-				US: {
-					code: 'USD',
-					symbol: '$',
-					symbolPosition: 'left',
-					thousandSeparator: ',',
-					decimalSeparator: '.',
-					precision: 2,
-				},
+beforeEach( () => {
+	global.wcpaySettings = {
+		...( global.wcpaySettings ?? {} ),
+		shouldUseExplicitPrice: true,
+		zeroDecimalCurrencies: [ 'vnd', 'jpy', 'xpf' ],
+		connect: { country: 'US' },
+		currencyData: {
+			US: {
+				code: 'USD',
+				symbol: '$',
+				symbolPosition: 'left',
+				thousandSeparator: ',',
+				decimalSeparator: '.',
+				precision: 2,
 			},
-		} as unknown as typeof wcpaySettings;
-	} );
+		},
+	} as unknown as typeof wcpaySettings;
+} );
 
+describe( 'formatBalanceAmount', () => {
 	// Every row of the Balance report design, in report order.
 	it.each( [
-		[ 'Starting balance', -123400, '-$1,234.00 USD' ],
-		[ 'Total charges captured', 34514376, '+$345,143.76 USD' ],
-		[ 'Fees', -1783357, '-$17,833.57 USD' ],
-		[ 'Charge fees', -1723025, '-$17,230.25 USD' ],
-		[ 'Deposit fees', -52332, '-$523.32 USD' ],
-		[ 'Disputes fees', -8000, '-$80.00 USD' ],
-		[ 'Refunds', -3203311, '-$32,033.11 USD' ],
-		[ 'Disputes', -87598, '-$875.98 USD' ],
-		[ 'Net balance change', 29340110, '+$293,401.10 USD' ],
-		[ 'Payouts', -28267288, '-$282,672.88 USD' ],
-		[ 'Ending balance', -1072822, '-$10,728.22 USD' ],
-	] )( 'renders the %s row as %s', ( label, amount, expected ) => {
-		expect( formatBalanceAmount( amount as number, 'usd' ) ).toBe(
-			expected
-		);
+		{
+			label: 'Starting balance',
+			amount: -123400,
+			expected: '-$1,234.00 USD',
+		},
+		{
+			label: 'Total charges captured',
+			amount: 34514376,
+			expected: '+$345,143.76 USD',
+		},
+		{ label: 'Fees', amount: -1783357, expected: '-$17,833.57 USD' },
+		{ label: 'Charge fees', amount: -1723025, expected: '-$17,230.25 USD' },
+		{ label: 'Deposit fees', amount: -52332, expected: '-$523.32 USD' },
+		{ label: 'Disputes fees', amount: -8000, expected: '-$80.00 USD' },
+		{ label: 'Refunds', amount: -3203311, expected: '-$32,033.11 USD' },
+		{ label: 'Disputes', amount: -87598, expected: '-$875.98 USD' },
+		{
+			label: 'Net balance change',
+			amount: 29340110,
+			expected: '+$293,401.10 USD',
+		},
+		{ label: 'Payouts', amount: -28267288, expected: '-$282,672.88 USD' },
+		{
+			label: 'Ending balance',
+			amount: -1072822,
+			expected: '-$10,728.22 USD',
+		},
+	] )( 'renders the $label row as $expected', ( { amount, expected } ) => {
+		expect( formatBalanceAmount( amount, 'usd' ) ).toBe( expected );
 	} );
 
 	it( 'renders zero without a sign, so an empty line implies no direction', () => {
@@ -68,5 +83,41 @@ describe( 'formatBalanceAmount', () => {
 		} as unknown as typeof wcpaySettings;
 
 		expect( formatBalanceAmount( 123400, 'usd' ) ).toBe( '+$1,234.00' );
+	} );
+} );
+
+// The other Balance suites stub `formatExportAmount` with `amount => amount / 100`,
+// which ignores its currency argument. That hides the branch that decides whether
+// the `/100` happens at all, so a zero-decimal currency could silently be divided
+// and no test would catch it. This suite runs the real helper to pin that branch.
+describe( 'getBalanceCSV', () => {
+	const displayPeriod = {
+		start: '2026-05-01T00:00:00.000Z',
+		end: '2026-05-14T23:59:59.999Z',
+	};
+	const row: BalanceRow = {
+		key: 'total_charges_captured',
+		label: 'Total charges captured',
+		getAmount: () => 162672,
+	};
+
+	const buildCSV = ( currency: string ) =>
+		getBalanceCSV( {
+			visibleRows: [ row ],
+			summary: {} as Parameters< BalanceRow[ 'getAmount' ] >[ 0 ],
+			displayPeriod,
+			currency,
+		} );
+
+	it( 'exports a two-decimal currency in major units', () => {
+		expect( buildCSV( 'usd' ) ).toContain(
+			',"Total charges captured",1626.72,'
+		);
+	} );
+
+	it( 'leaves a zero-decimal currency amount unscaled', () => {
+		expect( buildCSV( 'jpy' ) ).toContain(
+			',"Total charges captured",162672,'
+		);
 	} );
 } );

--- a/client/reports/balance/__tests__/format.test.ts
+++ b/client/reports/balance/__tests__/format.test.ts
@@ -120,4 +120,22 @@ describe( 'getBalanceCSV', () => {
 			',"Total charges captured",162672,'
 		);
 	} );
+
+	it( 'flips the sign of displayNegative outflow rows to match the screen', () => {
+		const payouts: BalanceRow = {
+			key: 'payouts',
+			label: 'Payouts',
+			displayNegative: true,
+			getAmount: () => 1102608,
+		};
+
+		const csv = getBalanceCSV( {
+			visibleRows: [ payouts ],
+			summary: {} as Parameters< BalanceRow[ 'getAmount' ] >[ 0 ],
+			displayPeriod,
+			currency: 'usd',
+		} );
+
+		expect( csv ).toContain( ',Payouts,-11026.08,' );
+	} );
 } );

--- a/client/reports/balance/__tests__/index.test.tsx
+++ b/client/reports/balance/__tests__/index.test.tsx
@@ -129,18 +129,17 @@ jest.mock( '../balance-dataview', () => {
 	};
 } );
 
-// Mirror the production helper's contract: `skipSymbol = true` returns the
-// formatted amount followed by the ISO code (no `$`). `formatBalanceAmount`
-// then strips the trailing code and prepends `±USD ` for the code-first layout
-// the Figma uses.
+// Stand-ins for the production helpers, which both take minor units and are
+// covered by their own tests. They mirror the real contracts closely enough to
+// pin `formatBalanceAmount`'s sign handling and the CSV's major-unit scale:
+// `formatExplicitCurrency` renders `-$80.00 USD` (symbol first, ISO code last,
+// sign outside the symbol) and `formatExportAmount` converts to major units.
+// Thousands separators are omitted — they belong to the currency utility.
 jest.mock( 'multi-currency/interface/functions', () => ( {
-	formatExplicitCurrency: (
-		amount: number,
-		currency: string,
-		skipSymbol?: boolean
-	) =>
-		skipSymbol ? `${ amount } ${ currency }` : `${ currency } ${ amount }`,
-	// The production helper converts minor units to major units for CSV export.
+	formatExplicitCurrency: ( amount: number, currency: string ) =>
+		`${ amount < 0 ? '-' : '' }$${ Math.abs( amount / 100 ).toFixed(
+			2
+		) } ${ currency.toUpperCase() }`,
 	formatExportAmount: ( amount: number ) => amount / 100,
 } ) );
 
@@ -841,16 +840,17 @@ describe( 'BalanceReport', () => {
 			expectBalanceText( label );
 		}
 
-		// formatBalanceAmount renders sign + code + space + amount.
+		// formatBalanceAmount renders the standard WooPayments explicit currency
+		// format, with a `+` marking inflows.
 		expect(
-			within( getVisibleBalanceTable() ).getByText( '+USD 162672' )
+			within( getVisibleBalanceTable() ).getByText( '+$1626.72 USD' )
 		).toBeInTheDocument();
 		expect(
-			within( getVisibleBalanceTable() ).getByText( '-USD 6064' )
+			within( getVisibleBalanceTable() ).getByText( '-$60.64 USD' )
 		).toBeInTheDocument();
 		// Payouts is forced negative even when the raw value is positive.
 		expect(
-			within( getVisibleBalanceTable() ).getByText( '-USD 1102608' )
+			within( getVisibleBalanceTable() ).getByText( '-$11026.08 USD' )
 		).toBeInTheDocument();
 		const chargesRow = screen.getByRole( 'row', {
 			name: /Total charges captured/,

--- a/client/reports/balance/__tests__/index.test.tsx
+++ b/client/reports/balance/__tests__/index.test.tsx
@@ -925,6 +925,11 @@ describe( 'BalanceReport', () => {
 		expect( csv ).toContain(
 			'"Aperture Science LLC",acct_wcpay_123,refunds,Refunds,-215,3,usd,2026-05-01,2026-05-14'
 		);
+		// `payouts` is the only `displayNegative` row: the fixture stores it
+		// positive (1102608) but the screen and the CSV both show it negative.
+		expect( csv ).toContain(
+			'"Aperture Science LLC",acct_wcpay_123,payouts,Payouts,-11026.08,3,usd,2026-05-01,2026-05-14'
+		);
 		expect( csv ).toContain(
 			'"Aperture Science LLC",acct_wcpay_123,ending_balance,"Ending balance - formatted 2026-05-14 UTC",0,,usd,2026-05-01,2026-05-14'
 		);

--- a/client/reports/balance/__tests__/index.test.tsx
+++ b/client/reports/balance/__tests__/index.test.tsx
@@ -140,6 +140,8 @@ jest.mock( 'multi-currency/interface/functions', () => ( {
 		skipSymbol?: boolean
 	) =>
 		skipSymbol ? `${ amount } ${ currency }` : `${ currency } ${ amount }`,
+	// The production helper converts minor units to major units for CSV export.
+	formatExportAmount: ( amount: number ) => amount / 100,
 } ) );
 
 jest.mock( 'wcpay/utils/date-time', () => ( {
@@ -895,33 +897,33 @@ describe( 'BalanceReport', () => {
 			/^business_name,woopayments_account_id,row_key,label,amount,count,currency,period_start,period_end\n/
 		);
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,starting_balance,"Starting balance - formatted 2026-05-01 UTC",1000,,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,starting_balance,"Starting balance - formatted 2026-05-01 UTC",10,,usd,2026-05-01,2026-05-14'
 		);
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,total_charges_captured,"Total charges captured",162672,8,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,total_charges_captured,"Total charges captured",1626.72,8,usd,2026-05-01,2026-05-14'
 		);
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,fees,Fees,-6064,,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,fees,Fees,-60.64,,usd,2026-05-01,2026-05-14'
 		);
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,charge_fees,"Charge fees",-5958,,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,charge_fees,"Charge fees",-59.58,,usd,2026-05-01,2026-05-14'
 		);
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,dispute_fees,"Dispute fees",-1500,,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,dispute_fees,"Dispute fees",-15,,usd,2026-05-01,2026-05-14'
 		);
 		// `fee_refunds` is positive in the fixture — pins the sign convention
 		// for the one sub-row that diverges from the negative fee siblings.
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,fee_refunds,"Fee refunds",1644,,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,fee_refunds,"Fee refunds",16.44,,usd,2026-05-01,2026-05-14'
 		);
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,payout_fees,"Payout fees",-100,,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,payout_fees,"Payout fees",-1,,usd,2026-05-01,2026-05-14'
 		);
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,reader_fees,"Reader costs",-150,,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,reader_fees,"Reader costs",-1.5,,usd,2026-05-01,2026-05-14'
 		);
 		expect( csv ).toContain(
-			'"Aperture Science LLC",acct_wcpay_123,refunds,Refunds,-21500,3,usd,2026-05-01,2026-05-14'
+			'"Aperture Science LLC",acct_wcpay_123,refunds,Refunds,-215,3,usd,2026-05-01,2026-05-14'
 		);
 		expect( csv ).toContain(
 			'"Aperture Science LLC",acct_wcpay_123,ending_balance,"Ending balance - formatted 2026-05-14 UTC",0,,usd,2026-05-01,2026-05-14'
@@ -1034,7 +1036,7 @@ describe( 'BalanceReport', () => {
 
 			expect( mockDownloadCSVFile ).toHaveBeenCalledTimes( 1 );
 			expect( csv ).toContain(
-				'"Aperture Store",acct_wcpay_123,starting_balance,"Starting balance - formatted 2024-03-01 UTC",1000,,usd,2024-03-01,2024-03-31'
+				'"Aperture Store",acct_wcpay_123,starting_balance,"Starting balance - formatted 2024-03-01 UTC",10,,usd,2024-03-01,2024-03-31'
 			);
 			expect(
 				getPrintBusinessLines( getPrintReport( container ) )
@@ -1059,7 +1061,7 @@ describe( 'BalanceReport', () => {
 
 			expect( mockDownloadCSVFile ).toHaveBeenCalledTimes( 1 );
 			expect( csv ).toContain(
-				'\n,,starting_balance,"Starting balance - formatted 2024-03-01 UTC",1000,,usd,2024-03-01,2024-03-31'
+				'\n,,starting_balance,"Starting balance - formatted 2024-03-01 UTC",10,,usd,2024-03-01,2024-03-31'
 			);
 			expect(
 				getPrintBusinessLines( getPrintReport( container ) )
@@ -1078,7 +1080,7 @@ describe( 'BalanceReport', () => {
 
 			expect( mockDownloadCSVFile ).toHaveBeenCalledTimes( 1 );
 			expect( csv ).toContain(
-				'"Aperture Science LLC",,starting_balance,"Starting balance - formatted 2024-03-01 UTC",1000,,usd,2024-03-01,2024-03-31'
+				'"Aperture Science LLC",,starting_balance,"Starting balance - formatted 2024-03-01 UTC",10,,usd,2024-03-01,2024-03-31'
 			);
 			expect(
 				getPrintBusinessLines( getPrintReport( container ) )
@@ -1098,7 +1100,7 @@ describe( 'BalanceReport', () => {
 
 			expect( mockDownloadCSVFile ).toHaveBeenCalledTimes( 1 );
 			expect( csv ).toContain(
-				'"Smith, Jones & Associates",acct_wcpay_123,starting_balance,"Starting balance - formatted 2024-03-01 UTC",1000,,usd,2024-03-01,2024-03-31'
+				'"Smith, Jones & Associates",acct_wcpay_123,starting_balance,"Starting balance - formatted 2024-03-01 UTC",10,,usd,2024-03-01,2024-03-31'
 			);
 		} );
 	} );

--- a/client/reports/balance/format.ts
+++ b/client/reports/balance/format.ts
@@ -13,6 +13,7 @@ import {
 	formatExportAmount,
 } from 'multi-currency/interface/functions';
 import type { ReportsPeriodRange } from 'wcpay/reports/period-selector';
+import { getDisplayedAmount } from './rows';
 import type { BalanceRow } from './rows';
 import { getBalanceReportIdentity, getRowLabel } from './utils';
 
@@ -71,13 +72,12 @@ export const getBalanceCSV = ( {
 				{ value: row.key, display: row.key },
 				{ value: rowLabel, display: rowLabel },
 				{
-					// Export the raw amount, only rescaled from minor to major
-					// units. Unlike the on-screen and print tables, the CSV does
-					// not apply the `displayNegative` sign flip (e.g. Payouts) —
-					// it deliberately carries each row's stored sign so the file
-					// stays machine-readable. See the row contract in rows.ts.
+					// Rescaled from minor to major units, with the same
+					// `displayNegative` sign flip the on-screen and print tables
+					// apply (e.g. Payouts), so a summed CSV column matches what
+					// the merchant sees. See the row contract in rows.ts.
 					value: formatExportAmount(
-						row.getAmount( summary ),
+						getDisplayedAmount( row, row.getAmount( summary ) ),
 						currency
 					),
 					display: '',

--- a/client/reports/balance/format.ts
+++ b/client/reports/balance/format.ts
@@ -8,7 +8,10 @@ import { generateCSVDataFromTable } from '@woocommerce/csv-export';
 /**
  * Internal dependencies
  */
-import { formatExplicitCurrency } from 'multi-currency/interface/functions';
+import {
+	formatExplicitCurrency,
+	formatExportAmount,
+} from 'multi-currency/interface/functions';
 import type { ReportsPeriodRange } from 'wcpay/reports/period-selector';
 import type { BalanceRow } from './rows';
 import { getBalanceReportIdentity, getRowLabel } from './utils';
@@ -67,7 +70,13 @@ export const getBalanceCSV = ( {
 				},
 				{ value: row.key, display: row.key },
 				{ value: rowLabel, display: rowLabel },
-				{ value: row.getAmount( summary ), display: '' },
+				{
+					value: formatExportAmount(
+						row.getAmount( summary ),
+						currency
+					),
+					display: '',
+				},
 				{ value: count ?? '', display: '' },
 				{ value: currency, display: currency },
 				{ value: periodStart, display: periodStart },

--- a/client/reports/balance/format.ts
+++ b/client/reports/balance/format.ts
@@ -87,46 +87,22 @@ export const getBalanceCSV = ( {
 };
 
 /**
- * Formats a Balance summary amount in the "code-first with leading sign" style
- * used by the Balance report Figma design — e.g. `+USD 1,234.00` or `-USD 80.00`.
+ * Formats a Balance summary amount in the standard WooPayments currency style,
+ * with an explicit leading `+` on inflows — e.g. `+$1,234.00 USD` or
+ * `-$80.00 USD`.
  *
- * The default `formatExplicitCurrency` output puts the symbol before the amount
- * and the ISO code after it (`$1,234.00 USD`). Balance rows show every amount
- * with an explicit sign and the ISO code in front, with no currency symbol, so
- * that running totals are easy to scan and reconciliation against bank
- * statements doesn't require eyeballing past a `$`.
+ * `formatExplicitCurrency` already renders the leading `-` on outflows, so the
+ * `+` on inflows is the only Balance-specific part: the report states the
+ * direction of every movement rather than leaving it implied.
+ *
+ * Zero renders without a sign so reconciliation reports don't pin a misleading
+ * positive or negative direction onto an empty line.
  */
 export const formatBalanceAmount = (
 	amount: number,
 	currencyCode: string
 ): string => {
-	const upperCode = currencyCode.toUpperCase();
-	const isNegative = amount < 0;
-	const isZero = amount === 0;
-	const absoluteAmount = isNegative ? -amount : amount;
+	const formatted = formatExplicitCurrency( amount, currencyCode );
 
-	// `skipSymbol = true` removes the leading `$` (etc.) while keeping the
-	// currency utility's locale-aware number formatting. Depending on explicit
-	// pricing settings, the helper may also append a trailing ISO code.
-	const formatted = formatExplicitCurrency( absoluteAmount, upperCode, true );
-
-	// `formatExplicitCurrency` returns the value in one of two shapes depending
-	// on whether explicit pricing is enabled in settings:
-	//   • "1,234.00 USD"     — explicit pricing on (the common case)
-	//   • "1,234.00"         — explicit pricing off
-	// Move the ISO code to the front to match the Figma "code-first" pattern,
-	// and drop any stray spaces left behind by the symbol removal.
-	const withoutCode = formatted
-		.replace( new RegExp( `\\s*${ upperCode }\\s*$` ), '' )
-		.trim();
-
-	// Zero balances render without a sign so reconciliation reports don't pin a
-	// misleading positive or negative direction onto an empty line.
-	if ( isZero ) {
-		return `${ upperCode } ${ withoutCode }`;
-	}
-
-	const sign = isNegative ? '-' : '+';
-
-	return `${ sign }${ upperCode } ${ withoutCode }`;
+	return amount > 0 ? `+${ formatted }` : formatted;
 };

--- a/client/reports/balance/format.ts
+++ b/client/reports/balance/format.ts
@@ -71,6 +71,11 @@ export const getBalanceCSV = ( {
 				{ value: row.key, display: row.key },
 				{ value: rowLabel, display: rowLabel },
 				{
+					// Export the raw amount, only rescaled from minor to major
+					// units. Unlike the on-screen and print tables, the CSV does
+					// not apply the `displayNegative` sign flip (e.g. Payouts) —
+					// it deliberately carries each row's stored sign so the file
+					// stays machine-readable. See the row contract in rows.ts.
 					value: formatExportAmount(
 						row.getAmount( summary ),
 						currency

--- a/client/reports/balance/rows.ts
+++ b/client/reports/balance/rows.ts
@@ -58,7 +58,8 @@ export interface BalanceRow {
 	 * the raw value is positive. Used for rows that always represent an outflow
 	 * (e.g. Payouts), so the visual sign communicates direction-of-flow rather
 	 * than the storage sign of the underlying datum. Zero amounts are still
-	 * rendered without a sign. The CSV export uses the raw value.
+	 * rendered without a sign. The CSV export applies the same flip so a summed
+	 * column matches the on-screen table.
 	 */
 	displayNegative?: boolean;
 	getAmount: ( summary: ReportsBalanceSummary ) => number;
@@ -73,8 +74,8 @@ export const getRowDepth = ( row: BalanceRow ): BalanceRowDepth =>
  * rows (e.g. Payouts) render with a leading minus even when the underlying
  * datum is stored as a positive magnitude. Zero amounts pass through unchanged
  * so reconciliation reports don't pin a misleading sign onto an empty line.
- * The CSV export uses the raw value — only the on-screen and print tables
- * apply this transform.
+ * The on-screen table, the print view, and the CSV export all apply this
+ * transform so their signs agree.
  */
 export const getDisplayedAmount = (
 	row: BalanceRow,

--- a/client/reports/style.scss
+++ b/client/reports/style.scss
@@ -3,6 +3,15 @@
 body.woocommerce-admin-page__payments_reports {
 	background: #fff;
 
+	// WooCommerce core paints the page header #f0f0f1. On Reports the header
+	// sits directly above white content and the subcopy lives outside it, so
+	// the gray/white split reads as a seam rather than a header. Keep it white
+	// until the wider breadcrumbs/header migration lands. The core
+	// `border-bottom` stays and does the separating instead.
+	.woocommerce-layout__header {
+		background: #fff;
+	}
+
 	// Scope these WC layout overrides to the Reports section only so the
 	// Balance / Fees tabs flush against the left edge of the content area
 	// while still leaving room at the bottom for the WC footer.


### PR DESCRIPTION
Closes WOOPMNT-6274
Closes WOOPMNT-6272
Closes WOOPMNT-6275

#### Changes proposed in this Pull Request

Three presentation bugs in the Reports area, all found while grabbing launch screenshots. Each is one commit; none of them changes any underlying data.

The first two share a root cause — the Balance report hand-rolls amount formatting instead of using the helpers the rest of WooPayments already has — so fixing them together keeps the screen and the export on one consistent code path. The third is unrelated CSS on the same page, bundled here to spare you a second review of the same screens.

**WOOPMNT-6274 — Balance amounts diverged from WooPayments formatting.** The tab rendered `+USD 1,234.00`, putting the ISO code in front and dropping the currency symbol. That matched an earlier Figma, but it reads as unfamiliar accounting notation next to every other WooPayments screen — [Adam flagged it](https://a8c.slack.com/archives/C0AV35N7M40/p1782998413079239), and design has since corrected the mockups to the standard `+$1,234.00 USD`.

`formatBalanceAmount` existed only to produce that code-first layout: it asked `formatExplicitCurrency` to skip the symbol, regex-stripped the trailing ISO code, then re-emitted it as a prefix. With the design corrected, all of that reordering is dead weight — the shared helper already returns the target string, including the leading `-` on outflows. The explicit `+` on inflows is the only Balance-specific part left, so the report still states the direction of every movement:

```ts
export const formatBalanceAmount = ( amount, currencyCode ) => {
	const formatted = formatExplicitCurrency( amount, currencyCode );

	return amount > 0 ? `+${ formatted }` : formatted;
};
```

Both display call sites (the on-screen table and the print view) route through this, so one function fixes both.

**WOOPMNT-6272 — CSV exported cents.** Worth calling out, because the issue title is slightly misleading: there is **no PHP exporter** for Balance. Balance builds its CSV client-side; Fees exports server-side, where the backend converts to major units. That asymmetry is exactly why only Balance leaked cents — the client-side path wrote `row.getAmount()` (minor units) straight into the cell, so `$1,626.72` exported as `162672` while the same figure rendered correctly on screen.

The amount now goes through `formatExportAmount`, the shared helper every other WooPayments CSV export already uses (transactions, deposits, disputes, readers). It also handles zero-decimal currencies correctly — for JPY, minor units already equal major units, so the amount passes through unscaled. (The base was already right for JPY; the cents bug only affected two-decimal currencies.)

Net **−30 lines** of production code.

**WOOPMNT-6275 — Reports header was gray.** WooCommerce **core** paints `.woocommerce-layout__header` with `#f0f0f1`. On Reports that header sits directly above white content with the page subcopy outside it, so the gray/white split reads as a stray seam rather than a header. Nothing in WooPayments ever overrode it for this page.

Scoped inside the existing `body.woocommerce-admin-page__payments_reports` block — the same page-body scoping Settings and Fraud Protection already use for their WC-layout tweaks (Fraud Protection scopes a `.woocommerce-layout__header` override there too, for its border). Overriding the header *background* is new here, and it's genuinely required: core paints the header `#f0f0f1` and positions it `fixed`, so a transparent header would show content scrolling underneath. Core's `border-bottom` stays and does the separating instead, so the header still reads as a header without the color break. This is explicitly a stopgap; the broader breadcrumbs/page-header migration will make every WooPayments header consistent and this override goes away.

Guarded with a test so the override isn't silently dropped when the broader header migration lands. (The guard matches the SCSS source text — a tripwire, not a check of the rendered cascade.)

**Behavior change worth a reviewer's eye:** `formatExplicitCurrency` only appends the ISO code when `shouldUseExplicitPrice` is on. So on stores with explicit pricing **off**, Balance amounts now render as `+$1,234.00` with no trailing `USD`, where previously the code was always shown. That's deliberate — it's what every other WooPayments screen does, and it's what design asked for.

**Out of scope:** this changes *how* amounts are rendered and exported, not *what* they are. If a total still looks off, that's [TRAPLAT-4086](https://linear.app/a8c/issue/TRAPLAT-4086/reader-costs-counted-twice-in-balance-report-totals) (reader costs counted twice, server-side), not a regression here.

**How this could break / what guards it:** the risk is the currency helper behaving differently than expected across locales and zero-decimal currencies. The existing Balance suites all *mock* `multi-currency/interface/functions`, so none of them could prove real output. New `format.test.ts` runs `formatBalanceAmount` through the **real** currency utility and pins all 11 rows of the design, plus zero, JPY, and explicit-pricing-off. Feature is behind the default-off `_wcpay_feature_reports_area` flag, so blast radius is limited to merchants already opted into the beta.

#### Testing instructions

1. Enable the reports feature flag: `wp option update _wcpay_feature_reports_area 1`
2. Go to **Payments → Reports → Balance** and pick a date range with activity (I used 1–31 May 2026).
3. **Check the amounts** — every row should read `+$1,626.72 USD` / `-$58.14 USD` (symbol first, ISO code last), *not* `+USD 1,626.72`. Zero rows show `$0.00 USD` with no sign.
4. **Compare against the Fees tab** — the currency shape should now match.
5. Click **Print** — the print view should use the same format.
6. Click **Export** and open the CSV — the `amount` column should be in dollars (`1626.72`, `-58.14`), *not* cents (`162672`, `-5814`). Cross-check the figures against what's on screen; they should agree, including the **Payouts** row, which should be negative (e.g. `-11026.08`) to match the screen.
7. **Check the header** — the "Reports" title bar at the top should be white, matching the content below it, with a thin divider underneath. It should no longer be gray. (Both tabs; the Fees tab shares the same page body.)

Verified locally on Docker at 1–31 May 2026, and the Fees export was checked for consistency.

**Payouts CSV sign:** `payouts` is the only `displayNegative` row — stored positive but shown as an outflow everywhere. The on-screen and print tables already flip its sign via `getDisplayedAmount`; the CSV now runs through the same helper, so it exports `-11026.08` to match the screen instead of a bare positive. This previously carried the raw sign, which mattered more once the column moved to real dollars and someone might sum it.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


