### PR TITLE
Record the shopper's real IP on WooPay orders

### DIFF
--- a/changelog/WOOPAY-415-record-shopper-ip-on-woopay-orders
+++ b/changelog/WOOPAY-415-record-shopper-ip-on-woopay-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Record the shopper's own IP address on orders placed through WooPay, instead of the address of the server that proxied the checkout

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -61,6 +61,7 @@ class WooPay_Session {
 		add_action( 'woopay_restore_order_customer_id', [ __CLASS__, 'restore_order_customer_id_from_requests_with_verified_email' ] );
 		add_filter( 'woocommerce_order_needs_payment', [ __CLASS__, 'woopay_trial_subscriptions_handler' ], 20, 3 );
 		add_action( 'woocommerce_store_api_checkout_order_processed', [ __CLASS__, 'catch_woopay_checkout_errors' ], 1, 1 );
+		add_action( 'woocommerce_store_api_checkout_update_order_from_request', [ __CLASS__, 'set_woopay_order_customer_ip' ], 10, 1 );
 
 		register_deactivation_hook( WCPAY_PLUGIN_FILE, [ __CLASS__, 'run_and_remove_woopay_restore_order_customer_id_schedules' ] );
 
@@ -162,6 +163,95 @@ class WooPay_Session {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Records the shopper's own IP on an order placed through WooPay.
+	 *
+	 * WooPay places the order by calling this store's Store API from WordPress.com, so
+	 * `WC_Geolocation::get_ip_address()` sees a WordPress.com address and that is what
+	 * `OrderController::update_order_from_cart()` wrote onto the order. Merchants read that
+	 * field for fraud rules, IP filtering and audit, and a datacenter address tells them
+	 * nothing about the shopper. WooPay sends the address it saw the shopper's browser
+	 * arrive from, and this replaces the placeholder with it. See WOOPAY-415.
+	 *
+	 * Runs on `woocommerce_store_api_checkout_update_order_from_request`, which fires after
+	 * the draft order has taken its IP from the request and before the order is validated
+	 * and paid — so this is also the address that reaches Stripe on the mandate.
+	 *
+	 * Only a request that authenticated as WooPay is believed. That is asked through
+	 * `wcpay_is_woopay_store_api_request`, which `determine_current_user_for_woopay()` sets
+	 * once the request has passed whatever this release accepts as authentication, rather
+	 * than by naming a credential here. Naming one would tie this to a rollout it has
+	 * nothing to do with: WooPay is moving proxied Store API traffic off the blog token
+	 * signature and onto the Cart-Token, so a signature check here would quietly stop
+	 * matching and leave the order back on a WordPress.com address.
+	 *
+	 * How much that vouches for the address is therefore whatever the credential in force
+	 * vouches for. A blog token signature can only be produced by WooPay on WordPress.com,
+	 * so the address is WooPay's word. A Cart-Token identifies the cart rather than WooPay,
+	 * so under that model a shopper holding their own could name an address on their own
+	 * order — no worse than the store's own position behind a proxy that forwards
+	 * `X-Forwarded-For`, and better than the address being wrong for everyone.
+	 *
+	 * @param \WC_Order $order Order being updated from the checkout request.
+	 */
+	public static function set_woopay_order_customer_ip( $order ) {
+		if ( ! $order instanceof \WC_Order ) {
+			return;
+		}
+
+		if ( ! self::is_request_from_woopay() || ! \WC_Payments_Utils::is_store_api_request() ) {
+			return;
+		}
+
+		if ( ! self::is_woopay_enabled() ) {
+			return;
+		}
+
+		/**
+		 * Filters whether the current request is a WooPay Store API request.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @param bool $is_woopay_store_api_request Whether this is a WooPay Store API request.
+		 */
+		if ( ! apply_filters( 'wcpay_is_woopay_store_api_request', false ) ) {
+			return;
+		}
+
+		$customer_ip_address = self::get_woopay_customer_ip_address();
+
+		if ( null === $customer_ip_address ) {
+			return;
+		}
+
+		$order->set_customer_ip_address( $customer_ip_address );
+	}
+
+	/**
+	 * The shopper IP address WooPay sent with this request.
+	 *
+	 * WooPay proxies checkout to this store from WordPress.com, so the connection describes
+	 * WooPay rather than the shopper, and the `X-WooPay-Customer-IP` header is what carries
+	 * the address the shopper's browser actually arrived from.
+	 *
+	 * Absent on WooPay versions that do not send it yet, and on every request that is not
+	 * the checkout POST — WooPay only sends it where an order is created from it. Null in
+	 * both cases, which leaves the order with whatever the request itself resolved to.
+	 *
+	 * @return string|null The shopper's IP address, or null when none was sent or it does not parse.
+	 */
+	private static function get_woopay_customer_ip_address(): ?string {
+		if ( ! isset( $_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] ) ) {
+			return null;
+		}
+
+		$customer_ip_address = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] ) );
+
+		$validated = rest_is_ip_address( $customer_ip_address );
+
+		return false === $validated ? null : $validated;
 	}
 
 	/**

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -168,31 +168,18 @@ class WooPay_Session {
 	/**
 	 * Records the shopper's own IP on an order placed through WooPay.
 	 *
-	 * WooPay places the order by calling this store's Store API from WordPress.com, so
-	 * `WC_Geolocation::get_ip_address()` sees a WordPress.com address and that is what
-	 * `OrderController::update_order_from_cart()` wrote onto the order. Merchants read that
-	 * field for fraud rules, IP filtering and audit, and a datacenter address tells them
-	 * nothing about the shopper. WooPay sends the address it saw the shopper's browser
-	 * arrive from, and this replaces the placeholder with it. See WOOPAY-415.
+	 * WooPay places the order by calling this store's Store API from WordPress.com, so the
+	 * order ends up with a WordPress.com address instead of the shopper's. WooPay sends the
+	 * address it saw the shopper's browser arrive from, and this replaces that placeholder
+	 * with it. See WOOPAY-415.
 	 *
-	 * Runs on `woocommerce_store_api_checkout_update_order_from_request`, which fires after
-	 * the draft order has taken its IP from the request and before the order is validated
-	 * and paid — so this is also the address that reaches Stripe on the mandate.
+	 * Runs on `woocommerce_store_api_checkout_update_order_from_request`, after the draft
+	 * order has taken its IP from the request and before the order is paid — so this is also
+	 * the address that reaches Stripe on the mandate.
 	 *
-	 * Only a request that authenticated as WooPay is believed. That is asked through
-	 * `wcpay_is_woopay_store_api_request`, which `determine_current_user_for_woopay()` sets
-	 * once the request has passed whatever this release accepts as authentication, rather
-	 * than by naming a credential here. Naming one would tie this to a rollout it has
-	 * nothing to do with: WooPay is moving proxied Store API traffic off the blog token
-	 * signature and onto the Cart-Token, so a signature check here would quietly stop
-	 * matching and leave the order back on a WordPress.com address.
-	 *
-	 * How much that vouches for the address is therefore whatever the credential in force
-	 * vouches for. A blog token signature can only be produced by WooPay on WordPress.com,
-	 * so the address is WooPay's word. A Cart-Token identifies the cart rather than WooPay,
-	 * so under that model a shopper holding their own could name an address on their own
-	 * order — no worse than the store's own position behind a proxy that forwards
-	 * `X-Forwarded-For`, and better than the address being wrong for everyone.
+	 * Trust is delegated to `wcpay_is_woopay_store_api_request` rather than to a named
+	 * credential, so the check keeps matching as WooPay moves proxied Store API traffic off
+	 * the blog token signature and onto the Cart-Token.
 	 *
 	 * @param \WC_Order $order Order being updated from the checkout request.
 	 */

--- a/includes/woopay/class-woopay-session.php
+++ b/includes/woopay/class-woopay-session.php
@@ -61,7 +61,7 @@ class WooPay_Session {
 		add_action( 'woopay_restore_order_customer_id', [ __CLASS__, 'restore_order_customer_id_from_requests_with_verified_email' ] );
 		add_filter( 'woocommerce_order_needs_payment', [ __CLASS__, 'woopay_trial_subscriptions_handler' ], 20, 3 );
 		add_action( 'woocommerce_store_api_checkout_order_processed', [ __CLASS__, 'catch_woopay_checkout_errors' ], 1, 1 );
-		add_action( 'woocommerce_store_api_checkout_update_order_from_request', [ __CLASS__, 'set_woopay_order_customer_ip' ], 10, 1 );
+		add_action( 'woocommerce_store_api_checkout_update_order_from_request', [ __CLASS__, 'set_woopay_order_customer_ip' ], 10, 2 );
 
 		register_deactivation_hook( WCPAY_PLUGIN_FILE, [ __CLASS__, 'run_and_remove_woopay_restore_order_customer_id_schedules' ] );
 
@@ -181,10 +181,11 @@ class WooPay_Session {
 	 * credential, so the check keeps matching as WooPay moves proxied Store API traffic off
 	 * the blog token signature and onto the Cart-Token.
 	 *
-	 * @param \WC_Order $order Order being updated from the checkout request.
+	 * @param \WC_Order        $order   Order being updated from the checkout request.
+	 * @param \WP_REST_Request $request The checkout request the order is being updated from.
 	 */
-	public static function set_woopay_order_customer_ip( $order ) {
-		if ( ! $order instanceof \WC_Order ) {
+	public static function set_woopay_order_customer_ip( $order, $request = null ) {
+		if ( ! $order instanceof \WC_Order || ! $request instanceof \WP_REST_Request ) {
 			return;
 		}
 
@@ -207,9 +208,18 @@ class WooPay_Session {
 			return;
 		}
 
-		$customer_ip_address = self::get_woopay_customer_ip_address();
+		$customer_ip_address = self::get_woopay_customer_ip_address( $request );
 
 		if ( null === $customer_ip_address ) {
+			// A request that got this far authenticated as WooPay and still named no usable
+			// address. Worth saying so, because that is the shape a broken gate would take:
+			// the order silently keeps the WordPress.com address and nothing else fails.
+			// Only on the checkout POST — the hook also fires on the PATCH, which WooPay
+			// never sends the header on, and logging that would be noise on a normal flow.
+			if ( 'POST' === $request->get_method() ) {
+				Logger::log( 'WooPay checkout carried no usable shopper IP address; the order keeps the address the request arrived from.' );
+			}
+
 			return;
 		}
 
@@ -227,14 +237,19 @@ class WooPay_Session {
 	 * the checkout POST — WooPay only sends it where an order is created from it. Null in
 	 * both cases, which leaves the order with whatever the request itself resolved to.
 	 *
+	 * @param \WP_REST_Request $request The checkout request the order is being updated from.
+	 *
 	 * @return string|null The shopper's IP address, or null when none was sent or it does not parse.
 	 */
-	private static function get_woopay_customer_ip_address(): ?string {
-		if ( ! isset( $_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] ) ) {
+	private static function get_woopay_customer_ip_address( \WP_REST_Request $request ): ?string {
+		// Already unslashed by WP_REST_Server before the request reaches any route.
+		$customer_ip_address = $request->get_header( 'X-WooPay-Customer-IP' );
+
+		if ( null === $customer_ip_address ) {
 			return null;
 		}
 
-		$customer_ip_address = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] ) );
+		$customer_ip_address = sanitize_text_field( $customer_ip_address );
 
 		$validated = rest_is_ip_address( $customer_ip_address );
 

--- a/tests/unit/woopay/test-class-woopay-session.php
+++ b/tests/unit/woopay/test-class-woopay-session.php
@@ -93,8 +93,6 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 		remove_filter( 'wcpay_woopay_is_signed_with_blog_token', '__return_true' );
 		remove_filter( 'wcpay_is_woopay_store_api_request', '__return_true' );
 
-		unset( $_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] );
-
 		parent::tear_down();
 	}
 
@@ -122,18 +120,46 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 		$this->assertTrue( apply_filters( 'wcpay_is_woopay_store_api_request', false ) );
 	}
 
+	/**
+	 * The checkout request WooPay places the order with, carrying the address it saw the
+	 * shopper arrive from. Pass null to build the request WooPay releases that predate the
+	 * header send.
+	 *
+	 * @param string|null $customer_ip_address Address to put on the header, or null to omit it.
+	 * @param string      $method              HTTP method of the checkout request.
+	 */
+	private function checkout_request( $customer_ip_address = null, $method = 'POST' ): WP_REST_Request {
+		$request = new WP_REST_Request( $method, '/wc/store/v1/checkout' );
+
+		if ( null !== $customer_ip_address ) {
+			$request->set_header( 'X-WooPay-Customer-IP', $customer_ip_address );
+		}
+
+		return $request;
+	}
+
 	public function test_woopay_order_records_the_shopper_ip_address() {
 		$order = WC_Helper_Order::create_order();
 
 		$this->authenticate_woopay_request();
 
-		$_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] = '203.0.113.10';
-
-		WooPay_Session::set_woopay_order_customer_ip( $order );
+		WooPay_Session::set_woopay_order_customer_ip( $order, $this->checkout_request( '203.0.113.10' ) );
 
 		// Without this the order keeps the address the request arrived from, which for a
 		// WooPay checkout is a WordPress.com server rather than the shopper. See WOOPAY-415.
 		$this->assertSame( '203.0.113.10', $order->get_customer_ip_address() );
+	}
+
+	public function test_woopay_order_records_an_ipv6_shopper_address() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->authenticate_woopay_request();
+
+		// A shopper on an IPv6 connection is an ordinary case, not an edge one, and the
+		// address survives the trip only because rest_is_ip_address() validates both families.
+		WooPay_Session::set_woopay_order_customer_ip( $order, $this->checkout_request( '2001:db8::1' ) );
+
+		$this->assertSame( '2001:db8::1', $order->get_customer_ip_address() );
 	}
 
 	public function test_woopay_order_keeps_its_own_ip_address_when_none_is_sent() {
@@ -144,7 +170,7 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 
 		// Every WooPay release before this change sends no address, and neither does any
 		// request other than the checkout POST.
-		WooPay_Session::set_woopay_order_customer_ip( $order );
+		WooPay_Session::set_woopay_order_customer_ip( $order, $this->checkout_request() );
 
 		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
 	}
@@ -155,9 +181,7 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 
 		$this->authenticate_woopay_request();
 
-		$_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] = 'not-an-ip-address';
-
-		WooPay_Session::set_woopay_order_customer_ip( $order );
+		WooPay_Session::set_woopay_order_customer_ip( $order, $this->checkout_request( 'not-an-ip-address' ) );
 
 		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
 	}
@@ -168,9 +192,7 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 
 		// determine_current_user_for_woopay() never accepted this request's credentials, so
 		// the address on it is nobody's word in particular.
-		$_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] = '203.0.113.10';
-
-		WooPay_Session::set_woopay_order_customer_ip( $order );
+		WooPay_Session::set_woopay_order_customer_ip( $order, $this->checkout_request( '203.0.113.10' ) );
 
 		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
 	}
@@ -184,11 +206,40 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 		$restore_user_agent = $_SERVER['HTTP_USER_AGENT'];
 		unset( $_SERVER['HTTP_USER_AGENT'] );
 
-		$_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] = '203.0.113.10';
-
-		WooPay_Session::set_woopay_order_customer_ip( $order );
+		WooPay_Session::set_woopay_order_customer_ip( $order, $this->checkout_request( '203.0.113.10' ) );
 
 		$_SERVER['HTTP_USER_AGENT'] = $restore_user_agent;
+
+		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
+	}
+
+	public function test_order_ignores_the_shopper_ip_header_outside_a_store_api_request() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_ip_address( '198.51.100.20' );
+
+		$this->authenticate_woopay_request();
+
+		$restore_request_uri    = $_SERVER['REQUEST_URI'];
+		$_SERVER['REQUEST_URI'] = '/wp-admin/admin-ajax.php';
+
+		WooPay_Session::set_woopay_order_customer_ip( $order, $this->checkout_request( '203.0.113.10' ) );
+
+		$_SERVER['REQUEST_URI'] = $restore_request_uri;
+
+		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
+	}
+
+	public function test_order_ignores_the_shopper_ip_header_when_woopay_is_disabled() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_ip_address( '198.51.100.20' );
+
+		$this->authenticate_woopay_request();
+
+		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'no' );
+
+		WooPay_Session::set_woopay_order_customer_ip( $order, $this->checkout_request( '203.0.113.10' ) );
+
+		WC_Payments::get_gateway()->update_option( 'platform_checkout', 'yes' );
 
 		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
 	}

--- a/tests/unit/woopay/test-class-woopay-session.php
+++ b/tests/unit/woopay/test-class-woopay-session.php
@@ -91,8 +91,106 @@ class WooPay_Session_Test extends WCPAY_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		remove_filter( 'wcpay_woopay_is_signed_with_blog_token', '__return_true' );
+		remove_filter( 'wcpay_is_woopay_store_api_request', '__return_true' );
+
+		unset( $_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Puts the request in the state determine_current_user_for_woopay() leaves it in once it
+	 * has accepted the request's credentials, whichever credentials this release accepts.
+	 */
+	private function authenticate_woopay_request() {
+		add_filter( 'wcpay_is_woopay_store_api_request', '__return_true' );
+	}
+
+	public function test_an_accepted_woopay_request_marks_itself_as_one() {
+		// The IP gate reads this filter rather than naming a credential, so it is only as
+		// good as the auth path still setting it. Pin that here: if the two ever come apart,
+		// the order silently keeps the WordPress.com address instead.
+		WooPay_Session::determine_current_user_for_woopay( 0 );
+
+		/**
+		 * Filters whether the current request is a WooPay Store API request.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @param bool $is_woopay_store_api_request Whether this is a WooPay Store API request.
+		 */
+		$this->assertTrue( apply_filters( 'wcpay_is_woopay_store_api_request', false ) );
+	}
+
+	public function test_woopay_order_records_the_shopper_ip_address() {
+		$order = WC_Helper_Order::create_order();
+
+		$this->authenticate_woopay_request();
+
+		$_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] = '203.0.113.10';
+
+		WooPay_Session::set_woopay_order_customer_ip( $order );
+
+		// Without this the order keeps the address the request arrived from, which for a
+		// WooPay checkout is a WordPress.com server rather than the shopper. See WOOPAY-415.
+		$this->assertSame( '203.0.113.10', $order->get_customer_ip_address() );
+	}
+
+	public function test_woopay_order_keeps_its_own_ip_address_when_none_is_sent() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_ip_address( '198.51.100.20' );
+
+		$this->authenticate_woopay_request();
+
+		// Every WooPay release before this change sends no address, and neither does any
+		// request other than the checkout POST.
+		WooPay_Session::set_woopay_order_customer_ip( $order );
+
+		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
+	}
+
+	public function test_woopay_order_ignores_an_address_that_does_not_parse() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_ip_address( '198.51.100.20' );
+
+		$this->authenticate_woopay_request();
+
+		$_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] = 'not-an-ip-address';
+
+		WooPay_Session::set_woopay_order_customer_ip( $order );
+
+		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
+	}
+
+	public function test_order_ignores_the_shopper_ip_header_on_an_unauthenticated_request() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_ip_address( '198.51.100.20' );
+
+		// determine_current_user_for_woopay() never accepted this request's credentials, so
+		// the address on it is nobody's word in particular.
+		$_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] = '203.0.113.10';
+
+		WooPay_Session::set_woopay_order_customer_ip( $order );
+
+		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
+	}
+
+	public function test_order_ignores_the_shopper_ip_header_when_the_request_is_not_from_woopay() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_customer_ip_address( '198.51.100.20' );
+
+		$this->authenticate_woopay_request();
+
+		$restore_user_agent = $_SERVER['HTTP_USER_AGENT'];
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+
+		$_SERVER['HTTP_X_WOOPAY_CUSTOMER_IP'] = '203.0.113.10';
+
+		WooPay_Session::set_woopay_order_customer_ip( $order );
+
+		$_SERVER['HTTP_USER_AGENT'] = $restore_user_agent;
+
+		$this->assertSame( '198.51.100.20', $order->get_customer_ip_address() );
 	}
 
 	public function test_get_user_id_from_cart_token_with_guest_user() {


### PR DESCRIPTION
Fixes #11428

#### Changes proposed in this Pull Request

Orders placed through WooPay record a WooPay server address as the customer IP — the same few addresses on every WooPay order, whoever the shopper is. It is not a corrupted value, just the wrong one: WooPay places the order by calling the store's Store API from WordPress.com, so `WC_Geolocation::get_ip_address()` describes that connection and `OrderController::update_order_from_cart()` writes it onto the order.

Merchants read the customer IP for fraud rules, IP filtering and audit, and a datacenter address is worse than a missing one, because it looks like a real shopper.

WooPay now sends the address it saw the shopper's browser arrive from, in an `X-WooPay-Customer-IP` header on the checkout POST. This PR reads it and puts it on the order.

**Where it is applied.** On `woocommerce_store_api_checkout_update_order_from_request`, which fires after the draft order has taken its IP from the request and before the order is validated and paid. That ordering matters twice over: the placeholder is already there to be replaced, and the corrected address is the one that goes to Stripe on the mandate, since `get_mandate_ip_address()` prefers the order's own value.

**Why not `$_SERVER['HTTP_X_REAL_IP']`.** Planting the address there would fix this and the fraud fingerprint in one line, since `WC_Geolocation` prefers that header. But `WC_Geolocation` answers for the entire request, and Multi-Currency's automatic currency switcher is one of its callers — changing which country the order-placing request appears to come from could change the currency a checkout resolves to. Not something a customer-IP fix should do as a side effect. Writing the order field directly keeps the change to the field that is wrong.

**Trust.** Only a request that authenticated as WooPay is believed, alongside the existing checks that it is a WooPay Store API request and that WooPay is enabled. That is asked through `wcpay_is_woopay_store_api_request` — the flag `determine_current_user_for_woopay()` sets once the request has passed whatever this release accepts — rather than by naming a credential here. Naming one would tie this to a rollout it has nothing to do with: #12021 moves proxied Store API traffic off the blog token signature and onto the Cart-Token, and a signature check here would quietly stop matching, putting the order back on a WooPay address with nothing failing to say so.

What the address is worth therefore follows whatever credential is in force. A blog token signature can only be produced by WooPay on WordPress.com, so the address is WooPay's word. A Cart-Token identifies the cart rather than WooPay, so under that model a shopper holding their own could name an address on their own order — no worse than the store's own position behind a proxy that forwards `X-Forwarded-For`, and better than the address being wrong for every order. The value still has to satisfy `rest_is_ip_address()`.

**Saying so when it stops working.** The paragraph above describes a failure that is silent by construction, so there is one log line for it: a request that authenticated as WooPay and still carried no usable address. The other four gates stay quiet — a checkout that is not WooPay's trips them on every order, and logging that would bury the line that matters. It is written on the checkout POST only, since the hook also fires on the checkout PATCH, which WooPay never sends the header on.

Note this also fires for a WooPay build that predates the header, once per WooPay checkout, which is the same signal read a different way — worth knowing if this ships ahead of the platform side.

**Changelog:** added — merchants see a different, correct value in a field they use.

#### Testing instructions

Needs a WooPay platform sending the header, so test against a WooPay build carrying the counterpart branch. Without it, the header is never sent and there is nothing to observe.

1. On a store running this branch with WooPay enabled, check out through WooPay and complete the payment.
2. Open **WooCommerce → Orders → the new order**.
3. The **Customer IP** line in the order data panel, beside "Payment via", shows the shopper's own address instead of a `192.0.*` one.

Confirm nothing else moved:

- Check out on the same store **without** WooPay. The customer IP is unchanged from before this PR.
- Complete a WooPay checkout against a WooPay build that does **not** send the header. Checkout succeeds and the order keeps the address it would have had before.
- Order currency and totals are unaffected in all of the above.

The log line, under **WooCommerce → Status → Logs**, `woocommerce-payments-*`:

- Against a build that sends the header, no `WooPay checkout carried no usable shopper IP address` entry is written.
- Against one that does not, that entry appears once per completed WooPay checkout.
- A non-WooPay checkout writes nothing either way.

Command-line check:

```
wp eval 'echo wc_get_order( ORDER_ID )->get_customer_ip_address();'
```

---

* [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
* [x] Covered with tests (or have a good reason not to test in description ☝️)
* [x] Tested on mobile (or does not apply) — no UI changes

**Post merge**

- [ ] Link to testing instructions from release testing doc: _Add link here_
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

