### PR TITLE
fix: prevent "Create Account" nonce fatal after non-card payment

### DIFF
--- a/changelog/fix-woopmnt-6279-create-account-link-expired
+++ b/changelog/fix-woopmnt-6279-create-account-link-expired
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Create Account" failing with a nonce error on the order confirmation page after paying with a non-card method (e.g. Affirm).

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2234,19 +2234,16 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		// The provider redirect returns here as a top-level GET. The block checkout "Create
-		// Account" form on this same order-received page POSTs back with its own nonce; treating
-		// that POST as a return runs the nonce check below against the wrong nonce and, via
-		// check_admin_referer(), fatals the whole request with "The link you followed has
-		// expired" instead of creating the account (WOOPMNT-6279).
+		// The redirect return is always a top-level GET. Other requests to this page (e.g. the
+		// block "Create Account" form, which POSTs back with its own nonce) must not be treated
+		// as returns, or the nonce check below would fatal them via wp_nonce_ays(). See WOOPMNT-6279.
 		if ( 'GET' !== strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ?? '' ) ) ) ) {
 			return;
 		}
 
-		// Verify softly and bail on failure. A stale or refreshed return URL should quietly
-		// no-op rather than fatal the page via check_admin_referer()/wp_nonce_ays().
+		// Verify softly so a stale/refreshed return URL no-ops instead of fatalling.
 		$is_nonce_valid = wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ?? '' ) ), 'wcpay_process_redirect_order_nonce' );
-		if ( ! $is_nonce_valid || empty( $_GET['wc_payment_method'] ) ) {
+		if ( ! $is_nonce_valid ) {
 			return;
 		}
 

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -2234,7 +2234,18 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		$is_nonce_valid = check_admin_referer( 'wcpay_process_redirect_order_nonce' );
+		// The provider redirect returns here as a top-level GET. The block checkout "Create
+		// Account" form on this same order-received page POSTs back with its own nonce; treating
+		// that POST as a return runs the nonce check below against the wrong nonce and, via
+		// check_admin_referer(), fatals the whole request with "The link you followed has
+		// expired" instead of creating the account (WOOPMNT-6279).
+		if ( 'GET' !== strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ?? '' ) ) ) ) {
+			return;
+		}
+
+		// Verify softly and bail on failure. A stale or refreshed return URL should quietly
+		// no-op rather than fatal the page via check_admin_referer()/wp_nonce_ays().
+		$is_nonce_valid = wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ?? '' ) ), 'wcpay_process_redirect_order_nonce' );
 		if ( ! $is_nonce_valid || empty( $_GET['wc_payment_method'] ) ) {
 			return;
 		}

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -415,6 +415,52 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( Order_Status::ON_HOLD, $result_order->get_status() );
 	}
 
+	public function test_maybe_process_upe_redirect_ignores_create_account_form_post() {
+		$order = WC_Helper_Order::create_order();
+
+		global $wp;
+		$wp->query_vars['order-received'] = $order->get_id();
+		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
+
+		// The block checkout "Create Account" form POSTs back to the order-received URL, which
+		// for a non-card payment still carries wc_payment_method in the query string, but with
+		// the form's own nonce rather than the redirect nonce.
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_GET['wc_payment_method'] = 'woocommerce_payments';
+		$_POST['create-account']   = '1';
+		$_REQUEST['_wpnonce']      = wp_create_nonce( 'wc_create_account' );
+		$_POST['_wpnonce']         = $_REQUEST['_wpnonce'];
+
+		// Must bail without treating the POST as a redirect return, and without a fatal
+		// "the link you followed has expired" nonce die.
+		$this->card_gateway->maybe_process_upe_redirect();
+
+		$this->assertSame( Order_Status::PENDING, wc_get_order( $order->get_id() )->get_status() );
+
+		remove_filter( 'woocommerce_is_order_received_page', '__return_true' );
+		unset( $_SERVER['REQUEST_METHOD'], $_GET['wc_payment_method'], $_POST['create-account'] );
+	}
+
+	public function test_maybe_process_upe_redirect_does_not_fatal_on_stale_nonce() {
+		$order = WC_Helper_Order::create_order();
+
+		global $wp;
+		$wp->query_vars['order-received'] = $order->get_id();
+		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_GET['wc_payment_method'] = 'woocommerce_payments';
+		$_GET['_wpnonce']          = 'not-a-valid-nonce';
+
+		// A stale or refreshed return URL should quietly no-op rather than hard-die.
+		$this->card_gateway->maybe_process_upe_redirect();
+
+		$this->assertSame( Order_Status::PENDING, wc_get_order( $order->get_id() )->get_status() );
+
+		remove_filter( 'woocommerce_is_order_received_page', '__return_true' );
+		unset( $_SERVER['REQUEST_METHOD'], $_GET['wc_payment_method'], $_GET['_wpnonce'] );
+	}
+
 	public function test_process_redirect_payment_intent_succeded() {
 		$order = WC_Helper_Order::create_order();
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay.php
@@ -417,48 +417,80 @@ class WC_Payment_Gateway_WCPay_Test extends WCPAY_UnitTestCase {
 
 	public function test_maybe_process_upe_redirect_ignores_create_account_form_post() {
 		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_intent_id', 'pi_mock' );
+		$order->save();
 
 		global $wp;
 		$wp->query_vars['order-received'] = $order->get_id();
+		set_query_var( 'order-received', $order->get_id() );
 		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
 
-		// The block checkout "Create Account" form POSTs back to the order-received URL, which
-		// for a non-card payment still carries wc_payment_method in the query string, but with
-		// the form's own nonce rather than the redirect nonce.
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_GET['wc_payment_method'] = 'woocommerce_payments';
-		$_POST['create-account']   = '1';
-		$_REQUEST['_wpnonce']      = wp_create_nonce( 'wc_create_account' );
-		$_POST['_wpnonce']         = $_REQUEST['_wpnonce'];
+		// The block checkout "Create Account" form POSTs back to the very URL the shopper was
+		// returned to, so the query string still carries a valid redirect return: everything
+		// below would be processed if this were a GET. The request-method gate is the only
+		// thing that may stop it.
+		$_GET['wc_payment_method']            = 'woocommerce_payments';
+		$_GET['_wpnonce']                     = wp_create_nonce( 'wcpay_process_redirect_order_nonce' );
+		$_GET['payment_intent']               = 'pi_mock';
+		$_GET['payment_intent_client_secret'] = 'pi_mock_secret';
+		$_GET['key']                          = $order->get_order_key();
 
-		// Must bail without treating the POST as a redirect return, and without a fatal
-		// "the link you followed has expired" nonce die.
+		// ...but submitted by the form, which posts its own nonce.
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_POST['create-account']   = '1';
+		$_POST['_wpnonce']         = wp_create_nonce( 'wc_create_account' );
+		$_REQUEST['_wpnonce']      = $_POST['_wpnonce'];
+
 		$this->card_gateway->maybe_process_upe_redirect();
 
+		// The POST is not a return: the order is left untouched, and there's no fatal
+		// "the link you followed has expired" nonce die.
 		$this->assertSame( Order_Status::PENDING, wc_get_order( $order->get_id() )->get_status() );
 
 		remove_filter( 'woocommerce_is_order_received_page', '__return_true' );
-		unset( $_SERVER['REQUEST_METHOD'], $_GET['wc_payment_method'], $_POST['create-account'] );
+		unset(
+			$_SERVER['REQUEST_METHOD'],
+			$_GET['wc_payment_method'],
+			$_GET['_wpnonce'],
+			$_GET['payment_intent'],
+			$_GET['payment_intent_client_secret'],
+			$_GET['key'],
+			$_POST['create-account']
+		);
 	}
 
 	public function test_maybe_process_upe_redirect_does_not_fatal_on_stale_nonce() {
 		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data( '_intent_id', 'pi_mock' );
+		$order->save();
 
 		global $wp;
 		$wp->query_vars['order-received'] = $order->get_id();
+		set_query_var( 'order-received', $order->get_id() );
 		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
 
-		$_SERVER['REQUEST_METHOD'] = 'GET';
-		$_GET['wc_payment_method'] = 'woocommerce_payments';
-		$_GET['_wpnonce']          = 'not-a-valid-nonce';
+		// An otherwise processable return, so the nonce is the only thing that may stop it.
+		$_SERVER['REQUEST_METHOD']            = 'GET';
+		$_GET['wc_payment_method']            = 'woocommerce_payments';
+		$_GET['_wpnonce']                     = 'not-a-valid-nonce';
+		$_GET['payment_intent']               = 'pi_mock';
+		$_GET['payment_intent_client_secret'] = 'pi_mock_secret';
+		$_GET['key']                          = $order->get_order_key();
 
-		// A stale or refreshed return URL should quietly no-op rather than hard-die.
 		$this->card_gateway->maybe_process_upe_redirect();
 
+		// A stale or refreshed return URL quietly no-ops rather than hard-dying.
 		$this->assertSame( Order_Status::PENDING, wc_get_order( $order->get_id() )->get_status() );
 
 		remove_filter( 'woocommerce_is_order_received_page', '__return_true' );
-		unset( $_SERVER['REQUEST_METHOD'], $_GET['wc_payment_method'], $_GET['_wpnonce'] );
+		unset(
+			$_SERVER['REQUEST_METHOD'],
+			$_GET['wc_payment_method'],
+			$_GET['_wpnonce'],
+			$_GET['payment_intent'],
+			$_GET['payment_intent_client_secret'],
+			$_GET['key']
+		);
 	}
 
 	public function test_process_redirect_payment_intent_succeded() {


### PR DESCRIPTION
Fixes woocommerce/woocommerce#66474  <br>Upstream report: woocommerce/woocommerce#66474

#### Changes proposed in this Pull Request

Paying with a non-card WooPayments method (e.g. Affirm) and then clicking `Create Account` on the order confirmation page failed with `The link you followed has expired`, and no account was created. Card payments were fine.

<img src="https://github.com/user-attachments/assets/b3110686-e63f-42a6-89e3-896728d5f4b3 " alt="2026-07-14-woopmnt-6279-before-02-link-expired" width="2400" data-linear-height="2322" />

`maybe_process_upe_redirect()` runs on every request to the order-received page and validated its nonce with `check_admin_referer()`, which hard-dies on failure. The block `Create Account` form POSTs back to that same URL with its own nonce, so for non-card methods (which append `wc_payment_method` to the return URL) the handler re-fired on that POST and killed the request before the account was created.

Gating the handler to the genuine `GET` return, and verifying the nonce softly so an unrelated POST - or a stale return URL - no-ops instead of fatalling. The fix belongs in WooPayments: core's block behaves correctly, our handler was just too eager on a page it shares.

#### Testing instructions

1. On a US test store, enable a non-card WooPayments method that redirects offsite (Affirm is easiest), with guest checkout + delayed account creation on (WooCommerce → Settings → Accounts & Privacy).
2. As a guest, buy a product via the block checkout, pay with Affirm, and complete its authorization.
3. On the order-received page, click `Create Account`.

   <img src="https://github.com/user-attachments/assets/429141aa-e6e2-4e1a-80df-cf5ad13dd0b1 " alt="2026-07-14-woopmnt-6279-after-01-thankyou-create-account" width="2370" data-linear-height="3560" />

   \* Before: `The link you followed has expired`, no account. After: account created, logged in.

   <img src="https://github.com/user-attachments/assets/dc526d21-ac7d-4753-97ca-3f68346c0dd2 " alt="2026-07-14-woopmnt-6279-after-02-account-created" width="2370" data-linear-height="3410" />
4. Repeat with a card - `Create Account` should keep working.

Covered by unit tests in `tests/unit/test-class-wc-payment-gateway-wcpay.php`.

---

- [X] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [X] Covered with tests (or have a good reason not to test in description ☝️)
- [X] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](<https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions>) following [these instructions](<https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios>) : *Add link here / 'QA Testing Not Applicable'*
- [ ] Add or update [critical flows](<https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows>) and [testing instructions for critical flows](<https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows>), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.