### PR TITLE
fix: woopmnt-6323 query count

### DIFF
--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -37,6 +37,16 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	private $account;
 
 	/**
+	 * The product a [product_page] shortcode embeds on the current page.
+	 *
+	 * Resolving it walks the host post's content, so the answer is kept for the
+	 * request: is_product() alone is consulted dozens of times per page render.
+	 *
+	 * @var WC_Product|null|false False until resolved.
+	 */
+	private $shortcode_product = false;
+
+	/**
 	 * Initialize class actions.
 	 *
 	 * @param WC_Payment_Gateway_WCPay $gateway WCPay gateway.
@@ -229,7 +239,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	 * @return boolean
 	 */
 	public function is_product() {
-		return is_product() || null !== $this->get_product_page_shortcode_host();
+		return is_product() || null !== $this->get_shortcode_product();
 	}
 
 	/**
@@ -468,39 +478,18 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	public function get_product() {
 		global $post;
 
+		// WooCommerce sets up the global product for whatever it is rendering - the single
+		// product template and the [product_page] loop alike - so once a loop is running it
+		// already holds the product the shopper is looking at.
+		if ( isset( $GLOBALS['product'] ) && $GLOBALS['product'] instanceof WC_Product && $this->is_product() ) {
+			return $GLOBALS['product'];
+		}
+
 		if ( is_product() ) {
 			return wc_get_product( $post->ID );
 		}
 
-		$host = $this->get_product_page_shortcode_host();
-		if ( null !== $host ) {
-			// Extract all [product_page ...] tags and parse their attributes.
-			// This handles id/sku, unquoted values, single-quoted values, and extra
-			// attributes. We try each shortcode instance in order and return the
-			// first one that resolves to a product.
-			preg_match_all( '/\[product_page\b([^\]]*)\]/', $host->post_content, $shortcode_matches );
-			if ( isset( $shortcode_matches[1] ) && is_array( $shortcode_matches[1] ) ) {
-				foreach ( $shortcode_matches[1] as $attrs_str ) {
-					$atts = shortcode_parse_atts( $attrs_str );
-
-					if ( ! empty( $atts['id'] ) ) {
-						$product = wc_get_product( (int) $atts['id'] );
-						if ( $product ) {
-							return $product;
-						}
-					}
-
-					if ( ! empty( $atts['sku'] ) ) {
-						$product_id = wc_get_product_id_by_sku( $atts['sku'] );
-						if ( $product_id ) {
-							return wc_get_product( $product_id );
-						}
-					}
-				}
-			}
-		}
-
-		return null;
+		return $this->get_shortcode_product();
 	}
 
 	/**
@@ -849,29 +838,58 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	}
 
 	/**
-	 * Returns the singular post whose content embeds a [product_page] shortcode, if any.
+	 * Resolves the product embedded by a [product_page] shortcode on the current page.
 	 *
-	 * Read from the main query, not the `$post` / `$wp_query` globals: the shortcode renders
-	 * its product in its own loop, so by the time the button markup is emitted on
-	 * `woocommerce_after_add_to_cart_form` those globals point at the embedded product. The
-	 * `sku` syntax is where that bites — WooCommerce queries it via `meta_query` with no post
-	 * ID, so the inner query never derives `is_singular` the way the `id` syntax does.
-	 *
-	 * @return WP_Post|null The host post, or null when this request isn't one.
+	 * @return WC_Product|null
 	 */
-	private function get_product_page_shortcode_host() {
-		// Not every context has a main query (REST, cron, CLI, webhooks).
+	private function get_shortcode_product() {
+		if ( false !== $this->shortcode_product ) {
+			return $this->shortcode_product;
+		}
+
+		$this->shortcode_product = null;
+
+		// Read the host post off the main query: [product_page] renders in its own loop, so
+		// by the time the button markup goes out on woocommerce_after_add_to_cart_form the
+		// $post and $wp_query globals point at the embedded product, not at the page.
 		$main_query = $GLOBALS['wp_the_query'] ?? null;
 		if ( ! $main_query instanceof WP_Query || ! $main_query->is_singular() ) {
 			return null;
 		}
 
 		$host = $main_query->get_queried_object();
-		if ( ! $host instanceof WP_Post || ! has_shortcode( $host->post_content, 'product_page' ) ) {
+		if ( ! $host instanceof WP_Post ) {
 			return null;
 		}
 
-		return $host;
+		// WordPress's own shortcode regex, narrowed to this one tag: it hands back the raw
+		// attributes in the same pass and honours escaped [[product_page]] tags, which
+		// do_shortcode() skips too.
+		preg_match_all( '/' . get_shortcode_regex( [ 'product_page' ] ) . '/', $host->post_content, $matches, PREG_SET_ORDER );
+
+		foreach ( $matches as $match ) {
+			if ( '[' === $match[1] && ']' === $match[6] ) {
+				continue;
+			}
+
+			$atts       = shortcode_parse_atts( $match[3] );
+			$product_id = 0;
+
+			if ( ! empty( $atts['id'] ) ) {
+				$product_id = (int) $atts['id'];
+			} elseif ( ! empty( $atts['sku'] ) ) {
+				$product_id = wc_get_product_id_by_sku( $atts['sku'] );
+			}
+
+			$product = $product_id ? wc_get_product( $product_id ) : null;
+
+			if ( $product instanceof WC_Product ) {
+				$this->shortcode_product = $product;
+				break;
+			}
+		}
+
+		return $this->shortcode_product;
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -37,14 +37,28 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	private $account;
 
 	/**
-	 * The product a [product_page] shortcode embeds on the current page.
+	 * Whether the [product_page] shortcode context has been worked out for this request.
 	 *
-	 * Resolving it walks the host post's content, so the answer is kept for the
-	 * request: is_product() alone is consulted dozens of times per page render.
+	 * Only ever set once the main query and its host post are available, so a caller that
+	 * asks before WordPress has parsed the request cannot pin a "no" for the whole request.
 	 *
-	 * @var WC_Product|null|false False until resolved.
+	 * @var bool
 	 */
-	private $shortcode_product = false;
+	private $shortcode_context_resolved = false;
+
+	/**
+	 * Whether the host post embeds a [product_page] shortcode, however it resolves.
+	 *
+	 * @var bool
+	 */
+	private $has_product_page_shortcode = false;
+
+	/**
+	 * The product that shortcode embeds, or null when it names one that no longer exists.
+	 *
+	 * @var WC_Product|null
+	 */
+	private $shortcode_product = null;
 
 	/**
 	 * Initialize class actions.
@@ -239,7 +253,9 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	 * @return boolean
 	 */
 	public function is_product() {
-		return is_product() || null !== $this->get_shortcode_product();
+		$this->resolve_shortcode_context();
+
+		return is_product() || $this->has_product_page_shortcode;
 	}
 
 	/**
@@ -478,10 +494,12 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	public function get_product() {
 		global $post;
 
-		// WooCommerce sets up the global product for whatever it is rendering - the single
-		// product template and the [product_page] loop alike - so once a loop is running it
-		// already holds the product the shopper is looking at.
-		if ( isset( $GLOBALS['product'] ) && $GLOBALS['product'] instanceof WC_Product && $this->is_product() ) {
+		// The button markup goes out on woocommerce_after_add_to_cart_form, which only fires
+		// from inside a single-product loop - the product template's and the [product_page]
+		// shortcode's alike. WooCommerce has already set up the global product by then, so
+		// take its answer rather than deriving a second one. Narrow to that hook: elsewhere
+		// the global can be left over from an archive, cross-sell or [products] loop.
+		if ( doing_action( 'woocommerce_after_add_to_cart_form' ) && isset( $GLOBALS['product'] ) && $GLOBALS['product'] instanceof WC_Product ) {
 			return $GLOBALS['product'];
 		}
 
@@ -489,7 +507,9 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			return wc_get_product( $post->ID );
 		}
 
-		return $this->get_shortcode_product();
+		$this->resolve_shortcode_context();
+
+		return $this->shortcode_product;
 	}
 
 	/**
@@ -838,58 +858,71 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	}
 
 	/**
-	 * Resolves the product embedded by a [product_page] shortcode on the current page.
+	 * Works out, once per request, whether the current page embeds a [product_page]
+	 * shortcode and which product it names.
 	 *
-	 * @return WC_Product|null
+	 * Reads the host post off the main query rather than the $post / $wp_query globals:
+	 * the shortcode renders in its own loop, so by the time the button markup goes out
+	 * those globals point at the embedded product instead of at the page.
+	 *
+	 * @return void
 	 */
-	private function get_shortcode_product() {
-		if ( false !== $this->shortcode_product ) {
-			return $this->shortcode_product;
+	private function resolve_shortcode_context() {
+		if ( $this->shortcode_context_resolved ) {
+			return;
 		}
 
-		$this->shortcode_product = null;
-
-		// Read the host post off the main query: [product_page] renders in its own loop, so
-		// by the time the button markup goes out on woocommerce_after_add_to_cart_form the
-		// $post and $wp_query globals point at the embedded product, not at the page.
+		// A caller can reach this before WordPress has parsed the request - is_product() is
+		// public, so anything on init can - and the answer would be a meaningless "no".
+		// Leave the context unresolved so the next caller works it out for real.
 		$main_query = $GLOBALS['wp_the_query'] ?? null;
 		if ( ! $main_query instanceof WP_Query || ! $main_query->is_singular() ) {
-			return null;
+			return;
 		}
 
 		$host = $main_query->get_queried_object();
 		if ( ! $host instanceof WP_Post ) {
-			return null;
+			return;
 		}
 
-		// WordPress's own shortcode regex, narrowed to this one tag: it hands back the raw
-		// attributes in the same pass and honours escaped [[product_page]] tags, which
-		// do_shortcode() skips too.
-		preg_match_all( '/' . get_shortcode_regex( [ 'product_page' ] ) . '/', $host->post_content, $matches, PREG_SET_ORDER );
+		$this->shortcode_context_resolved = true;
 
+		// WordPress's own shortcode regex, narrowed to this one tag: it hands back the raw
+		// attributes in the same pass and marks escaped [[product_page]] tags, which
+		// do_shortcode() skips too.
+		if ( ! preg_match_all( '/' . get_shortcode_regex( [ 'product_page' ] ) . '/', $host->post_content, $matches, PREG_SET_ORDER ) ) {
+			return;
+		}
+
+		$atts = null;
 		foreach ( $matches as $match ) {
 			if ( '[' === $match[1] && ']' === $match[6] ) {
 				continue;
 			}
 
-			$atts       = shortcode_parse_atts( $match[3] );
-			$product_id = 0;
-
-			if ( ! empty( $atts['id'] ) ) {
-				$product_id = (int) $atts['id'];
-			} elseif ( ! empty( $atts['sku'] ) ) {
-				$product_id = wc_get_product_id_by_sku( $atts['sku'] );
-			}
-
-			$product = $product_id ? wc_get_product( $product_id ) : null;
-
-			if ( $product instanceof WC_Product ) {
-				$this->shortcode_product = $product;
-				break;
-			}
+			$atts = shortcode_parse_atts( $match[3] );
+			break;
 		}
 
-		return $this->shortcode_product;
+		if ( null === $atts ) {
+			return;
+		}
+
+		// Presence is recorded whatever the attributes point at: is_product() has always
+		// answered "does this page embed the shortcode", and a shortcode naming a product
+		// that no longer exists must not turn that into a "no".
+		$this->has_product_page_shortcode = true;
+
+		$product_id = 0;
+		if ( ! empty( $atts['id'] ) ) {
+			$product_id = absint( $atts['id'] );
+		} elseif ( ! empty( $atts['sku'] ) ) {
+			$product_id = wc_get_product_id_by_sku( $atts['sku'] );
+		}
+
+		$product = $product_id ? wc_get_product( $product_id ) : null;
+
+		$this->shortcode_product = $product instanceof WC_Product ? $product : null;
 	}
 
 	/**

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -1138,6 +1138,27 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	}
 
 	/**
+	 * Publishes a page with the given content and navigates to it.
+	 *
+	 * @param string $content The page content.
+	 * @return int The page ID.
+	 */
+	private function go_to_page_with_content( string $content ): int {
+		$page_id = wp_insert_post(
+			[
+				'post_title'   => 'Test page',
+				'post_content' => $content,
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+			]
+		);
+
+		$this->go_to( get_permalink( $page_id ) );
+
+		return $page_id;
+	}
+
+	/**
 	 * @dataProvider get_product_shortcode_syntaxes_provider
 	 */
 	public function test_get_product_from_product_page_shortcode( string $shortcode_template, bool $use_sku ) {
@@ -1186,6 +1207,89 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		$this->assertArrayHasKey( 'is_product', $observed, 'woocommerce_after_add_to_cart_form did not fire.' );
 		$this->assertTrue( $observed['is_product'] );
 		$this->assertSame( $product->get_id(), $observed['product_id'] );
+	}
+
+	/**
+	 * is_product() and get_product() are public, so anything hooked early — a third-party
+	 * plugin on `init`, say — can reach them before WordPress has parsed the request. The
+	 * answer at that point is meaningless, and caching it would silently disable express
+	 * checkout for the rest of the request.
+	 */
+	public function test_early_call_does_not_pin_the_shortcode_context() {
+		// The main query is unparsed at this point, exactly as it is on `init`.
+		$this->assertFalse( $this->system_under_test->is_product() );
+		$this->assertNull( $this->system_under_test->get_product() );
+
+		list( $product ) = $this->go_to_page_embedding_product( '[product_page sku="%s"]', true );
+
+		$this->assertTrue( $this->system_under_test->is_product() );
+		$this->assertSame( $product->get_id(), $this->system_under_test->get_product()->get_id() );
+	}
+
+	/**
+	 * wc_get_product_id_by_sku() is an uncached direct database query, and a single page
+	 * render asks the helper for the page context dozens of times.
+	 */
+	public function test_repeated_calls_look_the_sku_up_once() {
+		list( $product ) = $this->go_to_page_embedding_product( '[product_page sku="%s"]', true );
+
+		// Counted from here so the uniqueness check WooCommerce runs when the fixture saves
+		// its SKU isn't mistaken for one of the helper's lookups.
+		$lookups = 0;
+		add_filter(
+			'woocommerce_get_product_id_by_sku',
+			function ( $id ) use ( &$lookups ) {
+				++$lookups;
+				return $id;
+			}
+		);
+
+		for ( $i = 0; $i < 5; $i++ ) {
+			$this->system_under_test->is_product();
+			$this->system_under_test->get_product();
+		}
+
+		$this->assertSame( 1, $lookups );
+		$this->assertSame( $product->get_id(), $this->system_under_test->get_product()->get_id() );
+	}
+
+	/**
+	 * The global product is only the right answer while the button markup is being emitted.
+	 * Anywhere else it can be left over from an archive, cross-sell or [products] loop.
+	 */
+	public function test_unrelated_global_product_does_not_override_the_shortcode_product() {
+		list( $product ) = $this->go_to_page_embedding_product( '[product_page id="%s"]', false );
+
+		$GLOBALS['product'] = WC_Helper_Product::create_simple_product();
+
+		$resolved = $this->system_under_test->get_product();
+		unset( $GLOBALS['product'] );
+
+		$this->assertSame( $product->get_id(), $resolved->get_id() );
+	}
+
+	/**
+	 * do_shortcode() leaves [[product_page]] alone and prints it literally, so no product
+	 * is ever rendered and no express checkout button belongs on the page.
+	 */
+	public function test_escaped_shortcode_is_not_treated_as_a_product_page() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->go_to_page_with_content( '[[product_page id="' . $product->get_id() . '"]]' );
+
+		$this->assertFalse( $this->system_under_test->is_product() );
+		$this->assertNull( $this->system_under_test->get_product() );
+	}
+
+	/**
+	 * is_product() answers "does this page embed the shortcode", which it has to keep doing
+	 * when the shortcode names a product that no longer exists — it is public, and callers
+	 * gate their own product handling on get_product() returning something.
+	 */
+	public function test_shortcode_naming_a_missing_product_is_still_a_product_page() {
+		$this->go_to_page_with_content( '[product_page id="999999"]' );
+
+		$this->assertTrue( $this->system_under_test->is_product() );
+		$this->assertNull( $this->system_under_test->get_product() );
 	}
 
 	public function test_should_not_show_express_checkout_button_when_product_not_purchasable() {

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -1138,6 +1138,24 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	}
 
 	/**
+	 * Puts the main query back to the unparsed state a request has on `init`.
+	 *
+	 * WordPress 6.0's test teardown resets $wp_query but not $wp_the_query, so an earlier
+	 * test's go_to() otherwise leaves the main query pointing at its page for the rest of
+	 * the run. Mirrors what go_to() itself does.
+	 *
+	 * @return void
+	 */
+	private function reset_main_query() {
+		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting the main query, as go_to() does.
+		$GLOBALS['wp_the_query'] = new WP_Query();
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Resetting the main query, as go_to() does.
+		$GLOBALS['wp_query'] = $GLOBALS['wp_the_query'];
+	}
+
+	/**
 	 * Publishes a page with the given content and navigates to it.
 	 *
 	 * @param string $content The page content.
@@ -1216,7 +1234,8 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	 * checkout for the rest of the request.
 	 */
 	public function test_early_call_does_not_pin_the_shortcode_context() {
-		// The main query is unparsed at this point, exactly as it is on `init`.
+		$this->reset_main_query();
+
 		$this->assertFalse( $this->system_under_test->is_product() );
 		$this->assertNull( $this->system_under_test->get_product() );
 


### PR DESCRIPTION
Fixes WOOPMNT-6323

#### Changes proposed in this Pull Request

While reviewing #12014 I noticed the helper works out the page context from scratch on every call. On a page that embeds a product by SKU that came to 98 full scans of the post content and 26 uncached SKU queries per page load, 136 database queries in total.

Three changes:
- While the button markup is going out, read the product WooCommerce has already set up for the loop instead of resolving the shortcode attributes a second time
- Work the shortcode context out once per request
- One pass with WordPress' own shortcode regex, instead of a hand-rolled one plus a separate scan

The same page is now down to 2 SKU queries and 112 in total. Normal product, shop, cart, checkout and plain pages are untouched, same query counts as before.

Two fixes come along for free. A variation SKU now gives back the product the page actually renders, the parent, rather than the variation. And escaped `[[product_page]]` tags are left alone, the way `do_shortcode` leaves them.

I considered keeping the attribute parsing everywhere and just caching it, but taking the product WooCommerce has already resolved means we can't drift from what the page renders.

**Known gap, not fixed here.** SKU resolution still goes through the product lookup table, while WooCommerce's own shortcode queries post meta. On a store whose lookup table has gone stale the two disagree, the page renders the product and the buttons don't show. Could be its own issue

#### Testing instructions

- Same steps as https://github.com/Automattic/woocommerce-payments/pull/12014
- For the query count: with Query Monitor installed, compare the total on the SKU page against the #12014 branch

Before:
<img width="183" height="35" alt="Screenshot 2026-07-31 at 3 48 29 PM" src="https://github.com/user-attachments/assets/3be19de7-bc72-4cde-ad31-56e0847030aa" />

After:
<img width="185" height="34" alt="Screenshot 2026-07-31 at 3 48 12 PM" src="https://github.com/user-attachments/assets/b5cd3105-4b0e-48e4-8e40-014507bc88fc" />


-------------------

- [ ] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable, covered by #12014_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
