### PR TITLE
fix: ensure order note record for multi-dispute webhook

### DIFF
--- a/changelog/fix-multi-dispute-refund-order-note
+++ b/changelog/fix-multi-dispute-refund-order-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: ensure order note is recorded for multi-dispute refund

--- a/changelog/fix-multi-dispute-refund-order-note#2
+++ b/changelog/fix-multi-dispute-refund-order-note#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: record a dispute updated order note for every dispute on a charge

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -573,16 +573,17 @@ class WC_Payments_Order_Service {
 	 * @param string   $charge_id       The ID of the disputed charge associated with this order.
 	 * @param string   $status          The status of the dispute.
 	 * @param array    $dispute_summary Dispute summary information.
+	 * @param string   $dispute_id      The ID of the dispute. Keeps the note (and its refund) distinct when a charge carries more than one dispute.
 	 *
 	 * @return void
 	 */
-	public function mark_payment_dispute_closed( $order, $charge_id, $status, $dispute_summary = [] ): void {
+	public function mark_payment_dispute_closed( $order, $charge_id, $status, $dispute_summary = [], $dispute_id = '' ): void {
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return;
 		}
 
 		$is_inquiry = strpos( $status, 'warning_' ) === 0;
-		$note       = $this->generate_dispute_closed_note( $charge_id, $status, $is_inquiry );
+		$note       = $this->generate_dispute_closed_note( $charge_id, $status, $is_inquiry, $dispute_id );
 
 		if ( $this->order_note_exists( $order, $note ) ) {
 			return;
@@ -2303,14 +2304,15 @@ class WC_Payments_Order_Service {
 	 * @param string $charge_id The ID of the disputed charge associated with this order.
 	 * @param string $status    The status of the dispute.
 	 * @param bool   $is_inquiry Whether the dispute is an inquiry or not.
+	 * @param string $dispute_id The ID of the dispute, appended so a charge's several disputes each get a distinct note.
 	 *
 	 * @return string Note content.
 	 */
-	private function generate_dispute_closed_note( $charge_id, $status, $is_inquiry = false ) {
+	private function generate_dispute_closed_note( $charge_id, $status, $is_inquiry = false, $dispute_id = '' ) {
 		$dispute_url = $this->compose_dispute_url( $charge_id );
 
 		if ( $is_inquiry ) {
-			return sprintf(
+			$note = sprintf(
 				WC_Payments_Utils::esc_interpolated_html(
 				/* translators: %1: the dispute status */
 					__( 'Payment inquiry has been closed with status %1$s. See <a>payment status</a> for more details.', 'woocommerce-payments' ),
@@ -2321,19 +2323,33 @@ class WC_Payments_Order_Service {
 				$status,
 				$dispute_url
 			);
+		} else {
+			$note = sprintf(
+				WC_Payments_Utils::esc_interpolated_html(
+					/* translators: %1: the dispute status */
+					__( 'Dispute has been closed with status %1$s. See <a>dispute overview</a> for more details.', 'woocommerce-payments' ),
+					[
+						'a' => '<a href="%2$s" target="_blank" rel="noopener noreferrer">',
+					]
+				),
+				$status,
+				$dispute_url
+			);
 		}
 
-		return sprintf(
-			WC_Payments_Utils::esc_interpolated_html(
-				/* translators: %1: the dispute status */
-				__( 'Dispute has been closed with status %1$s. See <a>dispute overview</a> for more details.', 'woocommerce-payments' ),
-				[
-					'a' => '<a href="%2$s" target="_blank" rel="noopener noreferrer">',
-				]
-			),
-			$status,
-			$dispute_url
-		);
+		// Two disputes that close with the same status make identical note text, and
+		// order_note_exists() dedups on it. That check also gates the refund, so without
+		// the dispute ID the second lost dispute's refund just gets skipped. The ID keeps
+		// each note (and its refund) distinct; a re-delivered webhook still de-dupes.
+		if ( '' !== $dispute_id ) {
+			$note .= ' ' . sprintf(
+				/* translators: %s: the dispute ID */
+				esc_html__( '(Dispute ID: %s)', 'woocommerce-payments' ),
+				esc_html( $dispute_id )
+			);
+		}
+
+		return $note;
 	}
 
 	/**

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -767,7 +767,7 @@ class WC_Payments_Webhook_Processing_Service {
 			);
 		}
 
-		$this->order_service->mark_payment_dispute_closed( $order, $charge_id, $status, $dispute_summary );
+		$this->order_service->mark_payment_dispute_closed( $order, $charge_id, $status, $dispute_summary, $dispute_id );
 
 		// Clear dispute caches to trigger a fetch of new data.
 		$this->database_cache->delete_dispute_caches();

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -784,8 +784,11 @@ class WC_Payments_Webhook_Processing_Service {
 		$event_type   = $this->read_webhook_property( $event_body, 'type' );
 		$event_data   = $this->read_webhook_property( $event_body, 'data' );
 		$event_object = $this->read_webhook_property( $event_data, 'object' );
-		$charge_id    = $this->read_webhook_property( $event_object, 'charge' );
-		$order        = $this->wcpay_db->order_from_charge_id( $charge_id );
+		// Read the dispute ID defensively: only used to keep notes distinct, so a
+		// (theoretical) event without it should still create the note, not fatal.
+		$dispute_id = $this->has_webhook_property( $event_object, 'id' ) ? $this->read_webhook_property( $event_object, 'id' ) : '';
+		$charge_id  = $this->read_webhook_property( $event_object, 'charge' );
+		$order      = $this->wcpay_db->order_from_charge_id( $charge_id );
 
 		if ( ! $order ) {
 			throw new Invalid_Webhook_Data_Exception(
@@ -818,13 +821,24 @@ class WC_Payments_Webhook_Processing_Service {
 			)
 		);
 
-		if ( $this->order_service->order_note_exists( $order, $note ) ) {
-			return;
+		// The message is a fixed string per event type, so a charge's several disputes
+		// all produce byte-identical notes and order_note_exists() collapses them into
+		// one. The dispute ID keeps them distinct while still de-duplicating a
+		// re-delivered webhook for the same dispute.
+		if ( '' !== $dispute_id ) {
+			$note .= ' ' . sprintf(
+				/* translators: %s: the dispute ID */
+				esc_html__( '(Dispute ID: %s)', 'woocommerce-payments' ),
+				esc_html( $dispute_id )
+			);
 		}
 
-		$order->add_order_note( $note );
+		if ( ! $this->order_service->order_note_exists( $order, $note ) ) {
+			$order->add_order_note( $note );
+		}
 
-		// Clear dispute caches to trigger a fetch of new data.
+		// Clear dispute caches to trigger a fetch of new data. The dispute changed on
+		// Stripe's side even when its note is a duplicate of one already on the order.
 		$this->database_cache->delete_dispute_caches();
 	}
 

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -2158,6 +2158,73 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Two lost disputes on one charge should each record a refund. The dedup keyed
+	 * on charge + status, so the second was skipped — refund and all.
+	 */
+	public function test_mark_payment_dispute_closed_records_a_refund_per_lost_dispute(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->save();
+
+		$charge_id = 'ch_123';
+		$status    = 'lost';
+
+		// Act: two lost disputes on the same charge, each disputing part of the order.
+		$this->order_service->mark_payment_dispute_closed(
+			$order,
+			$charge_id,
+			$status,
+			[
+				'disputed_amount' => 3000,
+				'currency'        => 'usd',
+			],
+			'dp_first'
+		);
+		$this->order_service->mark_payment_dispute_closed(
+			$order,
+			$charge_id,
+			$status,
+			[
+				'disputed_amount' => 7000,
+				'currency'        => 'usd',
+			],
+			'dp_second'
+		);
+
+		// Assert: each lost dispute recorded its own refund.
+		$refunds = $order->get_refunds();
+		$this->assertCount( 2, $refunds );
+		$refund_totals = array_map(
+			function ( $refund ) {
+				return (float) $refund->get_total();
+			},
+			$refunds
+		);
+		$this->assertEqualsCanonicalizing( [ -30.00, -70.00 ], $refund_totals );
+
+		// Assert: each dispute produced its own closed note, distinguished by ID.
+		$contents = implode( "\n", wp_list_pluck( wc_get_order_notes( [ 'order_id' => $order->get_id() ] ), 'content' ) );
+		$this->assertStringContainsString( '(Dispute ID: dp_first)', $contents );
+		$this->assertStringContainsString( '(Dispute ID: dp_second)', $contents );
+
+		// Assert: re-delivering the same dispute's close does not double-refund.
+		$this->order_service->mark_payment_dispute_closed(
+			$order,
+			$charge_id,
+			$status,
+			[
+				'disputed_amount' => 3000,
+				'currency'        => 'usd',
+			],
+			'dp_first'
+		);
+		$this->assertCount( 2, $order->get_refunds() );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
 	 * Tests that mark_payment_dispute_closed handles missing amount in refund.
 	 */
 	public function test_mark_payment_dispute_closed_with_missing_amount_in_summary(): void {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -1962,8 +1962,9 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'add_order_note' )
 			->with(
-				$this->matchesRegularExpression(
-					'/Payment dispute has been updated/'
+				$this->logicalAnd(
+					$this->stringContains( 'Payment dispute has been updated' ),
+					$this->stringContains( '(Dispute ID: test_dispute_id)' )
 				)
 			);
 
@@ -2036,6 +2037,105 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 			->willReturn( $this->mock_order );
 
 		// Run the test.
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
+	 * Two disputes on one charge produce the same message, so without the dispute ID
+	 * their notes are identical and only the first one is ever recorded.
+	 */
+	public function test_dispute_updated_records_a_note_per_dispute() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->event_body['type']     = 'charge.dispute.funds_withdrawn';
+		$this->event_body['livemode'] = true;
+
+		$this->mock_db_wrapper
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $order );
+
+		$this->event_body['data']['object'] = [
+			'id'     => 'dp_first',
+			'charge' => 'test_charge_id',
+		];
+		$this->webhook_processing_service->process( $this->event_body );
+
+		$this->event_body['data']['object'] = [
+			'id'     => 'dp_second',
+			'charge' => 'test_charge_id',
+		];
+		$this->webhook_processing_service->process( $this->event_body );
+
+		$contents = wp_list_pluck( wc_get_order_notes( [ 'order_id' => $order->get_id() ] ), 'content' );
+
+		$this->assertCount( 2, preg_grep( '/deducted from your next payout/', $contents ) );
+		$this->assertCount( 1, preg_grep( '/\(Dispute ID: dp_first\)/', $contents ) );
+		$this->assertCount( 1, preg_grep( '/\(Dispute ID: dp_second\)/', $contents ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * A re-delivered event still has to be a no-op for the order timeline, while the
+	 * dispute caches get cleared either way — the event fired because data changed.
+	 */
+	public function test_dispute_updated_redelivery_does_not_duplicate_the_note() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->event_body['type']           = 'charge.dispute.funds_withdrawn';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'     => 'dp_first',
+			'charge' => 'test_charge_id',
+		];
+
+		$this->mock_db_wrapper
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $order );
+
+		$this->mock_database_cache
+			->expects( $this->exactly( 2 ) )
+			->method( 'delete_dispute_caches' );
+
+		$this->webhook_processing_service->process( $this->event_body );
+		$this->webhook_processing_service->process( $this->event_body );
+
+		$contents = wp_list_pluck( wc_get_order_notes( [ 'order_id' => $order->get_id() ] ), 'content' );
+
+		$this->assertCount( 1, preg_grep( '/deducted from your next payout/', $contents ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * The dispute ID is only there to keep notes apart, so an event without one still
+	 * has to record its note rather than fail.
+	 */
+	public function test_dispute_updated_without_dispute_id_still_adds_note() {
+		$this->event_body['type']           = 'charge.dispute.updated';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'charge' => 'test_charge_id',
+		];
+
+		$this->mock_order
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				$this->logicalAnd(
+					$this->stringContains( 'Payment dispute has been updated' ),
+					$this->logicalNot( $this->stringContains( 'Dispute ID' ) )
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_charge_id' )
+			->with( 'test_charge_id' )
+			->willReturn( $this->mock_order );
+
 		$this->webhook_processing_service->process( $this->event_body );
 	}
 


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Similar to https://github.com/Automattic/woocommerce-payments/pull/11991
Reported here: paJDYF-iBx-p2#comment-29870

Ensuring that the dispute loss note appears on multi-dispute.
The issue is that the "dispute lost" order note was appearing only for the first dispute.

Now adding a dispute ID to the order note, so that subsequent "dispute lost" webhooks are processed and adding a second order note.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> Seeing more than one dispute on a charge needs the companion server change from #11916 deployed or checked out locally.
> Also, make sure your local server is listening to webhooks. I find it easier to test on JN, TBH.

- As a customer, place an order with test card `4000000404000079` (auto-creates multiple disputes)
- As a merchant, open the order details page
- Click on the dispute warning banner/link to go to the transaction timeline
<img width="649" height="128" alt="Screenshot 2026-07-24 at 12 30 36 PM" src="https://github.com/user-attachments/assets/655cbe63-b661-4aaf-8ec4-19b1c0f6882f" />

- Challenge both disputes, on the cover letter replace everything with `losing_evidence`
<img width="594" height="386" alt="Screenshot 2026-07-27 at 12 34 58 PM" src="https://github.com/user-attachments/assets/fabbd93d-543d-4ae5-9226-20ae2326e220" />

- Check again the order notes - there should be two notes instead of one.
<img width="301" height="560" alt="Screenshot 2026-07-27 at 12 37 13 PM" src="https://github.com/user-attachments/assets/19dd59d3-e726-4004-9f86-76b51511e860" />


-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.