### PR TITLE
Catch API errors when mirroring the default payment method

### DIFF
--- a/changelog/fix-set-default-handler-api-exception
+++ b/changelog/fix-set-default-handler-api-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Catch API errors when mirroring a new default payment method to the server, so a token that is stale on the server side (e.g. detached via the Stripe dashboard) logs an error instead of taking down the request that set it as default.

--- a/changelog/fix-set-default-handler-api-exception
+++ b/changelog/fix-set-default-handler-api-exception
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Catch API errors when mirroring a new default payment method to the server, so a token that is stale on the server side (e.g. detached via the Stripe dashboard) tells the customer the change did not go through instead of taking down the request that set it as default.
+Tell the customer when a new default payment method fails to save on the server, instead of failing the request.

--- a/changelog/fix-set-default-handler-api-exception
+++ b/changelog/fix-set-default-handler-api-exception
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Catch API errors when mirroring a new default payment method to the server, so a token that is stale on the server side (e.g. detached via the Stripe dashboard) logs an error instead of taking down the request that set it as default.
+Catch API errors when mirroring a new default payment method to the server, so a token that is stale on the server side (e.g. detached via the Stripe dashboard) tells the customer the change did not go through instead of taking down the request that set it as default.

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -439,10 +439,16 @@ class WC_Payments_Token_Service {
 				}
 			} catch ( Exception $e ) {
 				// This runs inside a WooCommerce action during checkout and My Account requests,
-				// and the local token can be stale on the server side (e.g. the payment method
-				// was detached via the Stripe dashboard); failing to mirror the default must not
-				// take the request down. The next payment methods sync prunes stale tokens.
-				Logger::error( 'Failed to set the default payment method for customer: ' . $e );
+				// and failing to mirror the default must not take the request down. The local
+				// default is already written at this point. When the token is stale on the server
+				// side (e.g. the payment method was detached via the Stripe dashboard) the next
+				// payment methods sync prunes it; transient API failures are logged but not
+				// retried. Logged via wc_get_logger() rather than the WCPay logger so the failure
+				// is recorded even when the gateway's debug logging toggle is off.
+				wc_get_logger()->error(
+					'Failed to set the default payment method for customer: ' . $e,
+					[ 'source' => 'woocommerce-payments' ]
+				);
 			}
 		}
 	}

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -430,11 +430,19 @@ class WC_Payments_Token_Service {
 	public function woocommerce_payment_token_set_default( $token_id, $token ) {
 
 		if ( in_array( $token->get_gateway_id(), self::REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
-			$customer_id = $this->customer_service->get_customer_id_by_user_id( $token->get_user_id() );
-			if ( $customer_id ) {
-				$this->customer_service->set_default_payment_method_for_customer( $customer_id, $token->get_token() );
-				// Clear cached payment methods.
-				$this->clear_cached_payment_methods_for_user( $token->get_user_id() );
+			try {
+				$customer_id = $this->customer_service->get_customer_id_by_user_id( $token->get_user_id() );
+				if ( $customer_id ) {
+					$this->customer_service->set_default_payment_method_for_customer( $customer_id, $token->get_token() );
+					// Clear cached payment methods.
+					$this->clear_cached_payment_methods_for_user( $token->get_user_id() );
+				}
+			} catch ( Exception $e ) {
+				// This runs inside a WooCommerce action during checkout and My Account requests,
+				// and the local token can be stale on the server side (e.g. the payment method
+				// was detached via the Stripe dashboard); failing to mirror the default must not
+				// take the request down. The next payment methods sync prunes stale tokens.
+				Logger::error( 'Failed to set the default payment method for customer: ' . $e );
 			}
 		}
 	}

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -443,12 +443,9 @@ class WC_Payments_Token_Service {
 				// default is already written at this point. When the token is stale on the server
 				// side (e.g. the payment method was detached via the Stripe dashboard) the next
 				// payment methods sync prunes it; transient API failures are logged but not
-				// retried. Logged via wc_get_logger() rather than the WCPay logger so the failure
-				// is recorded even when the gateway's debug logging toggle is off.
-				wc_get_logger()->error(
-					'Failed to set the default payment method for customer: ' . $e,
-					[ 'source' => 'woocommerce-payments' ]
-				);
+				// retried. Logged via log_to_wc() rather than the WCPay logger so the failure is
+				// recorded even when the gateway's debug logging toggle is off.
+				WC_Payments_Utils::log_to_wc( 'Failed to set the default payment method for customer: ' . $e->getMessage() );
 			}
 		}
 	}

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -441,16 +441,21 @@ class WC_Payments_Token_Service {
 		try {
 			$this->customer_service->set_default_payment_method_for_customer( $customer_id, $token->get_token() );
 		} catch ( Exception $e ) {
-			// This runs inside a WooCommerce action during checkout and My Account requests, and
-			// failing to mirror the default must not take the request down. Logged via log_to_wc()
-			// rather than the WCPay logger so the failure is recorded even when the gateway's debug
-			// logging toggle is off, which is its shipped default.
-			WC_Payments_Utils::log_to_wc( 'Failed to set the default payment method for customer: ' . $e->getMessage() );
+			// WooCommerce writes the local default before firing this action, so a failed mirror
+			// must not take the request down. log_to_wc() because the WCPay logger is off by default.
+			WC_Payments_Utils::log_to_wc(
+				sprintf(
+					'Failed to set the default payment method %1$s for customer %2$s (user %3$d): %4$s',
+					$token->get_token(),
+					$customer_id,
+					$token->get_user_id(),
+					$e->getMessage()
+				)
+			);
 			$this->report_failed_default_payment_method_mirror();
 		} finally {
-			// Clear cached payment methods on both paths. The cache has no TTL, so leaving it in
-			// place after a failure keeps serving a payment method the server no longer has: the
-			// next read re-syncs instead, picking up the new default or pruning the stale token.
+			// The cache has no TTL, so keeping it after a failure goes on serving a payment method
+			// the server no longer has. Clearing it lets the next read re-sync and prune.
 			$this->clear_cached_payment_methods_for_user( $token->get_user_id() );
 		}
 	}

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -446,6 +446,7 @@ class WC_Payments_Token_Service {
 			// rather than the WCPay logger so the failure is recorded even when the gateway's debug
 			// logging toggle is off, which is its shipped default.
 			WC_Payments_Utils::log_to_wc( 'Failed to set the default payment method for customer: ' . $e->getMessage() );
+			$this->report_failed_default_payment_method_mirror();
 		} finally {
 			// Clear cached payment methods on both paths. The cache has no TTL, so leaving it in
 			// place after a failure keeps serving a payment method the server no longer has: the
@@ -561,5 +562,41 @@ class WC_Payments_Token_Service {
 		}
 
 		return $label;
+	}
+
+	/**
+	 * Tells the customer that the new default did not reach the server.
+	 *
+	 * WooCommerce's My Account handler adds "This payment method was successfully set as your
+	 * default." right after this action returns, with no way to signal a failure back to it. Left
+	 * alone, a swallowed error reads to the customer as a change that stuck. Suppress that one
+	 * message and put an error in its place instead.
+	 *
+	 * The same action also fires during checkout and in admin and REST flows, where there is no
+	 * customer reading notices, so this only runs for the My Account "Make default" request.
+	 *
+	 * @return void
+	 */
+	private function report_failed_default_payment_method_mirror() {
+		if ( ! isset( $GLOBALS['wp']->query_vars['set-default-payment-method'] ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'wc_add_notice' ) || ! did_action( 'woocommerce_init' ) || ! isset( WC()->session ) ) {
+			return;
+		}
+
+		// Returning an empty message from this filter drops the notice. The callback removes
+		// itself so it only ever eats the one success notice that follows this action.
+		$suppress_success_notice = function () use ( &$suppress_success_notice ) {
+			remove_filter( 'woocommerce_add_message', $suppress_success_notice, 100 );
+			return '';
+		};
+		add_filter( 'woocommerce_add_message', $suppress_success_notice, 100 );
+
+		wc_add_notice(
+			__( 'We could not set that payment method as your default. It may no longer be available, please reload the page and try again.', 'woocommerce-payments' ),
+			'error'
+		);
 	}
 }

--- a/includes/class-wc-payments-token-service.php
+++ b/includes/class-wc-payments-token-service.php
@@ -429,24 +429,28 @@ class WC_Payments_Token_Service {
 	 */
 	public function woocommerce_payment_token_set_default( $token_id, $token ) {
 
-		if ( in_array( $token->get_gateway_id(), self::REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
-			try {
-				$customer_id = $this->customer_service->get_customer_id_by_user_id( $token->get_user_id() );
-				if ( $customer_id ) {
-					$this->customer_service->set_default_payment_method_for_customer( $customer_id, $token->get_token() );
-					// Clear cached payment methods.
-					$this->clear_cached_payment_methods_for_user( $token->get_user_id() );
-				}
-			} catch ( Exception $e ) {
-				// This runs inside a WooCommerce action during checkout and My Account requests,
-				// and failing to mirror the default must not take the request down. The local
-				// default is already written at this point. When the token is stale on the server
-				// side (e.g. the payment method was detached via the Stripe dashboard) the next
-				// payment methods sync prunes it; transient API failures are logged but not
-				// retried. Logged via log_to_wc() rather than the WCPay logger so the failure is
-				// recorded even when the gateway's debug logging toggle is off.
-				WC_Payments_Utils::log_to_wc( 'Failed to set the default payment method for customer: ' . $e->getMessage() );
-			}
+		if ( ! in_array( $token->get_gateway_id(), self::REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
+			return;
+		}
+
+		$customer_id = $this->customer_service->get_customer_id_by_user_id( $token->get_user_id() );
+		if ( ! $customer_id ) {
+			return;
+		}
+
+		try {
+			$this->customer_service->set_default_payment_method_for_customer( $customer_id, $token->get_token() );
+		} catch ( Exception $e ) {
+			// This runs inside a WooCommerce action during checkout and My Account requests, and
+			// failing to mirror the default must not take the request down. Logged via log_to_wc()
+			// rather than the WCPay logger so the failure is recorded even when the gateway's debug
+			// logging toggle is off, which is its shipped default.
+			WC_Payments_Utils::log_to_wc( 'Failed to set the default payment method for customer: ' . $e->getMessage() );
+		} finally {
+			// Clear cached payment methods on both paths. The cache has no TTL, so leaving it in
+			// place after a failure keeps serving a payment method the server no longer has: the
+			// next read re-syncs instead, picking up the new default or pruning the stale token.
+			$this->clear_cached_payment_methods_for_user( $token->get_user_id() );
 		}
 	}
 

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -74,6 +74,10 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 	 * Post-test teardown
 	 */
 	public function tear_down() {
+		global $wp;
+
+		unset( $wp->query_vars['set-default-payment-method'] );
+		wc_clear_notices();
 		wp_set_current_user( $this->user_id );
 		// Restore the cache service in the main class.
 		WC_Payments::set_database_cache( $this->_cache );
@@ -556,6 +560,103 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 			get_user_meta( 1, '_wcpay_payment_methods', true ),
 			'The cached payment methods should be cleared when the server mirror fails'
 		);
+	}
+
+	public function test_woocommerce_payment_token_set_default_replaces_core_success_notice_on_failure() {
+		$this->set_default_payment_method_request();
+		wc_clear_notices();
+
+		$this->mock_customer_service
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_12345' );
+		$this->mock_customer_service
+			->method( 'set_default_payment_method_for_customer' )
+			->willThrowException( new \WCPay\Exceptions\API_Exception( 'No such PaymentMethod: pm_mock', 'resource_missing', 400 ) );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_gateway_id( 'woocommerce_payments' );
+		$token->set_token( 'pm_mock' );
+		$token->set_user_id( 1 );
+
+		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
+
+		// WooCommerce's My Account handler adds this unconditionally once the action returns.
+		wc_add_notice( 'This payment method was successfully set as your default.' );
+
+		$this->assertEmpty(
+			wc_get_notices( 'success' ),
+			'The customer should not be told the change stuck when the server never got it'
+		);
+		$this->assertNotEmpty( wc_get_notices( 'error' ) );
+		$this->assertStringContainsString(
+			'could not set that payment method as your default',
+			wc_get_notices( 'error' )[0]['notice']
+		);
+	}
+
+	public function test_woocommerce_payment_token_set_default_keeps_later_success_notices() {
+		$this->set_default_payment_method_request();
+		wc_clear_notices();
+
+		$this->mock_customer_service
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_12345' );
+		$this->mock_customer_service
+			->method( 'set_default_payment_method_for_customer' )
+			->willThrowException( new \WCPay\Exceptions\API_Exception( 'No such PaymentMethod: pm_mock', 'resource_missing', 400 ) );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_gateway_id( 'woocommerce_payments' );
+		$token->set_token( 'pm_mock' );
+		$token->set_user_id( 1 );
+
+		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
+
+		wc_add_notice( 'This payment method was successfully set as your default.' );
+		wc_add_notice( 'Some other success notice.' );
+
+		// Only the one notice that follows the action is dropped, the filter removes itself after.
+		$this->assertSame(
+			[ 'Some other success notice.' ],
+			array_column( wc_get_notices( 'success' ), 'notice' )
+		);
+	}
+
+	public function test_woocommerce_payment_token_set_default_does_not_notice_outside_my_account_form() {
+		wc_clear_notices();
+
+		$this->mock_customer_service
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_12345' );
+		$this->mock_customer_service
+			->method( 'set_default_payment_method_for_customer' )
+			->willThrowException( new \WCPay\Exceptions\API_Exception( 'No such PaymentMethod: pm_mock', 'resource_missing', 400 ) );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_gateway_id( 'woocommerce_payments' );
+		$token->set_token( 'pm_mock' );
+		$token->set_user_id( 1 );
+
+		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
+
+		// The same action fires during checkout and in admin and REST flows, where a notice about
+		// the default payment method would surface out of nowhere.
+		wc_add_notice( 'Some unrelated success notice.' );
+
+		$this->assertEmpty( wc_get_notices( 'error' ) );
+		$this->assertSame(
+			[ 'Some unrelated success notice.' ],
+			array_column( wc_get_notices( 'success' ), 'notice' )
+		);
+	}
+
+	/**
+	 * Puts the request in the shape WooCommerce's My Account "Make default" form handler runs in.
+	 */
+	private function set_default_payment_method_request() {
+		global $wp;
+
+		$wp->query_vars['set-default-payment-method'] = '1';
 	}
 
 	public function test_woocommerce_payment_token_set_default_other_gateway() {

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -534,7 +534,11 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 			$captured[0]['source'],
 			'The failure must log under the woopayments source so it lands in the log file support pulls'
 		);
+		// The IDs make the entry actionable: which payment method, on which customer and user.
 		$this->assertStringContainsString( 'default payment method', $captured[0]['message'] );
+		$this->assertStringContainsString( 'pm_mock', $captured[0]['message'] );
+		$this->assertStringContainsString( 'cus_12345', $captured[0]['message'] );
+		$this->assertStringContainsString( 'user 1', $captured[0]['message'] );
 	}
 
 	public function test_woocommerce_payment_token_set_default_clears_cache_on_failure() {

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -533,7 +533,7 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsString( 'default payment method', $captured[0]['message'] );
 	}
 
-	public function test_woocommerce_payment_token_set_default_skips_cache_clear_on_failure() {
+	public function test_woocommerce_payment_token_set_default_clears_cache_on_failure() {
 		update_user_meta( 1, '_wcpay_payment_methods', [ 'cached' ] );
 
 		$this->mock_customer_service
@@ -550,9 +550,11 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
 
-		$this->assertNotEmpty(
+		// The cache has no TTL, so keeping it after a failure would go on serving a payment method
+		// the server no longer has. Clearing it lets the next read prune the stale token.
+		$this->assertEmpty(
 			get_user_meta( 1, '_wcpay_payment_methods', true ),
-			'The cached payment methods should not be cleared when the server mirror fails'
+			'The cached payment methods should be cleared when the server mirror fails'
 		);
 	}
 

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -491,32 +491,21 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_woocommerce_payment_token_set_default_failure_is_logged_without_debug_toggle() {
-		// The WCPay logger is gated behind the enable_logging toggle (default off); a failed
-		// default-method mirror must reach the WooCommerce logs even with the toggle off.
+		// Regression guard: with the WCPay debug toggle off (and no dev mode in the test
+		// bootstrap), the gated WCPay logger produces nothing, so this test fails if the
+		// catch ever reverts to Logger::error().
 		update_option( 'woocommerce_woocommerce_payments_settings', [ 'enable_logging' => 'no' ] );
 
-		$spy = new class() extends WC_Logger {
-			/**
-			 * Captured error messages.
-			 *
-			 * @var array
-			 */
-			public $errors = [];
-
-			public function error( $message, $context = [] ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
-				$this->errors[] = $message;
-				parent::error( $message, $context );
-			}
+		$captured = [];
+		$capture  = function ( $message, $level, $context ) use ( &$captured ) {
+			$captured[] = [
+				'message' => $message,
+				'level'   => $level,
+				'source'  => $context['source'] ?? '',
+			];
+			return $message;
 		};
-
-		$spy_class = get_class( $spy );
-		add_filter(
-			'woocommerce_logging_class',
-			function () use ( $spy_class ) {
-				return $spy_class;
-			}
-		);
-		$logger = wc_get_logger();
+		add_filter( 'woocommerce_logger_log_message', $capture, 10, 3 );
 
 		$this->mock_customer_service
 			->method( 'get_customer_id_by_user_id' )
@@ -532,10 +521,16 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
 
-		remove_all_filters( 'woocommerce_logging_class' );
+		remove_filter( 'woocommerce_logger_log_message', $capture );
 
-		$this->assertNotEmpty( $logger->errors, 'The failed default-method mirror should be logged even with the debug toggle off' );
-		$this->assertStringContainsString( 'default payment method', $logger->errors[0] );
+		$this->assertNotEmpty( $captured, 'The failed default-method mirror should be logged even with the debug toggle off' );
+		$this->assertSame( 'error', $captured[0]['level'] );
+		$this->assertSame(
+			'woopayments',
+			$captured[0]['source'],
+			'The failure must log under the woopayments source so it lands in the log file support pulls'
+		);
+		$this->assertStringContainsString( 'default payment method', $captured[0]['message'] );
 	}
 
 	public function test_woocommerce_payment_token_set_default_skips_cache_clear_on_failure() {

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -490,6 +490,77 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
 	}
 
+	public function test_woocommerce_payment_token_set_default_failure_is_logged_without_debug_toggle() {
+		// The WCPay logger is gated behind the enable_logging toggle (default off); a failed
+		// default-method mirror must reach the WooCommerce logs even with the toggle off.
+		update_option( 'woocommerce_woocommerce_payments_settings', [ 'enable_logging' => 'no' ] );
+
+		$spy = new class() extends WC_Logger {
+			/**
+			 * Captured error messages.
+			 *
+			 * @var array
+			 */
+			public $errors = [];
+
+			public function error( $message, $context = [] ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
+				$this->errors[] = $message;
+				parent::error( $message, $context );
+			}
+		};
+
+		$spy_class = get_class( $spy );
+		add_filter(
+			'woocommerce_logging_class',
+			function () use ( $spy_class ) {
+				return $spy_class;
+			}
+		);
+		$logger = wc_get_logger();
+
+		$this->mock_customer_service
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_12345' );
+		$this->mock_customer_service
+			->method( 'set_default_payment_method_for_customer' )
+			->willThrowException( new \WCPay\Exceptions\API_Exception( 'No such PaymentMethod: pm_mock', 'resource_missing', 400 ) );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_gateway_id( 'woocommerce_payments' );
+		$token->set_token( 'pm_mock' );
+		$token->set_user_id( 1 );
+
+		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
+
+		remove_all_filters( 'woocommerce_logging_class' );
+
+		$this->assertNotEmpty( $logger->errors, 'The failed default-method mirror should be logged even with the debug toggle off' );
+		$this->assertStringContainsString( 'default payment method', $logger->errors[0] );
+	}
+
+	public function test_woocommerce_payment_token_set_default_skips_cache_clear_on_failure() {
+		update_user_meta( 1, '_wcpay_payment_methods', [ 'cached' ] );
+
+		$this->mock_customer_service
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( 'cus_12345' );
+		$this->mock_customer_service
+			->method( 'set_default_payment_method_for_customer' )
+			->willThrowException( new \WCPay\Exceptions\API_Exception( 'No such PaymentMethod: pm_mock', 'resource_missing', 400 ) );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_gateway_id( 'woocommerce_payments' );
+		$token->set_token( 'pm_mock' );
+		$token->set_user_id( 1 );
+
+		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
+
+		$this->assertNotEmpty(
+			get_user_meta( 1, '_wcpay_payment_methods', true ),
+			'The cached payment methods should not be cleared when the server mirror fails'
+		);
+	}
+
 	public function test_woocommerce_payment_token_set_default_other_gateway() {
 		$this->mock_customer_service
 			->expects( $this->never() )

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -467,6 +467,29 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
 	}
 
+	public function test_woocommerce_payment_token_set_default_swallows_api_exception() {
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'get_customer_id_by_user_id' )
+			->with( 1 )
+			->willReturn( 'cus_12345' );
+
+		$this->mock_customer_service
+			->expects( $this->once() )
+			->method( 'set_default_payment_method_for_customer' )
+			->with( 'cus_12345', 'pm_mock' )
+			->willThrowException( new \WCPay\Exceptions\API_Exception( 'No such PaymentMethod: pm_mock', 'resource_missing', 400 ) );
+
+		$token = new WC_Payment_Token_CC();
+		$token->set_gateway_id( 'woocommerce_payments' );
+		$token->set_token( 'pm_mock' );
+		$token->set_user_id( 1 );
+
+		// The handler runs inside a WooCommerce action during checkout and My Account
+		// requests; a token that is stale on the server side must not escalate to a fatal.
+		$this->token_service->woocommerce_payment_token_set_default( 'pm_mock', $token );
+	}
+
 	public function test_woocommerce_payment_token_set_default_other_gateway() {
 		$this->mock_customer_service
 			->expects( $this->never() )

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -659,15 +659,6 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
-	/**
-	 * Puts the request in the shape WooCommerce's My Account "Make default" form handler runs in.
-	 */
-	private function set_default_payment_method_request() {
-		global $wp;
-
-		$wp->query_vars['set-default-payment-method'] = '1';
-	}
-
 	public function test_woocommerce_payment_token_set_default_other_gateway() {
 		$this->mock_customer_service
 			->expects( $this->never() )
@@ -1544,5 +1535,14 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 
 		// Should return unchanged when wallet type not found.
 		$this->assertEquals( 'Visa', $result['method']['brand'] );
+	}
+
+	/**
+	 * Puts the request in the shape WooCommerce's My Account "Make default" form handler runs in.
+	 */
+	private function set_default_payment_method_request() {
+		global $wp;
+
+		$wp->query_vars['set-default-payment-method'] = '1';
 	}
 }

--- a/tests/unit/test-class-wc-payments-token-service.php
+++ b/tests/unit/test-class-wc-payments-token-service.php
@@ -55,6 +55,10 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// The failure paths under test log through wc_get_logger(). Returning null from this
+		// filter stops the handlers, so the tests do not write into wp-content/uploads/wc-logs.
+		add_filter( 'woocommerce_logger_log_message', '__return_null', 100 );
+
 		$this->original_gateway = WC_Payments::get_gateway();
 
 		$this->user_id = get_current_user_id();
@@ -76,6 +80,7 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 	public function tear_down() {
 		global $wp;
 
+		remove_filter( 'woocommerce_logger_log_message', '__return_null', 100 );
 		unset( $wp->query_vars['set-default-payment-method'] );
 		wc_clear_notices();
 		wp_set_current_user( $this->user_id );
@@ -495,10 +500,10 @@ class WC_Payments_Token_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_woocommerce_payment_token_set_default_failure_is_logged_without_debug_toggle() {
-		// Regression guard: with the WCPay debug toggle off (and no dev mode in the test
-		// bootstrap), the gated WCPay logger produces nothing, so this test fails if the
-		// catch ever reverts to Logger::error().
-		update_option( 'woocommerce_woocommerce_payments_settings', [ 'enable_logging' => 'no' ] );
+		// Regression guard: the gated WCPay logger writes nothing while the debug toggle is off,
+		// which is the default here, so this test fails if the catch ever reverts to
+		// Logger::error(). Asserted rather than assumed, since the guard is void without it.
+		$this->assertFalse( \WCPay\Logger::can_log(), 'Precondition: the gated WCPay logger must be off' );
 
 		$captured = [];
 		$capture  = function ( $message, $level, $context ) use ( &$captured ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `woocommerce_payment_token_set_default` handler mirrors a newly chosen default payment method to the server with no error handling. When the local token is stale on the server side (e.g. the payment method was detached via the Stripe dashboard while the customer had My Account open), `update_customer` throws an `API_Exception`, and since the handler runs inside a WooCommerce action during checkout and My Account requests, the uncaught exception takes the whole request down.

Our own cache is what makes that stale read possible. `_wcpay_payment_methods` user meta has no TTL, and `clear_cached_payment_methods_for_user()` is the only thing that invalidates it. So the My Account page load fills the cache, the dashboard detach makes it stale, and the "Make default" click that follows resolves the token from the stale cache instead of pruning it. The same failure is also reachable for customers with enough tokens to trip the sync bail-out in our `woocommerce_get_customer_payment_tokens` callback (`count >= posts_per_page` skips the pruning), and it would become the failure mode for anyone racing a server-side detach if core ever decoupled `set_users_default()` from the filtered read (proposed in woocommerce/woocommerce#66642, since closed).

Three changes, all in `WC_Payments_Token_Service::woocommerce_payment_token_set_default()`:

* **Catch the exception** so the mirror failure no longer takes the request down. We deliberately do not retry.
* **Clear the payment methods cache on both paths**, in a `finally`. The next read then always re-syncs: it picks up the new default on success, and prunes the token that is gone on failure. Without this the detached card stays listed and marked default on every subsequent page load, so the failure never self-heals.
* **Replace core's success notice with an error.** `WC_Form_Handler::set_default_payment_method_action()` adds "This payment method was successfully set as your default." unconditionally once the action returns, with no way for the action to signal a failure back. Left alone, a swallowed error reads to the customer as a change that stuck. We drop that one message through the `woocommerce_add_message` filter and put an error in its place. The filter removes itself after the first message it eats, so any later success notice on the request is untouched, and it only arms on the My Account `set-default-payment-method` request, since the same action also fires during checkout and in admin and REST flows.

The failure is logged through `WC_Payments_Utils::log_to_wc()` (source `woopayments`) rather than the gated WCPay logger, so it lands in the regular WooPayments log file even when the gateway's debug logging toggle is off, which is its shipped default.

**How can this code break?** The catch is scoped to the mirror call, so a failure there now logs instead of fataling. Known rough edge: on a *transient* API failure rather than a stale token, the local `is_default` flag stays flipped to the card the customer clicked, so they see the error while that card still shows as default after the reload. A retry fixes it. Rolling back the previous default is not cheap, since `set_users_default()` may already have cleared it before our action fires, depending on token order.

**Backward compatibility:** no public signatures, hooks, or option keys change. The new `woocommerce_add_message` filter callback is added and removed inside a single request and only on the My Account "Make default" route.

#### Testing instructions

* Run `./bin/run-tests.sh --filter WC_Payments_Token_Service_Test` and confirm all 54 tests pass, including the ones covering the swallowed exception, the non-gated log write (asserted with the debug toggle off), the cache clear on failure, the replaced success notice, and the contexts where no notice should appear.
* Manual (dev mode): save two cards for a customer, open **My Account → Payment methods** (this fills the cached payment method list), detach the non-default card via the Stripe dashboard, then click **Make default** on it *without reloading*.
* [ ] Confirm the page responds normally, with the error "We could not set that payment method as your default. It may no longer be available, please reload the page and try again." and **no** success notice.
* [ ] Confirm the detached card is gone from the list and the store still has a working default.
* [ ] Confirm an error is written to the WooPayments log (source `woopayments`) even with the gateway's debug logging setting disabled.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file (added manually: `changelog/fix-set-default-handler-api-exception`)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
