### PR TITLE
fix(e2e): locate the subscription change-payment action by its URL contract

### DIFF
--- a/changelog/woopmnt-fix-subscriptions-shopper-change-payment-locator
+++ b/changelog/woopmnt-fix-subscriptions-shopper-change-payment-locator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Make the subscriptions manage-payments E2E test locate the "Change payment" action by its URL contract instead of its ARIA role.

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-manage-payments.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-manage-payments.spec.ts
@@ -15,6 +15,11 @@ import * as navigation from '../../../utils/shopper-navigation';
 const changePaymentMethodButtonSelector =
 	'button[name="woocommerce_change_payment"], #place_order';
 
+// Target the subscription action by the query arg the change-payment endpoint reads.
+// Subscriptions renders these actions as anchors styled as buttons, so matching on an
+// ARIA role couples the test to markup that has already changed once upstream.
+const changePaymentMethodActionSelector = 'a[href*="change_payment_method="]';
+
 const navigateToSubscriptionDetails = async (
 	page: Page,
 	subscriptionId: string
@@ -24,7 +29,7 @@ const navigateToSubscriptionDetails = async (
 		.getByLabel( `View subscription number ${ subscriptionId }` )
 		.click();
 
-	await page.getByRole( 'button', { name: 'Change payment' } ).click();
+	await page.locator( changePaymentMethodActionSelector ).first().click();
 
 	await expect(
 		page.getByRole( 'heading', {

--- a/tests/qit/test-package/tests/woopayments/subscriptions/shopper-subscriptions-manage-payments.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/subscriptions/shopper-subscriptions-manage-payments.spec.ts
@@ -18,6 +18,11 @@ import {
 } from '../../../utils/shopper';
 import { goToSubscriptions } from '../../../utils/shopper-navigation';
 
+// Target the subscription action by the query arg the change-payment endpoint reads.
+// Subscriptions renders these actions as anchors styled as buttons, so matching on an
+// ARIA role couples the test to markup that has already changed once upstream.
+const changePaymentMethodActionSelector = 'a[href*="change_payment_method="]';
+
 const navigateToSubscriptionDetails = async (
 	page: Page,
 	subscriptionId: string
@@ -27,7 +32,7 @@ const navigateToSubscriptionDetails = async (
 		.getByLabel( `View subscription number ${ subscriptionId }` )
 		.click();
 
-	await page.getByRole( 'button', { name: 'Change payment' } ).click();
+	await page.locator( changePaymentMethodActionSelector ).first().click();
 
 	await expect(
 		page.getByRole( 'heading', {


### PR DESCRIPTION
Fixes [WOOPMNT-6361](https://linear.app/a8c/issue/WOOPMNT-6361/fix-subscriptions-manage-payments-e2e-tests-broken-by-change-payment)

#### Changes proposed in this Pull Request

Two `@critical` subscriptions shopper tests have been red on `develop` since **Aug 7**, on all four matrix slots, timing out in their shared `beforeEach`:

```
Test timeout of 120000ms exceeded while running "beforeEach" hook.
  - waiting for getByRole('button', { name: 'Change payment' })
```

**The copy didn't change — the role did.** The failure snapshot shows the control present and correctly labelled, as a **link**:

```yaml
- cell "Cancel Change payment Renew now":
    - link "Cancel"
    - link "Change payment"        # role is link, text unchanged
      - /url: …/checkout/order-pay/109/?pay_for_order=true&key=…&change_payment_method=109&_wpnonce=…
    - link "Renew now"
```

Subscriptions renders subscription actions as anchors styled as buttons (`subscription-details.php`: `<a href=… class="button {$key}">`), so `getByRole( 'button', … )` matches nothing.

This PR locates the action by the query arg the change-payment endpoint actually reads:

```diff
-await page.getByRole( 'button', { name: 'Change payment' } ).click();
+await page.locator( 'a[href*="change_payment_method="]' ).first().click();
```

`change_payment_method=<id>` is built by `WC_Subscriptions_Change_Payment_Gateway::change_payment_method_button()` and is independent of the element's tag, ARIA role, CSS classes and label text. No collision on the page: "Cancel" uses `change_subscription_to=cancelled`, "Renew now" uses `subscription_renewal`.

**Alternatives considered.** `getByRole( 'link', … )` would recouple to *both* things that just broke. `a.change_payment_method` is plausible — the class derives from the same action key — but is not directly evidenced: the snapshot exposes the URL, not the class list, and the trace zip in the artifact is truncated. Preferring the hook actually observed. This also mirrors the hardening already applied to the change-payment form's **submit** button a few lines above (`'button[name="woocommerce_change_payment"], #place_order'`) — same lesson, previously half-applied.

**Both copies are updated.** The QIT twin carried the identical locator and passes today only because QIT runs an older Subscriptions version — the same version lag that hid the Action Scheduler break in #12028. Fixed proactively rather than waiting for it to bite.

<!-- How can this code break? -->
**How this could break:** if Subscriptions ever stops putting `change_payment_method` in the action URL. That's the functional contract the endpoint reads, so it's considerably more stable than the role or the label.

#### Testing instructions

This is a test-only change; CI is the real check.

1. Confirm `subscriptions - shopper` passes on all four slots (it is currently red on `develop`).
2. Confirm `subscriptions | WC …` QIT jobs stay green.

Manual sanity check, if you want it:

1. Buy a subscription as a shopper, go to **My account → Subscriptions → View** a subscription.
2. Inspect the **Change payment** control in the Actions row — it should be an `<a>` whose `href` contains `change_payment_method=<subscription id>`.
3. Clicking it lands on the **Change payment method** page.

**Backward compatibility:** none — no plugin code changes, only E2E/QIT specs.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
