### PR TITLE
dev: document transact-platform-server local checkout in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,21 @@ WooPayments integrates with WooCommerce core via hooks, filters, and APIs.
 - `$order->set_status()`/`$order->update_status()` — always trace what hooks and emails fire
 - Code hooking into `admin_init` or `init` — trace performance implications
 
+## Transact Platform Server Reference
+
+WooPayments' server-side counterpart (webhook handlers, dispute/notification link-building, account backend) lives in `transact-platform-server`, a separate wpcom-side repo — not in this one.
+
+**Locations (priority order, matches `bin/setup-e2e-local.sh` auto-detection):**
+1. `../transact-platform-server` — sibling checkout (if available)
+2. `~/src/transact-platform-server`
+3. `~/projects/transact-platform-server`
+
+**Key paths:** `server/wp-content/rest-api-plugins/endpoints/wcpay/` (dispute/email/webhook logic), `server/wp-content/rest-api-plugins/endpoints/transact/` (core Transact API)
+
+**Caveat:** `server/` and `missioncontrol/` are gitignored rsync mirrors of the wpcom sandbox — no git history locally, content reflects whatever was last pulled. See `tests/e2e/README.md` for the `TRANSACT_PLATFORM_SERVER_REPO` env var used to wire a checkout into E2E tests.
+
+**Check it when** an investigation bottoms out at "this must be server-side" — webhook processing, dispute/reminder notification links, account/onboarding backend logic not found in `includes/wc-payment-api/` or `src/`.
+
 ## Directory Structure
 
 | Directory | Purpose | Notes |

--- a/changelog/dev-agents-md-transact-platform-server-reference
+++ b/changelog/dev-agents-md-transact-platform-server-reference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Document the transact-platform-server local checkout convention in AGENTS.md


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Adds a "Transact Platform Server Reference" section to `AGENTS.md`, mirroring the existing "WooCommerce Core Reference" pattern.

While investigating a dispute-notification link-routing question, we found that the relevant server-side logic (a `client_version >= 6.6.0` gate deciding which deep link a dispute notification embeds) lives entirely in the separate `transact-platform-server` repo, not in this one. `bin/setup-e2e-local.sh` already auto-detects a local checkout of that repo for E2E setup (`../transact-platform-server`, `~/src/transact-platform-server`, `~/projects/transact-platform-server`), but nothing pointed engineers or AI agents at it for general investigation — so it's easy to independently conclude server-side logic is "unverifiable" when a local checkout is sitting right there.

This documents the existing convention (reusing the setup script's already-established candidate paths) so future investigations know to check it, and notes the gitignored-rsync-mirror caveat for `server/`/`missioncontrol/`.

No functional/runtime changes — `AGENTS.md` only.

#### Testing instructions

*

Documentation-only change; QA testing not applicable.

-------------------

- [x] Run `npm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️) — N/A, documentation only.
- [ ] Tested on mobile (or does not apply) — N/A, documentation only.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. — N/A
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. — N/A