### PR TITLE
chore: Omit WC tested-up-to bump from the changelog

### DIFF
--- a/changelog/bump-wc-tested-up-to-11-0-0
+++ b/changelog/bump-wc-tested-up-to-11-0-0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump WC tested up to version to 11.0.0

--- a/changelog/remove-wc-tested-up-to-changelog-entry
+++ b/changelog/remove-wc-tested-up-to-changelog-entry
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Dev-only WC tested-up-to header bump; intentionally omitted from the changelog.


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

Follow-up to #11977: replaces the `changelog/bump-wc-tested-up-to-11-0-0` entry with a Comment-only changelog file. The tested-up-to header bump is a dev-only compatibility declaration with no user-facing change, so it shouldn't take up a line in the release changelog. The Comment-only file keeps the check-changelog CI requirement satisfied while compiling to nothing.

The cherry-pick to `release/11.0.0` (#11979) carries the same swap, so the entry won't appear in the 11.0.0 changelog nor leak into the next release's changelog from `develop`.

#### Testing instructions

* Verify `changelog/bump-wc-tested-up-to-11-0-0` is gone and the new file only has frontmatter (`Significance`/`Type`/`Comment`) with no entry text.
* `./vendor/bin/changelogger validate` passes.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)