### PR TITLE
dev: fix Compressed Size base install failing on release PRs

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -30,11 +30,14 @@ jobs:
                   # The action installs both this branch and the base branch
                   # under the Node version from this branch's .nvmrc. Let the
                   # base comparison install old package engine metadata.
-                  # --ignore-scripts: the base branch has no pnpm-lock.yaml, so
-                  # its install would trip pnpm 10's CI hard-fail on un-approved
-                  # dependency build scripts (ERR_PNPM_IGNORED_BUILDS). The
-                  # webpack bundle build doesn't need those scripts, so skip them.
-                  install-script: pnpm install --no-frozen-lockfile --ignore-scripts --config.engine-strict=false
+                  # --ignore-scripts: the webpack bundle build doesn't need
+                  # dependency build scripts, so skip them on both installs.
+                  # --config.strict-dep-builds=false: --ignore-scripts alone
+                  # doesn't prevent ERR_PNPM_IGNORED_BUILDS — the base-branch
+                  # reinstall re-checks builds approved by this branch's
+                  # allowBuilds against the base's older or absent allowlist
+                  # and hard-fails (seen on release→trunk PRs).
+                  install-script: pnpm install --no-frozen-lockfile --ignore-scripts --config.engine-strict=false --config.strict-dep-builds=false
                   pattern: '{release/**/*.js,release/**/*.css}'
                   exclude: '{release/vendor/**}'
                   package-manager: pnpm

--- a/changelog/fix-bundle-size-strict-dep-builds
+++ b/changelog/fix-bundle-size-strict-dep-builds
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: CI-only Compressed Size workflow fix; intentionally omitted from the changelog.


### PR DESCRIPTION
Fixes WOOPMNT-6306

The `Compressed Size / Bundle size check` fails on the 11.0.0 release PR: https://github.com/Automattic/woocommerce-payments/actions/runs/29911423318/job/88898343756

## Changes proposed in this Pull Request

The bundle size action builds this branch, then checks out the base branch in the same working tree and rebuilds it for comparison. On release→trunk PRs the base (`trunk`, still npm-era) has no `pnpm-workspace.yaml`, so the base-branch reinstall re-checks the builds approved by this branch's `allowBuilds` (esbuild, `@parcel/watcher`) against an absent allowlist and hard-fails with `ERR_PNPM_IGNORED_BUILDS` — even though `--ignore-scripts` is passed (that flag only helps on a fresh install; the inherited `node_modules` state is what trips the strict check).

This adds `--config.strict-dep-builds=false` to the action's `install-script`. The install never runs dependency build scripts anyway (`--ignore-scripts`), so the build-approval policy adds nothing in this compare-only CI context, and the supply-chain guards for real installs (`minimumReleaseAge`, `blockExoticSubdeps`, `allowBuilds` in `pnpm-workspace.yaml`) are untouched.

This also protects future release PRs: once trunk is pnpm-era, a package newly added to `allowBuilds` on develop but not yet on trunk would trip the same error.

Changelog entry is Comment-only (CI-only change, nothing user-facing to ship).

**Backward compatibility:** none — CI workflow only; no public PHP/JS surface, hooks, or REST contracts touched.

### How to test the changes in this Pull Request

Reproduced and verified locally with a minimal two-phase install (both pnpm 11.13.1 — this branch's pin — and 11.15.1, the corepack fallback used for trunk's pin-less checkout):

1. In an empty dir, create `package.json` with `esbuild` + `@parcel/watcher` deps and a `pnpm-workspace.yaml` with `allowBuilds` for both; run `CI=true pnpm install --no-frozen-lockfile --ignore-scripts --config.engine-strict=false` → passes.
2. Delete `pnpm-workspace.yaml` and `pnpm-lock.yaml` (simulating the trunk checkout), rerun the same install → fails with `ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: @parcel/watcher@2.5.6, esbuild@0.25.12` (the exact CI error).
3. Rerun step 2 with `--config.strict-dep-builds=false` appended → passes.

**Validated end-to-end in CI:** throwaway draft PR #11982 (head = `release/11.0.0` + this fix, base = `trunk` — the same combination as #11974) ran the fixed workflow, and the `Compressed Size` check [passed in 2m56s](https://github.com/Automattic/woocommerce-payments/actions/runs/29914407596/job/88904736053). The job log confirms the previously failing path executed for real: the base-branch install completed clean under pnpm 11.15.1 (the corepack fallback that previously hit `ERR_PNPM_IGNORED_BUILDS`) and trunk's comparison build ran to completion. #11982 was closed unmerged once the result was in.

- [x] Run `pnpm run changelog:add` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — verified via local reproduction; not testable in-repo.

## Post merge

- [ ] Cherry-pick to `release/11.0.0` so the release PR's bundle size check passes.
