### PR TITLE
fix: send a WooPayments user agent on ExPlat assignment requests

### DIFF
--- a/changelog/fix-explat-request-user-agent
+++ b/changelog/fix-explat-request-user-agent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Send a WooPayments user agent on ExPlat assignment requests so experiment assignments are not filtered out as bot traffic.

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -221,7 +221,13 @@ class Experimental_Abtest {
 		);
 
 		// The request blocks admin page render, so it must not wait the default 5 seconds.
-		$get = wp_remote_get( $url, [ 'timeout' => 3 ] );
+		$get = wp_remote_get(
+			$url,
+			[
+				'timeout'    => 3,
+				'user-agent' => 'WooPayments/' . WCPAY_VERSION_NUMBER,
+			]
+		);
 
 		return $get;
 	}

--- a/tests/unit/test-class-experimental-abtest.php
+++ b/tests/unit/test-class-experimental-abtest.php
@@ -199,6 +199,33 @@ class Experimental_Abtest_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
+	public function test_the_explat_request_does_not_use_the_default_wordpress_user_agent() {
+		$captured = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) use ( &$captured ) {
+				if ( false === strpos( $url, 'experiments/0.1.0/assignments' ) ) {
+					return $pre;
+				}
+
+				$captured = $args;
+
+				return [ 'body' => '{"variations":{},"assignments":{},"ttl":7200}' ];
+			},
+			10,
+			3
+		);
+
+		( new \WCPay\Experimental_Abtest( 'jetpack:anonJ', 'woocommerce', true ) )->get_variation( 'some_test' );
+
+		$this->assertSame(
+			'WooPayments/' . WCPAY_VERSION_NUMBER,
+			$captured['user-agent'] ?? null,
+			'The default WordPress user agent is bot-filtered by the ExPlat assigner, so no assignment would ever be created.'
+		);
+	}
+
 	/**
 	 * Short-circuit the ExPlat request with a canned response and count the calls.
 	 *


### PR DESCRIPTION
Fixes WOOPMNT-6080

#### Changes proposed in this Pull Request

This contains a fix for ExPlat assignment by passing the user agent via the request.

- Send `WooPayments/{version}` as the user agent on the ExPlat assignment request.
- Add a unit test asserting the request does not use the default WordPress user agent.

#### Testing instructions

1. Run `pnpm test:php -- --filter Experimental_Abtest_Test`. All tests should pass.
2. On a dev store running this branch, with usage tracking enabled (`wp option update woocommerce_allow_tracking yes`), log the outgoing request's user agent and trigger a lookup:
   ```php
   add_filter( 'http_request_args', function ( $args, $url ) {
       if ( false !== strpos( $url, 'experiments/0.1.0/assignments' ) ) {
           error_log( 'ExPlat UA: ' . ( $args['user-agent'] ?? 'default' ) );
       }
       return $args;
   }, 10, 2 );
   ( new WCPay\Experimental_Abtest( 'woo:ua-test', 'woocommerce', true ) )->get_variation( 'nonexistent_test_name' );
   ```
   The debug log should show `ExPlat UA: WooPayments/<version>`, not `WordPress/...`.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
