### PR TITLE
fix: skip webhook token save when the order is already paid

### DIFF
--- a/changelog/fix-webhook-token-save-skip-paid-orders
+++ b/changelog/fix-webhook-token-save-skip-paid-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix redelivered payment webhooks re-attaching the original checkout card to subscriptions that have since been changed to a different payment method.

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -608,6 +608,12 @@ class WC_Payments_Webhook_Processing_Service {
 			return;
 		}
 
+		// A paid order already had its token saved at checkout, so this is a redelivered event.
+		// Saving again could re-point sibling subscriptions to a card the customer has since replaced.
+		if ( $order->is_paid() ) {
+			return;
+		}
+
 		$previous_token_id = $this->get_order_last_payment_token_id( $order );
 
 		try {

--- a/includes/class-wc-payments-webhook-processing-service.php
+++ b/includes/class-wc-payments-webhook-processing-service.php
@@ -611,6 +611,7 @@ class WC_Payments_Webhook_Processing_Service {
 		// A paid order already had its token saved at checkout, so this is a redelivered event.
 		// Saving again could re-point sibling subscriptions to a card the customer has since replaced.
 		if ( $order->is_paid() ) {
+			Logger::log( 'Skipping webhook token save for paid order #' . $order->get_id() . '.' );
 			return;
 		}
 

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -931,6 +931,83 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Pins a deliberate narrowing: a paid order with no token also skips the webhook save,
+	 * leaving recovery to the renewal-time repair.
+	 */
+	public function test_payment_intent_successful_skips_token_save_when_order_paid_without_token() {
+		$this->event_body['type']           = 'payment_intent.succeeded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'pi_123123123123123',
+			'object'   => 'payment_intent',
+			'amount'   => 1500,
+			'charges'  => [
+				'data' => [
+					[
+						'id'                     => 'py_123123123123123',
+						'payment_method'         => 'pm_foo',
+						'payment_method_details' => [
+							'type' => 'card',
+						],
+					],
+				],
+			],
+			'currency' => 'eur',
+			'status'   => Intent_Status::SUCCEEDED,
+			'metadata' => [],
+		];
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'deserialize_payment_intention_object_from_array' )
+			->with( $this->event_body['data']['object'] )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [ 'request_three_d_secure' => 'automatic' ] ],
+					]
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( $this->mock_order );
+
+		$this->mock_order
+			->method( 'get_total' )
+			->willReturn( 15.00 );
+		$this->mock_order
+			->method( 'has_status' )
+			->willReturn( false );
+		$this->mock_order
+			->method( 'get_data_store' )
+			->willReturn( new \WC_Mock_WC_Data_Store() );
+		$this->mock_order
+			->method( 'get_meta' )
+			->willReturn( '' );
+		$this->mock_order
+			->method( 'is_paid' )
+			->willReturn( true );
+		$this->mock_order
+			->method( 'get_payment_tokens' )
+			->willReturn( [] );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'is_payment_recurring' )
+			->with( 1234 )
+			->willReturn( true );
+		$this->mock_wcpay_gateway
+			->expects( $this->never() )
+			->method( 'ensure_payment_method_token_for_order' );
+
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
 	 * Tests that a recurring payment_intent.succeeded event handles an expanded intent payment method fallback.
 	 */
 	public function test_payment_intent_successful_saves_token_from_expanded_intent_payment_method() {

--- a/tests/unit/test-class-wc-payments-webhook-processing-service.php
+++ b/tests/unit/test-class-wc-payments-webhook-processing-service.php
@@ -858,6 +858,79 @@ class WC_Payments_Webhook_Processing_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a redelivered payment_intent.succeeded event does not save a token on a paid order.
+	 */
+	public function test_payment_intent_successful_skips_token_save_when_order_already_paid() {
+		$this->event_body['type']           = 'payment_intent.succeeded';
+		$this->event_body['livemode']       = true;
+		$this->event_body['data']['object'] = [
+			'id'       => 'pi_123123123123123',
+			'object'   => 'payment_intent',
+			'amount'   => 1500,
+			'charges'  => [
+				'data' => [
+					[
+						'id'                     => 'py_123123123123123',
+						'payment_method'         => 'pm_foo',
+						'payment_method_details' => [
+							'type' => 'card',
+						],
+					],
+				],
+			],
+			'currency' => 'eur',
+			'status'   => Intent_Status::SUCCEEDED,
+			'metadata' => [],
+		];
+
+		$this->mock_api_client
+			->expects( $this->once() )
+			->method( 'deserialize_payment_intention_object_from_array' )
+			->with( $this->event_body['data']['object'] )
+			->willReturn(
+				WC_Helper_Intention::create_intention(
+					[
+						'status'                 => Intent_Status::SUCCEEDED,
+						'payment_method_options' => [ 'card' => [ 'request_three_d_secure' => 'automatic' ] ],
+					]
+				)
+			);
+
+		$this->mock_db_wrapper
+			->expects( $this->once() )
+			->method( 'order_from_intent_id' )
+			->with( 'pi_123123123123123' )
+			->willReturn( $this->mock_order );
+
+		$this->mock_order
+			->method( 'get_total' )
+			->willReturn( 15.00 );
+		$this->mock_order
+			->method( 'has_status' )
+			->willReturn( false );
+		$this->mock_order
+			->method( 'get_data_store' )
+			->willReturn( new \WC_Mock_WC_Data_Store() );
+		$this->mock_order
+			->method( 'get_meta' )
+			->willReturn( '' );
+		$this->mock_order
+			->method( 'is_paid' )
+			->willReturn( true );
+
+		$this->mock_wcpay_gateway
+			->expects( $this->once() )
+			->method( 'is_payment_recurring' )
+			->with( 1234 )
+			->willReturn( true );
+		$this->mock_wcpay_gateway
+			->expects( $this->never() )
+			->method( 'ensure_payment_method_token_for_order' );
+
+		$this->webhook_processing_service->process( $this->event_body );
+	}
+
+	/**
 	 * Tests that a recurring payment_intent.succeeded event handles an expanded intent payment method fallback.
 	 */
 	public function test_payment_intent_successful_saves_token_from_expanded_intent_payment_method() {


### PR DESCRIPTION
Closes WOOPMNT-6331.

Bug introduced in PR #11897. Finding H1 from the [11.0.0 release readiness review](https://wcpay.wordpress.com/2026/07/30/release-11-0-0-readiness/).

#### Changes proposed in this Pull Request

#11897 added a webhook-time token save so a subscription bought while the checkout AJAX response was lost still has a card for renewals. The save ran on every delivery of `payment_intent.succeeded`, and through `add_token_to_order()` it copies the checkout card onto every subscription of the order whose token differs. A redelivered event (platform retry, outage replay) could therefore re-attach the original checkout card to a subscription the customer had since moved to a different card, silently changing which card the next renewal charges.

- Skip the webhook token save when the order is already paid. The lost-AJAX case always has a pending order, so the first delivery keeps working. Anything after payment is a redelivery and is ignored.
- The renewal-time token repair remains the backstop for paid orders that are missing a token.

**Compatibility:** the change is a guard clause in a private method on the webhook path. No signatures, hooks, options or response shapes change.

**Known narrowing** (from review): a checkout token-save failure is caught without re-throwing, so an order can end up paid with no token. When checkout wins the race against webhook delivery, the first `payment_intent.succeeded` now skips the repair for that order too, and recovery happens at the renewal-time repair instead of at webhook delivery. This is deliberate, to keep the guard simple for the release cherry-pick. It's pinned by `test_payment_intent_successful_skips_token_save_when_order_paid_without_token`, and the skip is logged with the order ID.

This is ready to cherry-pick into `release/11.0.0` if wanted; leaving that call to the release lead.

#### Testing instructions

Requires WooCommerce Subscriptions and WooPayments in test mode.

**Happy path: first delivery still saves the token**

1. Run the regression test: `vendor/bin/phpunit --configuration phpunit.xml.dist --filter 'WC_Payments_Webhook_Processing_Service_Test'`. All tests should pass, including `test_payment_intent_successful_saves_token_before_completing_recurring_order`.

**Regression: redelivered webhook no longer re-points the subscription**

1. Purchase a subscription product with test card `4242 4242 4242 4242`. Note the order ID, its `_intent_id` meta and the payment method ID (`pm_...`) on the saved token.
2. Attach a different card to the subscription so it becomes the active token (My Account &rarr; Subscriptions &rarr; Change payment, or attach a second token via `wp shell`).
3. Replay the success event through the webhook service via `wp eval`, substituting your IDs:

```php
$event = [ 'id' => 'evt_replay', 'type' => 'payment_intent.succeeded', 'livemode' => false, 'data' => [ 'object' => [ 'id' => '<intent_id>', 'object' => 'payment_intent', 'amount' => 999, 'currency' => 'usd', 'status' => 'succeeded', 'metadata' => [ 'order_id' => '<order_id>' ], 'charges' => [ 'data' => [ [ 'id' => 'ch_replay', 'payment_method' => '<pm_id>', 'payment_method_details' => [ 'type' => 'card' ] ] ] ] ] ] ];
$ref = new ReflectionProperty( 'WC_Payments', 'webhook_processing_service' );
$ref->setAccessible( true );
$ref->getValue()->process( $event );
```

4. Check the subscription's payment tokens: the replacement card should still be the active (last) token. On `develop` without this fix, the same replay re-attaches the original checkout card.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
