### PR TITLE
Cherry-pick: Bump WC tested up to version to 11.0.0 (#11977)

### DIFF
--- a/changelog/bump-wc-tested-up-to-11-0-0
+++ b/changelog/bump-wc-tested-up-to-11-0-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WC tested up to version to 11.0.0

--- a/changelog/bump-wc-tested-up-to-11-0-0
+++ b/changelog/bump-wc-tested-up-to-11-0-0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump WC tested up to version to 11.0.0

--- a/changelog/remove-wc-tested-up-to-changelog-entry
+++ b/changelog/remove-wc-tested-up-to-changelog-entry
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Dev-only WC tested-up-to header bump; intentionally omitted from the changelog.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 10.9.0
+ * WC tested up to: 11.0.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Version: 11.0.0


### PR DESCRIPTION
## Summary

Cherry-picks commit `cdbd58a36` (chore: Bump WC tested up to version to 11.0.0, #11977) from `develop` into the `release/11.0.0` branch, so the WooPayments 11.0.0 release ships declaring compatibility with WooCommerce 11.0.0.

**Original PR:** #11977

The changelog entry is intentionally a Comment-only file — the header bump is a dev-only compatibility declaration, so it's omitted from the shipped changelog. #11980 applies the same swap on `develop`.

## Test plan

- Verify the plugin header in `woocommerce-payments.php` on this branch shows `WC tested up to: 11.0.0`.
- CI should pass; no manual testing beyond that (header change only, changelog file compiles to nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)