### PR TITLE
fix: multiple disputes order notes

### DIFF
--- a/changelog/fix-multiple-disputes-notes-and-notice
+++ b/changelog/fix-multiple-disputes-notes-and-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reflect all of a charge's disputes in order notes and the order dispute notice when a charge has more than one, and align the 'Dispute N of M' label on the transaction details page.

--- a/changelog/fix-multiple-disputes-notes-and-notice#2
+++ b/changelog/fix-multiple-disputes-notes-and-notice#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure a disputed order is placed on hold even when its dispute note already exists, and avoid a fatal when a dispute webhook references an unknown charge.

--- a/changelog/fix-multiple-disputes-notes-and-notice#2
+++ b/changelog/fix-multiple-disputes-notes-and-notice#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Ensure a disputed order is placed on hold even when its dispute note already exists, and avoid a fatal when a dispute webhook references an unknown charge.
+Avoid a fatal when a dispute webhook references an unknown charge.

--- a/client/components/disputed-order-notice/__tests__/index.test.js
+++ b/client/components/disputed-order-notice/__tests__/index.test.js
@@ -165,6 +165,48 @@ describe( 'DisputedOrderNoticeHandler', () => {
 		);
 	} );
 
+	test( 'calls the consolidated notice inquiries when every awaiting item is an inquiry', () => {
+		const fixedDate = new Date( '2023-10-20T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'warning_needs_response',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698672000 },
+					},
+					{
+						id: 'dp_2',
+						status: 'warning_needs_response',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText(
+				'This order has 2 payment inquiries totaling $25.50.'
+			)
+		).toBeInTheDocument();
+	} );
+
 	test( 'disables order refunds when any dispute is not refundable, even behind a refundable one', () => {
 		const onDisableOrderRefund = jest.fn();
 		useCharge.mockReturnValue( {

--- a/client/components/disputed-order-notice/__tests__/index.test.js
+++ b/client/components/disputed-order-notice/__tests__/index.test.js
@@ -109,4 +109,94 @@ describe( 'DisputedOrderNoticeHandler', () => {
 			screen.queryByText( /Please resolve the dispute on this order of/ )
 		).not.toBeInTheDocument();
 	} );
+
+	test( 'consolidates multiple awaiting-response disputes into one notice, using the summed amount and earliest due date', () => {
+		const fixedDate = new Date( '2023-10-20T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'needs_response',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						// Oct 30, 2023 — the later deadline.
+						evidence_details: { due_by: 1698672000 },
+					},
+					{
+						id: 'dp_2',
+						status: 'needs_response',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						// Oct 28, 2023 — the earliest deadline, so the one shown.
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText(
+				'This order has 2 payment disputes totaling $25.50.'
+			)
+		).toBeInTheDocument();
+
+		// The earliest of the two deadlines is surfaced.
+		expect(
+			screen.getAllByText( /Please respond before Oct 28, 2023/ ).length
+		).toBeGreaterThan( 0 );
+
+		// A single consolidated notice, not one per dispute.
+		expect( screen.getAllByRole( 'button' ) ).toHaveLength( 1 );
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent(
+			'Respond now'
+		);
+	} );
+
+	test( 'disables order refunds when any dispute is not refundable, even behind a refundable one', () => {
+		const onDisableOrderRefund = jest.fn();
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'won',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+					{
+						id: 'dp_2',
+						status: 'needs_response',
+						reason: 'fraudulent',
+						amount: 1550,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ onDisableOrderRefund }
+			/>
+		);
+
+		expect( onDisableOrderRefund ).toHaveBeenCalledWith( 'needs_response' );
+	} );
 } );

--- a/client/components/disputed-order-notice/index.js
+++ b/client/components/disputed-order-notice/index.js
@@ -16,6 +16,7 @@ import {
 	isRefundable,
 	isUnderReview,
 } from 'wcpay/disputes/utils';
+import { getChargeDisputes } from 'wcpay/utils/charge';
 import { useCharge } from 'wcpay/data/charges';
 import { recordEvent } from 'tracks';
 import './style.scss';
@@ -25,25 +26,36 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 	const { data: charge } = useCharge( chargeId );
 	const disputeDetailsUrl = getDetailsURL( chargeId, 'transactions' );
 
-	// Disable the refund button if there's an active dispute.
+	// A charge can carry more than one dispute (e.g. AmEx/Klarna partial
+	// disputes). `getChargeDisputes` returns them all, falling back to the
+	// single `charge.dispute` for payloads without the array.
+	const disputes = charge ? getChargeDisputes( charge ) : [];
+
+	// Disable the refund button if any dispute blocks refunds.
 	useEffect( () => {
-		const { dispute } = charge;
-		if ( ! charge?.dispute ) {
-			return;
-		}
-		if ( ! isRefundable( dispute.status ) ) {
-			onDisableOrderRefund( dispute.status );
+		const blocking = ( charge ? getChargeDisputes( charge ) : [] ).find(
+			( dispute ) => ! isRefundable( dispute.status )
+		);
+		if ( blocking ) {
+			onDisableOrderRefund( blocking.status );
 		}
 	}, [ charge, onDisableOrderRefund ] );
 
-	const { dispute } = charge;
-	if ( ! charge?.dispute ) {
+	if ( ! disputes.length ) {
 		return null;
 	}
 
+	// Refund/edit locking and the "under review" / "lost" states are
+	// charge-wide, so surface them if ANY dispute is in that state before
+	// considering the respond-by notices below.
+
 	// Special case the dispute "under review" notice which is much simpler.
-	// (And return early.)
-	if ( isUnderReview( dispute.status ) && ! isInquiry( dispute.status ) ) {
+	if (
+		disputes.some(
+			( dispute ) =>
+				isUnderReview( dispute.status ) && ! isInquiry( dispute.status )
+		)
+	) {
 		return (
 			<DisputeOrderLockedNotice
 				message={ __(
@@ -56,13 +68,12 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 	}
 
 	// Special case lost disputes.
-	// (And return early.)
 	// I suspect this is unnecessary, as any lost disputes will have already been
 	// refunded as part of `charge.dispute.closed` webhook handler.
 	// This may be dead code. Leaving in for now as this is consistent with
 	// the logic before this PR.
 	// https://github.com/Automattic/woocommerce-payments/pull/7557
-	if ( dispute.status === 'lost' ) {
+	if ( disputes.some( ( dispute ) => dispute.status === 'lost' ) ) {
 		return (
 			<DisputeOrderLockedNotice
 				message={ __(
@@ -74,37 +85,75 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 		);
 	}
 
-	// Only show the notice if the dispute is awaiting a response.
-	if ( ! isAwaitingResponse( dispute.status ) ) {
-		return null;
-	}
-
-	// Bail if we don't have due_by for whatever reason.
-	if ( ! dispute.evidence_details?.due_by ) {
-		return null;
-	}
-
-	// Get current time in UTC for consistent timezone-independent comparison
+	// Get current time in UTC for consistent timezone-independent comparison.
 	const now = moment().utc();
-	// Parse the Unix timestamp as UTC since it's stored that way in the API
-	const dueBy = moment.unix( dispute.evidence_details?.due_by ).utc();
 
-	// If the dispute is due in the past, don't show notice.
-	if ( ! now.isBefore( dueBy ) ) {
+	// Disputes still awaiting a response, with a deadline in the future.
+	const awaitingDisputes = disputes.filter( ( dispute ) => {
+		if (
+			! isAwaitingResponse( dispute.status ) ||
+			! dispute.evidence_details?.due_by
+		) {
+			return false;
+		}
+		// Parse the Unix timestamp as UTC since it's stored that way in the API.
+		return now.isBefore(
+			moment.unix( dispute.evidence_details.due_by ).utc()
+		);
+	} );
+
+	if ( ! awaitingDisputes.length ) {
 		return null;
 	}
+
+	// A single dispute keeps its detailed, reason-specific notice. Several are
+	// consolidated into one so the order screen isn't stacked with
+	// near-identical notices — the transaction page (one click away) breaks
+	// them down per dispute.
+	if ( awaitingDisputes.length === 1 ) {
+		const dispute = awaitingDisputes[ 0 ];
+		const dueBy = moment.unix( dispute.evidence_details.due_by ).utc();
+		return (
+			<DisputeNeedsResponseNotice
+				chargeId={ chargeId }
+				disputeReason={ dispute.reason }
+				formattedAmount={ formatExplicitCurrency(
+					dispute.amount,
+					dispute.currency
+				) }
+				isPreDisputeInquiry={ isInquiry( dispute.status ) }
+				dueBy={ dueBy }
+				countdownDays={ Math.floor( dueBy.diff( now, 'days', true ) ) }
+				disputeDetailsUrl={ disputeDetailsUrl }
+			/>
+		);
+	}
+
+	const earliestDueBy = awaitingDisputes
+		.map( ( dispute ) =>
+			moment.unix( dispute.evidence_details.due_by ).utc()
+		)
+		.reduce( ( earliest, dueBy ) =>
+			dueBy.isBefore( earliest ) ? dueBy : earliest
+		);
+	// Disputes on one charge share its currency, so summing the minor-unit
+	// amounts and formatting with the first dispute's currency is safe.
+	const totalAmount = awaitingDisputes.reduce(
+		( sum, dispute ) => sum + dispute.amount,
+		0
+	);
 
 	return (
-		<DisputeNeedsResponseNotice
-			chargeId={ chargeId }
-			disputeReason={ dispute.reason }
+		<MultipleDisputesNeedsResponseNotice
+			disputeCount={ awaitingDisputes.length }
 			formattedAmount={ formatExplicitCurrency(
-				dispute.amount,
-				dispute.currency
+				totalAmount,
+				awaitingDisputes[ 0 ].currency
 			) }
-			isPreDisputeInquiry={ isInquiry( dispute.status ) }
-			dueBy={ dueBy }
-			countdownDays={ Math.floor( dueBy.diff( now, 'days', true ) ) }
+			dueBy={ earliestDueBy }
+			countdownDays={ Math.floor(
+				earliestDueBy.diff( now, 'days', true )
+			) }
 			disputeDetailsUrl={ disputeDetailsUrl }
 		/>
 	);
@@ -255,6 +304,88 @@ const DisputeNeedsResponseNotice = ( {
 			] }
 		>
 			{ noticeBody }
+		</InlineNotice>
+	);
+};
+
+// Consolidated notice for a charge with several disputes awaiting a response.
+// Rather than stack a full per-dispute notice for each, it sums the disputed
+// amounts and surfaces the earliest deadline; the transaction page it links to
+// breaks the disputes down individually.
+const MultipleDisputesNeedsResponseNotice = ( {
+	disputeCount,
+	formattedAmount,
+	dueBy,
+	countdownDays,
+	disputeDetailsUrl,
+} ) => {
+	useEffect( () => {
+		recordEvent( 'wcpay_order_dispute_notice_view', {
+			is_inquiry: false,
+			dispute_reason: 'multiple',
+			due_by_days: countdownDays,
+			dispute_count: disputeCount,
+		} );
+	}, [ countdownDays, disputeCount ] );
+
+	const buttonLabel =
+		countdownDays < 1
+			? __( 'Respond today', 'woocommerce-payments' )
+			: __( 'Respond now', 'woocommerce-payments' );
+
+	const message = sprintf(
+		// Translators: %1$d is the number of disputes on the order, %2$s is the combined disputed amount.
+		__(
+			'This order has %1$d payment disputes totaling %2$s.',
+			'woocommerce-payments'
+		),
+		disputeCount,
+		formattedAmount
+	);
+
+	let suffix = sprintf(
+		// Translators: %1$s is the earliest dispute due date.
+		__( 'Please respond before %1$s.', 'woocommerce-payments' ),
+		formatDateTimeFromString( dueBy.toISOString() )
+	);
+	if ( countdownDays < 7 ) {
+		const daysLeft =
+			countdownDays < 1
+				? __( '(Last day today)', 'woocommerce-payments' )
+				: sprintf(
+						// Translators: %s is the number of days left to respond to the earliest dispute.
+						_n(
+							'(%s day left)',
+							'(%s days left)',
+							countdownDays,
+							'woocommerce-payments'
+						),
+						countdownDays
+				  );
+		suffix = `${ suffix } ${ daysLeft }`;
+	}
+
+	return (
+		<InlineNotice
+			status={ countdownDays < 3 ? 'error' : 'warning' }
+			isDismissible={ false }
+			actions={ [
+				{
+					label: buttonLabel,
+					variant: 'secondary',
+					onClick: () => {
+						recordEvent(
+							'wcpay_order_dispute_notice_action_click',
+							{
+								due_by_days: countdownDays,
+							}
+						);
+						window.location = disputeDetailsUrl;
+					},
+				},
+			] }
+		>
+			<strong>{ message }</strong> { suffix }
 		</InlineNotice>
 	);
 };

--- a/client/components/disputed-order-notice/index.js
+++ b/client/components/disputed-order-notice/index.js
@@ -142,10 +142,17 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 		( sum, dispute ) => sum + dispute.amount,
 		0
 	);
+	// `awaitingDisputes` can include inquiries (warning_* statuses). Only call
+	// them inquiries when every one is; a single real dispute in the mix is the
+	// more urgent framing, so the notice speaks of "disputes".
+	const allInquiries = awaitingDisputes.every( ( dispute ) =>
+		isInquiry( dispute.status )
+	);
 
 	return (
 		<MultipleDisputesNeedsResponseNotice
 			disputeCount={ awaitingDisputes.length }
+			isPreDisputeInquiry={ allInquiries }
 			formattedAmount={ formatExplicitCurrency(
 				totalAmount,
 				awaitingDisputes[ 0 ].currency
@@ -314,6 +321,7 @@ const DisputeNeedsResponseNotice = ( {
 // breaks the disputes down individually.
 const MultipleDisputesNeedsResponseNotice = ( {
 	disputeCount,
+	isPreDisputeInquiry,
 	formattedAmount,
 	dueBy,
 	countdownDays,
@@ -321,27 +329,37 @@ const MultipleDisputesNeedsResponseNotice = ( {
 } ) => {
 	useEffect( () => {
 		recordEvent( 'wcpay_order_dispute_notice_view', {
-			is_inquiry: false,
+			is_inquiry: isPreDisputeInquiry,
 			dispute_reason: 'multiple',
 			due_by_days: countdownDays,
 			dispute_count: disputeCount,
 		} );
-	}, [ countdownDays, disputeCount ] );
+	}, [ countdownDays, disputeCount, isPreDisputeInquiry ] );
 
 	const buttonLabel =
 		countdownDays < 1
 			? __( 'Respond today', 'woocommerce-payments' )
 			: __( 'Respond now', 'woocommerce-payments' );
 
-	const message = sprintf(
-		// Translators: %1$d is the number of disputes on the order, %2$s is the combined disputed amount.
-		__(
-			'This order has %1$d payment disputes totaling %2$s.',
-			'woocommerce-payments'
-		),
-		disputeCount,
-		formattedAmount
-	);
+	const message = isPreDisputeInquiry
+		? sprintf(
+				// Translators: %1$d is the number of inquiries on the order, %2$s is the combined amount.
+				__(
+					'This order has %1$d payment inquiries totaling %2$s.',
+					'woocommerce-payments'
+				),
+				disputeCount,
+				formattedAmount
+		  )
+		: sprintf(
+				// Translators: %1$d is the number of disputes on the order, %2$s is the combined disputed amount.
+				__(
+					'This order has %1$d payment disputes totaling %2$s.',
+					'woocommerce-payments'
+				),
+				disputeCount,
+				formattedAmount
+		  );
 
 	let suffix = sprintf(
 		// Translators: %1$s is the earliest dispute due date.

--- a/client/components/disputed-order-notice/index.js
+++ b/client/components/disputed-order-notice/index.js
@@ -145,14 +145,14 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 	// `awaitingDisputes` can include inquiries (warning_* statuses). Only call
 	// them inquiries when every one is; a single real dispute in the mix is the
 	// more urgent framing, so the notice speaks of "disputes".
-	const allInquiries = awaitingDisputes.every( ( dispute ) =>
+	const isAllInquiries = awaitingDisputes.every( ( dispute ) =>
 		isInquiry( dispute.status )
 	);
 
 	return (
 		<MultipleDisputesNeedsResponseNotice
 			disputeCount={ awaitingDisputes.length }
-			isPreDisputeInquiry={ allInquiries }
+			isPreDisputeInquiry={ isAllInquiries }
 			formattedAmount={ formatExplicitCurrency(
 				totalAmount,
 				awaitingDisputes[ 0 ].currency

--- a/client/payment-details/summary/style.scss
+++ b/client/payment-details/summary/style.scss
@@ -122,7 +122,8 @@
 	font-weight: 600;
 	letter-spacing: 0.5px;
 	color: $studio-gray-60;
-	margin: $grid-unit-15 $grid-unit-20 0;
+	// Match the padding of the "Dispute details" heading below.
+	margin: $grid-unit-15 $grid-unit-30 0;
 }
 
 .woocommerce-list--horizontal {

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -555,19 +555,14 @@ class WC_Payments_Order_Service {
 			return;
 		}
 
-		// A dispute holds the order whether or not its note already exists, so
-		// apply the hold before the note de-dup. Gating it behind the de-dup
-		// would leave a replayed webhook unable to restore on-hold if the order
-		// had since been moved off it. Re-holding an already-held order is a
-		// no-op ($order->update_status() records no transition).
-		$this->update_order_status( $order, Order_Status::ON_HOLD );
-
 		$is_inquiry = strpos( $status, 'warning_' ) === 0;
 		$note       = $this->generate_dispute_created_note( $charge_id, $amount, $reason, $due_by, $is_inquiry, $dispute_id );
-		if ( ! $this->order_note_exists( $order, $note ) ) {
-			$order->add_order_note( $note );
+		if ( $this->order_note_exists( $order, $note ) ) {
+			return;
 		}
 
+		$this->update_order_status( $order, Order_Status::ON_HOLD );
+		$order->add_order_note( $note );
 		$order->save();
 	}
 

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -546,22 +546,28 @@ class WC_Payments_Order_Service {
 	 * @param string   $reason     The reason for the dispute – human-readable text.
 	 * @param string   $due_by     The deadline for responding to the dispute - formatted date string.
 	 * @param string   $status     The status of the dispute.
+	 * @param string   $dispute_id The ID of the dispute. Distinguishes the notes when a charge carries more than one dispute.
 	 *
 	 * @return void
 	 */
-	public function mark_payment_dispute_created( $order, $charge_id, $amount, $reason, $due_by, $status = '' ) {
+	public function mark_payment_dispute_created( $order, $charge_id, $amount, $reason, $due_by, $status = '', $dispute_id = '' ) {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return;
 		}
 
+		// A dispute holds the order whether or not its note already exists, so
+		// apply the hold before the note de-dup. Gating it behind the de-dup
+		// would leave a replayed webhook unable to restore on-hold if the order
+		// had since been moved off it. Re-holding an already-held order is a
+		// no-op ($order->update_status() records no transition).
+		$this->update_order_status( $order, Order_Status::ON_HOLD );
+
 		$is_inquiry = strpos( $status, 'warning_' ) === 0;
-		$note       = $this->generate_dispute_created_note( $charge_id, $amount, $reason, $due_by, $is_inquiry );
-		if ( $this->order_note_exists( $order, $note ) ) {
-			return;
+		$note       = $this->generate_dispute_created_note( $charge_id, $amount, $reason, $due_by, $is_inquiry, $dispute_id );
+		if ( ! $this->order_note_exists( $order, $note ) ) {
+			$order->add_order_note( $note );
 		}
 
-		$this->update_order_status( $order, Order_Status::ON_HOLD );
-		$order->add_order_note( $note );
 		$order->save();
 	}
 
@@ -2240,17 +2246,18 @@ class WC_Payments_Order_Service {
 	 * @param string $reason     The reason for the dispute – human-readable text.
 	 * @param string $due_by     The deadline for responding to the dispute - formatted date string.
 	 * @param bool   $is_inquiry  Whether the dispute is an inquiry or not.
+	 * @param string $dispute_id The ID of the dispute, appended so a charge's several disputes each get a distinct note.
 	 *
 	 * @return string Note content.
 	 */
-	private function generate_dispute_created_note( $charge_id, $amount, $reason, $due_by, $is_inquiry = false ) {
+	private function generate_dispute_created_note( $charge_id, $amount, $reason, $due_by, $is_inquiry = false, $dispute_id = '' ) {
 		$dispute_url = $this->compose_dispute_url( $charge_id );
 
 		// Get merchant-friendly dispute reason description.
 		$reason = WC_Payments_Utils::get_dispute_reason_description( $reason );
 
 		if ( $is_inquiry ) {
-			return sprintf(
+			$note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
 					/* translators: %1: the disputed amount and currency; %2: the dispute reason; %3 the deadline date for responding to the inquiry */
 					__( 'A payment inquiry has been raised for %1$s with reason "%2$s". <a>Response due by %3$s</a>.', 'woocommerce-payments' ),
@@ -2263,21 +2270,35 @@ class WC_Payments_Order_Service {
 				$due_by,
 				$dispute_url
 			);
+		} else {
+			$note = sprintf(
+				WC_Payments_Utils::esc_interpolated_html(
+					/* translators: %1: the disputed amount and currency; %2: the dispute reason; %3 the deadline date for responding to dispute */
+					__( 'Payment has been disputed for %1$s with reason "%2$s". <a>Response due by %3$s</a>.', 'woocommerce-payments' ),
+					[
+						'a' => '<a href="%4$s" target="_blank" rel="noopener noreferrer">',
+					]
+				),
+				$amount,
+				$reason,
+				$due_by,
+				$dispute_url
+			);
 		}
 
-		return sprintf(
-			WC_Payments_Utils::esc_interpolated_html(
-				/* translators: %1: the disputed amount and currency; %2: the dispute reason; %3 the deadline date for responding to dispute */
-				__( 'Payment has been disputed for %1$s with reason "%2$s". <a>Response due by %3$s</a>.', 'woocommerce-payments' ),
-				[
-					'a' => '<a href="%4$s" target="_blank" rel="noopener noreferrer">',
-				]
-			),
-			$amount,
-			$reason,
-			$due_by,
-			$dispute_url
-		);
+		// A charge can carry several disputes with identical amount, reason and
+		// deadline; without the dispute ID their notes are byte-identical and
+		// order_note_exists() collapses them into one. It also keeps a
+		// re-delivered webhook for the same dispute de-duplicated.
+		if ( '' !== $dispute_id ) {
+			$note .= ' ' . sprintf(
+				/* translators: %s: the dispute ID */
+				esc_html__( '(Dispute ID: %s)', 'woocommerce-payments' ),
+				esc_html( $dispute_id )
+			);
+		}
+
+		return $note;
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -688,24 +688,20 @@ class WC_Payments_Webhook_Processing_Service {
 	private function process_webhook_dispute_created( $event_body ) {
 		$event_data   = $this->read_webhook_property( $event_body, 'data' );
 		$event_object = $this->read_webhook_property( $event_data, 'object' );
-		$charge_id    = $this->read_webhook_property( $event_object, 'charge' );
-		$reason       = $this->read_webhook_property( $event_object, 'reason' );
-		$amount_raw   = $this->read_webhook_property( $event_object, 'amount' );
-		$evidence     = $this->read_webhook_property( $event_object, 'evidence_details' );
-		$status       = $this->read_webhook_property( $event_object, 'status' );
-		$due_by       = $this->read_webhook_property( $evidence, 'due_by' );
+		// Read the dispute ID defensively: only used to keep notes distinct, so a
+		// (theoretical) event without it should still create the note, not fatal.
+		$dispute_id = $this->has_webhook_property( $event_object, 'id' ) ? $this->read_webhook_property( $event_object, 'id' ) : '';
+		$charge_id  = $this->read_webhook_property( $event_object, 'charge' );
+		$reason     = $this->read_webhook_property( $event_object, 'reason' );
+		$amount_raw = $this->read_webhook_property( $event_object, 'amount' );
+		$evidence   = $this->read_webhook_property( $event_object, 'evidence_details' );
+		$status     = $this->read_webhook_property( $event_object, 'status' );
+		$due_by     = $this->read_webhook_property( $evidence, 'due_by' );
 
 		$order = $this->wcpay_db->order_from_charge_id( $charge_id );
 
-		$currency      = $order->get_currency();
-		$amount_string = wc_price( WC_Payments_Utils::interpret_stripe_amount( $amount_raw, $currency ), [ 'currency' => strtoupper( $currency ) ] );
-
-		// Explicitly add currency info if needed (multi-currency stores).
-		$amount = WC_Payments_Explicit_Price_Formatter::get_explicit_price_with_currency( $amount_string, $currency );
-
-		// Convert due_by to a date string in the store timezone.
-		$due_by = date_i18n( wc_date_format(), $due_by );
-
+		// order_from_charge_id() returns false when no order matches, so guard
+		// before dereferencing $order below.
 		if ( ! $order ) {
 			throw new Invalid_Webhook_Data_Exception(
 				sprintf(
@@ -716,7 +712,16 @@ class WC_Payments_Webhook_Processing_Service {
 			);
 		}
 
-		$this->order_service->mark_payment_dispute_created( $order, $charge_id, $amount, $reason, $due_by, $status );
+		$currency      = $order->get_currency();
+		$amount_string = wc_price( WC_Payments_Utils::interpret_stripe_amount( $amount_raw, $currency ), [ 'currency' => strtoupper( $currency ) ] );
+
+		// Explicitly add currency info if needed (multi-currency stores).
+		$amount = WC_Payments_Explicit_Price_Formatter::get_explicit_price_with_currency( $amount_string, $currency );
+
+		// Convert due_by to a date string in the store timezone.
+		$due_by = date_i18n( wc_date_format(), $due_by );
+
+		$this->order_service->mark_payment_dispute_created( $order, $charge_id, $amount, $reason, $due_by, $status, $dispute_id );
 
 		// Clear dispute caches to trigger a fetch of new data.
 		$this->database_cache->delete_dispute_caches();

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1141,6 +1141,77 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 
 
 	/**
+	 * A charge can carry several disputes with identical amount, reason and
+	 * deadline. The dispute ID keeps their notes distinct so they are not
+	 * collapsed into one, while a re-delivered webhook for the same dispute
+	 * still de-duplicates.
+	 */
+	public function test_mark_payment_dispute_created_distinguishes_disputes_by_id() {
+		$charge_id = 'ch_123';
+		$amount    = '$123.45';
+		$reason    = 'product_not_received';
+		$deadline  = 'June 7, 2023';
+
+		$dispute_notes = function () {
+			$notes = wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] );
+			return array_values(
+				array_filter(
+					$notes,
+					function ( $note ) {
+						return false !== strpos( $note->content, 'Payment has been disputed' );
+					}
+				)
+			);
+		};
+
+		// Act: Two disputes sharing everything but their ID.
+		$this->order_service->mark_payment_dispute_created( $this->order, $charge_id, $amount, $reason, $deadline, '', 'dp_first' );
+		$this->order_service->mark_payment_dispute_created( $this->order, $charge_id, $amount, $reason, $deadline, '', 'dp_second' );
+
+		// Assert: Both disputes produced a note, each carrying its own ID.
+		$this->assertCount( 2, $dispute_notes() );
+		$contents = implode( "\n", wp_list_pluck( $dispute_notes(), 'content' ) );
+		$this->assertStringContainsString( '(Dispute ID: dp_first)', $contents );
+		$this->assertStringContainsString( '(Dispute ID: dp_second)', $contents );
+
+		// Assert: Re-delivering the same dispute does not add another note.
+		$this->order_service->mark_payment_dispute_created( $this->order, $charge_id, $amount, $reason, $deadline, '', 'dp_first' );
+		$this->assertCount( 2, $dispute_notes() );
+	}
+
+	/**
+	 * A replayed dispute-created webhook restores on-hold even when the note
+	 * already exists, without adding a duplicate note.
+	 */
+	public function test_mark_payment_dispute_created_reapplies_on_hold_when_note_exists() {
+		$charge_id = 'ch_123';
+		$amount    = '$123.45';
+		$reason    = 'product_not_received';
+		$deadline  = 'June 7, 2023';
+
+		// First delivery: order goes on-hold with a note.
+		$this->order_service->mark_payment_dispute_created( $this->order, $charge_id, $amount, $reason, $deadline, '', 'dp_1' );
+		$this->assertTrue( $this->order->has_status( [ Order_Status::ON_HOLD ] ) );
+
+		// The order is moved back off hold while the dispute note is still present.
+		$this->order->update_status( Order_Status::PROCESSING );
+		$this->order->save();
+
+		// Act: the same dispute is delivered again.
+		$this->order_service->mark_payment_dispute_created( $this->order, $charge_id, $amount, $reason, $deadline, '', 'dp_1' );
+
+		// Assert: the hold is restored and the note is not duplicated.
+		$this->assertTrue( $this->order->has_status( [ Order_Status::ON_HOLD ] ) );
+		$dispute_notes = array_filter(
+			wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] ),
+			function ( $note ) {
+				return false !== strpos( $note->content, 'Payment has been disputed' );
+			}
+		);
+		$this->assertCount( 1, $dispute_notes );
+	}
+
+	/**
 	 * Tests if the payment was updated to show inquiry created.
 	 */
 	public function test_mark_payment_dispute_created_for_inquiry() {

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -1185,38 +1185,6 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
-	 * A replayed dispute-created webhook restores on-hold even when the note
-	 * already exists, without adding a duplicate note.
-	 */
-	public function test_mark_payment_dispute_created_reapplies_on_hold_when_note_exists() {
-		$charge_id = 'ch_123';
-		$amount    = '$123.45';
-		$reason    = 'product_not_received';
-		$deadline  = 'June 7, 2023';
-
-		// First delivery: order goes on-hold with a note.
-		$this->order_service->mark_payment_dispute_created( $this->order, $charge_id, $amount, $reason, $deadline, '', 'dp_1' );
-		$this->assertTrue( $this->order->has_status( [ Order_Status::ON_HOLD ] ) );
-
-		// The order is moved back off hold while the dispute note is still present.
-		$this->order->update_status( Order_Status::PROCESSING );
-		$this->order->save();
-
-		// Act: the same dispute is delivered again.
-		$this->order_service->mark_payment_dispute_created( $this->order, $charge_id, $amount, $reason, $deadline, '', 'dp_1' );
-
-		// Assert: the hold is restored and the note is not duplicated.
-		$this->assertTrue( $this->order->has_status( [ Order_Status::ON_HOLD ] ) );
-		$dispute_notes = array_filter(
-			wc_get_order_notes( [ 'order_id' => $this->order->get_id() ] ),
-			function ( $note ) {
-				return false !== strpos( $note->content, 'Payment has been disputed' );
-			}
-		);
-		$this->assertCount( 1, $dispute_notes );
-	}
-
-	/**
 	 * Tests if the payment was updated to show inquiry created.
 	 */
 	public function test_mark_payment_dispute_created_for_inquiry() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -1881,7 +1881,7 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 
 	/**
 	 * A dispute created event for an unknown charge throws a handled exception
-	 * rather than fataling on a null order.
+	 * rather than fatalling on a null order.
 	 */
 	public function test_dispute_created_with_unknown_charge_id_throws() {
 		$this->event_body['type']           = 'charge.dispute.created';

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -1880,6 +1880,36 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * A dispute created event for an unknown charge throws a handled exception
+	 * rather than fataling on a null order.
+	 */
+	public function test_dispute_created_with_unknown_charge_id_throws() {
+		$this->event_body['type']           = 'charge.dispute.created';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'               => 'test_dispute_id',
+			'charge'           => 'unknown_charge_id',
+			'reason'           => 'test_reason',
+			'amount'           => 9900,
+			'status'           => 'test_status',
+			'evidence_details' => [
+				'due_by' => 'test_due_by',
+			],
+		];
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'unknown_charge_id' )
+			->willReturn( false );
+
+		$this->expectException( Invalid_Webhook_Data_Exception::class );
+		$this->expectExceptionMessage( 'Could not find order via charge ID: unknown_charge_id' );
+
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
 	 * Tests that a dispute closed event adds a respective order note.
 	 */
 	public function test_dispute_closed_order_note() {


### PR DESCRIPTION
Follow-up to #11916, from feedback on the call for testing ( paJDYF-iBx-p2#comment-29866 ).

#### Changes proposed in this Pull Request

A charge can have more than one dispute (e.g. AmEx/Klarna partial disputes), but a few places still only surfaced one:

- Order notes showed a single dispute
- The order-edit warning showed just one dispute
- The "Dispute N of M" label on the transaction page was slightly misaligned

Notes now carry every dispute (kept distinct by dispute ID), the order-edit warning consolidates them into one message, and the label lines up with the section below it.

Fixing.

#### Testing instructions

> Seeing more than one dispute on a charge needs the companion server change from #11916 deployed or checked out locally.

- As a customer, place an order with test card `4000000404000079` (auto-creates multiple disputes)
- As a merchant, open the order details page
- The order notes list one note per dispute
<img width="279" height="829" alt="Screenshot 2026-07-24 at 2 54 37 PM" src="https://github.com/user-attachments/assets/24ff2b9b-87a9-45bb-8509-b50df4f34691" />

- The dispute warning is a single consolidated message
<img width="649" height="128" alt="Screenshot 2026-07-24 at 12 30 36 PM" src="https://github.com/user-attachments/assets/655cbe63-b661-4aaf-8ec4-19b1c0f6882f" />

- Go to **Payments → Transactions** and open that transaction
- The "Dispute N of M" label lines up with the "Dispute details" heading below it
<img width="1065" height="1322" alt="Screenshot 2026-07-24 at 12 32 36 PM" src="https://github.com/user-attachments/assets/7dfb0b5e-a509-4438-87cd-3e8be209daa0" />


-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable until the companion server change ships_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.