### PR TITLE
Exclude test-mode WooPayments usage from the incentives eligibility check

### DIFF
--- a/changelog/woopmnt-6320-test-mode-orders-from-test-drive-permanently-destroy-switch
+++ b/changelog/woopmnt-6320-test-mode-orders-from-test-drive-permanently-destroy-switch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop counting test-mode WooPayments usage - a test-drive account or test-mode orders - when determining WooPayments incentives eligibility, so trialing WooPayments no longer disqualifies a store from incentives. Stores already disqualified this way get their eligibility re-determined once.

--- a/includes/class-wc-payments-incentives-service.php
+++ b/includes/class-wc-payments-incentives-service.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\WooCommerce\Admin\WCAdminHelper;
+use WCPay\Constants\Order_Mode;
 use WCPay\Database_Cache;
 
 /**
@@ -17,6 +18,40 @@ use WCPay\Database_Cache;
  */
 class WC_Payments_Incentives_Service {
 	const PREFIX = 'woocommerce_admin_pes_incentive_';
+
+	/**
+	 * The option name used to store whether the store had WooPayments in use.
+	 *
+	 * We use the same option key as the WC core suggestion incentives.
+	 *
+	 * @see \Automattic\WooCommerce\Internal\Admin\Suggestions\Incentives\WooPayments
+	 */
+	const STORE_HAD_WOOPAYMENTS_OPTION_NAME = self::PREFIX . 'woopayments_store_had_woopayments';
+
+	/**
+	 * The option name used to store the logic version that determined the store had WooPayments value.
+	 *
+	 * We use the same option key as the WC core suggestion incentives.
+	 *
+	 * @see \Automattic\WooCommerce\Internal\Admin\Suggestions\Incentives\WooPayments
+	 */
+	const STORE_HAD_WOOPAYMENTS_VERSION_OPTION_NAME = self::STORE_HAD_WOOPAYMENTS_OPTION_NAME . '_version';
+
+	/**
+	 * The version of the logic used to determine if the store had WooPayments in use.
+	 *
+	 * The determined value is stored long-term (see `has_wcpay()`), and WooCommerce core
+	 * stores its own determination under the very same option name. Persisting the version
+	 * alongside the value lets us tell a value determined by the current logic from one
+	 * determined by an earlier (or by WC core's, potentially older) logic, so a stale
+	 * positive gets re-determined instead of being trusted forever.
+	 *
+	 * Bump this whenever the determination logic gets stricter. Keep it in sync with the
+	 * WC core copy of this logic.
+	 *
+	 * @var int
+	 */
+	private const STORE_HAD_WOOPAYMENTS_LOGIC_VERSION = 2;
 
 	/**
 	 * The transient name for incentives cache.
@@ -38,6 +73,13 @@ class WC_Payments_Incentives_Service {
 	 * @var string
 	 */
 	private $store_had_woopayments_option_name;
+
+	/**
+	 * The option name used to store the logic version that determined the store had WooPayments value.
+	 *
+	 * @var string
+	 */
+	private $store_had_woopayments_version_option_name;
 
 	/**
 	 * The memoized incentives to avoid fetching multiple times during a request.
@@ -66,7 +108,9 @@ class WC_Payments_Incentives_Service {
 		// @see \Automattic\WooCommerce\Internal\Admin\Suggestions\Incentives\WooPayments.
 		$this->cache_transient_name              = self::PREFIX . 'woopayments_cache';
 		$this->store_has_orders_transient_name   = self::PREFIX . 'woopayments_store_has_orders';
-		$this->store_had_woopayments_option_name = self::PREFIX . 'woopayments_store_had_woopayments';
+		$this->store_had_woopayments_option_name = self::STORE_HAD_WOOPAYMENTS_OPTION_NAME;
+
+		$this->store_had_woopayments_version_option_name = self::STORE_HAD_WOOPAYMENTS_VERSION_OPTION_NAME;
 	}
 
 	/**
@@ -367,7 +411,7 @@ class WC_Payments_Incentives_Service {
 
 	/**
 	 * Check if WooPayments payment gateway was active and set up at some point,
-	 * or there are orders processed with it, at some moment.
+	 * or there are live-mode orders processed with it, at some moment.
 	 *
 	 * @return boolean Whether the store has WooPayments.
 	 */
@@ -378,20 +422,46 @@ class WC_Payments_Incentives_Service {
 		// Since the past can't be changed, neither can this value.
 		$had_wcpay = get_option( $this->store_had_woopayments_option_name );
 		if ( false !== $had_wcpay ) {
-			return filter_var( $had_wcpay, FILTER_VALIDATE_BOOLEAN );
+			$stored_value = filter_var( $had_wcpay, FILTER_VALIDATE_BOOLEAN );
+
+			// A stored negative is always trusted: each revision of this logic is stricter than
+			// the one before it, so a store that didn't qualify under an earlier revision can't
+			// start qualifying under this one.
+			//
+			// A stored positive is only trusted when the current logic determined it. Earlier
+			// revisions counted test-mode usage (a test-drive account or a test-mode order) as
+			// the real thing and froze the result, so those positives get re-determined once.
+			// WooCommerce core writes this same option and may still be running an older
+			// revision of the shared logic, so this is what keeps the two safe to ship in any
+			// order rather than whichever one runs first winning permanently.
+			if ( ! $stored_value
+				|| (int) get_option( $this->store_had_woopayments_version_option_name, 0 ) >= self::STORE_HAD_WOOPAYMENTS_LOGIC_VERSION ) {
+
+				return $stored_value;
+			}
 		}
 
 		// We need to determine the value.
 		// Start with the assumption that the store didn't have WooPayments in use.
 		$had_wcpay = false;
 
-		// We consider the store to have WooPayments if there is meaningful account data in the WooPayments account cache.
-		// This implies that WooPayments was active at some point and that it was connected.
+		// We consider the store to have WooPayments if there is meaningful live account data
+		// in the WooPayments account cache.
+		// This implies that WooPayments was active at some point and that it was connected with a live account.
 		if ( $this->has_wcpay_account_data() ) {
 			$had_wcpay = true;
 		}
 
-		// If there is at least one order processed with WooPayments, we consider the store to have WooPayments.
+		// If there is at least one live-mode order processed with WooPayments, we consider the store to have WooPayments.
+		// Test-mode orders (e.g. placed while trialing WooPayments with a test-drive account) don't count
+		// since they don't represent real usage of WooPayments.
+		//
+		// Orders carrying no order mode meta at all don't count either, since the meta is what tells the two
+		// apart. That covers orders placed before WooPayments started saving it (April 2022, WooPayments 4.1.0)
+		// and orders created outside the checkout flow that saves it, like WooPayments Subscriptions renewals.
+		// Such a store may end up considered incentive-eligible despite having used WooPayments, which is the
+		// far less harmful direction to err in than permanently withholding incentives from a store that only
+		// ever tried WooPayments out.
 		if ( false === $had_wcpay && ! empty(
 			wc_get_orders(
 				[
@@ -399,30 +469,55 @@ class WC_Payments_Incentives_Service {
 					'return'         => 'ids',
 					'limit'          => 1,
 					'orderby'        => 'none',
+					// Use the order mode meta saved by WooPayments to only count live-mode orders.
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_key'       => WC_Payments_Order_Service::WCPAY_MODE_META_KEY,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+					'meta_value'     => Order_Mode::PRODUCTION,
 				]
 			)
 		) ) {
 			$had_wcpay = true;
 		}
 
-		// Store the value for future use.
+		// Store the value, and the logic version that determined it, for future use.
 		update_option( $this->store_had_woopayments_option_name, $had_wcpay ? 'yes' : 'no' );
+		update_option( $this->store_had_woopayments_version_option_name, self::STORE_HAD_WOOPAYMENTS_LOGIC_VERSION );
 
 		return $had_wcpay;
 	}
 
 	/**
-	 * Check if there is meaningful data in the WooPayments account cache.
+	 * Check if there is meaningful live account data in the WooPayments account cache.
+	 *
+	 * Sandbox accounts don't count: a test-drive account is a trial of WooPayments,
+	 * not actual use of it. This mirrors how we decide whether an account belongs to
+	 * a genuine live merchant.
+	 *
+	 * @see WC_Payments_Account::maybe_record_kyc_completion_date()
 	 *
 	 * @return boolean
 	 */
 	private function has_wcpay_account_data(): bool {
 		$account_data = $this->database_cache->get( Database_Cache::ACCOUNT_KEY, true );
-		if ( ! empty( $account_data['account_id'] ) ) {
-			return true;
+		if ( empty( $account_data['account_id'] ) ) {
+			return false;
 		}
 
-		return false;
+		// A test-drive account is a trial of WooPayments, not real usage of it.
+		if ( ! empty( $account_data['is_test_drive'] ) ) {
+			return false;
+		}
+
+		// Sandbox accounts don't count either.
+		// Both flags are only acted upon when present: cached account data written by
+		// older WooPayments versions may not carry them, and we'd rather keep counting
+		// those stores as WooPayments users than reclassify them on missing data.
+		if ( isset( $account_data['is_live'] ) && ! $account_data['is_live'] ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/class-wc-payments-onboarding-service.php
+++ b/includes/class-wc-payments-onboarding-service.php
@@ -934,6 +934,14 @@ class WC_Payments_Onboarding_Service {
 		update_option( self::TEST_MODE_OPTION, 'no' );
 		self::clear_account_options();
 
+		// Clear the stored flag for whether the store had WooPayments in use,
+		// so incentive eligibility is re-determined for the fresh onboarding.
+		// Deleting is safe even though WooCommerce core shares these options: if an
+		// older core copy re-freezes a stale positive from test-mode usage, the logic
+		// version marker gets it re-determined on the next evaluation. See WOOPMNT-6320.
+		delete_option( WC_Payments_Incentives_Service::STORE_HAD_WOOPAYMENTS_OPTION_NAME );
+		delete_option( WC_Payments_Incentives_Service::STORE_HAD_WOOPAYMENTS_VERSION_OPTION_NAME );
+
 		// Discard any ongoing onboarding session.
 		delete_transient( WC_Payments_Account::ONBOARDING_STATE_TRANSIENT );
 		$this->clear_embedded_kyc_in_progress();

--- a/tests/unit/test-class-wc-payments-incentives-service.php
+++ b/tests/unit/test-class-wc-payments-incentives-service.php
@@ -94,7 +94,12 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 		$menu = null; // phpcs:ignore: WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'woocommerce_order_query' );
+		remove_all_filters( 'woocommerce_order_query_args' );
 		remove_filter( 'woocommerce_available_payment_gateways', '__return_empty_array' );
+
+		delete_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' );
+		delete_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version' );
 
 		$this->incentives_service->clear_cache();
 
@@ -369,6 +374,8 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 		// Arrange.
 		set_transient( $this->transient_has_orders_key, 'yes', HOUR_IN_SECONDS );
 		update_option( $had_woopayments_option_key, 'yes' );
+		// A stored positive is only trusted when determined by the current logic version.
+		update_option( $had_woopayments_option_key . '_version', 2 );
 		$call_count = 0;
 		add_filter(
 			'woocommerce_order_query_args',
@@ -388,6 +395,7 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 		// Clean up.
 		delete_transient( $this->transient_has_orders_key );
 		delete_option( $had_woopayments_option_key );
+		delete_option( $had_woopayments_option_key . '_version' );
 	}
 
 	public function test_get_connect_incentive_has_orders_is_cached_longer_when_has_orders() {
@@ -452,6 +460,175 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 		remove_all_filters( 'pre_set_transient_' . $this->transient_has_orders_key );
 	}
 
+	public function test_has_wcpay_ignores_test_mode_orders() {
+		// Arrange.
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->update_meta_data( '_wcpay_mode', 'test' );
+		$order->save();
+
+		// Act.
+		$result = $this->invoke_has_wcpay( $this->incentives_service );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertSame( 'no', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+		$this->assertSame( 2, (int) get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version' ) );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	public function test_has_wcpay_counts_live_mode_orders() {
+		// Arrange.
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->update_meta_data( '_wcpay_mode', 'prod' );
+		$order->save();
+
+		// Act.
+		$result = $this->invoke_has_wcpay( $this->incentives_service );
+
+		// Assert.
+		$this->assertTrue( $result );
+		$this->assertSame( 'yes', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Such orders predate WooPayments saving the mode meta, or were created outside the checkout flow
+	 * that saves it. Erring towards incentive eligibility is intentional.
+	 */
+	public function test_has_wcpay_ignores_orders_without_mode_meta() {
+		// Arrange.
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->save();
+
+		// Act.
+		$result = $this->invoke_has_wcpay( $this->incentives_service );
+
+		// Assert.
+		$this->assertFalse( $result );
+		$this->assertSame( 'no', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	public function test_has_wcpay_ignores_test_drive_account_data() {
+		// Arrange.
+		$service = $this->incentives_service_with_account_data(
+			[
+				'account_id'    => 'acct_123',
+				'is_live'       => false,
+				'is_test_drive' => true,
+			]
+		);
+
+		// Act & assert.
+		$this->assertFalse( $this->invoke_has_wcpay( $service ) );
+		$this->assertSame( 'no', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+	}
+
+	public function test_has_wcpay_ignores_sandbox_account_data() {
+		// Arrange.
+		$service = $this->incentives_service_with_account_data(
+			[
+				'account_id' => 'acct_123',
+				'is_live'    => false,
+			]
+		);
+
+		// Act & assert.
+		$this->assertFalse( $this->invoke_has_wcpay( $service ) );
+		$this->assertSame( 'no', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+	}
+
+	public function test_has_wcpay_counts_live_account_data() {
+		// Arrange.
+		$service = $this->incentives_service_with_account_data(
+			[
+				'account_id'    => 'acct_123',
+				'is_live'       => true,
+				'is_test_drive' => false,
+			]
+		);
+
+		// Act & assert.
+		$this->assertTrue( $this->invoke_has_wcpay( $service ) );
+		$this->assertSame( 'yes', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+	}
+
+	/**
+	 * Cached account data written by older WooPayments versions may not carry the mode flags,
+	 * and we'd rather keep counting those stores as WooPayments users than reclassify them on missing data.
+	 */
+	public function test_has_wcpay_counts_account_data_without_mode_flags() {
+		// Arrange.
+		$service = $this->incentives_service_with_account_data( [ 'account_id' => 'acct_123' ] );
+
+		// Act & assert.
+		$this->assertTrue( $this->invoke_has_wcpay( $service ) );
+		$this->assertSame( 'yes', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+	}
+
+	/**
+	 * A stored positive determined by an earlier logic version is re-determined.
+	 *
+	 * This is what keeps a value frozen by an earlier revision of this logic - or by a WC core
+	 * copy running an older revision - from disqualifying the store forever.
+	 */
+	public function test_has_wcpay_redetermines_stale_positive() {
+		// Arrange.
+		// A positive stored without a logic version, as an earlier revision would have left it.
+		update_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments', 'yes' );
+		delete_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version' );
+
+		// Act & assert.
+		$this->assertFalse( $this->invoke_has_wcpay( $this->incentives_service ) );
+		$this->assertSame( 'no', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+		$this->assertSame( 2, (int) get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version' ) );
+	}
+
+	public function test_has_wcpay_trusts_current_positive() {
+		// Arrange.
+		update_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments', 'yes' );
+		update_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version', 2 );
+
+		// Act & assert.
+		$this->assertTrue( $this->invoke_has_wcpay( $this->incentives_service ) );
+		$this->assertSame( 'yes', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+	}
+
+	/**
+	 * A stored negative is trusted regardless of the logic version that determined it.
+	 *
+	 * Each revision of the logic is stricter than the one before it, so a store that didn't
+	 * qualify under an earlier revision can't start qualifying under the current one.
+	 */
+	public function test_has_wcpay_trusts_stale_negative() {
+		// Arrange.
+		// A live-mode order that would determine a positive if the stored value were re-determined.
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'woocommerce_payments' );
+		$order->update_meta_data( '_wcpay_mode', 'prod' );
+		$order->save();
+
+		// A negative stored without a logic version, as an earlier revision would have left it.
+		update_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments', 'no' );
+		delete_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version' );
+
+		// Act & assert.
+		$this->assertFalse( $this->invoke_has_wcpay( $this->incentives_service ) );
+		$this->assertSame( 'no', get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
 	/**
 	 * Mocks the cache with the given incentives list.
 	 *
@@ -500,5 +677,33 @@ class WC_Payments_Incentives_Service_Test extends WCPAY_UnitTestCase {
 				return $orders;
 			}
 		);
+	}
+
+	/**
+	 * Invokes the private has_wcpay() method on the given service instance.
+	 *
+	 * @param WC_Payments_Incentives_Service $service The service instance.
+	 *
+	 * @return bool The has_wcpay() result.
+	 */
+	private function invoke_has_wcpay( WC_Payments_Incentives_Service $service ): bool {
+		$has_wcpay = new ReflectionMethod( $service, 'has_wcpay' );
+		$has_wcpay->setAccessible( true );
+
+		return $has_wcpay->invoke( $service );
+	}
+
+	/**
+	 * Builds an incentives service whose account cache returns the given account data.
+	 *
+	 * @param array $account_data The account data the database cache should return.
+	 *
+	 * @return WC_Payments_Incentives_Service The service instance.
+	 */
+	private function incentives_service_with_account_data( array $account_data ): WC_Payments_Incentives_Service {
+		$mock_database_cache = $this->createMock( Database_Cache::class );
+		$mock_database_cache->method( 'get' )->willReturn( $account_data );
+
+		return new WC_Payments_Incentives_Service( $mock_database_cache );
 	}
 }

--- a/tests/unit/test-class-wc-payments-onboarding-service.php
+++ b/tests/unit/test-class-wc-payments-onboarding-service.php
@@ -163,6 +163,19 @@ class WC_Payments_Onboarding_Service_Test extends WCPAY_UnitTestCase {
 		$this->onboarding_service->clear_cached_onboarding_fields_data();
 	}
 
+	public function test_cleanup_on_account_reset_deletes_store_had_woopayments_options() {
+		// Arrange.
+		update_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments', 'yes' );
+		update_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version', 2 );
+
+		// Act.
+		$this->onboarding_service->cleanup_on_account_reset();
+
+		// Assert.
+		$this->assertFalse( get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments' ) );
+		$this->assertFalse( get_option( 'woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version' ) );
+	}
+
 	public function test_create_embedded_kyc_session() {
 		// Arrange.
 		$this->mock_api_client


### PR DESCRIPTION
Fixes WOOPMNT-6320

### Description

A test-mode order placed while trialing WooPayments with a test-drive account permanently disqualified the store from the Switch and Action Incentives:

- `WC_Payments_Incentives_Service::has_wcpay()` counted **any** WooPayments usage as the real thing — any order paid via WooPayments regardless of payment mode, and any cached account regardless of it being a test-drive/sandbox one — and froze the first truthy answer forever in the `woocommerce_admin_pes_incentive_woopayments_store_had_woopayments` option.
- Nothing ever deleted that option: `cleanup_on_account_reset()` tears down gateway options, onboarding state, and the entire database cache, but left this one behind.
- The incentives endpoint trusts the client-reported `has_wcpay`, so the frozen value was authoritative server-side.

This PR makes the determination count only **real** usage, and makes stale frozen values self-correct:

- **Only live-mode orders count**: the `wc_get_orders()` call in `has_wcpay()` now filters on the `_wcpay_mode = prod` order meta (saved since April 2022, WooPayments 4.1.0). Test-mode orders don't count, and neither do orders carrying no mode meta at all (pre-4.1.0, or created outside the checkout flow that saves it, like Subscriptions renewals) — erring towards incentive eligibility is the far less harmful direction than permanently withholding incentives from a store that only ever tried WooPayments out.
- **Only live account data counts**: `has_wcpay_account_data()` now excludes test-drive accounts (`is_test_drive`) and sandbox accounts (`is_live === false`), mirroring how `WC_Payments_Account::maybe_record_kyc_completion_date()` identifies genuine live merchants. Both flags are only acted upon when present, so cached data written by older versions keeps counting.
- **A logic version marker makes stale values self-correct**: the determined value is stored together with the logic version that produced it (`..._store_had_woopayments_version`). A stored **negative** is always trusted (each revision is stricter than the last). A stored **positive** is only trusted when the current logic determined it — positives frozen by earlier revisions get re-determined once, lazily, on the next incentives evaluation. Since WooCommerce core shares these options by design and may be running an older revision of the shared logic (its companion fix is woocommerce/woocommerce#67154), the marker is also what makes the two copies **safe to ship in any order**: if an older copy wins a race and re-freezes a stale positive, the newer logic re-determines it on the next pass instead of trusting it forever.
- **Account reset clears the flags**: `cleanup_on_account_reset()` now deletes the option and its version sibling, so discarding a test-drive account re-determines eligibility for the fresh onboarding.

**Trade-offs / how this could break:**

- Orders without the `_wcpay_mode` meta no longer count. Worst case: a store whose only WooPayments usage predates April 2022 (or happened entirely outside the meta-saving checkout flow) becomes incentive-eligible — deliberate, and far less harmful than the false-ineligibility this fixes.
- The version-gated re-determination means every store currently frozen at `yes` re-runs the determination **once** (one indexed, limit-1 order query plus an account-cache read) on its first incentives evaluation after updating. Stores at `no` and re-determined stores pay nothing further.

**Backward-compatibility impact:** No public surface removed or changed. New public constants (additive). `has_wcpay()` is private; the change alters computed eligibility context, which is its intent. The `..._version` option is a new key alongside the shared one; WC core's copy writes and reads it identically (shared by design, like the sibling keys). No new hooks, no REST changes, no global-state or multisite assumptions introduced (option functions are site-scoped, matching existing behavior).

The server-side belt-and-braces is also up (internal wpcom PR 231341): the incentives endpoint disregards a client-reported `has_wcpay=true` when the blog's WooPayments account history is entirely non-live, healing affected stores even before this fix reaches them.

### Testing instructions

No WooPayments account is needed — the determination reads plain order fields and options, so everything can be driven with WP-CLI.

**Test-mode orders no longer count (and live-mode ones still do):**

- Create a mock **test-mode** WooPayments order (equivalent to an order placed through checkout while WooPayments runs a test-drive account) — note the printed order ID:
  ```
  pnpm wp eval '
  $order = wc_create_order();
  $order->set_payment_method( "woocommerce_payments" );
  $order->update_meta_data( "_wcpay_mode", "test" );
  $order->save();
  echo "Created order " . $order->get_id() . "\n";'
  ```
- Evaluate the determination:
  ```
  pnpm wp eval '
  delete_option( "woocommerce_admin_pes_incentive_woopayments_store_had_woopayments" );
  delete_option( "woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version" );
  $svc = new WC_Payments_Incentives_Service( wcpay_get_container()->get( WCPay\Database_Cache::class ) );
  $m = new ReflectionMethod( $svc, "has_wcpay" ); $m->setAccessible( true );
  var_dump( $m->invoke( $svc ), get_option( "woocommerce_admin_pes_incentive_woopayments_store_had_woopayments" ) );'
  ```
- [ ] Verify the output is `bool(false)` / `string(2) "no"` — the test-mode order doesn't count. (On unfixed `develop`, the same snippet yields `bool(true)` / `"yes"`.)
- Flip the same order to **live mode** (replace `<ORDER_ID>`):
  ```
  pnpm wp eval '
  $order = wc_get_order( <ORDER_ID> );
  $order->update_meta_data( "_wcpay_mode", "prod" );
  $order->save();'
  ```
- [ ] Re-run the evaluation snippet and verify it now yields `bool(true)` / `string(3) "yes"`.

**Stale frozen positives are re-determined once:**

- Flip the order back to `test` mode (previous step with `"test"`), then simulate a store frozen by the old logic — a positive with no version marker:
  ```
  pnpm wp eval '
  update_option( "woocommerce_admin_pes_incentive_woopayments_store_had_woopayments", "yes" );
  delete_option( "woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version" );'
  ```
- Run only the evaluation part of the snippet above (without the two `delete_option` lines).
- [ ] Verify it yields `bool(false)` / `string(2) "no"`, and `pnpm wp option get woocommerce_admin_pes_incentive_woopayments_store_had_woopayments_version` returns `2` — the stale positive was re-determined and stamped with the current logic version.

**Account reset clears the flags:**

- With any value stored, reset the WooPayments account (WCPay Dev → Reset account, or the account tools context menu).
- [ ] Verify both options are gone: `pnpm wp option get woocommerce_admin_pes_incentive_woopayments_store_had_woopayments` and `... _version` both return an error.
- Clean up the mock order: `pnpm wp eval 'wc_get_order( <ORDER_ID> )->delete( true );'`

**Unit tests:** `WC_Payments_Incentives_Service_Test` (10 new tests covering order modes, account-data flags, and version gating) and `WC_Payments_Onboarding_Service_Test`.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


