### PR TITLE
Add per-account server flag support for Reports

### DIFF
--- a/.claude/docs/reports-fees-contract.md
+++ b/.claude/docs/reports-fees-contract.md
@@ -1,10 +1,10 @@
 # WooPayments Reports - Fees Contract
 
-**Last updated:** 2026-05-22
+**Last updated:** 2026-07-14
 
 ## Scope
 
-This document describes the current Phase 1 implementation contract for the WooPayments Reports Fees tab behind the `_wcpay_feature_reports_area` feature flag.
+This document describes the current Phase 1 implementation contract for the WooPayments Reports Fees tab behind `WC_Payments_Features::is_reports_area_enabled()`, which resolves the per-account server flag before falling back to the local `_wcpay_feature_reports_area` option.
 
 The implementation has two halves:
 
@@ -19,6 +19,10 @@ The implementation has two halves:
 -   REST base: `payments/reports/fees`.
 -   Registration: include and instantiate the controller next to the existing reports controllers in `includes/class-wc-payments.php`.
 -   Feature gate: `register_routes()` returns immediately when `! WC_Payments_Features::is_reports_area_enabled()`.
+    That method resolves in two steps: the per-account `reports_area_enabled` flag from the cached account
+    payload wins when the server has an opinion (`false` is an explicit kill switch and beats the local
+    option); otherwise the local `_wcpay_feature_reports_area` option decides, which is the publicly
+    documented snippet / WP CLI opt-in.
 -   Test bootstrap: `tests/unit/bootstrap.php` requires the controller after `class-wc-rest-payments-reports-transactions-controller.php`.
 
 When the flag is on, the controller registers:

--- a/changelog/feat-TRAPLAT-4104-reports-area-server-flag
+++ b/changelog/feat-TRAPLAT-4104-reports-area-server-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Allow the Reports area to be enabled per account from the server.

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -360,9 +360,25 @@ class WC_Payments_Features {
 	/**
 	 * Checks whether the Reports area is enabled. Disabled by default.
 	 *
+	 * Resolution order:
+	 *  1. The server's per-account flag, when it has an opinion. `false` is an explicit kill switch and
+	 *     deliberately beats the local option, so we can disable the area for a single account while we
+	 *     investigate an issue.
+	 *  2. Otherwise the local feature flag, which merchants can set themselves via the documented snippet
+	 *     or WP CLI.
+	 *
+	 * Note this is the only flag here where the server can act as an enabler rather than only as a veto.
+	 *
 	 * @return bool
 	 */
 	public static function is_reports_area_enabled(): bool {
+		$account     = WC_Payments::get_database_cache()->get( WCPay\Database_Cache::ACCOUNT_KEY, true );
+		$server_flag = is_array( $account ) ? ( $account['reports_area_enabled'] ?? null ) : null;
+
+		if ( null !== $server_flag ) {
+			return (bool) $server_flag;
+		}
+
 		return '1' === get_option( self::REPORTS_AREA_FLAG_NAME, '0' );
 	}
 

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -329,6 +329,54 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 		$this->assertFalse( WC_Payments_Features::is_frt_review_feature_active() );
 	}
 
+	public function test_is_reports_area_enabled_returns_true_when_server_enables_it() {
+		$this->mock_cache->method( 'get' )->willReturn( [ 'reports_area_enabled' => true ] );
+
+		$this->assertTrue( WC_Payments_Features::is_reports_area_enabled() );
+	}
+
+	public function test_is_reports_area_enabled_returns_false_when_server_disables_it_despite_local_flag() {
+		// The per-account kill switch must beat the merchant's own opt-in.
+		$this->mock_cache->method( 'get' )->willReturn( [ 'reports_area_enabled' => false ] );
+		$this->set_feature_flag_option( WC_Payments_Features::REPORTS_AREA_FLAG_NAME, '1' );
+
+		$this->assertFalse( WC_Payments_Features::is_reports_area_enabled() );
+
+		$this->clear_feature_flag_options( [ WC_Payments_Features::REPORTS_AREA_FLAG_NAME ] );
+	}
+
+	public function test_is_reports_area_enabled_falls_back_to_local_flag_when_server_has_no_opinion() {
+		// Server sends null - the documented snippet / WP CLI opt-in must still work.
+		$this->mock_cache->method( 'get' )->willReturn( [ 'reports_area_enabled' => null ] );
+		$this->set_feature_flag_option( WC_Payments_Features::REPORTS_AREA_FLAG_NAME, '1' );
+
+		$this->assertTrue( WC_Payments_Features::is_reports_area_enabled() );
+
+		$this->clear_feature_flag_options( [ WC_Payments_Features::REPORTS_AREA_FLAG_NAME ] );
+	}
+
+	public function test_is_reports_area_enabled_falls_back_to_local_flag_when_key_is_missing() {
+		// Older server / account payload without the key - behaves exactly as it does today.
+		$this->mock_cache->method( 'get' )->willReturn( [] );
+		$this->set_feature_flag_option( WC_Payments_Features::REPORTS_AREA_FLAG_NAME, '1' );
+
+		$this->assertTrue( WC_Payments_Features::is_reports_area_enabled() );
+
+		$this->clear_feature_flag_options( [ WC_Payments_Features::REPORTS_AREA_FLAG_NAME ] );
+	}
+
+	public function test_is_reports_area_enabled_returns_false_by_default() {
+		$this->mock_cache->method( 'get' )->willReturn( [] );
+
+		$this->assertFalse( WC_Payments_Features::is_reports_area_enabled() );
+	}
+
+	public function test_is_reports_area_enabled_returns_false_when_account_cache_is_not_set() {
+		$this->mock_cache->method( 'get' )->willReturn( null );
+
+		$this->assertFalse( WC_Payments_Features::is_reports_area_enabled() );
+	}
+
 	private function setup_enabled_flags( array $enabled_flags ) {
 		foreach ( array_keys( self::FLAG_OPTION_NAME_TO_FRONTEND_KEY_MAPPING ) as $flag ) {
 			add_filter(


### PR DESCRIPTION
Related to TRAPLAT-4104

#### Changes proposed in this Pull Request

The Reports area currently relies on the local `_wcpay_feature_reports_area` option, which means merchants must opt in themselves and there is no per-account server kill switch.

This change reads `reports_area_enabled` from the cached account payload before consulting the local option. Explicit server values win in both directions: `true` enables Reports for the account, while `false` disables it even when the merchant opted in locally. A null or missing server value preserves the documented local option behavior and its existing disabled-by-default value.

The PR also adds coverage for every resolution path, records the release changelog, and updates the Reports/Fees contract documentation.

⚠️ **This PR is one half of the change and should be tested together with the corresponding server-side branch**, which adds the per-account `reports_area_enabled` flag to the `GET accounts` payload (backed by an account meta value that we can set per account). Without the server branch the payload key is simply absent, which resolves to the local option — i.e. today's behavior.

#### Testing instructions

Unit tests for every resolution path run in CI, so the steps below cover only what CI cannot: the resolution against a real account payload, and the resulting admin UI.

**Prerequisites**

- A local Transact Platform server running the corresponding server-side branch.
- The client pointed at it — WooPayments Dev Tools → **Use local server** (WCPay Dev Settings shows _"Redirecting WCPay API requests to …"_).
- An onboarded test account.

The account payload is cached for 2h, so **after every server-side change, clear the cache**: WCPay Dev Settings (`/wp-admin/admin.php?page=wcpaydev`) → **Account cache contents (clear)**. Then reload wp-admin.

Server-side flag values are set from the Transact Platform repo:

```bash
# enable for this account
npm run cli -- wp wcpay set_account_meta <your_test_account_id> --key=reports_area_enabled --value=1

# disable for this account (kill switch)
npm run cli -- wp wcpay set_account_meta <your_test_account_id> --key=reports_area_enabled --value=0

# back to "no opinion" (removes the row — the command is interactive, so pipe `yes`)
yes | npm run cli -- wp wcpay remove_meta_from_all_accounts reports_area_enabled
```

**1. Server enables it — the merchant does nothing (the main scenario)**

- Set the local option OFF: `wp option update _wcpay_feature_reports_area 0`
- Set the server flag to `1` (above), then clear the account cache.
- ✅ **Payments → Reports** appears in the menu without the merchant touching anything, and both the **Balance** and **Fees** tabs render.

**2. Kill switch — the server disables it even for a merchant who opted in**

- Set the local option ON: `wp option update _wcpay_feature_reports_area 1`
- Set the server flag to `0`, then clear the account cache.
- ✅ **Payments → Reports** is gone from the menu, despite the local option being `1`.
- ✅ `window.wcpaySettings.featureFlags.reportsArea` is `undefined` (falsy flags are stripped by `array_filter`).
- ✅ The REST routes are not registered — `/wc/v3/payments/reports/balance` and `/wc/v3/payments/reports/fees` are absent.

**3. No server opinion — the documented opt-in still works (regression check)**

- Remove the server flag (above), then clear the account cache.
- With `_wcpay_feature_reports_area` = `1` → ✅ Reports is visible (local fallback, i.e. the currently documented snippet / WP CLI opt-in keeps working).
- With `_wcpay_feature_reports_area` = `0` → ✅ Reports is hidden (unchanged default).

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
