### PR TITLE
refactor: split and memoize the onboarding context

### DIFF
--- a/changelog/fix-onboarding-context-memoization
+++ b/changelog/fix-onboarding-context-memoization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Memoize the onboarding context value so consumers stop re-rendering on every parent render.

--- a/changelog/fix-onboarding-context-memoization
+++ b/changelog/fix-onboarding-context-memoization
@@ -1,4 +1,3 @@
 Significance: patch
 Type: dev
-
-Memoize the onboarding context value so consumers stop re-rendering on every parent render.
+Comment: Split the onboarding context into separate context, hook and provider modules, and memoize the context value. Refactor only, no change in behaviour.

--- a/client/onboarding/__tests__/context.test.tsx
+++ b/client/onboarding/__tests__/context.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 
@@ -93,5 +93,65 @@ describe( 'OnboardingContext', () => {
 		expect(
 			screen.getByText( 'errors: {"firstName":"Required"}' )
 		).toBeInTheDocument();
+	} );
+
+	it( 'returns the same context value when a parent re-renders', async () => {
+		const values: ReturnType< typeof useOnboardingContext >[] = [];
+
+		const TestComponent: React.FC = () => {
+			values.push( useOnboardingContext() );
+			return null;
+		};
+
+		const Parent: React.FC = () => {
+			const [ count, setCount ] = useState( 0 );
+			return (
+				<>
+					<button onClick={ () => setCount( count + 1 ) }>
+						Re-render parent
+					</button>
+					<OnboardingContextProvider>
+						<TestComponent />
+					</OnboardingContextProvider>
+				</>
+			);
+		};
+
+		render( <Parent /> );
+
+		await user.click( screen.getByText( 'Re-render parent' ) );
+
+		expect( values ).toHaveLength( 2 );
+		expect( values[ 1 ] ).toBe( values[ 0 ] );
+	} );
+
+	it( 'returns the same setters when onboarding state changes', async () => {
+		const setters: ReturnType< typeof useOnboardingContext >[] = [];
+
+		const TestComponent: React.FC = () => {
+			const context = useOnboardingContext();
+			const { data, setData } = context;
+			setters.push( context );
+			return (
+				<button
+					onClick={ () => setData( { business_type: 'Individual' } ) }
+				>
+					data: { JSON.stringify( data ) }
+				</button>
+			);
+		};
+
+		render(
+			<OnboardingContextProvider>
+				<TestComponent />
+			</OnboardingContextProvider>
+		);
+
+		await user.click( screen.getByText( 'data: {}' ) );
+
+		expect( setters ).toHaveLength( 2 );
+		expect( setters[ 1 ].setData ).toBe( setters[ 0 ].setData );
+		expect( setters[ 1 ].setErrors ).toBe( setters[ 0 ].setErrors );
+		expect( setters[ 1 ].setTouched ).toBe( setters[ 0 ].setTouched );
 	} );
 } );

--- a/client/onboarding/__tests__/context.test.tsx
+++ b/client/onboarding/__tests__/context.test.tsx
@@ -8,7 +8,9 @@ import user from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import { OnboardingContextProvider, useOnboardingContext } from '../context';
+import { OnboardingContextProvider } from '../context-provider';
+import { useOnboardingContext } from '../use-onboarding-context';
+import { OnboardingContextValue } from '../types';
 
 describe( 'OnboardingContext', () => {
 	it( 'sets initial values and updates correctly', async () => {
@@ -96,10 +98,10 @@ describe( 'OnboardingContext', () => {
 	} );
 
 	it( 'returns the same context value when a parent re-renders', async () => {
-		const values: ReturnType< typeof useOnboardingContext >[] = [];
+		const contexts: OnboardingContextValue[] = [];
 
 		const TestComponent: React.FC = () => {
-			values.push( useOnboardingContext() );
+			contexts.push( useOnboardingContext() );
 			return null;
 		};
 
@@ -107,8 +109,8 @@ describe( 'OnboardingContext', () => {
 			const [ count, setCount ] = useState( 0 );
 			return (
 				<>
-					<button onClick={ () => setCount( count + 1 ) }>
-						Re-render parent
+					<button onClick={ () => setCount( ( prev ) => prev + 1 ) }>
+						count: { count }
 					</button>
 					<OnboardingContextProvider>
 						<TestComponent />
@@ -119,24 +121,29 @@ describe( 'OnboardingContext', () => {
 
 		render( <Parent /> );
 
-		await user.click( screen.getByText( 'Re-render parent' ) );
+		await user.click( screen.getByText( 'count: 0' ) );
 
-		expect( values ).toHaveLength( 2 );
-		expect( values[ 1 ] ).toBe( values[ 0 ] );
+		expect( screen.getByText( 'count: 1' ) ).toBeInTheDocument();
+		expect( contexts.length ).toBeGreaterThan( 1 );
+
+		contexts.forEach( ( context ) =>
+			expect( context ).toBe( contexts[ 0 ] )
+		);
 	} );
 
 	it( 'returns the same setters when onboarding state changes', async () => {
-		const setters: ReturnType< typeof useOnboardingContext >[] = [];
+		const contexts: OnboardingContextValue[] = [];
 
 		const TestComponent: React.FC = () => {
 			const context = useOnboardingContext();
-			const { data, setData } = context;
-			setters.push( context );
+			contexts.push( context );
 			return (
 				<button
-					onClick={ () => setData( { business_type: 'Individual' } ) }
+					onClick={ () =>
+						context.setData( { business_type: 'Individual' } )
+					}
 				>
-					data: { JSON.stringify( data ) }
+					data: { JSON.stringify( context.data ) }
 				</button>
 			);
 		};
@@ -149,9 +156,14 @@ describe( 'OnboardingContext', () => {
 
 		await user.click( screen.getByText( 'data: {}' ) );
 
-		expect( setters ).toHaveLength( 2 );
-		expect( setters[ 1 ].setData ).toBe( setters[ 0 ].setData );
-		expect( setters[ 1 ].setErrors ).toBe( setters[ 0 ].setErrors );
-		expect( setters[ 1 ].setTouched ).toBe( setters[ 0 ].setTouched );
+		expect(
+			screen.getByText( 'data: {"business_type":"Individual"}' )
+		).toBeInTheDocument();
+
+		contexts.forEach( ( context ) => {
+			expect( context.setData ).toBe( contexts[ 0 ].setData );
+			expect( context.setErrors ).toBe( contexts[ 0 ].setErrors );
+			expect( context.setTouched ).toBe( contexts[ 0 ].setTouched );
+		} );
 	} );
 } );

--- a/client/onboarding/__tests__/form.test.tsx
+++ b/client/onboarding/__tests__/form.test.tsx
@@ -32,7 +32,7 @@ let setTemp = jest.fn();
 let validate = jest.fn();
 let error = jest.fn();
 
-jest.mock( '../context', () => ( {
+jest.mock( '../use-onboarding-context', () => ( {
 	useOnboardingContext: jest.fn( () => ( {
 		data,
 		errors,

--- a/client/onboarding/__tests__/validation.test.ts
+++ b/client/onboarding/__tests__/validation.test.ts
@@ -7,7 +7,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
  * Internal dependencies
  */
 import { useValidation } from '../validation';
-import { OnboardingContextProvider } from '../context';
+import { OnboardingContextProvider } from '../context-provider';
 
 describe( 'useValidation', () => {
 	it( 'uses correct string for error', () => {

--- a/client/onboarding/context-provider.tsx
+++ b/client/onboarding/context-provider.tsx
@@ -1,24 +1,21 @@
 /**
  * External dependencies
  */
-import React, {
-	createContext,
-	useCallback,
-	useContext,
-	useMemo,
-	useState,
-} from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { isNil, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { OnboardingFields } from './types';
+import { OnboardingContext } from './context';
+import { OnboardingContextValue, OnboardingFields } from './types';
 
-const useContextValue = ( initialState = {} as OnboardingFields ) => {
+const useContextValue = (
+	initialState = {} as OnboardingFields
+): OnboardingContextValue => {
 	const [ data, setData ] = useState( initialState );
 	const [ errors, setErrors ] = useState( {} as OnboardingFields );
-	const [ touched, setTouched ] = useState( {} as OnboardingFields );
+	const [ touched, setTouched ] = useState< Record< string, boolean > >( {} );
 
 	const updateData = useCallback(
 		( value: Record< string, string | undefined > ) =>
@@ -51,28 +48,16 @@ const useContextValue = ( initialState = {} as OnboardingFields ) => {
 	);
 };
 
-type ContextValue = ReturnType< typeof useContextValue >;
-
-const OnboardingContext = createContext< ContextValue | null >( null );
-
 export const OnboardingContextProvider: React.FC<
 	React.PropsWithChildren< {
 		initialData?: OnboardingFields;
 	} >
 > = ( { children, initialData } ) => {
+	const value = useContextValue( initialData );
+
 	return (
-		<OnboardingContext.Provider value={ useContextValue( initialData ) }>
+		<OnboardingContext.Provider value={ value }>
 			{ children }
 		</OnboardingContext.Provider>
 	);
-};
-
-export const useOnboardingContext = (): ContextValue => {
-	const context = useContext( OnboardingContext );
-	if ( ! context ) {
-		throw new Error(
-			'useOnboardingContext() must be used within <OnboardingContextProvider>'
-		);
-	}
-	return context;
 };

--- a/client/onboarding/context.ts
+++ b/client/onboarding/context.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { createContext } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { OnboardingContextValue } from './types';
+
+export const OnboardingContext = createContext< OnboardingContextValue | null >(
+	null
+);

--- a/client/onboarding/context.tsx
+++ b/client/onboarding/context.tsx
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import React, { createContext, useContext, useState } from 'react';
+import React, {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from 'react';
 import { isNil, omitBy } from 'lodash';
 
 /**
@@ -14,17 +20,35 @@ const useContextValue = ( initialState = {} as OnboardingFields ) => {
 	const [ errors, setErrors ] = useState( {} as OnboardingFields );
 	const [ touched, setTouched ] = useState( {} as OnboardingFields );
 
-	return {
-		data,
-		setData: ( value: Record< string, string | undefined > ) =>
+	const updateData = useCallback(
+		( value: Record< string, string | undefined > ) =>
 			setData( ( prev ) => ( { ...prev, ...value } ) ),
-		errors,
-		setErrors: ( value: Record< string, string | undefined > ) =>
+		[]
+	);
+
+	const updateErrors = useCallback(
+		( value: Record< string, string | undefined > ) =>
 			setErrors( ( prev ) => omitBy( { ...prev, ...value }, isNil ) ),
-		touched,
-		setTouched: ( value: Record< string, boolean > ) =>
+		[]
+	);
+
+	const updateTouched = useCallback(
+		( value: Record< string, boolean > ) =>
 			setTouched( ( prev ) => ( { ...prev, ...value } ) ),
-	};
+		[]
+	);
+
+	return useMemo(
+		() => ( {
+			data,
+			setData: updateData,
+			errors,
+			setErrors: updateErrors,
+			touched,
+			setTouched: updateTouched,
+		} ),
+		[ data, errors, touched, updateData, updateErrors, updateTouched ]
+	);
 };
 
 type ContextValue = ReturnType< typeof useContextValue >;

--- a/client/onboarding/form.tsx
+++ b/client/onboarding/form.tsx
@@ -19,7 +19,7 @@ import {
 	TextField,
 	TextFieldProps,
 } from 'components/form/fields';
-import { useOnboardingContext } from './context';
+import { useOnboardingContext } from './use-onboarding-context';
 import { OnboardingFields } from './types';
 import { useValidation } from './validation';
 import { trackStepCompleted } from './tracking';

--- a/client/onboarding/index.tsx
+++ b/client/onboarding/index.tsx
@@ -7,7 +7,7 @@ import React, { useEffect } from 'react';
  * Internal dependencies
  */
 import Page from 'components/page';
-import { OnboardingContextProvider } from './context';
+import { OnboardingContextProvider } from './context-provider';
 import { Stepper } from 'components/stepper';
 import { getMccFromIndustry } from 'onboarding/utils';
 import { OnboardingForm } from './form';

--- a/client/onboarding/kyc/index.tsx
+++ b/client/onboarding/kyc/index.tsx
@@ -8,7 +8,7 @@ import React, { useEffect } from 'react';
  */
 import WooLogo from 'assets/images/woo-logo.svg';
 import Page from 'components/page';
-import { OnboardingContextProvider } from 'onboarding/context';
+import { OnboardingContextProvider } from 'onboarding/context-provider';
 import EmbeddedKyc from 'onboarding/steps/embedded-kyc';
 import { getConnectUrl } from 'utils';
 import { trackKycExit } from 'wcpay/onboarding/tracking';

--- a/client/onboarding/steps/__tests__/business-details.test.tsx
+++ b/client/onboarding/steps/__tests__/business-details.test.tsx
@@ -9,7 +9,8 @@ import user from '@testing-library/user-event';
  * Internal dependencies
  */
 import BusinessDetails from '../business-details';
-import { OnboardingContextProvider, useOnboardingContext } from '../../context';
+import { OnboardingContextProvider } from '../../context-provider';
+import { useOnboardingContext } from '../../use-onboarding-context';
 import {
 	getAvailableCountries,
 	getBusinessTypes,

--- a/client/onboarding/steps/__tests__/embedded-kyc.test.tsx
+++ b/client/onboarding/steps/__tests__/embedded-kyc.test.tsx
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import EmbeddedKyc from '../embedded-kyc';
-import { useOnboardingContext } from 'wcpay/onboarding/context';
+import { useOnboardingContext } from 'wcpay/onboarding/use-onboarding-context';
 import { isInDevMode } from 'wcpay/utils';
 
 /**
@@ -19,7 +19,7 @@ jest.mock( 'wcpay/embedded-components', () => {
 		),
 	};
 } );
-jest.mock( 'wcpay/onboarding/context', () => ( {
+jest.mock( 'wcpay/onboarding/use-onboarding-context', () => ( {
 	useOnboardingContext: jest.fn(),
 } ) );
 

--- a/client/onboarding/steps/__tests__/loading.test.tsx
+++ b/client/onboarding/steps/__tests__/loading.test.tsx
@@ -22,7 +22,7 @@ declare const global: {
 let data = {};
 const setData = jest.fn();
 
-jest.mock( '../../context', () => ( {
+jest.mock( '../../use-onboarding-context', () => ( {
 	useOnboardingContext: jest.fn( () => ( {
 		data,
 		setData,

--- a/client/onboarding/steps/business-details.tsx
+++ b/client/onboarding/steps/business-details.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { useOnboardingContext } from '../context';
+import { useOnboardingContext } from '../use-onboarding-context';
 import { Item } from 'components/custom-select-control';
 import { OnboardingFields } from '../types';
 import { OnboardingGroupedSelectField, OnboardingSelectField } from '../form';

--- a/client/onboarding/steps/embedded-kyc.tsx
+++ b/client/onboarding/steps/embedded-kyc.tsx
@@ -10,7 +10,7 @@ import { LoadError } from '@stripe/connect-js';
  * Internal dependencies
  */
 import StripeSpinner from 'wcpay/components/stripe-spinner';
-import { useOnboardingContext } from 'wcpay/onboarding/context';
+import { useOnboardingContext } from 'wcpay/onboarding/use-onboarding-context';
 import { finalizeOnboarding } from 'wcpay/onboarding/utils';
 import { getConnectUrl, getOverviewUrl, isInDevMode } from 'wcpay/utils';
 import { trackEmbeddedStepChange } from 'wcpay/onboarding/tracking';

--- a/client/onboarding/steps/loading.tsx
+++ b/client/onboarding/steps/loading.tsx
@@ -7,7 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { useOnboardingContext } from '../context';
+import { useOnboardingContext } from '../use-onboarding-context';
 import { fromDotNotation } from '../utils';
 import { trackRedirected, useTrackAbandoned } from '../tracking';
 import LoadBar from 'components/load-bar';

--- a/client/onboarding/tracking.ts
+++ b/client/onboarding/tracking.ts
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
  */
 
 import { useStepperContext } from 'components/stepper';
-import { useOnboardingContext } from './context';
+import { useOnboardingContext } from './use-onboarding-context';
 import { OnboardingFields } from './types';
 import { recordEvent } from 'tracks';
 

--- a/client/onboarding/types.ts
+++ b/client/onboarding/types.ts
@@ -12,6 +12,15 @@ export type OnboardingFields = {
 	mcc?: string;
 };
 
+export type OnboardingContextValue = {
+	data: OnboardingFields;
+	setData: ( value: Record< string, string | undefined > ) => void;
+	errors: OnboardingFields;
+	setErrors: ( value: Record< string, string | undefined > ) => void;
+	touched: Record< string, boolean >;
+	setTouched: ( value: Record< string, boolean > ) => void;
+};
+
 export interface Country {
 	key: string;
 	name: string;

--- a/client/onboarding/use-onboarding-context.ts
+++ b/client/onboarding/use-onboarding-context.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { useContext } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { OnboardingContext } from './context';
+import { OnboardingContextValue } from './types';
+
+export const useOnboardingContext = (): OnboardingContextValue => {
+	const context = useContext( OnboardingContext );
+	if ( ! context ) {
+		throw new Error(
+			'useOnboardingContext() must be used within <OnboardingContextProvider>'
+		);
+	}
+	return context;
+};

--- a/client/onboarding/validation.ts
+++ b/client/onboarding/validation.ts
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
  * Internal dependencies
  */
 import strings from './strings';
-import { useOnboardingContext } from './context';
+import { useOnboardingContext } from './use-onboarding-context';
 import { OnboardingFields } from './types';
 
 const isValid = ( name: keyof OnboardingFields, value?: string ): boolean => {


### PR DESCRIPTION
Fixes WOOPMNT-5754

#### Changes proposed in this Pull Request

The onboarding context handed out a new object, with new setters, on every render, so consumers were invalidated whenever a parent re-rendered. Memoizing the value.

Nothing in the onboarding tree is wrapped in `React.memo` today, so this saves no renders as it stands. What it buys is a stable identity, safe to rely on in a dependency array.

The ticket also flagged the layout: context, hook and provider shared one file, so importing the hook dragged the provider along. Split into three, matching the other contexts under `client/`. The rest is import churn, no logic. One type fix rides along — `touched` was typed as onboarding fields (strings) while it has only ever held booleans.

#### Testing instructions

Refactor only, so onboarding should behave exactly as it does on `develop`.

- Check out this branch and rebuild the client assets
- Visit `http://localhost:8082/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fonboarding`
- Pick a country and business type, leave a required field empty to get the validation error, then go back a step and check your answers are still there
- Confirm the KYC step still loads at `path=%2Fpayments%2Fonboarding%2Fkyc`
- Enjoy

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
