### PR TITLE
fix: restore well-formed transaction URL in test mode order note

### DIFF
--- a/changelog/fix-test-mode-payment-note-url
+++ b/changelog/fix-test-mode-payment-note-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed broken payment intent link in test mode order notes.

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -1911,16 +1911,17 @@ class WC_Payments_Order_Service {
 
 		return sprintf(
 			WC_Payments_Utils::esc_interpolated_html(
-				/* translators: %1: the charged amount, %2: WooPayments, %3: transaction ID of the payment */
+				/* translators: %1: the charged amount, %2: WooPayments, %3: transaction ID of the payment, %4: transaction details URL */
 				__( 'A test payment of %1$s was processed using %2$s in <strong>test mode</strong> (<a>%3$s</a>). No real funds were collected.', 'woocommerce-payments' ),
 				[
 					'strong' => '<strong>',
-					'a'      => ! empty( $transaction_url ) ? '<a href="' . $transaction_url . '" target="_blank" rel="noopener noreferrer">' : '<code>',
+					'a'      => ! empty( $transaction_url ) ? '<a href="%4$s" target="_blank" rel="noopener noreferrer">' : '<code>',
 				]
 			),
 			$formatted_amount,
 			'WooPayments',
-			WC_Payments_Utils::get_transaction_url_id( $intent_id, $charge_id )
+			WC_Payments_Utils::get_transaction_url_id( $intent_id, $charge_id ),
+			$transaction_url
 		);
 	}
 

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -222,6 +222,11 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( 'No real funds were collected', $notes[0]->content );
 		// Assert: The transaction link is preserved.
 		$this->assertStringContainsString( 'pi_mock', $notes[0]->content );
+		// Assert: The transaction URL is well-formed — path must contain the real slash-separated
+		// path, not the corrupted "0.000000" that sprintf produces when %2F is misread as a
+		// printf float specifier (%2F → 0.000000).
+		$this->assertStringContainsString( 'path=%2Fpayments%2Ftransactions%2Fdetails', $notes[0]->content );
+		$this->assertStringNotContainsString( '0.000000', $notes[0]->content );
 		// Assert: It does NOT use the standard "successfully charged" wording.
 		$this->assertStringNotContainsString( 'successfully charged', $notes[0]->content );
 	}


### PR DESCRIPTION
Fixes #WOOPMNT-6309

#### Changes proposed in this Pull Request

`generate_test_mode_payment_success_note()` was concatenating `$transaction_url` directly into the `sprintf` format string. After `rawurlencode()` was added to `compose_transaction_url()` (in #11815), the `%2F` sequences in the URL were misread by `sprintf` as printf float specifiers (`%2F` → `0.000000`), corrupting the path:

```
path=0.000000payments0.000000transactions0.000000details
```

All sibling note functions were already using the safe `%4$s` placeholder pattern — this function was the only one missed during the #11815 sweep.

The fix adopts the same pattern: pass `$transaction_url` as the fourth `sprintf` argument and reference it via `%4$s` in the element map, so `sprintf` substitutes it literally without re-scanning its content for format specifiers.

Only test mode payment success notes are affected — all other note-generating functions were already safe.

#### Testing instructions

* Enable test mode in WooPayments settings.
* Place an order and complete payment using a test card (e.g. 4242 4242 4242 4242).
* Open the order in WP Admin → WooCommerce → Orders.
* Find the note: _"A test payment of $X was processed using WooPayments in test mode (pi_…). No real funds were collected."_
* Click the payment intent ID link — it should open the transaction details page correctly.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)