### PR TITLE
chore: upgrade pnpm to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-strict-peer-dependencies=false
-engine-strict=true
-save-exact=true
+# pnpm 11 reads only auth/registry settings from .npmrc. All behavior settings
+# live in pnpm-workspace.yaml now (strictPeerDependencies, engineStrict,
+# saveExact were moved there). Keep this file for any future auth/registry entries.

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# pnpm 11 reads only auth/registry settings from .npmrc. All behavior settings
-# live in pnpm-workspace.yaml now (strictPeerDependencies, engineStrict,
-# saveExact were moved there). Keep this file for any future auth/registry entries.

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -15,7 +15,7 @@
  * Careful: @wordpress/private-apis needs the opposite — one shared instance, or
  * its registry throws `Cannot unlock an object that was not locked before`. npm
  * hoists it to a single copy; pnpm doesn't, so the `@wordpress/dataviews>*` pins
- * in package.json are load-bearing. A copy per package is the failure, not the
+ * in pnpm-workspace.yaml are load-bearing. A copy per package is the failure, not the
  * fix.
  */
 const PACKAGES_NEEDING_OWN_WP_DATA = [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,16 @@ pnpm run changelog:add -- --type=add --entry="Added feature" --significance=mino
 ```
 Types: `add`, `fix`, `update`, `dev`. Significances: `patch` (default), `minor`, `major`. Entries go in `changelog/`.
 
+### Dependencies & supply-chain cooldown
+
+All pnpm settings live in `pnpm-workspace.yaml` — since pnpm 11 the `package.json` `pnpm` field and non-auth `.npmrc` settings are no longer read. Three supply-chain guards are on:
+
+- **`minimumReleaseAge: 1440`** — pnpm won't resolve an npm version until it is 1 day old, closing the window between a malicious publish and its detection. It gates *resolution* (`pnpm add`/`update`, lockfile regeneration); on pnpm ≥ 11.1.3 `pnpm install --frozen-lockfile` also re-validates existing lockfile entries and aborts on a too-young pin (`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`). Dependabot's 7-day cooldown keeps its PRs clear of this.
+- **`blockExoticSubdeps: true`** — transitive dependencies must resolve from the registry; a transitive git/tarball URL fails the install.
+- **`allowBuilds`** — the build-script allowlist (`strictDepBuilds` is on by default, so a dependency whose install script is not listed here fails the install). List a package as `true` to let it build, `false` to silence it.
+
+**Pushing an urgent security bump through the cooldown:** add the package to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` (bare name or exact `pkg@version`), or run `pnpm audit --fix`, which auto-exempts advisory-patched versions. Remove the exclude once the version ages past the window.
+
 ### Other
 ```bash
 pnpm run i18n:pot                    # Generate translations

--- a/changelog/dev-upgrade-pnpm-to-11
+++ b/changelog/dev-upgrade-pnpm-to-11
@@ -1,3 +1,3 @@
 Significance: patch
 Type: dev
-Comment: Upgrade the pinned pnpm to v11. Build tooling only, not user-facing. Moves pnpm settings out of package.json/.npmrc into pnpm-workspace.yaml, converts the build-script allowlist to allowBuilds, and adopts pnpm 11's hardened supply-chain defaults (blockExoticSubdeps, strictDepBuilds). The lockfile is unchanged.
+Comment: Upgrade the pinned pnpm to v11. Build tooling only, not user-facing

--- a/changelog/dev-upgrade-pnpm-to-11
+++ b/changelog/dev-upgrade-pnpm-to-11
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Upgrade the pinned pnpm to v11. Build tooling only, not user-facing. Moves pnpm settings out of package.json/.npmrc into pnpm-workspace.yaml, converts the build-script allowlist to allowBuilds, and adopts pnpm 11's hardened supply-chain defaults (blockExoticSubdeps, strictDepBuilds). The lockfile is unchanged.

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
 	"license": "GPL-3.0-or-later",
 	"repository": "github:Automattic/woocommerce-payments",
 	"engines": {
-		"pnpm": ">=10",
+		"pnpm": ">=11",
 		"node": ">=24.15.0 <25"
 	},
-	"packageManager": "pnpm@10.30.2+sha512.36cdc707e7b7940a988c9c1ecf88d084f8514b5c3f085f53a2e244c2921d3b2545bc20dd4ebe1fc245feec463bb298aecea7a63ed1f7680b877dc6379d8d0cb4",
+	"packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
 	"config": {
 		"wp_org_slug": "woocommerce-payments",
 		"translate": true,
@@ -233,42 +233,5 @@
 		"webpack-dev-server": "5.2.3",
 		"webpack-merge": "5.8.0",
 		"whatwg-fetch": "3.6.20"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"esbuild",
-			"@parcel/watcher"
-		],
-		"ignoredBuiltDependencies": [
-			"core-js",
-			"core-js-pure",
-			"msw"
-		],
-		"overrides": {
-			"@woocommerce/components>@woocommerce/csv-export": "1.11.0",
-			"@woocommerce/components>@woocommerce/currency": "6.0.0",
-			"@woocommerce/dependency-extraction-webpack-plugin>@wordpress/dependency-extraction-webpack-plugin": "6.45.0",
-			"@wordpress/dataviews>@wordpress/data": "10.46.0",
-			"@wordpress/dataviews>@wordpress/element": "6.46.0",
-			"@wordpress/dataviews>@wordpress/compose": "7.46.0",
-			"@wordpress/dataviews>@wordpress/primitives": "4.46.0",
-			"@wordpress/dataviews>@wordpress/keycodes": "4.46.0",
-			"@wordpress/dataviews>@wordpress/deprecated": "4.46.0",
-			"@wordpress/dataviews>@wordpress/warning": "3.46.0",
-			"@wordpress/dataviews>@wordpress/date": "5.46.0",
-			"@wordpress/dataviews>@wordpress/private-apis": "1.46.0",
-			"@wordpress/dataviews>@wordpress/icons": "13.1.0",
-			"@wordpress/dataviews>@wordpress/rich-text": "7.46.0",
-			"@wordpress/scripts>@wordpress/eslint-plugin": "15.1.0",
-			"@woocommerce/eslint-plugin>@wordpress/eslint-plugin": "15.1.0",
-			"nwsapi": "2.2.12",
-			"serialize-javascript": "^7.0.5",
-			"i18n-calypso": "7.4.0",
-			"markdownlint-cli>minimatch": "^3.1.3",
-			"d3-color": "^3.1.0",
-			"d3-interpolate": "^3.0.1",
-			"d3-scale": "^4.0.2",
-			"d3-scale-chromatic": "^3.1.0"
-		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ overrides:
   d3-scale: ^4.0.2
   d3-scale-chromatic: ^3.1.0
 
-pnpmfileChecksum: sha256-xRxu356s4Z1sOi+zk7EoUU8EGPaKpwlG2618EeF7xjA=
+pnpmfileChecksum: sha256-U+gZPrmrFy5zRdE8K7tIgZTqnM8+wLR/R7S3IkpwhQo=
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,56 @@
-# pnpm settings (not a workspace definition — no `packages:` key, so this
-# does not turn the repo into a pnpm workspace).
-#
+# pnpm settings (not a workspace definition — no `packages:` key, so this does
+# not turn the repo into a pnpm workspace). Since pnpm 11 this file is the home
+# for all pnpm settings: the package.json "pnpm" field and non-auth .npmrc
+# settings are no longer read.
+
 # Supply-chain hardening against fast-moving npm attacks (Shai-Hulud-style):
 minimumReleaseAge: 1440      # 1 day — packages must be published this many minutes ago before pnpm will resolve them, closing the fast-attack window between a malicious publish and its detection/unpublish. Under Dependabot's 7-day cooldown, and matches pnpm 11's default.
 blockExoticSubdeps: true     # Refuse non-registry (git/tarball/etc.) transitive deps. The lockfile has zero exotic resolutions today, so this is free to enable and prevents new ones from sneaking in.
+
+# Migrated from .npmrc — pnpm 11 reads only auth/registry settings from .npmrc.
+strictPeerDependencies: false
+engineStrict: true
+saveExact: true
+
+# Build-script allowlist. Replaces the package.json pnpm.onlyBuiltDependencies +
+# ignoredBuiltDependencies keys (both removed in pnpm 11). strictDepBuilds
+# defaults to true in pnpm 11, so a dependency that ships a build script and is
+# not listed here fails the install — this map is the allow (true) / deny (false)
+# gate. Scoped names must be quoted (YAML rejects a bare leading `@`).
+allowBuilds:
+  esbuild: true
+  '@parcel/watcher': true
+  core-js: false
+  core-js-pure: false
+  msw: false
+
+# Migrated verbatim from package.json pnpm.overrides. The '@wordpress/dataviews>*'
+# pins are load-bearing: they keep @wordpress/private-apis a single shared copy so
+# its lock/unlock registry singleton works — pinning them away fails 14 Jest suites
+# with "Cannot unlock an object that was not locked before". Keys/values are quoted
+# because many contain characters YAML treats specially (`@`, `>`, leading `^`).
+overrides:
+  '@woocommerce/components>@woocommerce/csv-export': '1.11.0'
+  '@woocommerce/components>@woocommerce/currency': '6.0.0'
+  '@woocommerce/dependency-extraction-webpack-plugin>@wordpress/dependency-extraction-webpack-plugin': '6.45.0'
+  '@wordpress/dataviews>@wordpress/data': '10.46.0'
+  '@wordpress/dataviews>@wordpress/element': '6.46.0'
+  '@wordpress/dataviews>@wordpress/compose': '7.46.0'
+  '@wordpress/dataviews>@wordpress/primitives': '4.46.0'
+  '@wordpress/dataviews>@wordpress/keycodes': '4.46.0'
+  '@wordpress/dataviews>@wordpress/deprecated': '4.46.0'
+  '@wordpress/dataviews>@wordpress/warning': '3.46.0'
+  '@wordpress/dataviews>@wordpress/date': '5.46.0'
+  '@wordpress/dataviews>@wordpress/private-apis': '1.46.0'
+  '@wordpress/dataviews>@wordpress/icons': '13.1.0'
+  '@wordpress/dataviews>@wordpress/rich-text': '7.46.0'
+  '@wordpress/scripts>@wordpress/eslint-plugin': '15.1.0'
+  '@woocommerce/eslint-plugin>@wordpress/eslint-plugin': '15.1.0'
+  'nwsapi': '2.2.12'
+  'serialize-javascript': '^7.0.5'
+  'i18n-calypso': '7.4.0'
+  'markdownlint-cli>minimatch': '^3.1.3'
+  'd3-color': '^3.1.0'
+  'd3-interpolate': '^3.0.1'
+  'd3-scale': '^4.0.2'
+  'd3-scale-chromatic': '^3.1.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,22 +1,14 @@
-# pnpm settings (not a workspace definition — no `packages:` key, so this does
-# not turn the repo into a pnpm workspace). Since pnpm 11 this file is the home
-# for all pnpm settings: the package.json "pnpm" field and non-auth .npmrc
-# settings are no longer read.
-
+# pnpm settings (not a workspace definition — no `packages:` key, so this
+# does not turn the repo into a pnpm workspace).
+#
 # Supply-chain hardening against fast-moving npm attacks (Shai-Hulud-style):
 minimumReleaseAge: 1440      # 1 day — packages must be published this many minutes ago before pnpm will resolve them, closing the fast-attack window between a malicious publish and its detection/unpublish. Under Dependabot's 7-day cooldown, and matches pnpm 11's default.
 blockExoticSubdeps: true     # Refuse non-registry (git/tarball/etc.) transitive deps. The lockfile has zero exotic resolutions today, so this is free to enable and prevents new ones from sneaking in.
 
-# Migrated from .npmrc — pnpm 11 reads only auth/registry settings from .npmrc.
 strictPeerDependencies: false
 engineStrict: true
 saveExact: true
 
-# Build-script allowlist. Replaces the package.json pnpm.onlyBuiltDependencies +
-# ignoredBuiltDependencies keys (both removed in pnpm 11). strictDepBuilds
-# defaults to true in pnpm 11, so a dependency that ships a build script and is
-# not listed here fails the install — this map is the allow (true) / deny (false)
-# gate. Scoped names must be quoted (YAML rejects a bare leading `@`).
 allowBuilds:
   esbuild: true
   '@parcel/watcher': true
@@ -24,11 +16,6 @@ allowBuilds:
   core-js-pure: false
   msw: false
 
-# Migrated verbatim from package.json pnpm.overrides. The '@wordpress/dataviews>*'
-# pins are load-bearing: they keep @wordpress/private-apis a single shared copy so
-# its lock/unlock registry singleton works — pinning them away fails 14 Jest suites
-# with "Cannot unlock an object that was not locked before". Keys/values are quoted
-# because many contain characters YAML treats specially (`@`, `>`, leading `^`).
 overrides:
   '@woocommerce/components>@woocommerce/csv-export': '1.11.0'
   '@woocommerce/components>@woocommerce/currency': '6.0.0'


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Phase 2 (of 2) of the pnpm supply-chain hardening from #11963.

Here, I'm updating `pnpm` from 10.30.2 to v11 (11.13.1).
v11 has stricter defaults, on top of the cooldown we already ship — `blockExoticSubdeps` and `strictDepBuilds`.

v11 no longer reads the `pnpm` field in `package.json` or the non-auth settings in `.npmrc`, so those move into `pnpm-workspace.yaml`, and the build-script allowlist becomes the new `allowBuilds` map.

Node's already on 24 and CI provisions pnpm through corepack, so nothing else needs to change.

#### Testing instructions

- Check out this branch
- `corepack enable`, then `pnpm install --frozen-lockfile` — should print `✓ Lockfile passes supply-chain policies`, skip the resolution step, and leave `pnpm-lock.yaml` unchanged
- Confirm the only allowed build scripts are `esbuild` and `@parcel/watcher`
- `pnpm run lint:js` — passes
- `pnpm run test:js` — full suite green
- `pnpm run build:client` — builds

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
