### PR TITLE
fix: add accessible label to Multi-Currency switcher select

### DIFF
--- a/changelog/fix-mccy-currency-switcher-a11y-label
+++ b/changelog/fix-mccy-currency-switcher-a11y-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add an accessible label to the Multi-Currency switcher so screen readers announce it correctly

--- a/includes/multi-currency/CurrencySwitcherBlock.php
+++ b/includes/multi-currency/CurrencySwitcherBlock.php
@@ -140,7 +140,7 @@ class CurrencySwitcherBlock {
 		$widget_content  = '<form>';
 		$widget_content .= $this->get_get_params();
 		$widget_content .= '<div class="currency-switcher-holder" style="' . esc_attr( $div_styles ) . '">';
-		$widget_content .= '<select name="currency" class="js-woopayments-currency-switcher" onchange="this.form.submit()" style="' . esc_attr( $select_styles ) . '">';
+		$widget_content .= '<select name="currency" class="js-woopayments-currency-switcher" aria-label="' . esc_attr__( 'Select your currency', 'woocommerce-payments' ) . '" onchange="this.form.submit()" style="' . esc_attr( $select_styles ) . '">';
 
 		foreach ( $enabled_currencies as $currency ) {
 			$widget_content .= $this->render_currency_option( $currency, $with_symbol, $with_flag );

--- a/includes/multi-currency/CurrencySwitcherWidget.php
+++ b/includes/multi-currency/CurrencySwitcherWidget.php
@@ -106,7 +106,7 @@ class CurrencySwitcherWidget extends WC_Widget {
 			<select
 				name="currency"
 				class="js-woopayments-currency-switcher"
-				aria-label="<?php echo esc_attr( $title ); ?>"
+				aria-label="<?php echo esc_attr( ! empty( $title ) ? $title : __( 'Select your currency', 'woocommerce-payments' ) ); ?>"
 				onchange="this.form.submit()"
 			>
 				<?php

--- a/includes/multi-currency/client/blocks/currency-switcher.js
+++ b/includes/multi-currency/client/blocks/currency-switcher.js
@@ -316,6 +316,10 @@ registerBlockType( 'woocommerce-payments/multi-currency-switcher', {
 				<div className="currency-switcher-holder" style={ styles.div }>
 					<select
 						name="currency"
+						aria-label={ __(
+							'Select your currency',
+							'woocommerce-payments'
+						) }
 						disabled={ isLoading }
 						style={ styles.select }
 					>

--- a/tests/unit/multi-currency/test-class-currency-switcher-block.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-block.php
@@ -125,6 +125,20 @@ class WCPay_Multi_Currency_Currency_Switcher_Block_Tests extends WCPAY_UnitTestC
 		}
 	}
 
+	public function test_render_block_widget_adds_aria_label() {
+		$this->mock_compatibility->expects( $this->once() )
+			->method( 'should_disable_currency_switching' )
+			->willReturn( false );
+
+		$this->mock_multi_currency->expects( $this->once() )
+			->method( 'get_enabled_currencies' )
+			->willReturn( $this->mock_currencies );
+
+		$result = $this->currency_switcher_block->render_block_widget( [], '' );
+
+		$this->assertStringContainsString( 'aria-label="Select your currency"', $result );
+	}
+
 	public function block_widget_attributes_provider(): array {
 		return [
 			'with_defaults'                 => [

--- a/tests/unit/multi-currency/test-class-currency-switcher-widget.php
+++ b/tests/unit/multi-currency/test-class-currency-switcher-widget.php
@@ -71,6 +71,12 @@ class WCPay_Multi_Currency_Currency_Switcher_Widget_Tests extends WCPAY_UnitTest
 		$this->render_widget( $instance );
 	}
 
+	public function test_widget_renders_fallback_aria_label_when_title_is_empty() {
+		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
+		$this->expectOutputRegex( '/aria-label="Select your currency"/' );
+		$this->render_widget();
+	}
+
 	public function test_widget_renders_enabled_currencies_with_symbol() {
 		$this->mock_compatibility->method( 'should_disable_currency_switching' )->willReturn( false );
 		$this->expectOutputRegex( '/value="USD">&#36; USD.+value="CAD">&#36; CAD.+value="EUR">&euro; EUR.+value="CHF">CHF/s' );

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -1128,7 +1128,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 						<select
 				name="currency"
 				class="js-woopayments-currency-switcher"
-				aria-label=""
+				aria-label="Select your currency"
 				onchange="this.form.submit()"
 			>
 				<option value="USD" selected>&#36; USD</option><option value="BIF">Fr BIF</option><option value="CAD">&#36; CAD</option><option value="GBP">&pound; GBP</option>			</select>


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Lighthouse flagged the Multi-Currency switcher for the `select-name` a11y audit.
The block renders a `<select>` element with no accessible name.

Adding a translatable `aria-label` ("Select your currency") to the block render and its editor preview.

Before:
<img width="538" height="400" alt="Screenshot 2026-07-21 at 4 23 13 PM" src="https://github.com/user-attachments/assets/a859061c-b5d6-4c8d-90ee-9f259367682f" />

#### Testing instructions

1. Enable Multi-Currency with 2+ currencies.
2. Add the **Currency Switcher** block to a page/template (front end).
3. Inspect the `<select>`. it should have `aria-label="Select your currency"`.
4. Run a Lighthouse accessibility audit (using Chrome dev-tools), `select-name` no longer fails.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

