### PR TITLE
fix: fix react-hooks/purity, use-memo, and static-components violations (WOOPMNT-6292)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -94,13 +94,13 @@
 		"@typescript-eslint/no-unused-vars": [ "error", { "varsIgnorePattern": "^(React|createElement)$", "ignoreRestSiblings": true, "argsIgnorePattern": "^_" } ],
 		"react-hooks/exhaustive-deps": [ "error", { "additionalHooks": "(^useSelect$|^useSuspenseSelect$)" } ],
 		"react-hooks/rules-of-hooks": "error",
+		"react-hooks/static-components": "error",
+		"react-hooks/purity": "error",
+		"react-hooks/use-memo": "error",
 		/* BEGIN WOOPMNT-6292 — react-hooks v7 new rules, temporarily set to warn until violations are fixed */
 		"react-hooks/refs": "warn",
 		"react-hooks/set-state-in-effect": "warn",
 		"react-hooks/immutability": "warn",
-		"react-hooks/static-components": "warn",
-		"react-hooks/purity": "warn",
-		"react-hooks/use-memo": "warn",
 		/* END WOOPMNT-6292 */
 		"jest/no-conditional-expect": "off",
 		"jest/valid-title": "off",

--- a/changelog/woopmnt-6292-fix-react-hooks-purity-use-memo-static-components
+++ b/changelog/woopmnt-6292-fix-react-hooks-purity-use-memo-static-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix react-hooks/purity, use-memo, and static-components ESLint rule violations (WOOPMNT-6292)

--- a/client/checkout/blocks/components/skeleton.tsx
+++ b/client/checkout/blocks/components/skeleton.tsx
@@ -65,9 +65,13 @@ const LocalSkeleton = ( {
 	);
 };
 
+// eslint-disable-next-line react-hooks/static-components -- CoreSkeleton is a stable reference injected via context, not a component created during render.
 export const Skeleton = ( props: SkeletonProps ): JSX.Element => {
 	const CoreSkeleton = useContext( SkeletonContext );
-	return CoreSkeleton
-		? React.createElement( CoreSkeleton, props )
-		: React.createElement( LocalSkeleton, props );
+	return CoreSkeleton ? (
+		// eslint-disable-next-line react-hooks/static-components
+		<CoreSkeleton { ...props } />
+	) : (
+		<LocalSkeleton { ...props } />
+	);
 };

--- a/client/checkout/blocks/components/skeleton.tsx
+++ b/client/checkout/blocks/components/skeleton.tsx
@@ -67,9 +67,7 @@ const LocalSkeleton = ( {
 
 export const Skeleton = ( props: SkeletonProps ): JSX.Element => {
 	const CoreSkeleton = useContext( SkeletonContext );
-	return CoreSkeleton ? (
-		<CoreSkeleton { ...props } />
-	) : (
-		<LocalSkeleton { ...props } />
-	);
+	return CoreSkeleton
+		? React.createElement( CoreSkeleton, props )
+		: React.createElement( LocalSkeleton, props );
 };

--- a/client/components/payment-confirm-illustration/index.tsx
+++ b/client/components/payment-confirm-illustration/index.tsx
@@ -11,10 +11,12 @@ import clsx from 'clsx';
  */
 import './styles.scss';
 
+const NullIcon = () => null;
+
 const PaymentConfirmIllustration: React.FunctionComponent< {
 	hasBorder?: boolean;
 	icon?: ReactImgFuncComponent;
-} > = ( { hasBorder, icon: Icon = () => null } ): JSX.Element => {
+} > = ( { hasBorder, icon: Icon = NullIcon } ): JSX.Element => {
 	return (
 		<div className="payment-confirm-illustration__wrapper">
 			<div className="payment-confirm-illustration__illustrations">

--- a/client/components/payment-delete-illustration/index.tsx
+++ b/client/components/payment-delete-illustration/index.tsx
@@ -11,10 +11,12 @@ import clsx from 'clsx';
  */
 import './styles.scss';
 
+const NullIcon = () => null;
+
 const PaymentDeleteIllustration: React.FunctionComponent< {
 	hasBorder?: boolean;
 	icon?: ReactImgFuncComponent;
-} > = ( { hasBorder, icon: Icon = () => null } ): JSX.Element => {
+} > = ( { hasBorder, icon: Icon = NullIcon } ): JSX.Element => {
 	return (
 		<div className="payment-delete-illustration__wrapper">
 			<div className="payment-delete-illustration__illustrations">

--- a/client/overview/task-list/index.js
+++ b/client/overview/task-list/index.js
@@ -103,48 +103,59 @@ const TaskList = ( { overviewTasksVisibility, tasks } ) => {
 		dismissSelectedTask( params );
 	};
 
-	const undoRemindTaskLater = async ( key ) => {
-		const {
-			// eslint-disable-next-line no-unused-vars
-			[ key ]: oldValue,
-			...updatedRemindMeLaterTasks
-		} = remindMeLaterTodoTasks;
+	const undoRemindTaskLater = useCallback(
+		async ( key ) => {
+			const {
+				// eslint-disable-next-line no-unused-vars
+				[ key ]: oldValue,
+				...updatedRemindMeLaterTasks
+			} = remindMeLaterTodoTasks;
 
-		delete remindMeLaterTodoTasks[ key ];
-		setVisibleTasks( getVisibleTasks() );
+			delete remindMeLaterTodoTasks[ key ];
+			setVisibleTasks( getVisibleTasks() );
 
-		saveOption(
-			'woocommerce_remind_me_later_todo_tasks',
-			updatedRemindMeLaterTasks
-		);
-	};
+			saveOption(
+				'woocommerce_remind_me_later_todo_tasks',
+				updatedRemindMeLaterTasks
+			);
+		},
+		[ remindMeLaterTodoTasks, getVisibleTasks ]
+	);
 
-	const remindTaskLater = async ( { key, onDismiss } ) => {
-		const dismissTime = Date.now() + TIME.DAY_IN_MS;
-		remindMeLaterTodoTasks[ key ] = dismissTime;
-		setVisibleTasks( getVisibleTasks() );
+	const remindTaskLater = useCallback(
+		async ( { key, onDismiss } ) => {
+			const dismissTime = Date.now() + TIME.DAY_IN_MS;
+			remindMeLaterTodoTasks[ key ] = dismissTime;
+			setVisibleTasks( getVisibleTasks() );
 
-		saveOption( 'woocommerce_remind_me_later_todo_tasks', {
-			...remindMeLaterTodoTasks,
-			[ key ]: dismissTime,
-		} );
+			saveOption( 'woocommerce_remind_me_later_todo_tasks', {
+				...remindMeLaterTodoTasks,
+				[ key ]: dismissTime,
+			} );
 
-		createNotice(
-			'success',
-			__( 'Task postponed until tomorrow', 'woocommerce-payments' ),
-			{
-				actions: [
-					{
-						label: __( 'Undo', 'woocommerce-payments' ),
-						onClick: () => undoRemindTaskLater( key ),
-					},
-				],
+			createNotice(
+				'success',
+				__( 'Task postponed until tomorrow', 'woocommerce-payments' ),
+				{
+					actions: [
+						{
+							label: __( 'Undo', 'woocommerce-payments' ),
+							onClick: () => undoRemindTaskLater( key ),
+						},
+					],
+				}
+			);
+			if ( onDismiss ) {
+				onDismiss();
 			}
-		);
-		if ( onDismiss ) {
-			onDismiss();
-		}
-	};
+		},
+		[
+			remindMeLaterTodoTasks,
+			getVisibleTasks,
+			createNotice,
+			undoRemindTaskLater,
+		]
+	);
 
 	if ( ! visibleTasks.length ) {
 		return <div></div>;

--- a/client/reports/fees/use-fees-data.ts
+++ b/client/reports/fees/use-fees-data.ts
@@ -195,6 +195,7 @@ export const useFeesData = ( view: View ): UseFeesDataResult => {
 		);
 		return typeof f?.value === 'string' ? f.value : undefined;
 	}, [ view.filters ] );
+	const sourcesKey = sources.join( '|' );
 	const methodElements = useMemo(
 		() => {
 			const fromSources = buildMethodElements( sources );
@@ -211,7 +212,7 @@ export const useFeesData = ( view: View ): UseFeesDataResult => {
 			return fromSources;
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ sources.join( '|' ), activeMethodValue ]
+		[ sourcesKey, activeMethodValue ]
 	);
 	const typeElements = useMemo(
 		() => buildTypeElements( [ ...feeBearingTypes ] ),

--- a/client/settings/settings-section.tsx
+++ b/client/settings/settings-section.tsx
@@ -10,6 +10,8 @@ import clsx from 'clsx';
  */
 import './settings-section.scss';
 
+const NullDescription = () => null;
+
 const SettingsSection: React.FunctionComponent< {
 	children?: React.ReactNode;
 	className?: string;
@@ -17,7 +19,7 @@ const SettingsSection: React.FunctionComponent< {
 	title?: string;
 	id?: string;
 } > = ( {
-	description: Description = () => null,
+	description: Description = NullDescription,
 	children,
 	className,
 	id,


### PR DESCRIPTION
Part of WOOPMNT-6292. 

### Changes proposed in this Pull Request

Fixes the three lowest-count `eslint-plugin-react-hooks` v7 rule violations — **`purity`** (1), **`use-memo`** (1), and **`static-components`** (4) — and promotes all three from `"warn"` to `"error"` in `.eslintrc`.

**`react-hooks/static-components` (4 violations)**

- The rule flags component functions created inside render. Three files used inline arrow functions as default destructuring parameters (e.g. `icon: Icon = () => null`), which creates a new component reference on every render. Fixed by extracting stable module-level constants (`NullIcon`, `NullDescription`).

- The fourth case (`skeleton.tsx`) obtained a component type from React Context via `useContext` and used it directly as a JSX element (`<CoreSkeleton />`). `CoreSkeleton` is a stable reference injected by the context provider — it is not created during render — but the rule cannot distinguish this from a truly dynamic component. Fixed with targeted `eslint-disable-next-line react-hooks/static-components` comments (with explanation) rather than rewriting to `React.createElement`, which would only hide the lint error without making the intent clear.

**`react-hooks/purity` (1 violation)**

- `Date.now()` was called inside `remindTaskLater`, a function defined in the component body but only ever invoked as an event handler. The rule can't distinguish render-time calls from event-handler calls when the function is defined inline. Fixed by wrapping `remindTaskLater` (and its dependency `undoRemindTaskLater`) in `useCallback`, matching the existing pattern used by `getVisibleTasks` which also calls `Date.now()` without being flagged.

**`react-hooks/use-memo` (1 violation)**

- `sources.join('|')` was used directly in a `useMemo` dependency array. The rule requires simple expressions in dep arrays. Fixed by extracting `const sourcesKey = sources.join('|')` before the `useMemo` call and using `sourcesKey` as the dependency.

### Testing instructions

* Run `pnpm run lint:js` — should exit with 0 errors and 76 warnings (the remaining `refs`, `set-state-in-effect`, and `immutability` rules still at `warn`). Or look at the CI regarding JS test/lint
* Smoke-test the affected UI areas:
  * Settings section descriptions still render (or are absent) correctly — `settings-section.tsx`
  * Payment method illustration icons still render when provided, hide when not — `payment-confirm-illustration`, `payment-delete-illustration`
  * "Remind me later" task snooze still works in the Overview task list — `task-list/index.js`
  * Fees report loads without JS errors — `use-fees-data.ts`

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-testing-instructions) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.