### PR TITLE
fix: surface dispute deadline when a sibling dispute locks the order

### DIFF
--- a/changelog/fix-multiple-disputes-notice-precedence
+++ b/changelog/fix-multiple-disputes-notice-precedence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show the evidence response deadline on the order screen when a charge has a dispute that still needs a response alongside one that is under review or lost.

--- a/client/components/disputed-order-notice/__tests__/index.test.js
+++ b/client/components/disputed-order-notice/__tests__/index.test.js
@@ -241,4 +241,331 @@ describe( 'DisputedOrderNoticeHandler', () => {
 
 		expect( onDisableOrderRefund ).toHaveBeenCalledWith( 'needs_response' );
 	} );
+
+	test( 'surfaces the response deadline when a sibling dispute is under review', () => {
+		const fixedDate = new Date( '2023-10-20T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		const onDisableOrderRefund = jest.fn();
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'under_review',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+					{
+						id: 'dp_2',
+						status: 'needs_response',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ onDisableOrderRefund }
+			/>
+		);
+
+		expect(
+			screen.getAllByText(
+				/This order has a payment dispute for \$15\.50 for the reason 'Product not received'\./
+			)[ 0 ]
+		).toBeInTheDocument();
+		expect(
+			screen.getAllByText( /Please respond before Oct 28, 2023/ )[ 0 ]
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent(
+			'Respond now'
+		);
+
+		expect(
+			screen.queryAllByText( /This order has an active payment dispute/ )
+		).toHaveLength( 0 );
+
+		expect( onDisableOrderRefund ).toHaveBeenCalledWith( 'under_review' );
+	} );
+
+	test( 'surfaces the response deadline when a sibling dispute is lost', () => {
+		const fixedDate = new Date( '2023-10-20T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'lost',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+					{
+						id: 'dp_2',
+						status: 'needs_response',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getAllByText(
+				/This order has a payment dispute for \$15\.50 for the reason 'Product not received'\./
+			)[ 0 ]
+		).toBeInTheDocument();
+		expect(
+			screen.getAllByText( /Please respond before Oct 28, 2023/ )[ 0 ]
+		).toBeInTheDocument();
+
+		expect(
+			screen.queryAllByText(
+				/have been disabled as a result of a lost dispute/
+			)
+		).toHaveLength( 0 );
+	} );
+
+	test( 'still disables order refunds when the lost dispute notice gives way to a response deadline', () => {
+		const fixedDate = new Date( '2023-10-20T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		const onDisableOrderRefund = jest.fn();
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'lost',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+					{
+						id: 'dp_2',
+						status: 'needs_response',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ onDisableOrderRefund }
+			/>
+		);
+
+		expect( onDisableOrderRefund ).toHaveBeenCalled();
+	} );
+
+	test( 'sums only the awaiting disputes when a locked sibling is on the same charge', () => {
+		const fixedDate = new Date( '2023-10-20T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'under_review',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+					{
+						id: 'dp_2',
+						status: 'needs_response',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						// Oct 30, 2023 — the later deadline.
+						evidence_details: { due_by: 1698672000 },
+					},
+					{
+						id: 'dp_3',
+						status: 'needs_response',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						// Oct 28, 2023 — the earliest deadline, so the one shown.
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText(
+				'This order has 2 payment disputes totaling $25.50.'
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.getAllByText( /Please respond before Oct 28, 2023/ )[ 0 ]
+		).toBeInTheDocument();
+	} );
+
+	test( 'leads with the inquiry deadline when a real dispute on the same charge is under review', () => {
+		const fixedDate = new Date( '2023-10-20T00:00:00Z' );
+		jest.useFakeTimers();
+		jest.setSystemTime( fixedDate );
+
+		const onDisableOrderRefund = jest.fn();
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'warning_needs_response',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+					{
+						id: 'dp_2',
+						status: 'under_review',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ onDisableOrderRefund }
+			/>
+		);
+
+		expect(
+			screen.getAllByText(
+				/Please resolve the inquiry on this order of \$10\.00/
+			)[ 0 ]
+		).toBeInTheDocument();
+		expect(
+			screen.queryAllByText( /This order has an active payment dispute/ )
+		).toHaveLength( 0 );
+
+		// The under-review lock is left to the refund button's tooltip.
+		expect( onDisableOrderRefund ).toHaveBeenCalledWith( 'under_review' );
+	} );
+
+	test( 'keeps the under review notice when no dispute is awaiting a response', () => {
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'lost',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+					{
+						id: 'dp_2',
+						status: 'under_review',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getAllByText(
+				/This order has an active payment dispute/
+			)[ 0 ]
+		).toBeInTheDocument();
+		expect(
+			screen.queryAllByText(
+				/have been disabled as a result of a lost dispute/
+			)
+		).toHaveLength( 0 );
+	} );
+
+	test( 'explains the refund lock with the most severe dispute, not the first one listed', () => {
+		const onDisableOrderRefund = jest.fn();
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'needs_response',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+					{
+						id: 'dp_2',
+						status: 'lost',
+						reason: 'product_not_received',
+						amount: 1550,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ onDisableOrderRefund }
+			/>
+		);
+
+		expect( onDisableOrderRefund ).toHaveBeenCalledWith( 'lost' );
+	} );
 } );

--- a/client/components/disputed-order-notice/__tests__/index.test.js
+++ b/client/components/disputed-order-notice/__tests__/index.test.js
@@ -568,4 +568,33 @@ describe( 'DisputedOrderNoticeHandler', () => {
 
 		expect( onDisableOrderRefund ).toHaveBeenCalledWith( 'lost' );
 	} );
+
+	test( 'reports charge_refunded as the lock reason when it is the only blocking dispute', () => {
+		const onDisableOrderRefund = jest.fn();
+		useCharge.mockReturnValue( {
+			data: {
+				disputes: [
+					{
+						id: 'dp_1',
+						status: 'charge_refunded',
+						reason: 'fraudulent',
+						amount: 1000,
+						currency: 'USD',
+						evidence_details: { due_by: 1698500219 },
+					},
+				],
+			},
+		} );
+
+		render(
+			<DisputedOrderNoticeHandler
+				chargeId="ch_123"
+				onDisableOrderRefund={ onDisableOrderRefund }
+			/>
+		);
+
+		expect( onDisableOrderRefund ).toHaveBeenCalledWith(
+			'charge_refunded'
+		);
+	} );
 } );

--- a/client/components/disputed-order-notice/index.js
+++ b/client/components/disputed-order-notice/index.js
@@ -24,11 +24,12 @@ import { formatDateTimeFromString } from 'wcpay/utils/date-time';
 
 // Which dispute gets to explain the refund lock when several block refunds at
 // once. Ordered most to least severe, and exhaustive over the non-refundable
-// statuses. `charge_refunded` sorts last because `disableWooOrderRefundButton`
-// has no wording for it and would leave the tooltip blank. `lost` outranks
-// `under_review` here even though the notice below leads with the under-review
-// wording: the button never comes back once a dispute is lost, so a permanent
-// reason explains a permanently disabled control better than a temporary one.
+// statuses, so `disableWooOrderRefundButton` always has wording to show. `lost`
+// outranks `under_review` here even though the notice below leads with the
+// under-review wording: the button never comes back once a dispute is lost, so a
+// permanent reason explains a permanently disabled control better than a
+// temporary one. `charge_refunded` is last — the money is already back with the
+// customer, so it is the least pressing thing to tell the merchant about.
 const lockReasonPriority = [
 	'lost',
 	'under_review',

--- a/client/components/disputed-order-notice/index.js
+++ b/client/components/disputed-order-notice/index.js
@@ -22,6 +22,20 @@ import { recordEvent } from 'tracks';
 import './style.scss';
 import { formatDateTimeFromString } from 'wcpay/utils/date-time';
 
+// Which dispute gets to explain the refund lock when several block refunds at
+// once. Ordered most to least severe, and exhaustive over the non-refundable
+// statuses. `charge_refunded` sorts last because `disableWooOrderRefundButton`
+// has no wording for it and would leave the tooltip blank. `lost` outranks
+// `under_review` here even though the notice below leads with the under-review
+// wording: the button never comes back once a dispute is lost, so a permanent
+// reason explains a permanently disabled control better than a temporary one.
+const lockReasonPriority = [
+	'lost',
+	'under_review',
+	'needs_response',
+	'charge_refunded',
+];
+
 const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 	const { data: charge } = useCharge( chargeId );
 	const disputeDetailsUrl = getDetailsURL( chargeId, 'transactions' );
@@ -31,11 +45,20 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 	// single `charge.dispute` for payloads without the array.
 	const disputes = charge ? getChargeDisputes( charge ) : [];
 
-	// Disable the refund button if any dispute blocks refunds.
+	// Disable the refund button if any dispute blocks refunds. The status drives
+	// the tooltip wording, so pick by severity rather than by array order —
+	// otherwise a charge with both a lost and an unanswered dispute explains the
+	// lock as temporary depending on how the server happened to order them.
 	useEffect( () => {
-		const blocking = ( charge ? getChargeDisputes( charge ) : [] ).find(
+		const blockers = ( charge ? getChargeDisputes( charge ) : [] ).filter(
 			( dispute ) => ! isRefundable( dispute.status )
 		);
+		const blocking =
+			lockReasonPriority
+				.map( ( status ) =>
+					blockers.find( ( dispute ) => dispute.status === status )
+				)
+				.find( Boolean ) ?? blockers[ 0 ];
 		if ( blocking ) {
 			onDisableOrderRefund( blocking.status );
 		}
@@ -43,46 +66,6 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 
 	if ( ! disputes.length ) {
 		return null;
-	}
-
-	// Refund/edit locking and the "under review" / "lost" states are
-	// charge-wide, so surface them if ANY dispute is in that state before
-	// considering the respond-by notices below.
-
-	// Special case the dispute "under review" notice which is much simpler.
-	if (
-		disputes.some(
-			( dispute ) =>
-				isUnderReview( dispute.status ) && ! isInquiry( dispute.status )
-		)
-	) {
-		return (
-			<DisputeOrderLockedNotice
-				message={ __(
-					'This order has an active payment dispute. Refunds and order editing are disabled.',
-					'woocommerce-payments'
-				) }
-				disputeDetailsUrl={ disputeDetailsUrl }
-			/>
-		);
-	}
-
-	// Special case lost disputes.
-	// I suspect this is unnecessary, as any lost disputes will have already been
-	// refunded as part of `charge.dispute.closed` webhook handler.
-	// This may be dead code. Leaving in for now as this is consistent with
-	// the logic before this PR.
-	// https://github.com/Automattic/woocommerce-payments/pull/7557
-	if ( disputes.some( ( dispute ) => dispute.status === 'lost' ) ) {
-		return (
-			<DisputeOrderLockedNotice
-				message={ __(
-					'Refunds and order editing have been disabled as a result of a lost dispute.',
-					'woocommerce-payments'
-				) }
-				disputeDetailsUrl={ disputeDetailsUrl }
-			/>
-		);
 	}
 
 	// Get current time in UTC for consistent timezone-independent comparison.
@@ -102,7 +85,50 @@ const DisputedOrderNoticeHandler = ( { chargeId, onDisableOrderRefund } ) => {
 		);
 	} );
 
+	// There is only one notice slot, and a charge can be locked by one dispute
+	// while another still needs evidence. The deadline wins: miss it and the
+	// money is gone for good, whereas the lock doesn't expire and is already
+	// carried by the disabled refund button and its tooltip. Every locked notice
+	// therefore belongs inside this guard; one placed outside it would hide a
+	// live deadline.
 	if ( ! awaitingDisputes.length ) {
+		// Special case the dispute "under review" notice which is much simpler.
+		if (
+			disputes.some(
+				( dispute ) =>
+					isUnderReview( dispute.status ) &&
+					! isInquiry( dispute.status )
+			)
+		) {
+			return (
+				<DisputeOrderLockedNotice
+					message={ __(
+						'This order has an active payment dispute. Refunds and order editing are disabled.',
+						'woocommerce-payments'
+					) }
+					disputeDetailsUrl={ disputeDetailsUrl }
+				/>
+			);
+		}
+
+		// Special case lost disputes.
+		// I suspect this is unnecessary, as any lost disputes will have already
+		// been refunded as part of `charge.dispute.closed` webhook handler.
+		// This may be dead code. Leaving in for now as this is consistent with
+		// the logic before this PR.
+		// https://github.com/Automattic/woocommerce-payments/pull/7557
+		if ( disputes.some( ( dispute ) => dispute.status === 'lost' ) ) {
+			return (
+				<DisputeOrderLockedNotice
+					message={ __(
+						'Refunds and order editing have been disabled as a result of a lost dispute.',
+						'woocommerce-payments'
+					) }
+					disputeDetailsUrl={ disputeDetailsUrl }
+				/>
+			);
+		}
+
 		return null;
 	}
 

--- a/client/order/index.js
+++ b/client/order/index.js
@@ -39,6 +39,11 @@ function disableWooOrderRefundButton( disputeStatus ) {
 			'Refunds and order editing have been disabled as a result of a lost dispute.',
 			'woocommerce-payments'
 		);
+	} else if ( disputeStatus === 'charge_refunded' ) {
+		tooltipText = __(
+			'Refunds and order editing have been disabled because the payment was refunded to resolve a dispute.',
+			'woocommerce-payments'
+		);
 	}
 
 	jQuery( refundButton )


### PR DESCRIPTION
Follow-up to #11916 / #11991 / #11993 — found this while auditing the multi-dispute surface for anything those PRs left behind.

#### Changes proposed in this Pull Request

`DisputedOrderNoticeHandler` returns the "under review" and "lost" notices before it works out which disputes are still awaiting a response.
#11991 broadened those checks to `.some()` over all of a charge's disputes, so now any dispute in one of those states short-circuits the whole notice. A dispute needing evidence in three days gets hidden behind a sibling that's already been challenged or lost. The merchant just sees "This order has an active payment dispute", no deadline, no amount, no Respond button.

Moved the awaiting-response check above the locked branches so it wins the single notice slot; the locked notices are now the fallback for when nothing is actionable. Also had the refund-lock tooltip pick its wording by severity instead of by whatever order the server happens to return disputes in — that was silently flipping between "temporary" and "permanent" wording depending on array order.

I considered stacking both notices at once, but that needs a new visual hierarchy and produces a copy collision ("2 disputes totaling $25.50" right above "an active payment dispute"). More of a product change than a regression fix.

#### Testing instructions

- Ensure your local server is listening to webhooks and forwarding to the client
- As a customer, place an order with test card `4000000404000079` (creates multiple disputes).
- As a merchant, go to Payments → Transactions, open the transaction
- Challenge one of the two disputes, replacing the cover letter with `losing_evidence`, leaving the other alone
- Open the order-edit screen. Before this PR: only "This order has an active payment dispute", no deadline for the unanswered one. After: the remaining dispute's amount, reason, deadline and a Respond now button show up, and the refund button stays disabled with a tooltip explaining why.

Before:
<img width="729" height="276" alt="Screenshot 2026-07-27 at 9 06 58 PM" src="https://github.com/user-attachments/assets/46624ec0-9541-4369-8470-d7ed683ac2d3" />

After:
<img width="746" height="236" alt="Screenshot 2026-07-27 at 9 11 04 PM" src="https://github.com/user-attachments/assets/6c721b31-37ac-4cc2-a386-7803cb447bb5" />

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios)
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
