### PR TITLE
fix: decide express checkout setup_future_usage server-side

### DIFF
--- a/changelog/woopmnt-6335-express-checkout-setup_future_usage-detection-only
+++ b/changelog/woopmnt-6335-express-checkout-setup_future_usage-detection-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix express checkout payments failing when a plugin other than WooCommerce Subscriptions saves the payment method

--- a/changelog/woopmnt-6335-express-checkout-setup_future_usage-detection-only
+++ b/changelog/woopmnt-6335-express-checkout-setup_future_usage-detection-only
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: fix
 
-Fix express checkout payments failing when the payment method will be saved for a subscription the page cannot see, including renewals paid from the order-pay page and subscriptions plugins other than WooCommerce Subscriptions
+Fix express checkout payments failing when the payment method will be saved for a subscription the page cannot see, such as one from a subscriptions plugin other than WooCommerce Subscriptions, or a subscription order paid from the order-pay page

--- a/changelog/woopmnt-6335-express-checkout-setup_future_usage-detection-only
+++ b/changelog/woopmnt-6335-express-checkout-setup_future_usage-detection-only
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix express checkout payments failing when a plugin other than WooCommerce Subscriptions saves the payment method
+Fix express checkout payments failing when the payment method will be saved for a subscription the page cannot see, including renewals paid from the order-pay page and subscriptions plugins other than WooCommerce Subscriptions

--- a/client/express-checkout/shortcode-buttons-express/__tests__/tokenized-express-checkout--product-page.test.js
+++ b/client/express-checkout/shortcode-buttons-express/__tests__/tokenized-express-checkout--product-page.test.js
@@ -582,7 +582,7 @@ describe( 'Tokenized Express Checkout Element - Product page logic', () => {
 
 	it( 'should use setupFutureUsage for subscription products', async () => {
 		global.wcpayExpressCheckoutParams.flags.isEceUsingConfirmationTokens = true;
-		global.wcpayExpressCheckoutParams.has_subscription = true;
+		global.wcpayExpressCheckoutParams.setup_future_usage = 'off_session';
 		global.wcpayExpressCheckoutParams.product.product_type = 'subscription';
 
 		await jest.isolateModulesAsync( async () => {
@@ -603,7 +603,7 @@ describe( 'Tokenized Express Checkout Element - Product page logic', () => {
 
 	it( 'should use setupFutureUsage for variable-subscription products', async () => {
 		global.wcpayExpressCheckoutParams.flags.isEceUsingConfirmationTokens = true;
-		global.wcpayExpressCheckoutParams.has_subscription = true;
+		global.wcpayExpressCheckoutParams.setup_future_usage = 'off_session';
 		global.wcpayExpressCheckoutParams.product.product_type =
 			'variable-subscription';
 
@@ -620,10 +620,12 @@ describe( 'Tokenized Express Checkout Element - Product page logic', () => {
 		);
 	} );
 
-	it( 'should use setupFutureUsage when has_subscription is true', async () => {
+	// A non-subscription product whose payment method the server will still save —
+	// the WOOPMNT-6335 case, where the client cannot infer it and has to be told.
+	it( 'should use setupFutureUsage the server declares for a simple product', async () => {
 		global.wcpayExpressCheckoutParams.flags.isEceUsingConfirmationTokens = true;
 		global.wcpayExpressCheckoutParams.product.product_type = 'simple';
-		global.wcpayExpressCheckoutParams.has_subscription = true;
+		global.wcpayExpressCheckoutParams.setup_future_usage = 'off_session';
 
 		await jest.isolateModulesAsync( async () => {
 			await import( '..' );
@@ -634,6 +636,23 @@ describe( 'Tokenized Express Checkout Element - Product page logic', () => {
 			expect.objectContaining( {
 				mode: 'payment',
 				setupFutureUsage: 'off_session',
+			} )
+		);
+	} );
+
+	it( 'should omit setupFutureUsage when the server declares none', async () => {
+		global.wcpayExpressCheckoutParams.flags.isEceUsingConfirmationTokens = true;
+		global.wcpayExpressCheckoutParams.product.product_type = 'simple';
+		global.wcpayExpressCheckoutParams.setup_future_usage = null;
+
+		await jest.isolateModulesAsync( async () => {
+			await import( '..' );
+		} );
+
+		expect( global.Stripe ).toHaveBeenCalled();
+		expect( stripeInstance.elements ).toHaveBeenCalledWith(
+			expect.not.objectContaining( {
+				setupFutureUsage: expect.anything(),
 			} )
 		);
 	} );

--- a/client/express-checkout/shortcode-buttons-express/index.js
+++ b/client/express-checkout/shortcode-buttons-express/index.js
@@ -233,9 +233,8 @@ jQuery( ( $ ) => {
 					?.isEceUsingConfirmationTokens ?? true;
 			const isManualCaptureEnabled =
 				getExpressCheckoutData( 'is_manual_capture' ) ?? false;
-			const {
-				setupFutureUsage = getSetupFutureUsageForContext(),
-			} = creationOptions;
+			const { setupFutureUsage = getSetupFutureUsageForContext() } =
+				creationOptions;
 
 			// Build the payment method types array based on enabled methods.
 			// This array is sent to the server to ensure PaymentIntent uses matching types.

--- a/client/express-checkout/shortcode-buttons-express/index.js
+++ b/client/express-checkout/shortcode-buttons-express/index.js
@@ -27,7 +27,10 @@ import {
 import { resolveExpressCheckoutCurrency } from '../utils/resolve-currency';
 import { getResolvedCurrency } from '../utils/resolved-currency-cache';
 import { rememberElementCurrency } from '../utils/element-currency-cache';
-import { getSetupFutureUsageForCart } from '../utils/subscriptions';
+import {
+	getSetupFutureUsageForCart,
+	getSetupFutureUsageForContext,
+} from '../utils/subscriptions';
 import {
 	onAbortPaymentHandler,
 	onCancelHandler,
@@ -230,10 +233,8 @@ jQuery( ( $ ) => {
 					?.isEceUsingConfirmationTokens ?? true;
 			const isManualCaptureEnabled =
 				getExpressCheckoutData( 'is_manual_capture' ) ?? false;
-			const hasSubscription =
-				getExpressCheckoutData( 'has_subscription' ) ?? false;
 			const {
-				setupFutureUsage = hasSubscription ? 'off_session' : null,
+				setupFutureUsage = getSetupFutureUsageForContext(),
 			} = creationOptions;
 
 			// Build the payment method types array based on enabled methods.
@@ -583,11 +584,7 @@ jQuery( ( $ ) => {
 					total,
 					currency: getResolvedCurrency( initialCurrency ),
 					enabledMethods: enabledMethodsOverride,
-					setupFutureUsage: getExpressCheckoutData(
-						'has_subscription'
-					)
-						? 'off_session'
-						: null,
+					setupFutureUsage: getSetupFutureUsageForContext(),
 				} );
 			} else {
 				expressCheckoutButtonUi.hideContainer();

--- a/client/express-checkout/utils/__tests__/checkPaymentMethodIsAvailable.test.js
+++ b/client/express-checkout/utils/__tests__/checkPaymentMethodIsAvailable.test.js
@@ -219,4 +219,47 @@ describe( 'checkPaymentMethodIsAvailable', () => {
 			expect.objectContaining( { amount: 1 } )
 		);
 	} );
+
+	// This probe builds its own Elements instance to ask which wallets are available. If its
+	// setupFutureUsage diverges from the one the real button mints with, availability is
+	// answered for a different payment than the shopper actually makes.
+	describe( 'setupFutureUsage', () => {
+		afterEach( () => {
+			delete global.wcpayExpressCheckoutParams;
+		} );
+
+		it( 'passes the value the server declared', async () => {
+			global.wcpayExpressCheckoutParams = {
+				setup_future_usage: 'off_session',
+			};
+
+			await checkPaymentMethodIsAvailable(
+				'applePay',
+				createCart( '1000', 'USD' ),
+				mockApi
+			);
+
+			expect( mockStripe.elements ).toHaveBeenCalledWith(
+				expect.objectContaining( { setupFutureUsage: 'off_session' } )
+			);
+		} );
+
+		it( 'omits it when the server declared none', async () => {
+			global.wcpayExpressCheckoutParams = {
+				setup_future_usage: null,
+			};
+
+			await checkPaymentMethodIsAvailable(
+				'applePay',
+				createCart( '1000', 'USD' ),
+				mockApi
+			);
+
+			expect( mockStripe.elements ).toHaveBeenCalledWith(
+				expect.not.objectContaining( {
+					setupFutureUsage: expect.anything(),
+				} )
+			);
+		} );
+	} );
 } );

--- a/client/express-checkout/utils/__tests__/checkPaymentMethodIsAvailable.test.js
+++ b/client/express-checkout/utils/__tests__/checkPaymentMethodIsAvailable.test.js
@@ -34,12 +34,14 @@ describe( 'checkPaymentMethodIsAvailable', () => {
 	let mockStripe;
 	let eventHandlers;
 
-	const createCart = ( totalPrice, currencyCode ) => ( {
+	const createCart = ( totalPrice, currencyCode, extensions = {} ) => ( {
 		cartTotals: {
 			total_price: totalPrice,
 			currency_code: currencyCode,
 			currency_minor_unit: 2,
 		},
+		cartItems: [],
+		extensions,
 	} );
 
 	beforeEach( () => {
@@ -228,14 +230,12 @@ describe( 'checkPaymentMethodIsAvailable', () => {
 			delete global.wcpayExpressCheckoutParams;
 		} );
 
-		it( 'passes the value the server declared', async () => {
-			global.wcpayExpressCheckoutParams = {
-				setup_future_usage: 'off_session',
-			};
-
+		it( 'passes the value the server declared on the cart', async () => {
 			await checkPaymentMethodIsAvailable(
 				'applePay',
-				createCart( '1000', 'USD' ),
+				createCart( '1000', 'USD', {
+					wcpay: { setup_future_usage: 'off_session' },
+				} ),
 				mockApi
 			);
 
@@ -245,13 +245,33 @@ describe( 'checkPaymentMethodIsAvailable', () => {
 		} );
 
 		it( 'omits it when the server declared none', async () => {
+			await checkPaymentMethodIsAvailable(
+				'applePay',
+				createCart( '1000', 'USD', {
+					wcpay: { setup_future_usage: null },
+				} ),
+				mockApi
+			);
+
+			expect( mockStripe.elements ).toHaveBeenCalledWith(
+				expect.not.objectContaining( {
+					setupFutureUsage: expect.anything(),
+				} )
+			);
+		} );
+
+		// The page-load globals go stale the moment the shopper edits the cart without a
+		// reload, so the live cart has to win.
+		it( 'reads the live cart rather than the page-load globals', async () => {
 			global.wcpayExpressCheckoutParams = {
-				setup_future_usage: null,
+				setup_future_usage: 'off_session',
 			};
 
 			await checkPaymentMethodIsAvailable(
 				'applePay',
-				createCart( '1000', 'USD' ),
+				createCart( '1000', 'USD', {
+					wcpay: { setup_future_usage: null },
+				} ),
 				mockApi
 			);
 

--- a/client/express-checkout/utils/__tests__/subscriptions.test.ts
+++ b/client/express-checkout/utils/__tests__/subscriptions.test.ts
@@ -1,9 +1,15 @@
 /**
+ * External dependencies
+ */
+import { addFilter, removeAllFilters } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import {
 	cartHasAnySubscription,
 	getSetupFutureUsageForCart,
+	getSetupFutureUsageForContext,
 } from '../subscriptions';
 
 const buildSubscriptionSchedule = ( { billingPeriod = 'month' } = {} ) => ( {
@@ -175,18 +181,136 @@ describe( 'cartHasAnySubscription', () => {
 } );
 
 describe( 'getSetupFutureUsageForCart', () => {
-	it( 'returns null for a regular cart', () => {
-		expect( getSetupFutureUsageForCart( regularCart ) ).toBeNull();
+	afterEach( () => {
+		removeAllFilters( 'wcpay.express-checkout.setup-future-usage' );
 	} );
 
-	it( 'returns off_session when the cart contains a subscription', () => {
-		expect(
-			getSetupFutureUsageForCart( {
-				items: [],
-				extensions: {
-					subscriptions: [ buildSubscriptionSchedule() ],
-				},
-			} )
-		).toBe( 'off_session' );
+	describe( 'falling back to the WC Subscriptions heuristic', () => {
+		// The Store API extension only registers on WooCommerce versions exposing
+		// `woocommerce_store_api_register_endpoint_data`, so the cart response can
+		// legitimately arrive with no `wcpay` extension at all.
+		it( 'returns null for a regular cart', () => {
+			expect( getSetupFutureUsageForCart( regularCart ) ).toBeNull();
+		} );
+
+		it( 'returns off_session when the cart contains a subscription', () => {
+			expect(
+				getSetupFutureUsageForCart( {
+					items: [],
+					extensions: {
+						subscriptions: [ buildSubscriptionSchedule() ],
+					},
+				} )
+			).toBe( 'off_session' );
+		} );
+
+		it( 'falls back when the wcpay extension omits the key', () => {
+			expect(
+				getSetupFutureUsageForCart( {
+					items: [],
+					extensions: {
+						subscriptions: [ buildSubscriptionSchedule() ],
+						wcpay: {},
+					},
+				} )
+			).toBe( 'off_session' );
+		} );
+	} );
+
+	describe( 'preferring the server-computed value', () => {
+		// The WOOPMNT-6335 case: a cart with no subscription the client can see, whose
+		// payment method the server will nonetheless save.
+		it( 'returns off_session the server declares for a cart with no subscription', () => {
+			expect(
+				getSetupFutureUsageForCart( {
+					...regularCart,
+					extensions: {
+						wcpay: { setup_future_usage: 'off_session' },
+					},
+				} )
+			).toBe( 'off_session' );
+		} );
+
+		// Presence beats truthiness: an explicit null is the server deciding, not an absence.
+		it( 'returns null the server declares even when the heuristic would say off_session', () => {
+			expect(
+				getSetupFutureUsageForCart( {
+					items: [],
+					extensions: {
+						subscriptions: [ buildSubscriptionSchedule() ],
+						wcpay: { setup_future_usage: null },
+					},
+				} )
+			).toBeNull();
+		} );
+	} );
+
+	describe( 'the extensibility filter', () => {
+		it( 'can declare off_session for a cart that looks regular', () => {
+			addFilter(
+				'wcpay.express-checkout.setup-future-usage',
+				'test/declare',
+				() => 'off_session'
+			);
+
+			expect( getSetupFutureUsageForCart( regularCart ) ).toBe(
+				'off_session'
+			);
+		} );
+
+		it( 'can suppress off_session and receives the cart data', () => {
+			const seen: unknown[] = [];
+			addFilter(
+				'wcpay.express-checkout.setup-future-usage',
+				'test/suppress',
+				( value: unknown, cartData: unknown ) => {
+					seen.push( cartData );
+					return null;
+				}
+			);
+
+			expect(
+				getSetupFutureUsageForCart( {
+					items: [],
+					extensions: {
+						wcpay: { setup_future_usage: 'off_session' },
+					},
+				} )
+			).toBeNull();
+			expect( seen ).toHaveLength( 1 );
+		} );
+	} );
+} );
+
+describe( 'getSetupFutureUsageForContext', () => {
+	afterEach( () => {
+		removeAllFilters( 'wcpay.express-checkout.setup-future-usage' );
+		delete ( global as Record< string, unknown > )
+			.wcpayExpressCheckoutParams;
+	} );
+
+	it( 'returns the localized value', () => {
+		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {
+			setup_future_usage: 'off_session',
+		};
+
+		expect( getSetupFutureUsageForContext() ).toBe( 'off_session' );
+	} );
+
+	it( 'returns null when the localized value is absent', () => {
+		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {};
+
+		expect( getSetupFutureUsageForContext() ).toBeNull();
+	} );
+
+	it( 'runs through the same filter as the cart path', () => {
+		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {};
+		addFilter(
+			'wcpay.express-checkout.setup-future-usage',
+			'test/declare',
+			() => 'off_session'
+		);
+
+		expect( getSetupFutureUsageForContext() ).toBe( 'off_session' );
 	} );
 } );

--- a/client/express-checkout/utils/__tests__/subscriptions.test.ts
+++ b/client/express-checkout/utils/__tests__/subscriptions.test.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { addFilter, removeFilter } from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
 import {
@@ -11,8 +6,6 @@ import {
 	getSetupFutureUsageForCart,
 	getSetupFutureUsageForContext,
 } from '../subscriptions';
-
-const testFilterNamespace = 'wcpay-test/setup-future-usage';
 
 const buildSubscriptionSchedule = ( { billingPeriod = 'month' } = {} ) => ( {
 	billing_period: billingPeriod,
@@ -183,13 +176,6 @@ describe( 'cartHasAnySubscription', () => {
 } );
 
 describe( 'getSetupFutureUsageForCart', () => {
-	afterEach( () => {
-		removeFilter(
-			'wcpay.express-checkout.setup-future-usage',
-			testFilterNamespace
-		);
-	} );
-
 	describe( 'falling back to the WC Subscriptions heuristic', () => {
 		// A cart response that carries no `wcpay` extension degrades to the old
 		// WC Subscriptions detection rather than to "never save".
@@ -248,50 +234,10 @@ describe( 'getSetupFutureUsageForCart', () => {
 			).toBeNull();
 		} );
 	} );
-
-	describe( 'the extensibility filter', () => {
-		it( 'can declare off_session for a cart that looks regular', () => {
-			addFilter(
-				'wcpay.express-checkout.setup-future-usage',
-				testFilterNamespace,
-				() => 'off_session'
-			);
-
-			expect( getSetupFutureUsageForCart( regularCart ) ).toBe(
-				'off_session'
-			);
-		} );
-
-		it( 'can suppress off_session and receives the cart data', () => {
-			const seen: unknown[] = [];
-			addFilter(
-				'wcpay.express-checkout.setup-future-usage',
-				testFilterNamespace,
-				( value: unknown, cartData: unknown ) => {
-					seen.push( cartData );
-					return null;
-				}
-			);
-
-			expect(
-				getSetupFutureUsageForCart( {
-					items: [],
-					extensions: {
-						wcpay: { setup_future_usage: 'off_session' },
-					},
-				} )
-			).toBeNull();
-			expect( seen ).toHaveLength( 1 );
-		} );
-	} );
 } );
 
 describe( 'getSetupFutureUsageForContext', () => {
 	afterEach( () => {
-		removeFilter(
-			'wcpay.express-checkout.setup-future-usage',
-			testFilterNamespace
-		);
 		delete ( global as Record< string, unknown > )
 			.wcpayExpressCheckoutParams;
 	} );
@@ -308,17 +254,6 @@ describe( 'getSetupFutureUsageForContext', () => {
 		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {};
 
 		expect( getSetupFutureUsageForContext() ).toBeNull();
-	} );
-
-	it( 'runs through the same filter as the cart path', () => {
-		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {};
-		addFilter(
-			'wcpay.express-checkout.setup-future-usage',
-			testFilterNamespace,
-			() => 'off_session'
-		);
-
-		expect( getSetupFutureUsageForContext() ).toBe( 'off_session' );
 	} );
 
 	// `wcpay_express_checkout_js_params` is a documented extension point, and

--- a/client/express-checkout/utils/__tests__/subscriptions.test.ts
+++ b/client/express-checkout/utils/__tests__/subscriptions.test.ts
@@ -191,9 +191,8 @@ describe( 'getSetupFutureUsageForCart', () => {
 	} );
 
 	describe( 'falling back to the WC Subscriptions heuristic', () => {
-		// The Store API extension only registers on WooCommerce versions exposing
-		// `woocommerce_store_api_register_endpoint_data`, so the cart response can
-		// legitimately arrive with no `wcpay` extension at all.
+		// A cart response that carries no `wcpay` extension degrades to the old
+		// WC Subscriptions detection rather than to "never save".
 		it( 'returns null for a regular cart', () => {
 			expect( getSetupFutureUsageForCart( regularCart ) ).toBeNull();
 		} );

--- a/client/express-checkout/utils/__tests__/subscriptions.test.ts
+++ b/client/express-checkout/utils/__tests__/subscriptions.test.ts
@@ -320,4 +320,39 @@ describe( 'getSetupFutureUsageForContext', () => {
 
 		expect( getSetupFutureUsageForContext() ).toBe( 'off_session' );
 	} );
+
+	// `wcpay_express_checkout_js_params` is a documented extension point, and
+	// `has_subscription` was the only lever before `setup_future_usage` existed — quite
+	// possibly forced by an integration working around this very bug.
+	describe( 'legacy has_subscription overrides', () => {
+		it( 'honours has_subscription when the server declared nothing', () => {
+			( global as Record< string, unknown > ).wcpayExpressCheckoutParams =
+				{
+					setup_future_usage: null,
+					has_subscription: true,
+				};
+
+			expect( getSetupFutureUsageForContext() ).toBe( 'off_session' );
+		} );
+
+		it( 'prefers the server value over the legacy flag', () => {
+			( global as Record< string, unknown > ).wcpayExpressCheckoutParams =
+				{
+					setup_future_usage: 'off_session',
+					has_subscription: false,
+				};
+
+			expect( getSetupFutureUsageForContext() ).toBe( 'off_session' );
+		} );
+
+		it( 'returns null when neither is set', () => {
+			( global as Record< string, unknown > ).wcpayExpressCheckoutParams =
+				{
+					setup_future_usage: null,
+					has_subscription: false,
+				};
+
+			expect( getSetupFutureUsageForContext() ).toBeNull();
+		} );
+	} );
 } );

--- a/client/express-checkout/utils/__tests__/subscriptions.test.ts
+++ b/client/express-checkout/utils/__tests__/subscriptions.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { addFilter, removeAllFilters } from '@wordpress/hooks';
+import { addFilter, removeFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -11,6 +11,8 @@ import {
 	getSetupFutureUsageForCart,
 	getSetupFutureUsageForContext,
 } from '../subscriptions';
+
+const testFilterNamespace = 'wcpay-test/setup-future-usage';
 
 const buildSubscriptionSchedule = ( { billingPeriod = 'month' } = {} ) => ( {
 	billing_period: billingPeriod,
@@ -182,7 +184,10 @@ describe( 'cartHasAnySubscription', () => {
 
 describe( 'getSetupFutureUsageForCart', () => {
 	afterEach( () => {
-		removeAllFilters( 'wcpay.express-checkout.setup-future-usage' );
+		removeFilter(
+			'wcpay.express-checkout.setup-future-usage',
+			testFilterNamespace
+		);
 	} );
 
 	describe( 'falling back to the WC Subscriptions heuristic', () => {
@@ -249,7 +254,7 @@ describe( 'getSetupFutureUsageForCart', () => {
 		it( 'can declare off_session for a cart that looks regular', () => {
 			addFilter(
 				'wcpay.express-checkout.setup-future-usage',
-				'test/declare',
+				testFilterNamespace,
 				() => 'off_session'
 			);
 
@@ -262,7 +267,7 @@ describe( 'getSetupFutureUsageForCart', () => {
 			const seen: unknown[] = [];
 			addFilter(
 				'wcpay.express-checkout.setup-future-usage',
-				'test/suppress',
+				testFilterNamespace,
 				( value: unknown, cartData: unknown ) => {
 					seen.push( cartData );
 					return null;
@@ -284,7 +289,10 @@ describe( 'getSetupFutureUsageForCart', () => {
 
 describe( 'getSetupFutureUsageForContext', () => {
 	afterEach( () => {
-		removeAllFilters( 'wcpay.express-checkout.setup-future-usage' );
+		removeFilter(
+			'wcpay.express-checkout.setup-future-usage',
+			testFilterNamespace
+		);
 		delete ( global as Record< string, unknown > )
 			.wcpayExpressCheckoutParams;
 	} );
@@ -307,7 +315,7 @@ describe( 'getSetupFutureUsageForContext', () => {
 		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {};
 		addFilter(
 			'wcpay.express-checkout.setup-future-usage',
-			'test/declare',
+			testFilterNamespace,
 			() => 'off_session'
 		);
 

--- a/client/express-checkout/utils/__tests__/subscriptions.test.ts
+++ b/client/express-checkout/utils/__tests__/subscriptions.test.ts
@@ -356,3 +356,44 @@ describe( 'getSetupFutureUsageForContext', () => {
 		} );
 	} );
 } );
+
+// Pay-for-order swaps the cart API for an order API, and the Store API extension registers
+// on the cart schema only — so the response can never carry it. The subscription being
+// renewed lives on the order, which only the server can see.
+describe( 'getSetupFutureUsageForCart on pay-for-order', () => {
+	afterEach( () => {
+		delete ( global as Record< string, unknown > )
+			.wcpayExpressCheckoutParams;
+	} );
+
+	it( 'falls back to the localized value instead of the cart heuristic', () => {
+		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {
+			button_context: 'pay_for_order',
+			setup_future_usage: 'off_session',
+		};
+
+		// An order response: no `wcpay` extension, and no WC Subscriptions cart data.
+		expect( getSetupFutureUsageForCart( regularCart ) ).toBe(
+			'off_session'
+		);
+	} );
+
+	it( 'still returns null when the order carries no subscription', () => {
+		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {
+			button_context: 'pay_for_order',
+			setup_future_usage: null,
+		};
+
+		expect( getSetupFutureUsageForCart( regularCart ) ).toBeNull();
+	} );
+
+	it( 'does not use the localized value in other contexts', () => {
+		( global as Record< string, unknown > ).wcpayExpressCheckoutParams = {
+			button_context: 'checkout',
+			setup_future_usage: 'off_session',
+		};
+
+		// The cart is the source of truth off the order-pay page.
+		expect( getSetupFutureUsageForCart( regularCart ) ).toBeNull();
+	} );
+} );

--- a/client/express-checkout/utils/__tests__/subscriptions.test.ts
+++ b/client/express-checkout/utils/__tests__/subscriptions.test.ts
@@ -325,14 +325,38 @@ describe( 'getSetupFutureUsageForContext', () => {
 	// `has_subscription` was the only lever before `setup_future_usage` existed — quite
 	// possibly forced by an integration working around this very bug.
 	describe( 'legacy has_subscription overrides', () => {
-		it( 'honours has_subscription when the server declared nothing', () => {
+		// The two are computed by different predicates over different state:
+		// `has_subscription` reads the live cart, `setup_future_usage` reads the order on
+		// the order-pay page. A shopper with a subscription in the cart paying an unrelated
+		// one-off order would otherwise mint a token declaring off_session against an intent
+		// that never asks for it — Stripe then vaults the card silently.
+		it( 'prefers an explicit server null over the legacy flag', () => {
 			( global as Record< string, unknown > ).wcpayExpressCheckoutParams =
 				{
 					setup_future_usage: null,
 					has_subscription: true,
 				};
 
+			expect( getSetupFutureUsageForContext() ).toBeNull();
+		} );
+
+		// Presence, not truthiness: only a payload missing the key falls back.
+		it( 'honours has_subscription when the server sent no key at all', () => {
+			( global as Record< string, unknown > ).wcpayExpressCheckoutParams =
+				{
+					has_subscription: true,
+				};
+
 			expect( getSetupFutureUsageForContext() ).toBe( 'off_session' );
+		} );
+
+		it( 'returns null when the key is absent and the legacy flag is false', () => {
+			( global as Record< string, unknown > ).wcpayExpressCheckoutParams =
+				{
+					has_subscription: false,
+				};
+
+			expect( getSetupFutureUsageForContext() ).toBeNull();
 		} );
 
 		it( 'prefers the server value over the legacy flag', () => {

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.ts
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.ts
@@ -10,7 +10,10 @@ import type { Stripe, AvailablePaymentMethods } from '@stripe/stripe-js';
  */
 import type WCPayAPI from 'wcpay/checkout/api';
 import { getExpressCheckoutData } from '.';
-import { getSetupFutureUsageForContext } from './subscriptions';
+import {
+	getSetupFutureUsageForCart,
+	type SetupFutureUsage,
+} from './subscriptions';
 import { transformPrice } from '../transformers/wc-to-stripe';
 
 interface CartTotals {
@@ -74,13 +77,13 @@ function checkAvailablePaymentMethods(
 	stripe: Stripe,
 	amount: number,
 	currency: string,
-	mode: string
+	mode: string,
+	setupFutureUsage: SetupFutureUsage
 ): Promise< Partial< AvailablePaymentMethods > > {
 	const useConfirmationToken =
 		getExpressCheckoutData( 'flags' )?.isEceUsingConfirmationTokens ?? true;
 	const isManualCaptureEnabled =
 		getExpressCheckoutData( 'is_manual_capture' ) ?? false;
-	const setupFutureUsage = getSetupFutureUsageForContext();
 
 	let container: HTMLDivElement | null = null;
 
@@ -145,7 +148,8 @@ let memoizedCheck:
 	| ( (
 			_amount: number,
 			_currency: string,
-			_mode: string
+			_mode: string,
+			_setupFutureUsage: SetupFutureUsage
 	  ) => Promise< Partial< AvailablePaymentMethods > > )
 	| null = null;
 
@@ -157,6 +161,7 @@ async function checkAllExpressMethodsAvailability(
 	api: WCPayAPI,
 	amount: number,
 	currency: string,
+	setupFutureUsage: SetupFutureUsage,
 	mode = 'payment'
 ): Promise< Partial< AvailablePaymentMethods > > {
 	if ( ! cachedStripePromise ) {
@@ -180,21 +185,37 @@ async function checkAllExpressMethodsAvailability(
 
 	if ( ! memoizedCheck ) {
 		memoizedCheck = memoize(
-			// eslint-disable-next-line @typescript-eslint/naming-convention
-			( _amount: number, _currency: string, _mode: string ) =>
+			(
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				_amount: number,
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				_currency: string,
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				_mode: string,
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				_setupFutureUsage: SetupFutureUsage
+			) =>
 				checkAvailablePaymentMethods(
 					stripe,
 					_amount,
 					_currency,
-					_mode
+					_mode,
+					_setupFutureUsage
 				),
-			// eslint-disable-next-line @typescript-eslint/naming-convention
-			( _amount: number, _currency: string, _mode: string ) =>
-				`${ _amount }-${ _currency }-${ _mode }`
+			(
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				_amount: number,
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				_currency: string,
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				_mode: string,
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				_setupFutureUsage: SetupFutureUsage
+			) => `${ _amount }-${ _currency }-${ _mode }-${ _setupFutureUsage }`
 		);
 	}
 
-	return memoizedCheck( amount, currency, mode );
+	return memoizedCheck( amount, currency, mode, setupFutureUsage );
 }
 
 /**
@@ -217,10 +238,19 @@ export async function checkPaymentMethodIsAvailable(
 
 	const totalPrice = getEffectiveTotalPrice( cart );
 
+	// Read the live cart, the same source the button itself uses. Resolving this from the
+	// page-load globals instead would advertise a wallet the button then mints a different
+	// token for, once the shopper changes the cart without a reload.
+	const setupFutureUsage = getSetupFutureUsageForCart( {
+		extensions: cart.extensions,
+		items: cart.cartItems,
+	} as Parameters< typeof getSetupFutureUsageForCart >[ 0 ] );
+
 	const availablePaymentMethods = await checkAllExpressMethodsAvailability(
 		api,
 		Number( totalPrice ),
-		cart.cartTotals.currency_code.toLowerCase()
+		cart.cartTotals.currency_code.toLowerCase(),
+		setupFutureUsage
 	);
 
 	return Boolean( availablePaymentMethods[ paymentMethod ] );

--- a/client/express-checkout/utils/checkPaymentMethodIsAvailable.ts
+++ b/client/express-checkout/utils/checkPaymentMethodIsAvailable.ts
@@ -10,6 +10,7 @@ import type { Stripe, AvailablePaymentMethods } from '@stripe/stripe-js';
  */
 import type WCPayAPI from 'wcpay/checkout/api';
 import { getExpressCheckoutData } from '.';
+import { getSetupFutureUsageForContext } from './subscriptions';
 import { transformPrice } from '../transformers/wc-to-stripe';
 
 interface CartTotals {
@@ -79,8 +80,7 @@ function checkAvailablePaymentMethods(
 		getExpressCheckoutData( 'flags' )?.isEceUsingConfirmationTokens ?? true;
 	const isManualCaptureEnabled =
 		getExpressCheckoutData( 'is_manual_capture' ) ?? false;
-	const hasSubscription =
-		getExpressCheckoutData( 'has_subscription' ) ?? false;
+	const setupFutureUsage = getSetupFutureUsageForContext();
 
 	let container: HTMLDivElement | null = null;
 
@@ -102,8 +102,8 @@ function checkAvailablePaymentMethods(
 				...( useConfirmationToken && isManualCaptureEnabled
 					? { captureMethod: 'manual' }
 					: {} ),
-				...( useConfirmationToken && hasSubscription
-					? { setupFutureUsage: 'off_session' }
+				...( useConfirmationToken && setupFutureUsage
+					? { setupFutureUsage }
 					: {} ),
 			} );
 

--- a/client/express-checkout/utils/express-checkout-data.ts
+++ b/client/express-checkout/utils/express-checkout-data.ts
@@ -135,6 +135,32 @@ export const getExpressCheckoutData = <
 };
 
 /**
+ * Whether the server sent a key at all.
+ *
+ * `getExpressCheckoutData()` collapses a missing key and an explicit `null` to the same
+ * `null`, which is fine for values where absence and "no" mean the same thing. It is not
+ * fine for a decision: the server declaring `setup_future_usage: null` means "this payment
+ * does not save the payment method", and that must outrank any older signal.
+ *
+ * @param key Key to look for.
+ * @return True when the key is present, whatever its value.
+ */
+export const hasExpressCheckoutData = (
+	key: keyof WCPayExpressCheckoutParams
+): boolean => {
+	if ( typeof window.wcpayExpressCheckoutParams !== 'undefined' ) {
+		return key in window.wcpayExpressCheckoutParams;
+	}
+
+	if ( typeof window.wc?.wcSettings !== 'undefined' ) {
+		const data = window.wc.wcSettings.getSetting( 'ece_data' );
+		return !! data && typeof data === 'object' && key in data;
+	}
+
+	return false;
+};
+
+/**
  * Re-applies location gating to the cart's express method list.
  *
  * The cart Store API extension is currency-fresh but location-blind, so on its

--- a/client/express-checkout/utils/express-checkout-data.ts
+++ b/client/express-checkout/utils/express-checkout-data.ts
@@ -36,6 +36,14 @@ export interface WCPayExpressCheckoutParams {
 	};
 
 	has_subscription?: boolean;
+
+	/**
+	 * The `setup_future_usage` the ConfirmationToken must be minted with, computed
+	 * server-side. Covers the product page, where no Store API cart exists yet — the
+	 * cart and checkout contexts read it off the cart response instead.
+	 */
+	setup_future_usage?: 'off_session' | null;
+
 	is_manual_capture?: boolean;
 
 	/**

--- a/client/express-checkout/utils/index.ts
+++ b/client/express-checkout/utils/index.ts
@@ -21,4 +21,6 @@ export { shouldUseConfirmationTokens } from './confirmation-tokens';
 export {
 	cartHasAnySubscription,
 	getSetupFutureUsageForCart,
+	getSetupFutureUsageForContext,
 } from './subscriptions';
+export type { SetupFutureUsage } from './subscriptions';

--- a/client/express-checkout/utils/subscriptions.ts
+++ b/client/express-checkout/utils/subscriptions.ts
@@ -125,15 +125,15 @@ export const getSetupFutureUsageForCart = (
 	cartData?: CartData
 ): SetupFutureUsage => {
 	const wcpayExtension = cartData?.extensions?.wcpay;
+	let value: SetupFutureUsage;
 
-	// Presence, not truthiness: an explicit `null` from the server is a decision
-	// ("this cart does not save the payment method") and must beat the heuristic.
-	const value =
-		wcpayExtension && 'setup_future_usage' in wcpayExtension
-			? wcpayExtension.setup_future_usage ?? null
-			: cartHasAnySubscription( cartData )
-			? 'off_session'
-			: null;
+	if ( wcpayExtension && 'setup_future_usage' in wcpayExtension ) {
+		// Presence, not truthiness: an explicit `null` from the server is a decision
+		// ("this cart does not save the payment method") and must beat the heuristic.
+		value = wcpayExtension.setup_future_usage ?? null;
+	} else {
+		value = cartHasAnySubscription( cartData ) ? 'off_session' : null;
+	}
 
 	return filterSetupFutureUsage( value, cartData );
 };

--- a/client/express-checkout/utils/subscriptions.ts
+++ b/client/express-checkout/utils/subscriptions.ts
@@ -114,9 +114,9 @@ const filterSetupFutureUsage = (
  *
  * The server decides this — it is the only side that knows every reason the payment
  * method might be saved, and it exposes one filter for the reasons it can't infer. The
- * WC Subscriptions heuristic below is the fallback for when the cart response carries no
- * `wcpay` extension at all (the Store API extension only registers on WooCommerce
- * versions that expose `woocommerce_store_api_register_endpoint_data`).
+ * WC Subscriptions heuristic below only runs when the cart response carries no `wcpay`
+ * extension, which no supported WooCommerce should produce; it is there so a cart that
+ * loses the extension degrades to the old behaviour rather than to "never save".
  *
  * @param cartData Cart data from Store API.
  * @return Stripe setupFutureUsage value.

--- a/client/express-checkout/utils/subscriptions.ts
+++ b/client/express-checkout/utils/subscriptions.ts
@@ -6,7 +6,10 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { getExpressCheckoutData } from './express-checkout-data';
+import {
+	getExpressCheckoutData,
+	hasExpressCheckoutData,
+} from './express-checkout-data';
 
 export type SetupFutureUsage = 'off_session' | null;
 
@@ -112,27 +115,31 @@ const filterSetupFutureUsage = (
  * Reads the server's decision out of the localized params, honouring the older
  * `has_subscription` flag it replaced.
  *
- * `has_subscription` was the only lever before `setup_future_usage` existed, and
- * `wcpay_express_checkout_js_params` is a documented extension point, so an integration
- * may already be forcing it — quite likely one working around this very bug. The server
- * never reports `has_subscription` true without also declaring `off_session`, so this
- * only ever fires for an override.
+ * Presence, not truthiness. The server declaring `null` is a decision — "this payment does
+ * not save the payment method" — and it has to outrank the older flag, because the two are
+ * computed by different predicates over different state: `has_subscription` reads the live
+ * cart via `has_subscription_product()`, while `setup_future_usage` reads the order on the
+ * order-pay page. A shopper with a subscription in the cart paying an unrelated one-off
+ * order would otherwise mint a token declaring `off_session` against an intent that never
+ * asks for it, and Stripe would silently vault their card with no WooPayments token
+ * recorded against it.
  *
- * Enabling only: a `has_subscription` of false cannot be told apart from the server
- * computing false, so it is not treated as a suppression. Use the
- * `wcpay_express_checkout_setup_future_usage` filter to suppress.
+ * The server always sends the key, so the fallback below only covers a stale cached asset
+ * or a payload something else has stripped. `wcpay_express_checkout_js_params` is a
+ * documented extension point, so an integration forcing `has_subscription` should move to
+ * the `wcpay_express_checkout_setup_future_usage` filter, which is evaluated server-side
+ * alongside everything else.
  *
  * @deprecated `has_subscription` support here is transitional; declare through the filter.
  *
  * @return Stripe setupFutureUsage value.
  */
 const getLocalizedSetupFutureUsage = (): SetupFutureUsage => {
-	const declared = getExpressCheckoutData( 'setup_future_usage' ) ?? null;
-	const legacy = getExpressCheckoutData( 'has_subscription' )
-		? 'off_session'
-		: null;
+	if ( hasExpressCheckoutData( 'setup_future_usage' ) ) {
+		return getExpressCheckoutData( 'setup_future_usage' ) ?? null;
+	}
 
-	return declared ?? legacy;
+	return getExpressCheckoutData( 'has_subscription' ) ? 'off_session' : null;
 };
 
 /**

--- a/client/express-checkout/utils/subscriptions.ts
+++ b/client/express-checkout/utils/subscriptions.ts
@@ -109,6 +109,33 @@ const filterSetupFutureUsage = (
 	) as SetupFutureUsage;
 
 /**
+ * Reads the server's decision out of the localized params, honouring the older
+ * `has_subscription` flag it replaced.
+ *
+ * `has_subscription` was the only lever before `setup_future_usage` existed, and
+ * `wcpay_express_checkout_js_params` is a documented extension point, so an integration
+ * may already be forcing it — quite likely one working around this very bug. The server
+ * never reports `has_subscription` true without also declaring `off_session`, so this
+ * only ever fires for an override.
+ *
+ * Enabling only: a `has_subscription` of false cannot be told apart from the server
+ * computing false, so it is not treated as a suppression. Use the
+ * `wcpay_express_checkout_setup_future_usage` filter to suppress.
+ *
+ * @deprecated `has_subscription` support here is transitional; declare through the filter.
+ *
+ * @return Stripe setupFutureUsage value.
+ */
+const getLocalizedSetupFutureUsage = (): SetupFutureUsage => {
+	const declared = getExpressCheckoutData( 'setup_future_usage' ) ?? null;
+	const legacy = getExpressCheckoutData( 'has_subscription' )
+		? 'off_session'
+		: null;
+
+	return declared ?? legacy;
+};
+
+/**
  * Gets the setupFutureUsage value that should be passed to Stripe Elements for
  * the current cart.
  *
@@ -145,6 +172,4 @@ export const getSetupFutureUsageForCart = (
  * @return Stripe setupFutureUsage value.
  */
 export const getSetupFutureUsageForContext = (): SetupFutureUsage =>
-	filterSetupFutureUsage(
-		getExpressCheckoutData( 'setup_future_usage' ) ?? null
-	);
+	filterSetupFutureUsage( getLocalizedSetupFutureUsage() );

--- a/client/express-checkout/utils/subscriptions.ts
+++ b/client/express-checkout/utils/subscriptions.ts
@@ -1,5 +1,20 @@
+/**
+ * External dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { getExpressCheckoutData } from './express-checkout-data';
+
+export type SetupFutureUsage = 'off_session' | null;
+
 type SubscriptionExtensions = {
 	subscriptions?: unknown[] | Record< string, unknown >;
+	wcpay?: {
+		setup_future_usage?: SetupFutureUsage;
+	};
 };
 
 type CartItem = {
@@ -72,13 +87,64 @@ export const cartHasAnySubscription = ( cartData?: CartData ): boolean => {
 };
 
 /**
+ * Applies the extensibility filter that has the last word on `setupFutureUsage`.
+ *
+ * Declare `off_session` only when the payment method really will be saved. Stripe
+ * inherits the token's value onto the PaymentIntent even when the intent itself omits
+ * it, so over-declaring silently attaches the shopper's card to the Stripe customer on
+ * an ordinary one-off purchase, with no WooPayments token recorded against it.
+ *
+ * @param value    Server-computed (or heuristic) value.
+ * @param cartData Cart data from Store API, when the caller has it.
+ * @return Stripe setupFutureUsage value.
+ */
+const filterSetupFutureUsage = (
+	value: SetupFutureUsage,
+	cartData?: CartData
+): SetupFutureUsage =>
+	applyFilters(
+		'wcpay.express-checkout.setup-future-usage',
+		value,
+		cartData
+	) as SetupFutureUsage;
+
+/**
  * Gets the setupFutureUsage value that should be passed to Stripe Elements for
  * the current cart.
+ *
+ * The server decides this — it is the only side that knows every reason the payment
+ * method might be saved, and it exposes one filter for the reasons it can't infer. The
+ * WC Subscriptions heuristic below is the fallback for when the cart response carries no
+ * `wcpay` extension at all (the Store API extension only registers on WooCommerce
+ * versions that expose `woocommerce_store_api_register_endpoint_data`).
  *
  * @param cartData Cart data from Store API.
  * @return Stripe setupFutureUsage value.
  */
 export const getSetupFutureUsageForCart = (
 	cartData?: CartData
-): 'off_session' | null =>
-	cartHasAnySubscription( cartData ) ? 'off_session' : null;
+): SetupFutureUsage => {
+	const wcpayExtension = cartData?.extensions?.wcpay;
+
+	// Presence, not truthiness: an explicit `null` from the server is a decision
+	// ("this cart does not save the payment method") and must beat the heuristic.
+	const value =
+		wcpayExtension && 'setup_future_usage' in wcpayExtension
+			? wcpayExtension.setup_future_usage ?? null
+			: cartHasAnySubscription( cartData )
+			? 'off_session'
+			: null;
+
+	return filterSetupFutureUsage( value, cartData );
+};
+
+/**
+ * Gets the setupFutureUsage value for contexts that have no Store API cart to read —
+ * the product page, where the express button is rendered before anything is in the cart.
+ *
+ * @return Stripe setupFutureUsage value.
+ */
+export const getSetupFutureUsageForContext = (): SetupFutureUsage =>
+	filterSetupFutureUsage(
+		getExpressCheckoutData( 'setup_future_usage' ) ?? null
+	);

--- a/client/express-checkout/utils/subscriptions.ts
+++ b/client/express-checkout/utils/subscriptions.ts
@@ -158,6 +158,14 @@ export const getSetupFutureUsageForCart = (
 		// Presence, not truthiness: an explicit `null` from the server is a decision
 		// ("this cart does not save the payment method") and must beat the heuristic.
 		value = wcpayExtension.setup_future_usage ?? null;
+	} else if (
+		getExpressCheckoutData( 'button_context' ) === 'pay_for_order'
+	) {
+		// Pay-for-order reads an order, not a cart, and the extension registers on the
+		// cart schema only — so this data will never carry it. The subscription being
+		// renewed lives on the order, which only the server can see, and the order does
+		// not change under us the way a cart does.
+		value = getLocalizedSetupFutureUsage();
 	} else {
 		value = cartHasAnySubscription( cartData ) ? 'off_session' : null;
 	}

--- a/client/express-checkout/utils/subscriptions.ts
+++ b/client/express-checkout/utils/subscriptions.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { applyFilters } from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
 import {
@@ -90,28 +85,6 @@ export const cartHasAnySubscription = ( cartData?: CartData ): boolean => {
 };
 
 /**
- * Applies the extensibility filter that has the last word on `setupFutureUsage`.
- *
- * Declare `off_session` only when the payment method really will be saved. Stripe
- * inherits the token's value onto the PaymentIntent even when the intent itself omits
- * it, so over-declaring silently attaches the shopper's card to the Stripe customer on
- * an ordinary one-off purchase, with no WooPayments token recorded against it.
- *
- * @param value    Server-computed (or heuristic) value.
- * @param cartData Cart data from Store API, when the caller has it.
- * @return Stripe setupFutureUsage value.
- */
-const filterSetupFutureUsage = (
-	value: SetupFutureUsage,
-	cartData?: CartData
-): SetupFutureUsage =>
-	applyFilters(
-		'wcpay.express-checkout.setup-future-usage',
-		value,
-		cartData
-	) as SetupFutureUsage;
-
-/**
  * Reads the server's decision out of the localized params, honouring the older
  * `has_subscription` flag it replaced.
  *
@@ -146,9 +119,13 @@ const getLocalizedSetupFutureUsage = (): SetupFutureUsage => {
  * Gets the setupFutureUsage value that should be passed to Stripe Elements for
  * the current cart.
  *
- * The server decides this — it is the only side that knows every reason the payment
- * method might be saved, and it exposes one filter for the reasons it can't infer. The
- * WC Subscriptions heuristic below only runs when the cart response carries no `wcpay`
+ * The server decides this — it is the only side that knows every reason the payment method
+ * might be saved, and `wcpay_express_checkout_setup_future_usage` is where it takes
+ * declarations for the reasons it can't infer. There is deliberately no client-side filter:
+ * the server also decides whether the payment actually saves the method, so a value
+ * declared only in the browser would guarantee the divergence Stripe punishes.
+ *
+ * The WC Subscriptions heuristic below only runs when the cart response carries no `wcpay`
  * extension, which no supported WooCommerce should produce; it is there so a cart that
  * loses the extension degrades to the old behaviour rather than to "never save".
  *
@@ -177,7 +154,7 @@ export const getSetupFutureUsageForCart = (
 		value = cartHasAnySubscription( cartData ) ? 'off_session' : null;
 	}
 
-	return filterSetupFutureUsage( value, cartData );
+	return value;
 };
 
 /**
@@ -187,4 +164,4 @@ export const getSetupFutureUsageForCart = (
  * @return Stripe setupFutureUsage value.
  */
 export const getSetupFutureUsageForContext = (): SetupFutureUsage =>
-	filterSetupFutureUsage( getLocalizedSetupFutureUsage() );
+	getLocalizedSetupFutureUsage();

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -5474,7 +5474,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 * what this payment is doing. Both directions are worth knowing about, for opposite reasons.
 	 *
 	 * Stripe fixes that value on the token before the wallet sheet opens, and the express
-	 * checkout predicate is re-evaluated here to infer what the token carries.
+	 * checkout predicate is re-evaluated here to infer what the token carries. Both values
+	 * compared below are server-side, so a client that mints a token differing from what it was
+	 * told to goes unseen here — Stripe's own rejection is what surfaces that case.
 	 *
 	 * **Token lacks it, this payment saves the method.** Stripe rejects the confirmation, so
 	 * the purchase fails every time. Something decided to save the payment method that the
@@ -5518,9 +5520,9 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		if ( $intent_requests_off_session ) {
 			Logger::error(
 				sprintf(
-					'Order %s is saving the payment method, but its confirmation token was minted without setup_future_usage, so Stripe will reject this payment. '
-					. 'Something outside WooCommerce Subscriptions is requesting the save. Declare it with the wcpay_express_checkout_setup_future_usage filter '
-					. 'so express checkout mints the token with off_session.',
+					'Order %s saves the payment method, but express checkout was told to mint its confirmation token without setup_future_usage, '
+					. 'so Stripe will reject this payment if the token followed that. Something outside WooCommerce Subscriptions is requesting the save. '
+					. 'Declare it with the wcpay_express_checkout_setup_future_usage filter so the token is minted with off_session.',
 					$order_id
 				)
 			);
@@ -5529,9 +5531,10 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 
 		Logger::error(
 			sprintf(
-				'Order %s was paid with a confirmation token minted for off_session use, but this payment does not save the payment method. '
-				. 'Stripe applies the token\'s setup_future_usage regardless, so the card is attached to the customer with no WooPayments token recorded against it. '
-				. 'Check whatever filters wcpay_express_checkout_setup_future_usage — declare off_session only when the payment method will genuinely be saved.',
+				'Order %s declared off_session to express checkout, but this payment does not save the payment method. '
+				. 'If the token was minted with it, Stripe applies the token\'s setup_future_usage regardless, so the card is attached to the customer '
+				. 'with no WooPayments token recorded against it. Check whatever filters wcpay_express_checkout_setup_future_usage — declare off_session '
+				. 'only when the payment method will genuinely be saved.',
 				$order_id
 			)
 		);

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -5513,8 +5513,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 		// Both surfaces the token can be minted from: the cart, and — on the order-pay page,
 		// which processes with an empty cart — the order. Asking the cart alone would report
 		// a mismatch on every successful renewal paid from that page.
-		$token_declares_off_session  = null !== $express_checkout_helper->get_setup_future_usage( 'cart' )
-			|| $this->is_payment_recurring( $order_id );
+		//
+		// `get_setup_future_usage()` fires `wcpay_express_checkout_setup_future_usage`, a
+		// hook whose callbacks are written for button render time and may not survive being
+		// called mid-payment. Nothing here is worth failing an order over, so a throwing
+		// callback costs the log line and no more.
+		try {
+			$token_declares_off_session = null !== $express_checkout_helper->get_setup_future_usage( 'cart' )
+				|| $this->is_payment_recurring( $order_id );
+		} catch ( Throwable $e ) {
+			Logger::error( 'Could not check setup_future_usage for order ' . $order_id . ': ' . $e->getMessage() );
+			return;
+		}
+
 		$intent_requests_off_session = $save_payment_method_to_store && $this->payment_method->is_reusable();
 
 		if ( $token_declares_off_session === $intent_requests_off_session ) {

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1872,6 +1872,7 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					// Non-reusable payment methods (e.g., iDEAL) will be used for manual renewals and don't support setup_future_usage.
 					if ( $this->payment_method->is_reusable() ) {
 						$request->setup_future_usage();
+						$this->log_unexpected_setup_future_usage( $payment_information );
 					}
 				}
 				if ( $scheduled_subscription_payment ) {
@@ -5464,6 +5465,47 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	 */
 	private function is_changing_payment_method_for_subscription_from_request( ?bool $is_changing_payment = null ): bool {
 		return $is_changing_payment ?? $this->is_changing_payment_method_for_subscription();
+	}
+
+	/**
+	 * Logs when a ConfirmationToken was almost certainly minted without the
+	 * `setup_future_usage` the PaymentIntent is now asking for.
+	 *
+	 * Stripe fixes that value on the token before the wallet sheet opens and rejects the
+	 * confirmation when the two disagree, so this combination is a purchase that fails
+	 * every time. It means something decided to save the payment method that the express
+	 * checkout predicate could not see while the cart was still open — typically a
+	 * subscriptions plugin other than WooCommerce Subscriptions, or an integration setting
+	 * `wc-woocommerce_payments-new-payment-method` as the order is processed.
+	 *
+	 * Diagnostic only. The request is deliberately left alone: dropping
+	 * `setup_future_usage` would let the payment through, but Stripe attaches the payment
+	 * method to the customer precisely because that parameter is present, so the token
+	 * saved afterwards would point at an unattached payment method and the first renewal
+	 * would fail instead — a quiet failure in place of a loud one.
+	 *
+	 * @param Payment_Information $payment_information The payment information for this order.
+	 */
+	private function log_unexpected_setup_future_usage( Payment_Information $payment_information ) {
+		if ( ! $payment_information->is_using_confirmation_token() ) {
+			return;
+		}
+
+		$express_checkout_helper = WC_Payments::get_express_checkout_helper();
+		if ( ! $express_checkout_helper || null !== $express_checkout_helper->get_setup_future_usage( 'cart' ) ) {
+			return;
+		}
+
+		$order = $payment_information->get_order();
+
+		Logger::error(
+			sprintf(
+				'Order %s is saving the payment method, but its confirmation token was minted without setup_future_usage, so Stripe will reject this payment. '
+				. 'Something outside WooCommerce Subscriptions is requesting the save. Declare it with the wcpay_express_checkout_setup_future_usage filter '
+				. 'so express checkout mints the token with off_session.',
+				$order ? $order->get_id() : 'unknown'
+			)
+		);
 	}
 
 	/**

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -1872,9 +1872,11 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 					// Non-reusable payment methods (e.g., iDEAL) will be used for manual renewals and don't support setup_future_usage.
 					if ( $this->payment_method->is_reusable() ) {
 						$request->setup_future_usage();
-						$this->log_unexpected_setup_future_usage( $payment_information );
 					}
 				}
+				// Outside the branch above: a confirmation token can disagree with this payment
+				// in either direction, and the direction that does not save is the silent one.
+				$this->log_setup_future_usage_mismatch( $payment_information, $save_payment_method_to_store );
 				if ( $scheduled_subscription_payment ) {
 					$mandate = $this->get_mandate_param_for_renewal_order( $order );
 					if ( $mandate ) {
@@ -5468,42 +5470,69 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Logs when a ConfirmationToken was almost certainly minted without the
-	 * `setup_future_usage` the PaymentIntent is now asking for.
+	 * Logs when the `setup_future_usage` a ConfirmationToken was minted with disagrees with
+	 * what this payment is doing. Both directions are worth knowing about, for opposite reasons.
 	 *
-	 * Stripe fixes that value on the token before the wallet sheet opens and rejects the
-	 * confirmation when the two disagree, so this combination is a purchase that fails
-	 * every time. It means something decided to save the payment method that the express
-	 * checkout predicate could not see while the cart was still open — typically a
-	 * subscriptions plugin other than WooCommerce Subscriptions, or an integration setting
+	 * Stripe fixes that value on the token before the wallet sheet opens, and the express
+	 * checkout predicate is re-evaluated here to infer what the token carries.
+	 *
+	 * **Token lacks it, this payment saves the method.** Stripe rejects the confirmation, so
+	 * the purchase fails every time. Something decided to save the payment method that the
+	 * predicate could not see while the cart was open — typically a subscriptions plugin other
+	 * than WooCommerce Subscriptions, or an integration setting
 	 * `wc-woocommerce_payments-new-payment-method` as the order is processed.
 	 *
-	 * Diagnostic only. The request is deliberately left alone: dropping
-	 * `setup_future_usage` would let the payment through, but Stripe attaches the payment
-	 * method to the customer precisely because that parameter is present, so the token
-	 * saved afterwards would point at an unattached payment method and the first renewal
-	 * would fail instead — a quiet failure in place of a loud one.
+	 * **Token carries it, this payment does not save.** Stripe applies the token's value even
+	 * though the intent omits it, so the card is attached to the customer while WooPayments
+	 * records no token against it. That one is silent, which is precisely why it is logged.
 	 *
-	 * @param Payment_Information $payment_information The payment information for this order.
+	 * Diagnostic only in both directions. The request is deliberately left alone: dropping
+	 * `setup_future_usage` would let a rejected payment through, but Stripe attaches the payment
+	 * method to the customer precisely because that parameter is present, so the token saved
+	 * afterwards would point at an unattached payment method and the first renewal would fail
+	 * instead — a quiet failure in place of a loud one.
+	 *
+	 * @param Payment_Information $payment_information         The payment information for this order.
+	 * @param bool                $save_payment_method_to_store Whether this payment saves the payment method.
 	 */
-	private function log_unexpected_setup_future_usage( Payment_Information $payment_information ) {
+	private function log_setup_future_usage_mismatch( Payment_Information $payment_information, bool $save_payment_method_to_store ) {
 		if ( ! $payment_information->is_using_confirmation_token() ) {
 			return;
 		}
 
 		$express_checkout_helper = WC_Payments::get_express_checkout_helper();
-		if ( ! $express_checkout_helper || null !== $express_checkout_helper->get_setup_future_usage( 'cart' ) ) {
+		if ( ! $express_checkout_helper ) {
 			return;
 		}
 
-		$order = $payment_information->get_order();
+		$token_declares_off_session  = null !== $express_checkout_helper->get_setup_future_usage( 'cart' );
+		$intent_requests_off_session = $save_payment_method_to_store && $this->payment_method->is_reusable();
+
+		if ( $token_declares_off_session === $intent_requests_off_session ) {
+			return;
+		}
+
+		$order    = $payment_information->get_order();
+		$order_id = $order ? $order->get_id() : 'unknown';
+
+		if ( $intent_requests_off_session ) {
+			Logger::error(
+				sprintf(
+					'Order %s is saving the payment method, but its confirmation token was minted without setup_future_usage, so Stripe will reject this payment. '
+					. 'Something outside WooCommerce Subscriptions is requesting the save. Declare it with the wcpay_express_checkout_setup_future_usage filter '
+					. 'so express checkout mints the token with off_session.',
+					$order_id
+				)
+			);
+			return;
+		}
 
 		Logger::error(
 			sprintf(
-				'Order %s is saving the payment method, but its confirmation token was minted without setup_future_usage, so Stripe will reject this payment. '
-				. 'Something outside WooCommerce Subscriptions is requesting the save. Declare it with the wcpay_express_checkout_setup_future_usage filter '
-				. 'so express checkout mints the token with off_session.',
-				$order ? $order->get_id() : 'unknown'
+				'Order %s was paid with a confirmation token minted for off_session use, but this payment does not save the payment method. '
+				. 'Stripe applies the token\'s setup_future_usage regardless, so the card is attached to the customer with no WooPayments token recorded against it. '
+				. 'Check whatever filters wcpay_express_checkout_setup_future_usage — declare off_session only when the payment method will genuinely be saved.',
+				$order_id
 			)
 		);
 	}

--- a/includes/class-wc-payment-gateway-wcpay.php
+++ b/includes/class-wc-payment-gateway-wcpay.php
@@ -5507,15 +5507,19 @@ class WC_Payment_Gateway_WCPay extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		$token_declares_off_session  = null !== $express_checkout_helper->get_setup_future_usage( 'cart' );
+		$order    = $payment_information->get_order();
+		$order_id = $order->get_id();
+
+		// Both surfaces the token can be minted from: the cart, and — on the order-pay page,
+		// which processes with an empty cart — the order. Asking the cart alone would report
+		// a mismatch on every successful renewal paid from that page.
+		$token_declares_off_session  = null !== $express_checkout_helper->get_setup_future_usage( 'cart' )
+			|| $this->is_payment_recurring( $order_id );
 		$intent_requests_off_session = $save_payment_method_to_store && $this->payment_method->is_reusable();
 
 		if ( $token_declares_off_session === $intent_requests_off_session ) {
 			return;
 		}
-
-		$order    = $payment_information->get_order();
-		$order_id = $order ? $order->get_id() : 'unknown';
 
 		if ( $intent_requests_off_session ) {
 			Logger::error(

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-handler.php
@@ -255,6 +255,8 @@ class WC_Payments_Express_Checkout_Button_Handler {
 						'display_prices_with_tax'    => 'incl' === get_option( 'woocommerce_tax_display_cart' ),
 					],
 					'has_subscription'            => $this->express_checkout_helper->has_subscription_product(),
+					// Covers the product page, where no Store API cart exists yet to carry it.
+					'setup_future_usage'          => $this->express_checkout_helper->get_setup_future_usage(),
 					'is_manual_capture'           => 'yes' === $this->gateway->get_option( 'manual_capture' ),
 					'button'                      => $this->get_button_settings(),
 					'login_confirmation'          => $this->get_login_confirmation_settings(),

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -427,8 +427,10 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	 *
 	 * @param string|null $context Button context to evaluate for ('product', 'cart',
 	 *                             'checkout', 'pay_for_order'). Defaults to the current
-	 *                             page's context. Pass 'cart' explicitly from request
-	 *                             handlers that carry no page context.
+	 *                             page's context. 'cart', 'checkout' and 'pay_for_order'
+	 *                             resolve from cart or order state, so request handlers
+	 *                             with no page context can name one; 'product' needs the
+	 *                             queried product and falls back to page state.
 	 *
 	 * @return string|null 'off_session' when the payment method will be saved, null otherwise.
 	 */
@@ -437,6 +439,9 @@ class WC_Payments_Express_Checkout_Button_Helper {
 
 		switch ( $context ) {
 			case 'cart':
+			case 'checkout':
+				// Both read the same cart. Naming either resolves without page state, which
+				// is what lets request handlers with no page context ask.
 				$will_be_saved = $this->cart_contains_subscription();
 				break;
 			case 'pay_for_order':
@@ -445,6 +450,8 @@ class WC_Payments_Express_Checkout_Button_Helper {
 				$will_be_saved = $this->order_contains_subscription();
 				break;
 			default:
+				// 'product' included: it needs the queried product, so it can only be
+				// answered from page state.
 				$will_be_saved = $this->has_subscription_product();
 				break;
 		}

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -331,21 +331,93 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		}
 
 		if ( $this->is_checkout() || $this->is_cart() ) {
-			if ( WC_Subscriptions_Cart::cart_contains_subscription() ) {
-				return true;
-			}
-			if ( function_exists( 'wcs_cart_contains_renewal' ) && wcs_cart_contains_renewal() ) {
-				return true;
-			}
-			if ( function_exists( 'wcs_cart_contains_resubscribe' ) && wcs_cart_contains_resubscribe() ) {
-				return true;
-			}
-			if ( function_exists( 'wcs_cart_contains_switches' ) && wcs_cart_contains_switches() ) {
-				return true;
-			}
+			return $this->cart_contains_subscription();
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks whether the cart holds a subscription schedule of any shape: an initial
+	 * purchase, a renewal, a resubscribe or a switch.
+	 *
+	 * Reads cart state only, with no page context, so callers that run outside a page
+	 * request can share it — notably the Store API cart endpoint, where `is_cart()` and
+	 * `is_checkout()` are both false and `has_subscription_product()` would always
+	 * report false.
+	 *
+	 * @return boolean
+	 */
+	public function cart_contains_subscription() {
+		if ( ! class_exists( 'WC_Subscriptions_Cart' ) ) {
+			return false;
+		}
+
+		if ( WC_Subscriptions_Cart::cart_contains_subscription() ) {
+			return true;
+		}
+		if ( function_exists( 'wcs_cart_contains_renewal' ) && wcs_cart_contains_renewal() ) {
+			return true;
+		}
+		if ( function_exists( 'wcs_cart_contains_resubscribe' ) && wcs_cart_contains_resubscribe() ) {
+			return true;
+		}
+		if ( function_exists( 'wcs_cart_contains_switches' ) && wcs_cart_contains_switches() ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the `setup_future_usage` that express checkout should mint its Stripe
+	 * ConfirmationToken with, for the current cart or product.
+	 *
+	 * Stripe fixes this value when the token is created — before the wallet sheet opens —
+	 * and rejects the confirmation if the PaymentIntent later asks for a different one.
+	 * The gateway asks for `off_session` whenever it saves the payment method, which it
+	 * does for WooCommerce Subscriptions carts and for anything setting
+	 * `wc-woocommerce_payments-new-payment-method`. Only the first of those is knowable
+	 * this early, so the filter below is how everything else declares itself.
+	 *
+	 * @param string|null $context Button context to evaluate for ('product', 'cart',
+	 *                             'checkout', 'pay_for_order'). Defaults to the current
+	 *                             page's context. Pass 'cart' explicitly from request
+	 *                             handlers that carry no page context.
+	 *
+	 * @return string|null 'off_session' when the payment method will be saved, null otherwise.
+	 */
+	public function get_setup_future_usage( ?string $context = null ) {
+		$context = $context ?? $this->get_button_context();
+
+		$will_be_saved = 'cart' === $context
+			? $this->cart_contains_subscription()
+			: $this->has_subscription_product();
+
+		/**
+		 * Filters the `setup_future_usage` express checkout mints its ConfirmationToken with.
+		 *
+		 * Return 'off_session' when the payment method will genuinely be saved for later —
+		 * a subscription plugin other than WooCommerce Subscriptions, or any integration that
+		 * sets `wc-woocommerce_payments-new-payment-method` while the order is processed.
+		 * Return null otherwise.
+		 *
+		 * Declare 'off_session' only when the payment method really will be saved. Stripe
+		 * inherits the token's value onto the PaymentIntent even when the intent itself omits
+		 * it, so over-declaring silently attaches the shopper's card to the Stripe customer on
+		 * an ordinary one-off purchase, with no WooPayments token recorded against it.
+		 *
+		 * @since 11.1.0
+		 *
+		 * @param string|null $setup_future_usage 'off_session' or null.
+		 * @param string      $context            Button context: 'product', 'cart', 'checkout',
+		 *                                        'pay_for_order', or '' when undetermined.
+		 */
+		return apply_filters(
+			'wcpay_express_checkout_setup_future_usage',
+			$will_be_saved ? 'off_session' : null,
+			$context
+		);
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -370,6 +370,28 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	}
 
 	/**
+	 * Checks whether the order being paid holds a subscription — a parent order or a
+	 * renewal. The pay-for-order page runs with an empty cart, so the cart-based and
+	 * product-based predicates both report false there while the gateway still saves the
+	 * payment method for the subscription on the order.
+	 *
+	 * @return boolean
+	 */
+	public function order_contains_subscription() {
+		if ( ! function_exists( 'wcs_order_contains_subscription' ) ) {
+			return false;
+		}
+
+		$order = $this->get_current_order();
+		if ( ! $order ) {
+			return false;
+		}
+
+		return wcs_order_contains_subscription( $order )
+			|| ( function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order ) );
+	}
+
+	/**
 	 * Returns the `setup_future_usage` that express checkout should mint its Stripe
 	 * ConfirmationToken with, for the current cart or product.
 	 *
@@ -390,9 +412,19 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	public function get_setup_future_usage( ?string $context = null ) {
 		$context = $context ?? $this->get_button_context();
 
-		$will_be_saved = 'cart' === $context
-			? $this->cart_contains_subscription()
-			: $this->has_subscription_product();
+		switch ( $context ) {
+			case 'cart':
+				$will_be_saved = $this->cart_contains_subscription();
+				break;
+			case 'pay_for_order':
+				// Paying an existing order leaves the cart empty, so the subscription this
+				// payment renews lives on the order and nowhere else.
+				$will_be_saved = $this->order_contains_subscription();
+				break;
+			default:
+				$will_be_saved = $this->has_subscription_product();
+				break;
+		}
 
 		/**
 		 * Filters the `setup_future_usage` express checkout mints its ConfirmationToken with.

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -370,25 +370,25 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	}
 
 	/**
-	 * Checks whether the order being paid holds a subscription — a parent order or a
-	 * renewal. The pay-for-order page runs with an empty cart, so the cart-based and
-	 * product-based predicates both report false there while the gateway still saves the
-	 * payment method for the subscription on the order.
+	 * Checks whether the order being paid is a recurring payment. The pay-for-order page
+	 * runs with an empty cart, so the cart-based and product-based predicates both report
+	 * false there while the gateway still saves the payment method for the subscription on
+	 * the order.
+	 *
+	 * Defers to the gateway's own `is_payment_recurring()` rather than re-deriving it. The
+	 * whole point of this predicate is to agree with the decision the gateway will make
+	 * after the wallet sheet closes, and two hand-maintained copies would drift — the
+	 * renewal clause was itself a later addition to that method.
 	 *
 	 * @return boolean
 	 */
 	public function order_contains_subscription() {
-		if ( ! function_exists( 'wcs_order_contains_subscription' ) ) {
-			return false;
-		}
-
 		$order = $this->get_order_being_paid();
 		if ( ! $order ) {
 			return false;
 		}
 
-		return wcs_order_contains_subscription( $order )
-			|| ( function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order ) );
+		return $this->gateway->is_payment_recurring( $order->get_id() );
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -348,7 +348,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	 *
 	 * @return boolean
 	 */
-	public function cart_contains_subscription() {
+	private function cart_contains_subscription() {
 		if ( ! class_exists( 'WC_Subscriptions_Cart' ) ) {
 			return false;
 		}
@@ -382,7 +382,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	 *
 	 * @return boolean
 	 */
-	public function order_contains_subscription() {
+	private function order_contains_subscription() {
 		$order = $this->get_order_being_paid();
 		if ( ! $order ) {
 			return false;
@@ -401,7 +401,7 @@ class WC_Payments_Express_Checkout_Button_Helper {
 	 *
 	 * @return WC_Order|WC_Order_Refund|false
 	 */
-	public function get_order_being_paid() {
+	private function get_order_being_paid() {
 		global $wp;
 
 		if ( isset( $wp->query_vars['order-pay'] ) ) {

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -468,11 +468,19 @@ class WC_Payments_Express_Checkout_Button_Helper {
 		 * @param string      $context            Button context: 'product', 'cart', 'checkout',
 		 *                                        'pay_for_order', or '' when undetermined.
 		 */
-		return apply_filters(
+		$setup_future_usage = apply_filters(
 			'wcpay_express_checkout_setup_future_usage',
 			$will_be_saved ? 'off_session' : null,
 			$context
 		);
+
+		// Normalise whatever came back to the two values Stripe and the Store API schema
+		// accept. The server infers the token's value from this while every client consumer
+		// gates on truthiness, so anything else — `false` from `__return_false`, `true` from
+		// `__return_true` — has the two sides disagreeing about the same payment. Anything
+		// that is not an explicit 'off_session' resolves to null, which fails loudly at
+		// Stripe rather than silently vaulting a card.
+		return 'off_session' === $setup_future_usage ? 'off_session' : null;
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-button-helper.php
@@ -382,13 +382,36 @@ class WC_Payments_Express_Checkout_Button_Helper {
 			return false;
 		}
 
-		$order = $this->get_current_order();
+		$order = $this->get_order_being_paid();
 		if ( ! $order ) {
 			return false;
 		}
 
 		return wcs_order_contains_subscription( $order )
 			|| ( function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order ) );
+	}
+
+	/**
+	 * Resolves the order the shopper is paying for on the order-pay endpoint.
+	 *
+	 * `get_current_order()` reads `$theorder` and `$post`, which only resolve an order on
+	 * the admin edit screen — on the front end `$post` is the checkout page, so it hands
+	 * back the wrong object or nothing at all. The order-pay endpoint carries the ID in a
+	 * query var instead, the same way the gateway and customer service read it.
+	 *
+	 * @return WC_Order|WC_Order_Refund|false
+	 */
+	public function get_order_being_paid() {
+		global $wp;
+
+		if ( isset( $wp->query_vars['order-pay'] ) ) {
+			$order = wc_get_order( absint( $wp->query_vars['order-pay'] ) );
+			if ( $order ) {
+				return $order;
+			}
+		}
+
+		return $this->get_current_order();
 	}
 
 	/**

--- a/includes/express-checkout/class-wc-payments-express-checkout-store-api-extension.php
+++ b/includes/express-checkout/class-wc-payments-express-checkout-store-api-extension.php
@@ -76,7 +76,11 @@ class WC_Payments_Express_Checkout_Store_API_Extension {
 	 * `methods_enabled_at_location` (the raw, currency-independent location
 	 * settings) to get the final set.
 	 *
-	 * @return array{express_checkout_methods: string[]}
+	 * Also carries the `setup_future_usage` the client must mint its ConfirmationToken
+	 * with. Deciding that server-side keeps one predicate — and one filter — behind every
+	 * express checkout surface, instead of each re-deriving it from the cart response.
+	 *
+	 * @return array{express_checkout_methods: string[], setup_future_usage: string|null}
 	 */
 	public function extend_cart_data() {
 		$methods = [];
@@ -89,7 +93,11 @@ class WC_Payments_Express_Checkout_Store_API_Extension {
 			$methods[] = 'amazon_pay';
 		}
 
-		return [ 'express_checkout_methods' => $methods ];
+		return [
+			'express_checkout_methods' => $methods,
+			// This endpoint has no page context, so the context is named rather than inferred.
+			'setup_future_usage'       => $this->express_checkout_helper->get_setup_future_usage( 'cart' ),
+		];
 	}
 
 	/**
@@ -107,6 +115,13 @@ class WC_Payments_Express_Checkout_Store_API_Extension {
 				'items'       => [
 					'type' => 'string',
 				],
+			],
+			'setup_future_usage'       => [
+				'description' => __( 'Whether Express Checkout should authorize the payment method for future off-session payments.', 'woocommerce-payments' ),
+				'type'        => [ 'string', 'null' ],
+				'enum'        => [ 'off_session', null ],
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
 			],
 		];
 	}

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-handler.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-handler.php
@@ -144,9 +144,15 @@ class WC_Payments_Express_Checkout_Button_Handler_Test extends WCPAY_UnitTestCas
 					'radius' => '10',
 				]
 			);
+		$this->mock_ece_button_helper
+			->method( 'get_setup_future_usage' )
+			->willReturn( 'off_session' );
+
 		$params = $this->system_under_test->get_express_checkout_params();
 		$this->assertArrayHasKey( 'store_name', $params );
 		$this->assertEquals( get_bloginfo( 'name' ), $params['store_name'] );
+		// The product page has no Store API cart to carry this, so it ships localized.
+		$this->assertSame( 'off_session', $params['setup_future_usage'] );
 	}
 
 	public function test_payment_fields_js_config_on_cart_page_with_cart_disabled() {

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -495,6 +495,45 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	}
 
 	/**
+	 * Every client consumer gates on truthiness while the server infers from `null !==`, so
+	 * a filter returning anything other than 'off_session' or null has the two sides
+	 * disagreeing about the same payment.
+	 *
+	 * @dataProvider provider_non_canonical_filter_returns
+	 *
+	 * @param mixed $returned What the filter hands back.
+	 */
+	public function test_get_setup_future_usage_normalises_non_canonical_filter_returns( $returned ) {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		$filter = function () use ( $returned ) {
+			return $returned;
+		};
+		add_filter( 'wcpay_express_checkout_setup_future_usage', $filter );
+
+		$actual = $this->system_under_test->get_setup_future_usage( 'cart' );
+
+		remove_filter( 'wcpay_express_checkout_setup_future_usage', $filter );
+
+		$this->assertNull( $actual );
+	}
+
+	/**
+	 * Data provider for the filter normalisation test.
+	 *
+	 * @return array
+	 */
+	public function provider_non_canonical_filter_returns() {
+		return [
+			'__return_false' => [ false ],
+			'__return_true'  => [ true ],
+			'empty string'   => [ '' ],
+			'on_session'     => [ 'on_session' ],
+			'zero'           => [ 0 ],
+		];
+	}
+
+	/**
 	 * Puts a real order on the order-pay endpoint, the way the front end does. Resolution
 	 * is deliberately left unmocked — mocking it is what hid the order going unresolved
 	 * outside the admin.

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -296,6 +296,122 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		$this->assertFalse( $helper->has_subscription_product() );
 	}
 
+	public function test_cart_contains_subscription_reads_cart_state_without_page_context() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		// No is_cart()/is_checkout() stubbing: the point is that this works with no page context.
+		$this->assertTrue( $this->system_under_test->cart_contains_subscription() );
+	}
+
+	public function test_cart_contains_subscription_detects_renewal_carts() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+		WC_Subscriptions::wcs_cart_contains_renewal(
+			function () {
+				return true;
+			}
+		);
+
+		$this->assertTrue( $this->system_under_test->cart_contains_subscription() );
+	}
+
+	public function test_cart_contains_subscription_is_false_for_a_plain_cart() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		$this->assertFalse( $this->system_under_test->cart_contains_subscription() );
+	}
+
+	public function test_get_setup_future_usage_is_off_session_for_a_subscription_cart() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		$helper = $this->make_helper_for_context( false, true, false );
+
+		$this->assertSame( 'off_session', $helper->get_setup_future_usage() );
+	}
+
+	public function test_get_setup_future_usage_is_null_for_a_plain_cart() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		$helper = $this->make_helper_for_context( false, true, false );
+
+		$this->assertNull( $helper->get_setup_future_usage() );
+	}
+
+	public function test_get_setup_future_usage_is_off_session_on_a_subscription_product_page() {
+		WC_Subscriptions_Product::$is_subscription = true;
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		$helper = $this->make_helper_for_context( true, false, false );
+
+		$this->assertSame( 'off_session', $helper->get_setup_future_usage() );
+	}
+
+	/**
+	 * The Store API cart endpoint carries no page context, so it names the context instead.
+	 * Without that, is_cart()/is_checkout() are both false and the cart would look plain.
+	 */
+	public function test_get_setup_future_usage_honours_a_named_cart_context_with_no_page_context() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		$this->assertSame( 'off_session', $this->system_under_test->get_setup_future_usage( 'cart' ) );
+	}
+
+	public function test_get_setup_future_usage_filter_can_declare_off_session() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		$seen_context = null;
+		$filter       = function ( $value, $context ) use ( &$seen_context ) {
+			$seen_context = $context;
+			return 'off_session';
+		};
+		add_filter( 'wcpay_express_checkout_setup_future_usage', $filter, 10, 2 );
+
+		$actual = $this->system_under_test->get_setup_future_usage( 'cart' );
+
+		remove_filter( 'wcpay_express_checkout_setup_future_usage', $filter, 10 );
+
+		$this->assertSame( 'off_session', $actual );
+		$this->assertSame( 'cart', $seen_context );
+	}
+
+	public function test_get_setup_future_usage_filter_can_suppress_off_session() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
+
+		$filter = function () {
+			return null;
+		};
+		add_filter( 'wcpay_express_checkout_setup_future_usage', $filter );
+
+		$actual = $this->system_under_test->get_setup_future_usage( 'cart' );
+
+		remove_filter( 'wcpay_express_checkout_setup_future_usage', $filter );
+
+		$this->assertNull( $actual );
+	}
+
+	/**
+	 * Builds a helper whose page context is pinned, so context-dependent predicates
+	 * can be exercised off an actual request.
+	 *
+	 * @param bool $is_product  Whether to report a product page.
+	 * @param bool $is_cart     Whether to report the cart page.
+	 * @param bool $is_checkout Whether to report the checkout page.
+	 *
+	 * @return WC_Payments_Express_Checkout_Button_Helper|MockObject
+	 */
+	private function make_helper_for_context( bool $is_product, bool $is_cart, bool $is_checkout ) {
+		$helper = $this->getMockBuilder( WC_Payments_Express_Checkout_Button_Helper::class )
+			->setConstructorArgs( [ $this->mock_wcpay_gateway, $this->mock_wcpay_account ] )
+			->onlyMethods( [ 'is_product', 'is_cart', 'is_checkout', 'is_pay_for_order_page' ] )
+			->getMock();
+
+		$helper->method( 'is_product' )->willReturn( $is_product );
+		$helper->method( 'is_cart' )->willReturn( $is_cart );
+		$helper->method( 'is_checkout' )->willReturn( $is_checkout );
+		$helper->method( 'is_pay_for_order_page' )->willReturn( false );
+
+		return $helper;
+	}
+
 	public function test_common_get_button_settings() {
 		$this->assertEquals(
 			[

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -299,14 +299,14 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		$this->assertFalse( $helper->has_subscription_product() );
 	}
 
-	public function test_cart_contains_subscription_reads_cart_state_without_page_context() {
+	public function test_named_cart_context_reads_cart_state_without_page_context() {
 		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
 
 		// No is_cart()/is_checkout() stubbing: the point is that this works with no page context.
-		$this->assertTrue( $this->system_under_test->cart_contains_subscription() );
+		$this->assertSame( 'off_session', $this->system_under_test->get_setup_future_usage( 'cart' ) );
 	}
 
-	public function test_cart_contains_subscription_detects_renewal_carts() {
+	public function test_named_cart_context_detects_renewal_carts() {
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 		WC_Subscriptions::wcs_cart_contains_renewal(
 			function () {
@@ -314,13 +314,13 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 			}
 		);
 
-		$this->assertTrue( $this->system_under_test->cart_contains_subscription() );
+		$this->assertSame( 'off_session', $this->system_under_test->get_setup_future_usage( 'cart' ) );
 	}
 
-	public function test_cart_contains_subscription_is_false_for_a_plain_cart() {
+	public function test_named_cart_context_is_null_for_a_plain_cart() {
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 
-		$this->assertFalse( $this->system_under_test->cart_contains_subscription() );
+		$this->assertNull( $this->system_under_test->get_setup_future_usage( 'cart' ) );
 	}
 
 	public function test_get_setup_future_usage_is_off_session_for_a_subscription_cart() {
@@ -438,14 +438,20 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	 * admin globals, where `$post` is the checkout page on the front end — so resolving
 	 * through it returns no order and the subscription goes undetected.
 	 */
-	public function test_get_order_being_paid_resolves_the_order_pay_query_var() {
+	public function test_pay_for_order_resolves_the_order_from_the_query_var() {
 		$order = WC_Helper_Order::create_order();
+
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+		WC_Subscriptions::set_wcs_order_contains_subscription(
+			function ( $order_id ) use ( $order ) {
+				// Answers only for this exact order, so resolving the checkout page — or
+				// nothing at all — cannot pass this.
+				return (int) $order_id === $order->get_id();
+			}
+		);
 		$this->set_order_pay_endpoint( $order );
 
-		$resolved = $this->system_under_test->get_order_being_paid();
-
-		$this->assertInstanceOf( WC_Order::class, $resolved );
-		$this->assertSame( $order->get_id(), $resolved->get_id() );
+		$this->assertSame( 'off_session', $this->system_under_test->get_setup_future_usage( 'pay_for_order' ) );
 	}
 
 	/**

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -105,6 +105,8 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		WC_Subscriptions::wcs_cart_contains_renewal( null );
 		WC_Subscriptions::wcs_cart_contains_resubscribe( null );
 		WC_Subscriptions::wcs_cart_contains_switches( null );
+		WC_Subscriptions::set_wcs_order_contains_subscription( null );
+		WC_Subscriptions::wcs_order_contains_renewal( null );
 		WC_Subscriptions_Product::$is_subscription = true;
 		WC_Subscriptions_Product::$trial_length    = 0;
 		WC()->cart->empty_cart();
@@ -400,6 +402,94 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		remove_filter( 'wcpay_express_checkout_setup_future_usage', $filter );
 
 		$this->assertNull( $actual );
+	}
+
+	/**
+	 * Paying an existing order runs with an empty cart, so the cart and product predicates
+	 * both report false while the gateway still saves the payment method for the
+	 * subscription on the order.
+	 */
+	public function test_get_setup_future_usage_reads_the_order_for_pay_for_order() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+		WC_Subscriptions::set_wcs_order_contains_subscription(
+			function () {
+				return true;
+			}
+		);
+
+		$actual = $this->make_helper_for_order()->get_setup_future_usage( 'pay_for_order' );
+
+		$this->assertSame( 'off_session', $actual );
+	}
+
+	public function test_get_setup_future_usage_is_null_for_a_pay_for_order_without_a_subscription() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		$actual = $this->make_helper_for_order()->get_setup_future_usage( 'pay_for_order' );
+
+		$this->assertNull( $actual );
+	}
+
+	/**
+	 * A renewal order carries the renewed subscription by reference rather than as a
+	 * subscription line item, so `wcs_order_contains_subscription()` alone misses it.
+	 */
+	public function test_get_setup_future_usage_recognises_a_renewal_order() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+		WC_Subscriptions::set_wcs_order_contains_subscription(
+			function () {
+				return false;
+			}
+		);
+		WC_Subscriptions::wcs_order_contains_renewal(
+			function () {
+				return true;
+			}
+		);
+
+		$actual = $this->make_helper_for_order()->get_setup_future_usage( 'pay_for_order' );
+
+		$this->assertSame( 'off_session', $actual );
+	}
+
+	/**
+	 * `get_current_order()` returns false off the order-pay page, and the subscription
+	 * predicates must not be handed that in place of an order.
+	 */
+	public function test_get_setup_future_usage_is_null_when_no_order_resolves() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+		WC_Subscriptions::set_wcs_order_contains_subscription(
+			function () {
+				return true;
+			}
+		);
+		WC_Subscriptions::wcs_order_contains_renewal(
+			function () {
+				return true;
+			}
+		);
+
+		$actual = $this->make_helper_for_order( false )->get_setup_future_usage( 'pay_for_order' );
+
+		$this->assertNull( $actual );
+	}
+
+	/**
+	 * Builds a helper resolving to a given order, for the pay-for-order context.
+	 *
+	 * @param WC_Order|false|null $order Order to resolve to, or false for none. Defaults
+	 *                                  to a freshly created order.
+	 *
+	 * @return WC_Payments_Express_Checkout_Button_Helper|MockObject
+	 */
+	private function make_helper_for_order( $order = null ) {
+		$helper = $this->getMockBuilder( WC_Payments_Express_Checkout_Button_Helper::class )
+			->setConstructorArgs( [ $this->mock_wcpay_gateway, $this->mock_wcpay_account ] )
+			->onlyMethods( [ 'get_current_order' ] )
+			->getMock();
+		$helper->method( 'get_current_order' )->willReturn( $order ?? WC_Helper_Order::create_order() );
+
+		return $helper;
 	}
 
 	/**

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -326,7 +326,7 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	public function test_get_setup_future_usage_is_off_session_for_a_subscription_cart() {
 		WC_Subscriptions_Cart::set_cart_contains_subscription( true );
 
-		$helper = $this->make_helper_for_context( false, true, false );
+		$helper = $this->make_helper_for_context( 'cart' );
 
 		$this->assertSame( 'off_session', $helper->get_setup_future_usage() );
 	}
@@ -334,7 +334,7 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	public function test_get_setup_future_usage_is_null_for_a_plain_cart() {
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 
-		$helper = $this->make_helper_for_context( false, true, false );
+		$helper = $this->make_helper_for_context( 'cart' );
 
 		$this->assertNull( $helper->get_setup_future_usage() );
 	}
@@ -343,7 +343,7 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		WC_Subscriptions_Product::$is_subscription = true;
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 
-		$helper = $this->make_helper_for_context( true, false, false );
+		$helper = $this->make_helper_for_context( 'product' );
 
 		$this->assertSame( 'off_session', $helper->get_setup_future_usage() );
 	}
@@ -357,7 +357,7 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		WC_Subscriptions_Product::$is_subscription = false;
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
 
-		$helper = $this->make_helper_for_context( true, false, false );
+		$helper = $this->make_helper_for_context( 'product' );
 
 		$this->assertNull( $helper->get_setup_future_usage() );
 	}
@@ -495,6 +495,25 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	}
 
 	/**
+	 * The handler calls `get_setup_future_usage()` with no argument, so the shipped value
+	 * comes from `get_button_context()`. Passing the context by hand in every other test
+	 * leaves that wiring unpinned for the branch this PR added.
+	 */
+	public function test_get_setup_future_usage_resolves_pay_for_order_with_no_argument() {
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+		WC_Subscriptions::set_wcs_order_contains_subscription(
+			function () {
+				return true;
+			}
+		);
+		$this->set_order_pay_endpoint( WC_Helper_Order::create_order() );
+
+		$helper = $this->make_helper_for_context( 'pay_for_order' );
+
+		$this->assertSame( 'off_session', $helper->get_setup_future_usage() );
+	}
+
+	/**
 	 * Every client consumer gates on truthiness while the server infers from `null !==`, so
 	 * a filter returning anything other than 'off_session' or null has the two sides
 	 * disagreeing about the same payment.
@@ -556,16 +575,17 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	 *
 	 * @return WC_Payments_Express_Checkout_Button_Helper|MockObject
 	 */
-	private function make_helper_for_context( bool $is_product, bool $is_cart, bool $is_checkout ) {
+	private function make_helper_for_context( string $context ) {
 		$helper = $this->getMockBuilder( WC_Payments_Express_Checkout_Button_Helper::class )
 			->setConstructorArgs( [ $this->mock_wcpay_gateway, $this->mock_wcpay_account ] )
 			->onlyMethods( [ 'is_product', 'is_cart', 'is_checkout', 'is_pay_for_order_page' ] )
 			->getMock();
 
-		$helper->method( 'is_product' )->willReturn( $is_product );
-		$helper->method( 'is_cart' )->willReturn( $is_cart );
-		$helper->method( 'is_checkout' )->willReturn( $is_checkout );
-		$helper->method( 'is_pay_for_order_page' )->willReturn( false );
+		$helper->method( 'is_product' )->willReturn( 'product' === $context );
+		$helper->method( 'is_cart' )->willReturn( 'cart' === $context );
+		// The order-pay page is part of checkout, so `is_checkout()` is true there too.
+		$helper->method( 'is_checkout' )->willReturn( in_array( $context, [ 'checkout', 'pay_for_order' ], true ) );
+		$helper->method( 'is_pay_for_order_page' )->willReturn( 'pay_for_order' === $context );
 
 		return $helper;
 	}

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -107,6 +107,7 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 		WC_Subscriptions::wcs_cart_contains_switches( null );
 		WC_Subscriptions::set_wcs_order_contains_subscription( null );
 		WC_Subscriptions::wcs_order_contains_renewal( null );
+		unset( $GLOBALS['wp']->query_vars['order-pay'] );
 		WC_Subscriptions_Product::$is_subscription = true;
 		WC_Subscriptions_Product::$trial_length    = 0;
 		WC()->cart->empty_cart();
@@ -416,18 +417,35 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 				return true;
 			}
 		);
+		$this->set_order_pay_endpoint( WC_Helper_Order::create_order() );
 
-		$actual = $this->make_helper_for_order()->get_setup_future_usage( 'pay_for_order' );
+		$actual = $this->system_under_test->get_setup_future_usage( 'pay_for_order' );
 
 		$this->assertSame( 'off_session', $actual );
 	}
 
 	public function test_get_setup_future_usage_is_null_for_a_pay_for_order_without_a_subscription() {
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+		$this->set_order_pay_endpoint( WC_Helper_Order::create_order() );
 
-		$actual = $this->make_helper_for_order()->get_setup_future_usage( 'pay_for_order' );
+		$actual = $this->system_under_test->get_setup_future_usage( 'pay_for_order' );
 
 		$this->assertNull( $actual );
+	}
+
+	/**
+	 * The order-pay page carries the order in a query var. `get_current_order()` reads the
+	 * admin globals, where `$post` is the checkout page on the front end — so resolving
+	 * through it returns no order and the subscription goes undetected.
+	 */
+	public function test_get_order_being_paid_resolves_the_order_pay_query_var() {
+		$order = WC_Helper_Order::create_order();
+		$this->set_order_pay_endpoint( $order );
+
+		$resolved = $this->system_under_test->get_order_being_paid();
+
+		$this->assertInstanceOf( WC_Order::class, $resolved );
+		$this->assertSame( $order->get_id(), $resolved->get_id() );
 	}
 
 	/**
@@ -447,14 +465,16 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 			}
 		);
 
-		$actual = $this->make_helper_for_order()->get_setup_future_usage( 'pay_for_order' );
+		$this->set_order_pay_endpoint( WC_Helper_Order::create_order() );
+
+		$actual = $this->system_under_test->get_setup_future_usage( 'pay_for_order' );
 
 		$this->assertSame( 'off_session', $actual );
 	}
 
 	/**
-	 * `get_current_order()` returns false off the order-pay page, and the subscription
-	 * predicates must not be handed that in place of an order.
+	 * Off the order-pay endpoint there is no order to read, and the subscription
+	 * predicates must not be handed a non-order in its place.
 	 */
 	public function test_get_setup_future_usage_is_null_when_no_order_resolves() {
 		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
@@ -469,27 +489,22 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 			}
 		);
 
-		$actual = $this->make_helper_for_order( false )->get_setup_future_usage( 'pay_for_order' );
+		$actual = $this->system_under_test->get_setup_future_usage( 'pay_for_order' );
 
 		$this->assertNull( $actual );
 	}
 
 	/**
-	 * Builds a helper resolving to a given order, for the pay-for-order context.
+	 * Puts a real order on the order-pay endpoint, the way the front end does. Resolution
+	 * is deliberately left unmocked — mocking it is what hid the order going unresolved
+	 * outside the admin.
 	 *
-	 * @param WC_Order|false|null $order Order to resolve to, or false for none. Defaults
-	 *                                  to a freshly created order.
-	 *
-	 * @return WC_Payments_Express_Checkout_Button_Helper|MockObject
+	 * @param WC_Order $order Order being paid.
 	 */
-	private function make_helper_for_order( $order = null ) {
-		$helper = $this->getMockBuilder( WC_Payments_Express_Checkout_Button_Helper::class )
-			->setConstructorArgs( [ $this->mock_wcpay_gateway, $this->mock_wcpay_account ] )
-			->onlyMethods( [ 'get_current_order' ] )
-			->getMock();
-		$helper->method( 'get_current_order' )->willReturn( $order ?? WC_Helper_Order::create_order() );
+	private function set_order_pay_endpoint( WC_Order $order ) {
+		global $wp;
 
-		return $helper;
+		$wp->query_vars['order-pay'] = (string) $order->get_id();
 	}
 
 	/**

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-button-helper.php
@@ -346,6 +346,20 @@ class WC_Payments_Express_Checkout_Button_Helper_Test extends WCPAY_UnitTestCase
 	}
 
 	/**
+	 * Counterpart to the test above. The subscription-product stub defaults to true, so
+	 * without this the product branch would assert `off_session` for every product page
+	 * and pin nothing.
+	 */
+	public function test_get_setup_future_usage_is_null_on_a_non_subscription_product_page() {
+		WC_Subscriptions_Product::$is_subscription = false;
+		WC_Subscriptions_Cart::set_cart_contains_subscription( false );
+
+		$helper = $this->make_helper_for_context( true, false, false );
+
+		$this->assertNull( $helper->get_setup_future_usage() );
+	}
+
+	/**
 	 * The Store API cart endpoint carries no page context, so it names the context instead.
 	 * Without that, is_cart()/is_checkout() are both false and the cart would look plain.
 	 */

--- a/tests/unit/express-checkout/test-class-wc-payments-express-checkout-store-api-extension.php
+++ b/tests/unit/express-checkout/test-class-wc-payments-express-checkout-store-api-extension.php
@@ -50,7 +50,13 @@ class WC_Payments_Express_Checkout_Store_API_Extension_Test extends WCPAY_UnitTe
 
 		$result = $this->extension->extend_cart_data();
 
-		$this->assertSame( [ 'express_checkout_methods' => [ 'payment_request' ] ], $result );
+		$this->assertSame(
+			[
+				'express_checkout_methods' => [ 'payment_request' ],
+				'setup_future_usage'       => null,
+			],
+			$result
+		);
 	}
 
 	public function test_extend_cart_data_includes_amazon_pay_when_can_use() {
@@ -59,7 +65,13 @@ class WC_Payments_Express_Checkout_Store_API_Extension_Test extends WCPAY_UnitTe
 
 		$result = $this->extension->extend_cart_data();
 
-		$this->assertSame( [ 'express_checkout_methods' => [ 'amazon_pay' ] ], $result );
+		$this->assertSame(
+			[
+				'express_checkout_methods' => [ 'amazon_pay' ],
+				'setup_future_usage'       => null,
+			],
+			$result
+		);
 	}
 
 	public function test_extend_cart_data_includes_both_when_both_pass() {
@@ -69,7 +81,10 @@ class WC_Payments_Express_Checkout_Store_API_Extension_Test extends WCPAY_UnitTe
 		$result = $this->extension->extend_cart_data();
 
 		$this->assertSame(
-			[ 'express_checkout_methods' => [ 'payment_request', 'amazon_pay' ] ],
+			[
+				'express_checkout_methods' => [ 'payment_request', 'amazon_pay' ],
+				'setup_future_usage'       => null,
+			],
 			$result
 		);
 	}
@@ -80,7 +95,38 @@ class WC_Payments_Express_Checkout_Store_API_Extension_Test extends WCPAY_UnitTe
 
 		$result = $this->extension->extend_cart_data();
 
-		$this->assertSame( [ 'express_checkout_methods' => [] ], $result );
+		$this->assertSame(
+			[
+				'express_checkout_methods' => [],
+				'setup_future_usage'       => null,
+			],
+			$result
+		);
+	}
+
+	public function test_extend_cart_data_carries_the_setup_future_usage_for_the_cart() {
+		$this->mock_gateway->method( 'is_payment_request_enabled' )->willReturn( false );
+		$this->mock_helper->method( 'can_use_amazon_pay' )->willReturn( false );
+		$this->mock_helper->method( 'get_setup_future_usage' )->willReturn( 'off_session' );
+
+		$result = $this->extension->extend_cart_data();
+
+		$this->assertSame( 'off_session', $result['setup_future_usage'] );
+	}
+
+	/**
+	 * This endpoint runs with no page context, so the context has to be named — inferring
+	 * it would make every cart look plain and mint tokens without `setup_future_usage`.
+	 */
+	public function test_extend_cart_data_asks_for_the_cart_context_explicitly() {
+		$this->mock_gateway->method( 'is_payment_request_enabled' )->willReturn( false );
+		$this->mock_helper->method( 'can_use_amazon_pay' )->willReturn( false );
+		$this->mock_helper->expects( $this->once() )
+			->method( 'get_setup_future_usage' )
+			->with( 'cart' )
+			->willReturn( null );
+
+		$this->extension->extend_cart_data();
 	}
 
 	public function test_extend_cart_schema_describes_the_methods_field() {
@@ -90,5 +136,14 @@ class WC_Payments_Express_Checkout_Store_API_Extension_Test extends WCPAY_UnitTe
 		$this->assertSame( 'array', $schema['express_checkout_methods']['type'] );
 		$this->assertSame( 'string', $schema['express_checkout_methods']['items']['type'] );
 		$this->assertTrue( $schema['express_checkout_methods']['readonly'] );
+	}
+
+	public function test_extend_cart_schema_describes_the_setup_future_usage_field() {
+		$schema = $this->extension->extend_cart_schema();
+
+		$this->assertArrayHasKey( 'setup_future_usage', $schema );
+		$this->assertSame( [ 'string', 'null' ], $schema['setup_future_usage']['type'] );
+		$this->assertSame( [ 'off_session', null ], $schema['setup_future_usage']['enum'] );
+		$this->assertTrue( $schema['setup_future_usage']['readonly'] );
 	}
 }

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -206,6 +206,13 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		$_GET     = [];
 		$_POST    = [];
 		$_REQUEST = [];
+
+		// capture_wcpay_logs() swaps the container's logger and puts the shared mode
+		// singleton into dev. Both outlive the test otherwise, leaving every later test
+		// in the process logging through a mock from a finished test.
+		wcpay_get_test_container()->reset_all_replacements();
+		WC_Payments::mode()->live();
+
 		parent::tear_down();
 	}
 
@@ -429,6 +436,45 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 	}
 
 	/**
+	 * An ordinary card subscription carries a payment method, not a confirmation token, so
+	 * none of this applies to it — its `setup_future_usage` is never pinned to anything.
+	 * Without the `is_using_confirmation_token()` guard every classic-checkout subscription
+	 * purchase would log an error telling the merchant to fix a problem they do not have.
+	 */
+	public function test_does_not_log_for_a_payment_method_subscription() {
+		$logged = $this->capture_wcpay_logs();
+
+		$this->process_subscription_payment_with_confirmation_token( null, false );
+
+		$this->assertEmpty( $this->logs_naming_the_setup_future_usage_filter( $logged ) );
+	}
+
+	/**
+	 * The opposite mismatch, and the quiet one: the token declares off_session while this
+	 * payment does not save the method. Stripe applies the token's value anyway, attaching
+	 * the card to the customer with nothing recorded locally, so it never surfaces as a
+	 * failed order.
+	 */
+	public function test_logs_when_the_token_declares_off_session_but_the_payment_does_not_save() {
+		$logged = $this->capture_wcpay_logs();
+
+		$this->process_payment_without_saving_with_confirmation_token( 'off_session' );
+
+		$this->assertNotEmpty(
+			$this->logs_naming_the_setup_future_usage_filter( $logged ),
+			'Expected a silently vaulted card to be logged.'
+		);
+	}
+
+	public function test_does_not_log_when_neither_side_wants_off_session() {
+		$logged = $this->capture_wcpay_logs();
+
+		$this->process_payment_without_saving_with_confirmation_token( null );
+
+		$this->assertEmpty( $this->logs_naming_the_setup_future_usage_filter( $logged ) );
+	}
+
+	/**
 	 * Replaces the internal logger with one backed by a mock WC_Logger that records
 	 * every call, so assertions can be made on what was logged rather than on
 	 * invocation-count matchers.
@@ -479,18 +525,15 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 	}
 
 	/**
-	 * Runs a paid subscription order through process_payment with a confirmation token,
-	 * with express checkout reporting the given `setup_future_usage` for the cart.
+	 * Runs a plain (non-subscription) order through process_payment with a confirmation
+	 * token, so nothing asks for the payment method to be saved.
 	 *
 	 * @param string|null $express_checkout_setup_future_usage What the ECE predicate reports.
 	 */
-	private function process_subscription_payment_with_confirmation_token( ?string $express_checkout_setup_future_usage ) {
-		$order         = WC_Helper_Order::create_order( self::USER_ID );
-		$subscriptions = [ new WC_Subscription() ];
-		$subscriptions[0]->set_parent( $order );
+	private function process_payment_without_saving_with_confirmation_token( ?string $express_checkout_setup_future_usage ) {
+		$order = WC_Helper_Order::create_order( self::USER_ID );
 
-		$this->mock_wcs_order_contains_subscription( true );
-		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
+		$this->mock_wcs_order_contains_subscription( false );
 
 		$_POST = [
 			'wcpay-confirmation-token' => 'ctoken_mock',
@@ -498,7 +541,61 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		];
 
 		$mock_ece_helper = $this->createMock( WC_Payments_Express_Checkout_Button_Helper::class );
-		$mock_ece_helper->method( 'get_setup_future_usage' )->willReturn( $express_checkout_setup_future_usage );
+		$mock_ece_helper->method( 'get_setup_future_usage' )
+			->with( 'cart' )
+			->willReturn( $express_checkout_setup_future_usage );
+
+		$original_ece_helper = WC_Payments::get_express_checkout_helper();
+		WC_Payments::set_express_checkout_helper( $mock_ece_helper );
+
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+		$request->expects( $this->never() )
+			->method( 'setup_future_usage' );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $this->payment_intent );
+
+		try {
+			$this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		} finally {
+			WC_Payments::set_express_checkout_helper( $original_ece_helper );
+		}
+	}
+
+	/**
+	 * Runs a paid subscription order through process_payment, with express checkout
+	 * reporting the given `setup_future_usage` for the cart.
+	 *
+	 * @param string|null $express_checkout_setup_future_usage What the ECE predicate reports.
+	 * @param bool        $use_confirmation_token              Whether to pay with a confirmation
+	 *                                                         token (express checkout) or a
+	 *                                                         payment method (classic checkout).
+	 */
+	private function process_subscription_payment_with_confirmation_token(
+		?string $express_checkout_setup_future_usage,
+		bool $use_confirmation_token = true
+	) {
+		$order         = WC_Helper_Order::create_order( self::USER_ID );
+		$subscriptions = [ new WC_Subscription() ];
+		$subscriptions[0]->set_parent( $order );
+
+		$this->mock_wcs_order_contains_subscription( true );
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
+
+		$_POST = $use_confirmation_token
+			? [
+				'wcpay-confirmation-token' => 'ctoken_mock',
+				'payment_method'           => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+			]
+			: [
+				'wcpay-payment-method' => self::PAYMENT_METHOD_ID,
+				'payment_method'       => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+			];
+
+		$mock_ece_helper = $this->createMock( WC_Payments_Express_Checkout_Button_Helper::class );
+		$mock_ece_helper->method( 'get_setup_future_usage' )
+			->with( 'cart' )
+			->willReturn( $express_checkout_setup_future_usage );
 
 		$original_ece_helper = WC_Payments::get_express_checkout_helper();
 		WC_Payments::set_express_checkout_helper( $mock_ece_helper );
@@ -526,6 +623,12 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		$order         = WC_Helper_Order::create_order( self::USER_ID, 0 );
 		$subscriptions = [ new WC_Subscription() ];
 		$subscriptions[0]->set_parent( $order );
+
+		// These stubs are static and shared across the class. Setting them here rather than
+		// inheriting whatever an earlier test happened to leave behind — without them this
+		// test passes only when it runs after one that sets them.
+		$this->mock_wcs_order_contains_subscription( true );
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
 
 		$request = $this->mock_wcpay_request( Create_And_Confirm_Setup_Intention::class );
 

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -12,6 +12,7 @@ use WCPay\Constants\Order_Status;
 use WCPay\Constants\Intent_Status;
 use WCPay\Duplicate_Payment_Prevention_Service;
 use WCPay\Duplicates_Detection_Service;
+use WCPay\Internal\Logger as InternalLogger;
 use WCPay\Payment_Methods\UPE_Payment_Method;
 use WCPay\PaymentMethods\Configs\Definitions\CardDefinition;
 use WCPay\Session_Rate_Limiter;
@@ -399,6 +400,126 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 		// The order status is NOT 'processing' yet - it will be set after frontend confirmation
 		// via the update_order_status AJAX handler. At this point it should not be 'failed'.
 		$this->assertNotEquals( Order_Status::FAILED, $result_order->get_status() );
+	}
+
+	/**
+	 * A confirmation token is minted before the wallet sheet opens, with a
+	 * `setup_future_usage` Stripe then refuses to disagree with. When the gateway decides
+	 * to save the payment method for a reason express checkout could not see while the
+	 * cart was open, that is a purchase that fails every time — so it gets logged rather
+	 * than surfacing only as an opaque Stripe error.
+	 */
+	public function test_logs_when_a_confirmation_token_was_minted_without_setup_future_usage() {
+		$logged = $this->capture_wcpay_logs();
+
+		$this->process_subscription_payment_with_confirmation_token( null );
+
+		$this->assertNotEmpty(
+			$this->logs_naming_the_setup_future_usage_filter( $logged ),
+			'Expected the mismatch to be logged with the filter that fixes it.'
+		);
+	}
+
+	public function test_does_not_log_when_the_confirmation_token_matches() {
+		$logged = $this->capture_wcpay_logs();
+
+		$this->process_subscription_payment_with_confirmation_token( 'off_session' );
+
+		$this->assertEmpty( $this->logs_naming_the_setup_future_usage_filter( $logged ) );
+	}
+
+	/**
+	 * Replaces the internal logger with one backed by a mock WC_Logger that records
+	 * every call, so assertions can be made on what was logged rather than on
+	 * invocation-count matchers.
+	 *
+	 * @return ArrayObject Collected [ level, message ] pairs, filled as the test runs.
+	 */
+	private function capture_wcpay_logs(): ArrayObject {
+		$logged = new ArrayObject();
+
+		$mock_logger = $this->getMockBuilder( 'WC_Logger' )
+			->setMethods( [ 'log' ] )
+			->getMock();
+
+		$mock_logger
+			->method( 'log' )
+			->willReturnCallback(
+				function ( $level, $message ) use ( $logged ) {
+					$logged[] = [
+						'level'   => $level,
+						'message' => $message,
+					];
+				}
+			);
+
+		wcpay_get_test_container()->replace(
+			InternalLogger::class,
+			new InternalLogger( $mock_logger, WC_Payments::mode() )
+		);
+		WC_Payments::mode()->dev();
+
+		return $logged;
+	}
+
+	/**
+	 * Narrows captured logs to the ones pointing at the express checkout filter.
+	 *
+	 * @param ArrayObject $logged Collected log calls.
+	 * @return array
+	 */
+	private function logs_naming_the_setup_future_usage_filter( ArrayObject $logged ): array {
+		return array_filter(
+			$logged->getArrayCopy(),
+			function ( $entry ) {
+				return 'error' === $entry['level']
+					&& false !== strpos( $entry['message'], 'wcpay_express_checkout_setup_future_usage' );
+			}
+		);
+	}
+
+	/**
+	 * Runs a paid subscription order through process_payment with a confirmation token,
+	 * with express checkout reporting the given `setup_future_usage` for the cart.
+	 *
+	 * @param string|null $express_checkout_setup_future_usage What the ECE predicate reports.
+	 */
+	private function process_subscription_payment_with_confirmation_token( ?string $express_checkout_setup_future_usage ) {
+		$order         = WC_Helper_Order::create_order( self::USER_ID );
+		$subscriptions = [ new WC_Subscription() ];
+		$subscriptions[0]->set_parent( $order );
+
+		$this->mock_wcs_order_contains_subscription( true );
+		$this->mock_wcs_get_subscriptions_for_order( $subscriptions );
+
+		$_POST = [
+			'wcpay-confirmation-token' => 'ctoken_mock',
+			'payment_method'           => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+		];
+
+		$mock_ece_helper = $this->createMock( WC_Payments_Express_Checkout_Button_Helper::class );
+		$mock_ece_helper->method( 'get_setup_future_usage' )->willReturn( $express_checkout_setup_future_usage );
+
+		$original_ece_helper = WC_Payments::get_express_checkout_helper();
+		WC_Payments::set_express_checkout_helper( $mock_ece_helper );
+
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+		$request->expects( $this->once() )
+			->method( 'setup_future_usage' );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $this->payment_intent );
+
+		// The intent succeeds, so the payment method is vaulted afterwards.
+		$this->mock_token_service
+			->method( 'add_payment_method_to_user' )
+			->willReturn( $this->token );
+
+		try {
+			$this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		} finally {
+			WC_Payments::set_express_checkout_helper( $original_ece_helper );
+		}
 	}
 
 	public function test_new_card_is_added_before_status_update() {

--- a/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
+++ b/tests/unit/test-class-wc-payment-gateway-wcpay-subscriptions-process-payment.php
@@ -419,7 +419,7 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 	public function test_logs_when_a_confirmation_token_was_minted_without_setup_future_usage() {
 		$logged = $this->capture_wcpay_logs();
 
-		$this->process_subscription_payment_with_confirmation_token( null );
+		$this->process_third_party_save_with_confirmation_token( null );
 
 		$this->assertNotEmpty(
 			$this->logs_naming_the_setup_future_usage_filter( $logged ),
@@ -430,9 +430,26 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 	public function test_does_not_log_when_the_confirmation_token_matches() {
 		$logged = $this->capture_wcpay_logs();
 
-		$this->process_subscription_payment_with_confirmation_token( 'off_session' );
+		$this->process_third_party_save_with_confirmation_token( 'off_session' );
 
 		$this->assertEmpty( $this->logs_naming_the_setup_future_usage_filter( $logged ) );
+	}
+
+	/**
+	 * The order-pay page processes with an empty cart, so the cart predicate reports false
+	 * there while the token was correctly minted from the order. Comparing against the cart
+	 * alone would log an error on every successful renewal paid from that page — telling the
+	 * merchant Stripe will reject a payment that just went through.
+	 */
+	public function test_does_not_log_for_a_recurring_order_the_cart_predicate_cannot_see() {
+		$logged = $this->capture_wcpay_logs();
+
+		$this->process_subscription_payment_with_confirmation_token( null );
+
+		$this->assertEmpty(
+			$this->logs_naming_the_setup_future_usage_filter( $logged ),
+			'A recurring order is visible to the pay-for-order predicate, so there is no mismatch.'
+		);
 	}
 
 	/**
@@ -530,6 +547,52 @@ class WC_Payment_Gateway_WCPay_Subscriptions_Process_Payment_Test extends WCPAY_
 	 *
 	 * @param string|null $express_checkout_setup_future_usage What the ECE predicate reports.
 	 */
+	/**
+	 * The WOOPMNT-6335 shape: an ordinary order that is not a WooCommerce Subscriptions
+	 * order at all, whose payment method something else asks to save — a subscriptions
+	 * plugin other than WCS, or any integration setting the new-payment-method flag. Nothing
+	 * express checkout could see while the cart was open, which is what makes it worth
+	 * logging.
+	 *
+	 * @param string|null $express_checkout_setup_future_usage What the cart predicate reports.
+	 */
+	private function process_third_party_save_with_confirmation_token( ?string $express_checkout_setup_future_usage ) {
+		$order = WC_Helper_Order::create_order( self::USER_ID );
+
+		$this->mock_wcs_order_contains_subscription( false );
+
+		$_POST = [
+			'wcpay-confirmation-token'                   => 'ctoken_mock',
+			'payment_method'                             => WC_Payment_Gateway_WCPay::GATEWAY_ID,
+			'wc-woocommerce_payments-new-payment-method' => 'true',
+		];
+
+		$mock_ece_helper = $this->createMock( WC_Payments_Express_Checkout_Button_Helper::class );
+		$mock_ece_helper->method( 'get_setup_future_usage' )
+			->with( 'cart' )
+			->willReturn( $express_checkout_setup_future_usage );
+
+		$original_ece_helper = WC_Payments::get_express_checkout_helper();
+		WC_Payments::set_express_checkout_helper( $mock_ece_helper );
+
+		$request = $this->mock_wcpay_request( Create_And_Confirm_Intention::class );
+		$request->expects( $this->once() )
+			->method( 'setup_future_usage' );
+		$request->expects( $this->once() )
+			->method( 'format_response' )
+			->willReturn( $this->payment_intent );
+
+		$this->mock_token_service
+			->method( 'add_payment_method_to_user' )
+			->willReturn( $this->token );
+
+		try {
+			$this->mock_wcpay_gateway->process_payment( $order->get_id() );
+		} finally {
+			WC_Payments::set_express_checkout_helper( $original_ece_helper );
+		}
+	}
+
 	private function process_payment_without_saving_with_confirmation_token( ?string $express_checkout_setup_future_usage ) {
 		$order = WC_Helper_Order::create_order( self::USER_ID );
 


### PR DESCRIPTION
Fixes WOOPMNT-6335

#### Changes proposed in this Pull Request

Express checkout mints a Stripe ConfirmationToken **before the wallet sheet opens**, and Stripe fixes `setup_future_usage` on it at that moment. If the PaymentIntent later asks for a different value, Stripe rejects the confirmation outright.

Until now the client decided that value on its own, from WooCommerce Subscriptions cart data. Any *other* reason the gateway saves the payment method was invisible to it — a subscriptions plugin other than WC Subscriptions, or any integration setting `wc-woocommerce_payments-new-payment-method` while the order is processed. The token said "don't save", the intent asked `off_session`, and Stripe returned:

> The provided setup_future_usage (off_session) does not match the setup_future_usage from the provided confirmation_token (null).

The shopper could not pay by wallet at all — every attempt, not an edge case.

**The server now decides.** It is the only side that knows every reason the payment method might be saved. The value reaches the client two ways: `extensions.wcpay.setup_future_usage` on the Store API cart, and the localized `wcpayExpressCheckoutParams`. For the reasons the server genuinely cannot infer, there is one new extension point: **`wcpay_express_checkout_setup_future_usage`** (PHP), which receives the button context so an integration can answer per surface.

Deliberately **no client-side filter**. The server also decides whether the payment actually saves the method, so a value declared only in the browser has nothing agreeing with it — declaring `off_session` there mints a token Stripe applies to an intent that never asked for it, silently vaulting the shopper's card. The PHP filter is evaluated alongside the save decision, which is the only place the two can be kept in agreement.

**Verified that a third-party plugin can actually use this.** The filter runs while the cart is open; the gateway's decision to save happens later, at `process_payment`. So the question is whether another subscriptions plugin can answer it *early enough*. Checked against YITH WooCommerce Subscription with WooCommerce Subscriptions deactivated: its public `YWSBS_Subscription_Cart::cart_has_subscriptions()` answers at cart time, and a real Google Pay purchase then completed with the card vaulted and the YITH subscription created. Details under Testing instructions.

**The predicate has to be accurate, not conservative.** It is tempting to declare `off_session` whenever unsure. Don't — I verified against Stripe that when the intent omits `setup_future_usage`, Stripe *inherits* the token's value onto it. Over-declaring therefore attaches the shopper's card to the Stripe customer on an ordinary one-off purchase, with no WooPayments token recorded against it. That failure is completely silent, which is why the filter docs say to declare `off_session` only when the payment method really will be saved.

Also in here:

- **Pay-for-order** reads the order rather than the cart, which is empty on that page.
- **`has_subscription`** — the flag `setup_future_usage` replaces — is still honoured when the server declares nothing, since `wcpay_express_checkout_js_params` is a documented extension point and an integration may already be forcing it to work around this very bug. Enabling only: a `false` cannot be distinguished from the server computing false, so suppression goes through the filter.
- **A diagnostic** logs when the server's predicate and the save decision disagree, in both directions. The `off_session`-without-a-save direction is the silent one, so it is logged loudly.

##### Backward compatibility

**Additive only. No symbol, hook, or response key is removed, renamed, or changed in signature.**

| Surface | Change |
|---|---|
| `WC_Payments_Express_Checkout_Button_Helper` | One new public method: `get_setup_future_usage()`. The predicates behind it (`cart_contains_subscription()`, `order_contains_subscription()`, `get_order_being_paid()`) are private, so they stay free to change |
| `has_subscription_product()` | Behaviour preserved — its cart branch was extracted into a private helper and is still called |
| `wcpay_express_checkout_js_params` | New `setup_future_usage` key; `has_subscription` retained and still honoured |
| Store API cart | New `extensions.wcpay.setup_future_usage` (`'off_session'` or `null`) |
| New hook | `wcpay_express_checkout_setup_future_usage` (PHP) |

##### How can this code break?

The risk is a wrong `off_session`, in either direction. Under-declaring fails loudly (Stripe rejects the confirmation). Over-declaring vaults a card silently. Everything here is arranged around that asymmetry:

- The predicate defers to the gateway's own `is_payment_recurring()` rather than re-deriving it, so the prediction and the decision cannot drift apart.
- The filter's return is normalised to `'off_session'` or `null`; anything else resolves to `null`, which fails loudly rather than vaulting silently.
- A throwing filter callback costs the diagnostic log line and nothing else, so it can never fail an order.
- The diagnostic reports both directions, and the silent one is logged loudly.

Covered by 102 PHP tests (86 on the predicate, 16 on the diagnostic) and 39 JS tests on the changed units. Each risky branch is mutation-tested: reverting the fix fails tests that previously passed.

#### Testing instructions

**Google Pay does not render over `http://localhost`.** Stripe.js requires a real HTTPS origin — stricter than the browser, whose own `PaymentRequest.canMakePayment()` returns `true` on localhost. Use a tunnel (`pnpm run tube:start`) and point **both** `siteurl` and `home` at the tunnel domain, otherwise WordPress appends the stored port to its redirects.

```
wp option update siteurl https://<your-subdomain>.jurassic.tube
wp option update home    https://<your-subdomain>.jurassic.tube
```

**1 — The fix (regression test for the reported bug)**

1. Install WooCommerce Subscriptions and create a simple subscription product.
2. Add it to the cart and open the block checkout over HTTPS.
3. Confirm the Google Pay button renders, and complete the purchase through the sheet.
4. ✅ The order is `processing`, the subscription is `active`, and the saved payment token is attached to **both**. The order note reads "Payment via Google Pay (WooPayments)".
5. ✅ No `does not match the setup_future_usage` error in the WooPayments logs.

**2 — A non-WCS subscriptions plugin (the reported shape)**

This is the scenario the fix exists for. Run it with **WooCommerce Subscriptions deactivated**, so nothing WCS-shaped can carry the result.

I used YITH WooCommerce Subscription. Note its free build has no WooPayments path at all — card charging is a Premium feature — so a snippet has to stand in for the half that asks us to vault the card:

```php
// Half 1 — stand-in for the plugin's own WooPayments integration.
add_action( 'woocommerce_rest_checkout_process_payment_with_context', function ( $context ) {
    if ( 'woocommerce_payments' !== $context->payment_method ) {
        return;
    }
    if ( ! YWSBS_Subscription_Cart::cart_has_subscriptions() ) {
        return;
    }
    $data = $context->payment_data;
    $data['wc-woocommerce_payments-new-payment-method'] = 'true';
    $context->set_payment_data( $data );
}, 100 ); // below WooCommerce Legacy.php's 999, which copies payment_data into $_POST

// Half 2 — what this PR adds: declare it through the filter.
add_filter( 'wcpay_express_checkout_setup_future_usage', function ( $sfu ) {
    return YWSBS_Subscription_Cart::cart_has_subscriptions() ? 'off_session' : $sfu;
} );
```

1. Put a YITH subscription product in the cart and open the block checkout over HTTPS.
2. ✅ The Store API cart carries `extensions.wcpay.setup_future_usage: "off_session"` with **no `subscriptions` extension present**, and `wcpayExpressCheckoutParams` shows `setup_future_usage: "off_session"` while the legacy `has_subscription` is `""` — the old detection saying "not a subscription", the new one getting it right.
3. Complete the purchase with Google Pay.
4. ✅ Order `processing`, the plugin's subscription created, payment token saved, and **no** `does not match the setup_future_usage` in the logs.
5. Remove half 2 only and retry → the purchase fails, and the log names the filter to reach for.

The generic form of this test, if you would rather not install anything: any snippet setting `wc-woocommerce_payments-new-payment-method` during processing on a regular cart, with and without the filter.

**3 — No over-declaring (the silent direction)**

1. Buy a regular product by wallet with no filter and no subscription in the cart.
2. ✅ The purchase succeeds and **no** payment method is saved against the customer — check My Account → Payment methods, and that the Stripe customer has no newly attached card.

**4 — Pay-for-order**

Note that stock WC Subscriptions rebuilds the cart and redirects `order-pay` to the checkout for both initial-payment and renewal orders, so this branch is reached by stores that opt out via `wcs_setup_cart_for_subscription_initial_payment` / `..._subscription_renewal`, and by non-WCS subscriptions plugins.

1. With that filter returning `false`, open the order-pay page for a pending order containing a subscription.
2. ✅ `wcpayExpressCheckoutParams.setup_future_usage` is `off_session`.
3. ✅ On a plain order it is `null`.

**5 — Existing behaviour is unchanged**

✅ A normal WC Subscriptions wallet purchase, and a normal one-off wallet purchase, both behave exactly as before.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
