### PR TITLE
fix: dedupe dispute webhook side effects on a dispute-scoped ledger

### DIFF
--- a/changelog/fix-dispute-webhook-idempotency-ledger
+++ b/changelog/fix-dispute-webhook-idempotency-ledger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: dedupe dispute webhook side effects on a dispute-scoped ledger instead of order note text

--- a/includes/class-wc-payments-order-service.php
+++ b/includes/class-wc-payments-order-service.php
@@ -230,6 +230,41 @@ class WC_Payments_Order_Service {
 	const IPP_CHANNEL_META_KEY = '_wcpay_ipp_channel';
 
 	/**
+	 * Meta key prefix, suffixed with the dispute ID, marking a dispute closure as already applied
+	 * to the order.
+	 *
+	 * The order note used to be the only guard against a redelivered webhook, but its wording is
+	 * translated and changes between releases. After an upgrade the note no longer matches, so the
+	 * side effects run again, and on a lost dispute that means a second refund. The dispute ID
+	 * changes with neither.
+	 *
+	 * Only the presence of the key is meaningful; the value records when it was applied.
+	 *
+	 * @const string
+	 */
+	const WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX = '_wcpay_dispute_closed_';
+
+	/**
+	 * Meta key prefix, suffixed with the dispute ID, marking a dispute creation as already applied
+	 * to the order.
+	 *
+	 * @see self::WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX for why the order note is not a durable guard.
+	 *
+	 * @const string
+	 */
+	const WCPAY_DISPUTE_CREATED_META_KEY_PREFIX = '_wcpay_dispute_created_';
+
+	/**
+	 * Meta key on the refund a lost dispute creates, holding that dispute's ID.
+	 *
+	 * A charge can lose more than one dispute, so without the link there is no way to tell the
+	 * refunds apart when reconciling an order against the platform.
+	 *
+	 * @const string
+	 */
+	const WCPAY_REFUND_DISPUTE_ID_META_KEY = '_wcpay_dispute_id';
+
+	/**
 	 * Meta key holding the IDs of the disputes recorded against this order that have
 	 * not closed yet. The list is order-wide; it is not keyed or scoped per charge.
 	 *
@@ -580,6 +615,18 @@ class WC_Payments_Order_Service {
 			return;
 		}
 
+		if ( $this->dispute_ledger_entry_exists( $order, self::WCPAY_DISPUTE_CREATED_META_KEY_PREFIX, $dispute_id ) ) {
+			return;
+		}
+
+		// A creation arriving after the closure is stale, so record it and leave the order alone.
+		// Holding the order again would suspend the subscription it is the parent of and stop the
+		// renewals, and the dispute would never leave the open list, since its close has been and gone.
+		if ( $this->dispute_ledger_entry_exists( $order, self::WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX, $dispute_id ) ) {
+			$this->record_dispute_ledger_entry( $order, self::WCPAY_DISPUTE_CREATED_META_KEY_PREFIX, $dispute_id );
+			return;
+		}
+
 		$is_inquiry = strpos( $status, 'warning_' ) === 0;
 		$note       = $this->generate_dispute_created_note( $charge_id, $amount, $reason, $due_by, $is_inquiry, $dispute_id );
 		if ( $this->order_note_exists( $order, $note ) ) {
@@ -587,6 +634,7 @@ class WC_Payments_Order_Service {
 		}
 
 		$this->update_order_status( $order, Order_Status::ON_HOLD );
+		$this->record_dispute_ledger_entry( $order, self::WCPAY_DISPUTE_CREATED_META_KEY_PREFIX, $dispute_id );
 		$order->add_order_note( $note );
 		$this->add_open_dispute_id( $order, $dispute_id );
 		$order->save();
@@ -608,6 +656,10 @@ class WC_Payments_Order_Service {
 			return;
 		}
 
+		if ( $this->dispute_ledger_entry_exists( $order, self::WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX, $dispute_id ) ) {
+			return;
+		}
+
 		$is_inquiry = strpos( $status, 'warning_' ) === 0;
 		$note       = $this->generate_dispute_closed_note( $charge_id, $status, $is_inquiry, $dispute_id );
 
@@ -620,6 +672,7 @@ class WC_Payments_Order_Service {
 		add_filter( 'woocommerce_email_enabled_customer_refunded_order', '__return_false' );
 		add_filter( 'woocommerce_email_enabled_customer_completed_renewal_order', '__return_false' );
 
+		$refund_failed    = false;
 		$open_dispute_ids = $this->close_open_dispute_id( $order, $dispute_id );
 
 		if ( 'lost' === $status ) {
@@ -644,7 +697,7 @@ class WC_Payments_Order_Service {
 				}
 			}
 
-			wc_create_refund(
+			$refund = wc_create_refund(
 				[
 					'amount'     => $refund_amount,
 					'reason'     => __( 'Dispute lost.', 'woocommerce-payments' ),
@@ -652,6 +705,21 @@ class WC_Payments_Order_Service {
 					'line_items' => $line_items,
 				]
 			);
+
+			// A WP_Error is not the only failure. wc_create_refund() hands the refund object back even
+			// when the save returned 0, since WC_Abstract_Order::save() swallows and logs its own
+			// exceptions, so a dropped refund shows up only as a zero ID.
+			// Writing meta to that object and saving it would recreate the row core had just decided
+			// not to keep, without the restock, the fully-refunded transition or
+			// `woocommerce_order_refunded` that wc_create_refund() wraps around it.
+			if ( is_wp_error( $refund ) || ! $refund instanceof WC_Order_Refund || ! $refund->get_id() ) {
+				$refund_failed = true;
+				$failure       = is_wp_error( $refund ) ? $refund->get_error_message() : 'the refund could not be saved';
+				Logger::error( 'Failed to refund order ' . $order->get_id() . ' for lost dispute ' . $dispute_id . ': ' . $failure );
+			} elseif ( '' !== $dispute_id ) {
+				$refund->update_meta_data( self::WCPAY_REFUND_DISPUTE_ID_META_KEY, $dispute_id );
+				$refund->save();
+			}
 		} elseif ( ! empty( $open_dispute_ids ) ) {
 			// Another dispute on the same charge is still running its evidence deadline, and
 			// the hold it put on the order has to outlive this one. Leave the status alone
@@ -690,6 +758,24 @@ class WC_Payments_Order_Service {
 		remove_filter( 'woocommerce_email_enabled_customer_completed_order', '__return_false' );
 		remove_filter( 'woocommerce_email_enabled_customer_refunded_order', '__return_false' );
 		remove_filter( 'woocommerce_email_enabled_customer_completed_renewal_order', '__return_false' );
+
+		// The ledger must never claim a refund that did not happen, or the amount stays owed with
+		// nothing left to retry against.
+		// Nothing comes back for this on its own: the webhook still answers 200, and the platform only
+		// replays what it recorded as failed. The note is the only way the merchant hears about it.
+		if ( $refund_failed ) {
+			$failure_note = $this->generate_dispute_closed_refund_failure_note( $dispute_id );
+
+			if ( ! $this->order_note_exists( $order, $failure_note ) ) {
+				$order->add_order_note( $failure_note );
+			}
+
+			return;
+		}
+
+		// Recorded before the note. A crash between the two then costs a missing note, which is
+		// cosmetic, rather than a replayable refund, which is not.
+		$this->record_dispute_ledger_entry( $order, self::WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX, $dispute_id );
 
 		$order->add_order_note( $note );
 	}
@@ -2479,6 +2565,68 @@ class WC_Payments_Order_Service {
 		}
 
 		return $note;
+	}
+
+	/**
+	 * Get content for the order note recording that a lost dispute's refund could not be created.
+	 *
+	 * @param string $dispute_id The ID of the dispute, appended so the note is scoped to it and a
+	 *                           redelivery of the same closure does not repeat it.
+	 *
+	 * @return string Note content.
+	 */
+	private function generate_dispute_closed_refund_failure_note( $dispute_id ) {
+		$note = esc_html__( 'Dispute closed as lost, but the refund it should have created failed. Refund this order manually to bring it back in step with the payment.', 'woocommerce-payments' );
+
+		if ( '' !== $dispute_id ) {
+			$note .= ' ' . sprintf(
+				/* translators: %s: the dispute ID */
+				esc_html__( '(Dispute ID: %s)', 'woocommerce-payments' ),
+				esc_html( $dispute_id )
+			);
+		}
+
+		return $note;
+	}
+
+	/**
+	 * Whether a dispute webhook has already been applied to the order.
+	 *
+	 * An empty dispute ID means the event carried no ID to key on, so there is nothing to look up
+	 * and the caller falls back to the order note check.
+	 *
+	 * @param WC_Order $order          Order object.
+	 * @param string   $meta_key_prefix One of the dispute ledger meta key prefixes.
+	 * @param string   $dispute_id     The ID of the dispute.
+	 *
+	 * @return bool
+	 */
+	private function dispute_ledger_entry_exists( WC_Order $order, string $meta_key_prefix, string $dispute_id ): bool {
+		if ( '' === $dispute_id ) {
+			return false;
+		}
+
+		return (bool) $order->meta_exists( $meta_key_prefix . $dispute_id );
+	}
+
+	/**
+	 * Records that a dispute webhook has been applied to the order.
+	 *
+	 * @param WC_Order $order           Order object.
+	 * @param string   $meta_key_prefix One of the dispute ledger meta key prefixes.
+	 * @param string   $dispute_id      The ID of the dispute.
+	 *
+	 * @return void
+	 */
+	private function record_dispute_ledger_entry( WC_Order $order, string $meta_key_prefix, string $dispute_id ): void {
+		if ( '' === $dispute_id ) {
+			return;
+		}
+
+		// save_meta_data() rather than save(): the callers already save the order around their own
+		// side effects, and the ledger entry has no business deciding when the rest of it gets written.
+		$order->update_meta_data( $meta_key_prefix . $dispute_id, gmdate( 'Y-m-d H:i:s' ) );
+		$order->save_meta_data();
 	}
 
 	/**

--- a/tests/unit/helpers/class-wc-helper-order.php
+++ b/tests/unit/helpers/class-wc-helper-order.php
@@ -78,6 +78,10 @@ class WC_Helper_Order {
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception.
 		$order                  = wc_create_order( $order_data );
 
+		// Order item rows outlive the rollback that removes the order between tests, while order IDs
+		// get handed out again, so a fresh order can arrive already carrying an earlier test's items.
+		$order->remove_order_items();
+
 		// Add order products.
 		$item = new WC_Order_Item_Product();
 		$item->set_props(

--- a/tests/unit/test-class-wc-payments-order-service.php
+++ b/tests/unit/test-class-wc-payments-order-service.php
@@ -2690,6 +2690,306 @@ class WC_Payments_Order_Service_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * A closure applied by a version that wrote ID-less notes is re-delivered after the upgrade. The
+	 * note no longer matches, so the ledger is the only thing standing between the order and a second
+	 * refund.
+	 */
+	public function test_mark_payment_dispute_closed_skips_a_redelivered_closure_recorded_in_the_ledger(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->save();
+
+		$dispute_summary = [
+			'disputed_amount' => 5000,
+			'currency'        => 'usd',
+		];
+
+		// Arrange: the closure as an earlier version applied it, an ID-less note and no ledger entry.
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', $dispute_summary );
+
+		// Arrange: the backfill attributes that note to the dispute it came from.
+		$order = wc_get_order( $order->get_id() );
+		$order->update_meta_data( WC_Payments_Order_Service::WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX . 'dp_redelivered', gmdate( 'Y-m-d H:i:s' ) );
+		$order->save_meta_data();
+
+		// Act: the platform redelivers the event, now carrying the dispute ID.
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', $dispute_summary, 'dp_redelivered' );
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertCount( 1, $order->get_refunds() );
+		$this->assertEquals( 50.00, $order->get_total_refunded() );
+		$this->assertTrue( $order->has_status( [ 'on-hold' ] ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * A second, genuinely new dispute on the same charge is indistinguishable from the first by
+	 * amount, status and note text. Its refund must still be applied.
+	 */
+	public function test_mark_payment_dispute_closed_refunds_a_second_dispute_on_the_same_charge(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->save();
+
+		$dispute_summary = [
+			'disputed_amount' => 3000,
+			'currency'        => 'usd',
+		];
+
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', $dispute_summary, 'dp_first' );
+		$this->order_service->mark_payment_dispute_closed( wc_get_order( $order->get_id() ), 'ch_123', 'lost', $dispute_summary, 'dp_second' );
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertCount( 2, $order->get_refunds() );
+		$this->assertEquals( 60.00, $order->get_total_refunded() );
+	}
+
+	/**
+	 * A crash between the side effects and the note leaves the ledger entry as the only record. It
+	 * has to be enough on its own.
+	 */
+	public function test_mark_payment_dispute_closed_skips_side_effects_when_only_the_ledger_is_present(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->update_meta_data( WC_Payments_Order_Service::WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX . 'dp_crashed', gmdate( 'Y-m-d H:i:s' ) );
+		$order->save();
+
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', [], 'dp_crashed' );
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertCount( 0, $order->get_refunds() );
+		$this->assertTrue( $order->has_status( [ 'on-hold' ] ) );
+
+		$contents = implode( "\n", wp_list_pluck( wc_get_order_notes( [ 'order_id' => $order->get_id() ] ), 'content' ) );
+		$this->assertStringNotContainsString( 'Dispute has been closed', $contents );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * The whole of a lost closure, end to end: the refund empties the order, the order lands on
+	 * `refunded`, and the ledger records the dispute that got it there.
+	 */
+	public function test_mark_payment_dispute_closed_records_the_ledger_on_a_fully_refunded_order(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->save();
+
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', [], 'dp_full' );
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertTrue( $order->has_status( [ 'refunded' ] ) );
+		$this->assertEquals( 100.00, $order->get_total_refunded() );
+		$this->assertEquals( 0.00, $order->get_remaining_refund_amount() );
+		$this->assertTrue( $order->meta_exists( '_wcpay_dispute_closed_dp_full' ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * The ledger is durable, so recording a refund that failed would strand the amount owed. Nothing
+	 * comes back for it either — the webhook still answers 200, and the platform only replays what it
+	 * recorded as failed — so the one thing the merchant gets is a note saying so.
+	 */
+	public function test_mark_payment_dispute_closed_does_not_record_the_ledger_when_the_refund_fails(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->save();
+
+		$reject_the_refund = function () {
+			throw new Exception( 'the refund was rejected' );
+		};
+		add_action( 'woocommerce_create_refund', $reject_the_refund );
+
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', [], 'dp_refund_failed' );
+
+		remove_action( 'woocommerce_create_refund', $reject_the_refund );
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertCount( 0, $order->get_refunds() );
+		$this->assertFalse( $order->meta_exists( '_wcpay_dispute_closed_dp_refund_failed' ) );
+
+		$contents = implode( "\n", wp_list_pluck( wc_get_order_notes( [ 'order_id' => $order->get_id() ] ), 'content' ) );
+		$this->assertStringNotContainsString( 'Dispute has been closed', $contents );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * A lost dispute the store cannot refund still has to leave a trace, or the order shows no sign
+	 * the dispute closed at all.
+	 */
+	public function test_mark_payment_dispute_closed_notes_a_refund_it_could_not_create(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->save();
+
+		$reject_the_refund = function () {
+			throw new Exception( 'the refund was rejected' );
+		};
+		add_action( 'woocommerce_create_refund', $reject_the_refund );
+
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', [], 'dp_refund_noted' );
+		// A redelivery of the same closure fails the same way and must not stack up notes.
+		$this->order_service->mark_payment_dispute_closed( wc_get_order( $order->get_id() ), 'ch_123', 'lost', [], 'dp_refund_noted' );
+
+		remove_action( 'woocommerce_create_refund', $reject_the_refund );
+
+		$contents = wp_list_pluck( wc_get_order_notes( [ 'order_id' => $order->get_id() ] ), 'content' );
+
+		$this->assertCount(
+			1,
+			array_filter(
+				$contents,
+				function ( $content ) {
+					return false !== strpos( $content, 'Dispute closed as lost, but the refund it should have created failed.' );
+				}
+			)
+		);
+		$this->assertStringContainsString( '(Dispute ID: dp_refund_noted)', implode( "\n", $contents ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * wc_create_refund() hands back the refund object even when saving it returned 0, because
+	 * WC_Abstract_Order::save() swallows its own exceptions. Treating that as a success would write
+	 * meta to the object and save it, creating the row core had just decided to abandon — and without
+	 * the restock, the status transition or the `woocommerce_order_refunded` hook that wrap a real
+	 * refund.
+	 */
+	public function test_mark_payment_dispute_closed_treats_an_unsaved_refund_as_a_failure(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->save();
+
+		$break_the_save = function () {
+			throw new Exception( 'the refund could not be written' );
+		};
+		add_action( 'woocommerce_before_order_refund_object_save', $break_the_save );
+
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', [], 'dp_unsaved_refund' );
+
+		remove_action( 'woocommerce_before_order_refund_object_save', $break_the_save );
+
+		$order = wc_get_order( $order->get_id() );
+
+		$this->assertCount( 0, $order->get_refunds() );
+		$this->assertFalse( $order->meta_exists( '_wcpay_dispute_closed_dp_unsaved_refund' ) );
+
+		$contents = implode( "\n", wp_list_pluck( wc_get_order_notes( [ 'order_id' => $order->get_id() ] ), 'content' ) );
+
+		$this->assertStringNotContainsString( 'Dispute has been closed', $contents );
+		$this->assertStringContainsString( 'Dispute closed as lost, but the refund it should have created failed.', $contents );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * Tests that the refund a lost dispute creates records which dispute it came from.
+	 */
+	public function test_mark_payment_dispute_closed_links_the_refund_to_the_dispute(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_total( 100.00 );
+		$order->set_status( Order_Status::ON_HOLD );
+		$order->save();
+
+		$this->order_service->mark_payment_dispute_closed( $order, 'ch_123', 'lost', [], 'dp_linked' );
+
+		$refunds = wc_get_order( $order->get_id() )->get_refunds();
+		$this->assertEquals( 'dp_linked', $refunds[0]->get_meta( '_wcpay_dispute_id' ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * Tests that a re-delivered dispute creation recorded in the ledger does not force the order back
+	 * to on-hold.
+	 */
+	public function test_mark_payment_dispute_created_skips_a_redelivered_event_recorded_in_the_ledger(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( Order_Status::COMPLETED );
+		$order->update_meta_data( WC_Payments_Order_Service::WCPAY_DISPUTE_CREATED_META_KEY_PREFIX . 'dp_created', gmdate( 'Y-m-d H:i:s' ) );
+		$order->save();
+
+		$this->order_service->mark_payment_dispute_created( $order, 'ch_123', '$10.00', 'fraudulent', '1 Jan 2026', '', 'dp_created' );
+
+		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( [ 'completed' ] ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * Tests that a dispute creation records its ledger entry, so a later re-delivery is recognised.
+	 */
+	public function test_mark_payment_dispute_created_records_a_ledger_entry(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		$this->order_service->mark_payment_dispute_created( $order, 'ch_123', '$10.00', 'fraudulent', '1 Jan 2026', '', 'dp_created' );
+
+		$this->assertTrue( wc_get_order( $order->get_id() )->meta_exists( '_wcpay_dispute_created_dp_created' ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * A creation arriving after its own closure must not re-hold the order: holding a subscription's
+	 * parent order suspends the subscription and stops renewals.
+	 */
+	public function test_mark_payment_dispute_created_leaves_the_order_alone_once_the_dispute_has_closed(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( Order_Status::COMPLETED );
+		$order->update_meta_data( WC_Payments_Order_Service::WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX . 'dp_closed', gmdate( 'Y-m-d H:i:s' ) );
+		$order->save();
+
+		$notes_before = count( wc_get_order_notes( [ 'order_id' => $order->get_id() ] ) );
+
+		$this->order_service->mark_payment_dispute_created( $order, 'ch_123', '$10.00', 'fraudulent', '1 Jan 2026', '', 'dp_closed' );
+
+		$refreshed = wc_get_order( $order->get_id() );
+
+		$this->assertTrue( $refreshed->has_status( [ 'completed' ] ) );
+
+		$this->assertCount( $notes_before, wc_get_order_notes( [ 'order_id' => $order->get_id() ] ) );
+
+		// Recorded anyway, so a further re-delivery short-circuits on the creation ledger.
+		$this->assertTrue( $refreshed->meta_exists( '_wcpay_dispute_created_dp_closed' ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * The guard is scoped to the dispute's own closure, so a second, still-open dispute on the same
+	 * charge is not silently swallowed.
+	 */
+	public function test_mark_payment_dispute_created_still_holds_the_order_for_a_different_open_dispute(): void {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( Order_Status::COMPLETED );
+		$order->update_meta_data( WC_Payments_Order_Service::WCPAY_DISPUTE_CLOSED_META_KEY_PREFIX . 'dp_first', gmdate( 'Y-m-d H:i:s' ) );
+		$order->save();
+
+		$this->order_service->mark_payment_dispute_created( $order, 'ch_123', '$10.00', 'fraudulent', '1 Jan 2026', '', 'dp_second' );
+
+		$this->assertTrue( wc_get_order( $order->get_id() )->has_status( [ 'on-hold' ] ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
 	 * Tests that mark_payment_dispute_closed handles missing amount in refund.
 	 */
 	public function test_mark_payment_dispute_closed_with_missing_amount_in_summary(): void {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Dispute webhooks use the order note text as their only idempotency guard.
#11991 / #11993 appended the dispute ID to those notes, which changed that key.
An event processed under 10.9.0 wrote a note without the ID, so _if_ the platform redelivers it after the store updates, the note no longer matches and the side effects run a second time: another local refund on a lost dispute, or the order forced back to completed on a won one.

There's no money movement involved.
A *fully* disputed order produces a $0 duplicate, because the refund is capped at the remaining refundable amount and there is none left.
Only a **partial** dispute yields a nonzero one. So this is a double-recorded refund, a wrong order total, and lost headroom to issue a genuine refund later, not money leaving twice.

The dispute-*created* note changed the same way, and that redelivery is worse than it looks. Forcing the order back to `on-hold` makes WooCommerce Subscriptions suspend every subscription on it, which stops renewals.

There's a second hole in the same method that isn't version-specific. The note is added *after* the refund, so a crash in between leaves the order unguarded, and even a same-version redelivery re-refunds.

Recording each dispute's outcome in dispute-scoped order meta and gating the side effects on that, instead of on display text. The ledger is written before the note, which closes the crash window too.

This is #12015 with the backfill taken out — the guard on its own, no Action Scheduler job and no migration on upgrade. Stores that closed disputes before updating stay exposed to the original redelivery; that's the trade #12015 exists to close, and it can land separately.

#### Considerations

**A failed refund is never recorded.** The ledger is durable, so claiming a refund that didn't happen would strand the amount owed with nothing left to retry against. A `WP_Error` isn't the only failure either: `wc_create_refund()` hands the refund object back even when the save returned 0, because core swallows and logs its own exceptions there, so a dropped refund shows up only as a zero ID. Both cases now leave the ledger alone and add a note telling the merchant to refund by hand. Nothing else comes back for it — the webhook still answers 200, and the platform only replays what it recorded as failed.

**A creation arriving after its own closure is recorded but not applied.** Re-holding the order would suspend the subscription it's the parent of, and the dispute would never leave the open list, since its close has been and gone.

**The refund a lost dispute creates now carries the dispute ID.** A charge can lose more than one dispute, and without the link there's no way to tell those refunds apart when reconciling an order against the platform.

**It fits with the open-dispute tally from #11997**, now on `develop`. The stale-creation guard also keeps a dispute that has already closed out of the open list.

One test-helper change came out of this. Order item rows outlive the rollback that removes the order between tests, and order IDs get reused, so a freshly created order could arrive already carrying an earlier test's line items. Any test counting its own items then saw one too many, depending only on how many orders ran before it. `WC_Helper_Order::create_order()` now clears them.

#### Backward compatibility

Additive only. No existing signature, hook, hook argument, option key or meta key was renamed, re-signed or reordered. The new surface is three constants on the order service and two private helpers.

Per-order meta only, so multisite-safe by construction.

#### Testing instructions

Automated coverage is the main story here, since the failure needs a redelivered webhook straddling a plugin update, which is awkward to stage by hand.

To exercise the live path manually, use JN:

- Take a store on this branch
- Place an order with `4000008400000779` (single dispute) and one with `4000000404000079` (multiple disputes)
- Place the same two as subscription orders
- The orders get a dispute note and go on hold
- Accept the disputes
- The orders should get refunded — check their order notes
- Check the refund's meta: it should carry `_wcpay_dispute_id`

I haven't found a reliable way to make the platform redeliver a webhook, so simulate the redelivery instead. Run this in your CLI against one of those orders:

```
wp eval '
$order_id = 123;
$charge_id = "ch_";
$dispute_id = "du_";
$order = wc_get_order( $order_id );
printf( "refunds before: %d\n", count( $order->get_refunds() ) );
WC_Payments::get_order_service()->mark_payment_dispute_closed( $order, $charge_id, "lost", [], $dispute_id );
printf( "refunds after:  %d\n", count( wc_get_order( $order_id )->get_refunds() ) );
'
```

- The count shouldn't change
- No second refund note on the order

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
