### PR TITLE
dev: expose develop sync PR URL in code freeze Slack notification

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -87,6 +87,7 @@ jobs:
       RELEASE_VERSION: ${{ needs.check-code-freeze.outputs.nextReleaseVersion }}
       RELEASE_DATE: ${{ needs.check-code-freeze.outputs.nextReleaseDate }}
       RELEASE_PR_ID: ${{ needs.create-release-pr.outputs.release-pr-id }}
+      DEVELOP_PR_URL: ${{ needs.create-release-pr.outputs.develop-pr-url }}
       GITHUB_RUN_ID: ${{ github.run_id }}
       CURRENT_VERSION: ${{ needs.check-code-freeze.outputs.currentVersion }}
       PRODUCT_AMBASSADORS_SLACK_IDS: "<@U03BURMGS95> <@UA4763TED>"  # Aashik and Francois. Update directly if needed.
@@ -119,7 +120,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "• Created a release branch `release/${{ env.RELEASE_VERSION }}` \n • Raised a <https://github.com/Automattic/woocommerce-payments/pull/${{ env.RELEASE_PR_ID }}|Pull Request> to `trunk`\n • Built a <https://github.com/Automattic/woocommerce-payments/actions/runs/${{ env.GITHUB_RUN_ID }}|zip file and ran smoke tests> against it"
+                    "text": "• Created a release branch `release/${{ env.RELEASE_VERSION }}` \n • Raised a <https://github.com/Automattic/woocommerce-payments/pull/${{ env.RELEASE_PR_ID }}|Pull Request> to `trunk`\n • Raised a <${{ env.DEVELOP_PR_URL }}|changelog sync PR> to `develop`\n • Built a <https://github.com/Automattic/woocommerce-payments/actions/runs/${{ env.GITHUB_RUN_ID }}|zip file and ran smoke tests> against it"
                   }
                 },
                 {

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -22,6 +22,9 @@ on:
       release-pr-id:
         description: "ID of the release PR created"
         value: ${{ jobs.prepare-release.outputs.release-pr-id }}
+      develop-pr-url:
+        description: "URL of the develop sync PR created"
+        value: ${{ jobs.prepare-release.outputs.develop-pr-url }}
 
 
   workflow_dispatch:
@@ -62,6 +65,7 @@ jobs:
     outputs:
       branch: ${{ steps.create_branch.outputs.branch-name }}
       release-pr-id: ${{ steps.create-pr-to-trunk.outputs.RELEASE_PR_ID }}
+      develop-pr-url: ${{ steps.open-develop-pr.outputs.DEVELOP_PR_URL }}
     env:
       RELEASE_VERSION: ${{ inputs.releaseVersion }}
       RELEASE_DATE_STRING: ${{ inputs.releaseDateString }}
@@ -143,6 +147,7 @@ jobs:
           echo "DEVELOP_BRANCH=$DEVELOP_BRANCH" >> "$GITHUB_ENV"
 
       - name: "Open PR against develop"
+        id: open-develop-pr
         if: ${{ ! inputs.dry-run }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOTWOO_TOKEN }}
@@ -156,6 +161,7 @@ jobs:
             --base develop \
             --head "$DEVELOP_BRANCH")
           echo "DEVELOP_PR_URL=$DEVELOP_PR_URL" >> "$GITHUB_ENV"
+          echo "DEVELOP_PR_URL=$DEVELOP_PR_URL" >> "$GITHUB_OUTPUT"
 
       - name: "Add comment to PR to trunk"
         if: ${{ ! inputs.dry-run }}

--- a/changelog/add-release-develop-pr-url-to-slack-notification
+++ b/changelog/add-release-develop-pr-url-to-slack-notification
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: Expose develop sync PR URL from release-pr.yml as a workflow output so release-code-freeze.yml can include it in the Slack notification.
+


### PR DESCRIPTION
Fixes #
See p1784688946311839/1784650024.041479-slack-CGGCLBN58

#### Changes proposed in this Pull Request

When the code freeze workflow runs, it sends a Slack notification listing the actions it performed. Previously the notification mentioned the trunk PR and the zip/smoke-test run, but not the changelog sync PR opened against `develop`. This change surfaces that URL so the release lead can find and merge the develop sync PR directly from the Slack message.


#### Testing instructions

* Trigger `release-code-freeze.yml` manually (or via `release-pr.yml` directly with a test version) and verify the Slack notification includes the develop sync PR link in the correct position.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.