### PR TITLE
fix: Sofort deprecation migration version

### DIFF
--- a/changelog/fix-sofort-deprecation-migration-version
+++ b/changelog/fix-sofort-deprecation-migration-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Re-run the sofort cleanup on stores where the payment method registry re-enabled it.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -765,15 +765,13 @@ class WC_Payments {
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Gateway_Settings_Sync( self::get_gateway(), self::get_payment_gateway_map() ), 'maybe_sync' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Delete_Active_WooPay_Webhook', 'maybe_delete' ] );
 		/**
-		 * Bumped migration version from for giropay from 7.9.0 to 11.0.0 because commit a4739037b re-added giropay to
-		 *              PaymentMethodDefinitionRegistry, which re-enabled them on accounts that
-		 *              still had fee data for them. Re-running the migration ensures those
-		 *              accounts are cleaned up after the registry fix in 11.0.0.
+		 * The version is the release that should run the cleanup, not the one that deprecated the method. A
+		 * cleanup only fires on stores upgrading from below it, so bump it whenever stores need it again.
 		 *
 		 * @see WOOPMNT-6277.
 		 */
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Payment_Method_Deprecation_Settings_Update( self::get_gateway(), self::get_payment_gateway_map(), 'giropay', '11.0.0' ), 'maybe_migrate' ] );
-		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Payment_Method_Deprecation_Settings_Update( self::get_gateway(), self::get_payment_gateway_map(), 'sofort', '8.9.0' ), 'maybe_migrate' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Payment_Method_Deprecation_Settings_Update( self::get_gateway(), self::get_payment_gateway_map(), 'sofort', '11.1.0' ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Erase_Bnpl_Announcement_Meta(), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Erase_Deprecated_Flags_And_Options(), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Manual_Capture_Payment_Method_Settings_Update( self::get_gateway(), self::get_payment_gateway_map() ), 'maybe_migrate' ] );


### PR DESCRIPTION
Raised in QAO-509.

#### Changes proposed in this Pull Request

The sofort cleanup is pinned to `8.9.0`, so it never runs — migrations only fire on stores upgrading from below their version. #11936 bumped giropay to `11.0.0` for this and left sofort behind.

Pointing it at `11.1.0`. `11.0.0` won't do, it already shipped.

Fixing.

#### Testing instructions

- Check out this branch
- Re-enable sofort, then rewind the stored version — in that order, the rewind is what arms the migration:
```
wp option patch update woocommerce_woocommerce_payments_settings upe_enabled_payment_method_ids '["card","sofort"]' --format=json
wp option update woocommerce_woocommerce_payments_version 10.9.0
```
- Read the settings back. Any request runs the migration, so this one does it and shows the result:
```
wp option pluck woocommerce_woocommerce_payments_settings upe_enabled_payment_method_ids --format=json
```
- Sofort is gone, and the version option is back to `11.0.0`
- The same steps on `develop` leave sofort in place

Don't look for sofort on the settings screen — #11936 took it out of the registry, so it doesn't render there either way.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
