### PR TITLE
dev: name the develop sync PR for what it actually carries

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -154,9 +154,9 @@ jobs:
           RELEASE_VERSION: ${{ steps.create_branch.outputs.trimmed-version }}
           RELEASE_PR_ID: ${{ steps.create-pr-to-trunk.outputs.RELEASE_PR_ID }}
         run: |
-          PR_BODY=$(echo -e "> [!NOTE]\n> As the release lead, please approve and merge this PR after the code freeze process is done successfully.\n\nApplies the changelog entries from \`release/$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge.\n\nRelated release PR: #${RELEASE_PR_ID}")
+          PR_BODY=$(echo -e "> [!NOTE]\n> As the release lead, please approve and merge this PR after the code freeze process is done successfully.\n\nApplies the **version bump and changelog entries** from \`release/$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge. Since \`trunk\` is no longer merged back, this PR is the only thing that brings the $RELEASE_VERSION version bump onto \`develop\`.\n\nRelated release PR: #${RELEASE_PR_ID}")
           DEVELOP_PR_URL=$(gh pr create \
-            --title "Changelog for develop from version $RELEASE_VERSION" \
+            --title "Sync develop after $RELEASE_VERSION: version bump + changelog" \
             --body "$PR_BODY" \
             --base develop \
             --head "$DEVELOP_BRANCH")

--- a/changelog/dev-rename-develop-sync-pr
+++ b/changelog/dev-rename-develop-sync-pr
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Rename the generated develop sync PR to "Sync develop after x.y.z: version bump + changelog" and expand its description, so the title and body both reflect that it carries the version bump as well as the changelog entries.


### PR DESCRIPTION
Fixes #WOOPMNT-6363

#### Changes proposed in this Pull Request

The code freeze opens **two** PRs: the release PR against `trunk`, and a sync PR against `develop`. The sync PR is generated in `release-pr.yml` with the title **"Changelog for develop from version x.y.z"** and a body describing it as applying *"the changelog entries"*.

Both describe half of what it does. The commit it cherry-picks is the one produced by `process-changelog` **and** `bump-version.sh` together — so the PR carries the version bump as well.

This renames it and expands the description:

| | Before | After |
|---|---|---|
| Title | `Changelog for develop from version 11.1.0` | `Sync develop after 11.1.0: version bump + changelog` |
| Body | "Applies the changelog entries from…" | "Applies the **version bump and changelog entries** from… Since `trunk` is no longer merged back, this PR is the only thing that brings the 11.1.0 version bump onto `develop`." |

#### Testing instructions

This only runs at code freeze, so the practical check is a read-through. The real verification is the next code freeze (11.1.0, scheduled Aug 26): the sync PR it opens should carry the new title and body.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — no test harness for workflow YAML in this repo; verified by rendering the shell locally.
- [x] Tested on mobile (or does not apply) — does not apply.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable. — not applicable
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable. — not applicable, internal tooling
