### PR TITLE
chore: add pnpm release cooldown and exotic-subdep block

### DIFF
--- a/changelog/chore-pnpm-release-cooldown
+++ b/changelog/chore-pnpm-release-cooldown
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Add a settings-only pnpm-workspace.yaml enabling minimumReleaseAge (1-day resolution cooldown) and blockExoticSubdeps as supply-chain hardening. Build tooling only, not user-facing.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm settings (not a workspace definition — no `packages:` key, so this
+# does not turn the repo into a pnpm workspace).
+#
+# Supply-chain hardening against fast-moving npm attacks (Shai-Hulud-style):
+minimumReleaseAge: 1440      # 1 day — packages must be published this many minutes ago before pnpm will resolve them, closing the fast-attack window between a malicious publish and its detection/unpublish. Under Dependabot's 7-day cooldown, and matches pnpm 11's default.
+blockExoticSubdeps: true     # Refuse non-registry (git/tarball/etc.) transitive deps. The lockfile has zero exotic resolutions today, so this is free to enable and prevents new ones from sneaking in.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adding a settings-only `pnpm-workspace.yaml` at the repo root to harden installs against fast-moving npm supply-chain attacks (Shai-Hulud style, where a compromised package gets published and pulled into installs before it's detected). Two settings, both supported on the current pnpm `10.30.2`:

- `minimumReleaseAge: 1440` - pnpm won't resolve a version until it's been published for at least a day, which closes the window between a malicious publish and its removal. 1440 matches pnpm 11's own default and sits under Dependabot's 7-day cooldown, so the two don't fight.
- `blockExoticSubdeps: true` - rejects non-registry (git/tarball) transitive deps. The lockfile has zero exotic resolutions today, so it's free.

There's no `packages:` key, so this does _not_ turn the repo into a pnpm workspace. It's just the (forward-compatible) home for these settings on pnpm 11. It's also safe for CI: the cooldown only applies at resolution time, and `pnpm install --frozen-lockfile` (what CI runs) skips resolution, so no lockfile churn and no `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Verified locally on pnpm 10.30.2.

This is Phase 1 of a phased plan. A pnpm 11 upgrade is a larger, separate follow-up, not part of this PR.

##### Backward compatibility

No public or exposed surface changes - tooling-only. This only affects local/CI dependency resolution; no PHP, JS, hook, REST, or option-key changes.

#### Testing instructions

- Check out this branch.
- Run `pnpm install --frozen-lockfile`.
- It should complete cleanly: no `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, and `git status` stays clean (no changes to `pnpm-lock.yaml`).


-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️) - config-only change; no code path to unit-test.
- [x] Tested on mobile (or does not apply) - does not apply.

**Post merge**

- [ ] QA Testing Not Applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
