### PR TITLE
fix: stop renewal token repair from re-pointing sibling subscriptions

### DIFF
--- a/changelog/fix-subscription-renewal-repair-sibling-token
+++ b/changelog/fix-subscription-renewal-repair-sibling-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop a subscription renewal token repair from silently re-pointing the other subscriptions created by the same checkout at the original order's card.

--- a/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
+++ b/includes/compat/subscriptions/trait-wc-payment-gateway-wcpay-subscriptions.php
@@ -515,8 +515,24 @@ trait WC_Payment_Gateway_WCPay_Subscriptions_Trait {
 		}
 
 		try {
-			$token = $this->ensure_payment_method_token_for_order( $parent_order, $payment_method_id, get_user_by( 'id', $subscription->get_customer_id() ) );
-			$this->add_token_to_order( $renewal_order, $token );
+			// The parent order is only a source for the payment method ID, never a write target:
+			// attaching the token to it would fan the token out to every subscription that order
+			// created (see maybe_add_token_to_subscription_order()), silently re-pointing sibling
+			// subscriptions the customer has since moved to a different card.
+			$token = $this->ensure_payment_method_token_for_order( $renewal_order, $payment_method_id, get_user_by( 'id', $subscription->get_customer_id() ) );
+
+			$subscription_token = $this->get_payment_token( $subscription );
+			if ( is_null( $subscription_token ) || $token->get_id() !== $subscription_token->get_id() ) {
+				$subscription->add_payment_token( $token );
+				$subscription->add_order_note(
+					sprintf(
+						/* translators: %s: the recovered payment method, e.g. "Visa ending in 4242 (expires 01/26)" */
+						__( 'The saved payment method for this subscription was missing, so WooPayments restored %s from the original order to complete the renewal.', 'woocommerce-payments' ),
+						$token->get_display_name()
+					)
+				);
+			}
+
 			$renewal_order->add_order_note( __( 'Recovered missing subscription payment method token from the parent order.', 'woocommerce-payments' ) );
 			return $token;
 		} catch ( Exception $e ) {

--- a/tests/unit/helpers/class-wc-helper-subscription.php
+++ b/tests/unit/helpers/class-wc-helper-subscription.php
@@ -293,4 +293,8 @@ class WC_Subscription extends WC_Mock_WC_Data {
 	public function set_payment_tokens( $tokens ) {
 		$this->payment_tokens = $tokens;
 	}
+
+	public function add_payment_token( $token ) {
+		$this->payment_tokens[] = $token->get_id();
+	}
 }

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -388,13 +388,9 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 
 		$this->order_service->set_payment_method_id_for_order( $parent_order, self::PAYMENT_METHOD_ID );
 
-		$mock_subscription = $this->createMock( WC_Subscription::class );
-		$mock_subscription
-			->method( 'get_parent_id' )
-			->willReturn( $parent_order->get_id() );
-		$mock_subscription
-			->method( 'get_customer_id' )
-			->willReturn( $user->ID );
+		$mock_subscription = new WC_Subscription();
+		$mock_subscription->set_parent( $parent_order );
+		$mock_subscription->set_customer_id( $user->ID );
 
 		$this->mock_wcs_get_subscriptions_for_renewal_order( [ '1' => $mock_subscription ] );
 		$this->mock_wcs_get_subscriptions_for_order( [] );
@@ -451,9 +447,73 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 
 		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
 
-		$this->assertContains( $token->get_id(), $parent_order->get_payment_tokens() );
 		$this->assertContains( $token->get_id(), $renewal_order->get_payment_tokens() );
 		$this->assertEquals( 'processing', $renewal_order->get_status() );
+	}
+
+	/**
+	 * Repairing a renewal token must not disturb the other subscriptions created by the same
+	 * checkout. Two subscriptions on different schedules share one parent order, and each may
+	 * have been pointed at a different saved card by the customer since. Recovering the parent
+	 * order's payment method for one of them must not silently re-point the others.
+	 */
+	public function test_scheduled_subscription_payment_repair_does_not_retoken_sibling_subscriptions() {
+		$parent_order  = WC_Helper_Order::create_order( self::USER_ID );
+		$renewal_order = WC_Helper_Order::create_order( self::USER_ID );
+		$token         = WC_Helper_Token::create_token( self::PAYMENT_METHOD_ID, self::USER_ID );
+		$sibling_token = WC_Helper_Token::create_token( 'pm_sibling_choice', self::USER_ID );
+		$user          = get_user_by( 'id', self::USER_ID );
+
+		$this->order_service->set_payment_method_id_for_order( $parent_order, self::PAYMENT_METHOD_ID );
+
+		$renewing_subscription = new WC_Subscription();
+		$renewing_subscription->set_parent( $parent_order );
+		$renewing_subscription->set_customer_id( $user->ID );
+
+		// A sibling subscription from the same checkout, deliberately pointed at another card.
+		$sibling_subscription = new WC_Subscription();
+		$sibling_subscription->set_parent( $parent_order );
+		$sibling_subscription->set_customer_id( $user->ID );
+		$sibling_subscription->set_payment_tokens( [ $sibling_token->get_id() ] );
+
+		$this->mock_wcs_get_subscriptions_for_renewal_order( [ '1' => $renewing_subscription ] );
+
+		// Mirror production: only the parent order resolves to the two sibling subscriptions.
+		WC_Subscriptions::set_wcs_get_subscriptions_for_order(
+			function ( $order_id ) use ( $parent_order, $renewing_subscription, $sibling_subscription ) {
+				return $parent_order->get_id() === $order_id
+					? [
+						'1' => $renewing_subscription,
+						'2' => $sibling_subscription,
+					]
+					: [];
+			}
+		);
+
+		$this->mock_customer_service
+			->method( 'get_customer_id_by_user_id' )
+			->willReturn( self::CUSTOMER_ID );
+
+		$this->mock_customer_service
+			->method( 'update_customer_for_user' )
+			->willReturn( self::CUSTOMER_ID );
+
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+		$request->method( 'set_amount' )->willReturn( $request );
+		$request->method( 'set_currency_code' )->willReturn( $request );
+		$request->method( 'format_response' )->willReturn( WC_Helper_Intention::create_intention() );
+
+		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
+
+		// The repair itself must still happen, otherwise the sibling assertion below is vacuous.
+		$this->assertContains( $token->get_id(), $renewal_order->get_payment_tokens() );
+		$this->assertContains( $token->get_id(), $renewing_subscription->get_payment_tokens() );
+
+		$this->assertSame(
+			[ $sibling_token->get_id() ],
+			$sibling_subscription->get_payment_tokens(),
+			'The sibling subscription must keep the card the customer chose for it.'
+		);
 	}
 
 	public function test_scheduled_subscription_payment_with_saved_customer_id() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions.php
@@ -466,9 +466,20 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 
 		$this->order_service->set_payment_method_id_for_order( $parent_order, self::PAYMENT_METHOD_ID );
 
-		$renewing_subscription = new WC_Subscription();
+		$renewing_subscription = $this->getMockBuilder( WC_Subscription::class )
+			->onlyMethods( [ 'add_order_note' ] )
+			->getMock();
 		$renewing_subscription->set_parent( $parent_order );
 		$renewing_subscription->set_customer_id( $user->ID );
+		$renewing_subscription
+			->expects( $this->once() )
+			->method( 'add_order_note' )
+			->with(
+				sprintf(
+					'The saved payment method for this subscription was missing, so WooPayments restored %s from the original order to complete the renewal.',
+					$token->get_display_name()
+				)
+			);
 
 		// A sibling subscription from the same checkout, deliberately pointed at another card.
 		$sibling_subscription = new WC_Subscription();
@@ -503,16 +514,29 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Test extends WCPAY_UnitTestCase {
 		$request->method( 'set_currency_code' )->willReturn( $request );
 		$request->method( 'format_response' )->willReturn( WC_Helper_Intention::create_intention() );
 
+		$parent_tokens_before = $parent_order->get_payment_tokens();
+
 		$this->wcpay_gateway->scheduled_subscription_payment( $renewal_order->get_total(), $renewal_order );
 
 		// The repair itself must still happen, otherwise the sibling assertion below is vacuous.
 		$this->assertContains( $token->get_id(), $renewal_order->get_payment_tokens() );
 		$this->assertContains( $token->get_id(), $renewing_subscription->get_payment_tokens() );
+		$this->assertSame(
+			$parent_tokens_before,
+			$parent_order->get_payment_tokens(),
+			'The historical parent order must remain a read-only recovery source.'
+		);
 
 		$this->assertSame(
 			[ $sibling_token->get_id() ],
 			$sibling_subscription->get_payment_tokens(),
 			'The sibling subscription must keep the card the customer chose for it.'
+		);
+
+		$renewal_notes = wp_list_pluck( wc_get_order_notes( [ 'order_id' => $renewal_order->get_id() ] ), 'content' );
+		$this->assertContains(
+			'Recovered missing subscription payment method token from the parent order.',
+			$renewal_notes
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Subscriptions bought in a single checkout on different schedules share one parent order. When a renewal order had no usable saved token, the repair added in #11897 recovered the payment method from the parent order and attached the token back onto that parent order.

`add_token_to_order()` fans a token out to every subscription its order created, through `maybe_add_token_to_subscription_order()`. So recovering a card for one subscription silently re-pointed its siblings at that same card. The affected subscription got no order note, and every later renewal charged a card the customer never chose for it.

This passes the renewal order to `ensure_payment_method_token_for_order()` instead. The parent order stays the source for the payment method ID and is never written to. A renewal order carries a `renewal` relation, which `wcs_get_subscriptions_for_order()` leaves out of its default `['parent', 'switch']` filter, so nothing fans out there.

- Attach the recovered token to the renewing subscription explicitly, since the renewal order no longer propagates it for us.
- Add an order note on that subscription naming the restored card, so the change is visible where it happened.

**Backward compatibility:** No public signature changes. `ensure_payment_method_token_for_order()` keeps its behavior and the webhook path in `WC_Payments_Webhook_Processing_Service` still uses it unchanged. The new order note is additive.

**Tests:** `test_scheduled_subscription_payment_repairs_missing_renewal_token_from_parent_order` asserted that the parent order received the token. That assertion described the bug, so it is gone. The same test also mocked `WC_Subscription` in a way that returned `null` from `get_payment_tokens()`, which the real `WC_Order` never does, so it now uses the real helper. The helper gained `add_payment_token()` to match `WC_Order`.

**Out of scope:** the WooCommerce Subscriptions gap that strands a subscription on a deleted token in the first place. `WCS_Payment_Tokens::get_subscriptions_from_token()` only queries `wc-pending`, `wc-active` and `wc-on-hold`, so a subscription sitting in `pending-cancel` is skipped when the customer deletes its card and no reassignment happens. That is the precondition rather than this regression, and it belongs upstream.

Bug introduced in PR #11897. It is new in 11.0.0 and has not shipped in a released version.

#### Testing instructions

Already verified:

- **Automated:** new regression test `test_scheduled_subscription_payment_repair_does_not_retoken_sibling_subscriptions`, watched failing before the fix. Full PHP suite green at 3874 tests. PHPCS clean.
- **Manual:** ran the full steps below end to end against WooCommerce Subscriptions 8.4.0 in test mode, with a real renewal charge. The renewing subscription recovered the Visa from the parent order and gained the note. The sibling kept its Mastercard and gained no note. The parent order's token list was untouched. Separately, reproduced the leak on the same setup with the fix reverted, where the sibling silently gained the Visa.

To test end to end, with WooCommerce Subscriptions active and WooPayments in test mode:

1. As a customer, save three cards under My account > Payment methods: Visa `4242 4242 4242 4242`, Mastercard `5555 5555 5555 4444`, Amex `3782 822463 10005`.
2. Create two subscription products on different schedules, one monthly and one yearly. The differing schedules matter, since same-schedule items collapse into a single subscription and this needs two.
3. Add both to the cart and check out with the Visa. Both subscriptions now hang off one parent order.
4. Under My account > Subscriptions, point the monthly subscription at the Amex, and the yearly one at the Mastercard. On both, untick **"Use this payment method for all of my current subscriptions"**. It is ticked by default, and leaving it on copies each card onto both subscriptions, which hides the bug entirely.
5. Cancel the monthly subscription. Its status must read Pending Cancellation.
6. Delete the Amex under My account > Payment methods.
7. Reactivate the monthly subscription. Its Payment line now reads just "Via Card".
8. As the merchant, open WooCommerce > Subscriptions, open the monthly subscription, and run Process renewal from the sidebar.

Expected: the monthly subscription renews on the Visa recovered from the parent order, and gains a note naming the restored card. The yearly subscription still shows the Mastercard and gains no note.

Before this PR, both subscriptions show the Visa and neither carries a note explaining it.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
