### PR TITLE
fix: convert block price-range screen-reader text in cache-optimized rendering mode

### DIFF
--- a/changelog/fix-woopmnt-6242-cache-mode-block-price-range-sr-label
+++ b/changelog/fix-woopmnt-6242-cache-mode-block-price-range-sr-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Multi-Currency: in cache-optimized rendering mode, read the price-range screen-reader label of WooCommerce blocks in the customer's currency instead of the store currency.

--- a/includes/multi-currency/client/async-renderer/__tests__/index.test.js
+++ b/includes/multi-currency/client/async-renderer/__tests__/index.test.js
@@ -746,6 +746,136 @@ describe( 'WCPayAsyncPriceRenderer', () => {
 		} );
 	} );
 
+	describe( 'convertBlockScreenReaderText', () => {
+		// Mirrors the markup WooCommerce's product-price block renders for a
+		// range-priced product: the visible prices carry the per-product Store
+		// API currency, the screen-reader label the (store) global currency.
+		const renderBlockPriceRange = ( { srText, min, max } ) => {
+			const wrapper = document.createElement( 'span' );
+			wrapper.className = 'price wc-block-components-product-price';
+			wrapper.innerHTML =
+				`<span class="screen-reader-text">${ srText }</span>` +
+				'<span aria-hidden="true">' +
+				`<span class="wc-block-components-product-price__value">${ min }</span>` +
+				'&nbsp;&mdash;&nbsp;' +
+				`<span class="wc-block-components-product-price__value">${ max }</span>` +
+				'</span>';
+			document.body.appendChild( wrapper );
+			return wrapper;
+		};
+
+		beforeEach( () => {
+			document.body.textContent = '';
+		} );
+
+		it( 'rebuilds the label from the visible prices', () => {
+			const wrapper = renderBlockPriceRange( {
+				srText: 'Price between $14.00 and $18.00',
+				min: '14,00 €',
+				max: '18,00 €',
+			} );
+
+			renderer.convertBlockScreenReaderText();
+
+			expect(
+				wrapper.querySelector( '.screen-reader-text' ).textContent
+			).toBe( 'Price between 14,00 € and 18,00 €' );
+		} );
+
+		it( 'picks up a re-rendered block on a second pass', () => {
+			const wrapper = renderBlockPriceRange( {
+				srText: 'Price between $14.00 and $18.00',
+				min: '14,00 €',
+				max: '18,00 €',
+			} );
+
+			renderer.convertBlockScreenReaderText();
+
+			wrapper.querySelector( '.screen-reader-text' ).textContent =
+				'Price between $20.00 and $30.00';
+			wrapper.querySelectorAll(
+				'.wc-block-components-product-price__value'
+			)[ 0 ].textContent = '20,00 €';
+			wrapper.querySelectorAll(
+				'.wc-block-components-product-price__value'
+			)[ 1 ].textContent = '30,00 €';
+
+			renderer.convertBlockScreenReaderText();
+
+			expect(
+				wrapper.querySelector( '.screen-reader-text' ).textContent
+			).toBe( 'Price between 20,00 € and 30,00 €' );
+		} );
+
+		it( 'leaves the label alone when the selected currency is the default', () => {
+			renderer.config = { ...mockConfig, selected_currency: 'USD' };
+			const wrapper = renderBlockPriceRange( {
+				srText: 'Price between $14.00 and $18.00',
+				min: '$14.00',
+				max: '$18.00',
+			} );
+
+			renderer.convertBlockScreenReaderText();
+
+			expect(
+				wrapper.querySelector( '.screen-reader-text' ).textContent
+			).toBe( 'Price between $14.00 and $18.00' );
+		} );
+
+		it( 'leaves sale-price labels alone', () => {
+			const wrapper = document.createElement( 'span' );
+			wrapper.className = 'price wc-block-components-product-price';
+			wrapper.innerHTML =
+				'<span class="screen-reader-text">Previous price:</span>' +
+				'<del class="wc-block-components-product-price__regular">18,00 €</del>' +
+				'<span class="screen-reader-text">Discounted price:</span>' +
+				'<ins class="wc-block-components-product-price__value">14,00 €</ins>';
+			document.body.appendChild( wrapper );
+
+			renderer.convertBlockScreenReaderText();
+
+			expect(
+				wrapper.querySelector( '.screen-reader-text' ).textContent
+			).toBe( 'Previous price:' );
+		} );
+
+		it( 'leaves server-rendered annotated labels to convertScreenReaderText', () => {
+			const wrapper = document.createElement( 'span' );
+			wrapper.className = 'price wc-block-components-product-price';
+			wrapper.innerHTML =
+				'<span class="screen-reader-text" data-wcpay-sr-type="range" ' +
+				'data-wcpay-sr-price-from="10" data-wcpay-sr-price-to="30">' +
+				'Price range: $10.00 through $30.00</span>' +
+				'<span aria-hidden="true">' +
+				'<span class="wc-block-components-product-price__value">8,99 €</span>' +
+				'<span class="wc-block-components-product-price__value">25,99 €</span>' +
+				'</span>';
+			document.body.appendChild( wrapper );
+
+			renderer.convertBlockScreenReaderText();
+
+			expect(
+				wrapper.querySelector( '.screen-reader-text' ).textContent
+			).toBe( 'Price range: $10.00 through $30.00' );
+		} );
+
+		it( 'does nothing when the config has not loaded', () => {
+			renderer.config = null;
+			const wrapper = renderBlockPriceRange( {
+				srText: 'Price between $14.00 and $18.00',
+				min: '14,00 €',
+				max: '18,00 €',
+			} );
+
+			expect( () =>
+				renderer.convertBlockScreenReaderText()
+			).not.toThrow();
+			expect(
+				wrapper.querySelector( '.screen-reader-text' ).textContent
+			).toBe( 'Price between $14.00 and $18.00' );
+		} );
+	} );
+
 	describe( 'convertAllPrices calls convertScreenReaderText', () => {
 		beforeEach( () => {
 			document.body.textContent = '';

--- a/includes/multi-currency/client/async-renderer/index.ts
+++ b/includes/multi-currency/client/async-renderer/index.ts
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import Decimal from 'decimal.js-light';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,6 +15,15 @@ const TIMEOUT_MS = 10000;
 const MAX_CACHE_SIZE = 500;
 const SESSION_CACHE_KEY = 'wcpay_mc_async_config';
 const SESSION_CACHE_TTL_MS = 300000; // 5 minutes, matches Cache-Control max-age.
+
+// Markup that still needs a conversion pass when it shows up in the DOM. Block
+// prices carry no "converted" marker because blocks re-render them, so they are
+// matched unconditionally and reconverted idempotently.
+const PENDING_PRICE_SELECTORS = [
+	'[data-wcpay-price]:not(.wcpay-price-converted)',
+	'[data-wcpay-sr-type]:not(.wcpay-sr-converted)',
+	'.wc-block-components-product-price',
+];
 
 type SymbolPosition = 'left' | 'left_space' | 'right' | 'right_space';
 
@@ -450,6 +460,7 @@ class WCPayAsyncPriceRenderer {
 		} );
 
 		this.convertScreenReaderText();
+		this.convertBlockScreenReaderText();
 	}
 
 	/**
@@ -529,6 +540,75 @@ class WCPayAsyncPriceRenderer {
 	}
 
 	/**
+	 * Rewrite WooCommerce Blocks price-range screen-reader labels in the selected currency.
+	 *
+	 * Blocks build the "Price between X and Y" label with the global
+	 * `wcSettings.currency` rather than the per-product Store API currency (see
+	 * WooCommerce's `product-price` base component). Cache-optimized mode
+	 * deliberately leaves that global as the store currency so the served HTML
+	 * stays identical for every visitor, which leaves the label — and only the
+	 * label — in the store currency.
+	 *
+	 * The visible prices next to it already come from the per-product Store API
+	 * currency and are correct, so the label is rebuilt from those rendered
+	 * values instead of re-converting the raw amounts, which the block markup
+	 * does not expose.
+	 */
+	convertBlockScreenReaderText(): void {
+		if (
+			! this.config ||
+			this.config.selected_currency === this.config.default_currency
+		) {
+			return;
+		}
+
+		const priceElements = document.querySelectorAll(
+			'.wc-block-components-product-price'
+		);
+
+		priceElements.forEach( ( priceEl ) => {
+			// Blocks render the range label as a direct child; SSR prices
+			// annotated by AsyncPriceRenderer are handled elsewhere.
+			const srEl = priceEl.querySelector(
+				':scope > .screen-reader-text:not([data-wcpay-sr-type])'
+			);
+
+			// Only the range variant wraps its prices in an aria-hidden span
+			// with both ends of the range; sale prices render a single value.
+			const values = priceEl.querySelectorAll(
+				'[aria-hidden="true"] .wc-block-components-product-price__value'
+			);
+
+			if ( ! srEl || values.length < 2 ) {
+				return;
+			}
+
+			const from = values[ 0 ].textContent?.trim();
+			const to = values[ values.length - 1 ].textContent?.trim();
+
+			if ( ! from || ! to ) {
+				return;
+			}
+
+			const label = sprintf(
+				// Uses WC's text domain so the label matches the block's own
+				// translation in every locale.
+				// eslint-disable-next-line @wordpress/i18n-text-domain
+				__( 'Price between %1$s and %2$s', 'woocommerce' ),
+				from,
+				to
+			);
+
+			// Assigning only on change keeps this idempotent, so repeated
+			// passes (MutationObserver, WC AJAX events) are free and a block
+			// re-render is picked up again.
+			if ( srEl.textContent !== label ) {
+				srEl.textContent = label;
+			}
+		} );
+	}
+
+	/**
 	 * Sync every currency switcher to the selected (localized) currency.
 	 *
 	 * In cache-optimized mode the switcher's selected <option> is baked into the
@@ -571,20 +651,13 @@ class WCPayAsyncPriceRenderer {
 					}
 
 					const el = node as Element;
-					if (
-						el.matches?.(
-							'[data-wcpay-price]:not(.wcpay-price-converted)'
-						) ||
-						el.querySelector?.(
-							'[data-wcpay-price]:not(.wcpay-price-converted)'
-						) ||
-						el.matches?.(
-							'[data-wcpay-sr-type]:not(.wcpay-sr-converted)'
-						) ||
-						el.querySelector?.(
-							'[data-wcpay-sr-type]:not(.wcpay-sr-converted)'
-						)
-					) {
+					const matchesAny = PENDING_PRICE_SELECTORS.some(
+						( selector ) =>
+							el.matches?.( selector ) ||
+							el.querySelector?.( selector )
+					);
+
+					if ( matchesAny ) {
 						hasNewPrices = true;
 						break;
 					}


### PR DESCRIPTION
Fixes [WOOPMNT-6242](https://linear.app/a8c/issue/WOOPMNT-6242/cache-mode-block-price-range-screen-reader-label-renders-in-store)

#### Changes proposed in this Pull Request

In Multi-Currency's **cache-optimized rendering mode**, WooCommerce blocks (All Products, Product Collection, …) announced a range-priced product's price to screen readers in the **store** currency — `Price between $14.00 and $18.00` — while the visible price next to it was correctly converted to `14,00 € — 18,00 €`. Sighted shoppers saw the right price; screen-reader users heard the wrong one. That's the whole defect: a11y-only, cache mode only, range-priced products only.

**Why it happens.** WooCommerce's `product-price` base component builds that label with `formatPrice( minPrice )` and passes no currency, so it falls back to `SITE_CURRENCY` — a module-scope snapshot of the global `wcSettings.currency`. It does *not* use the per-product Store API currency that the visible prices use. Cache mode deliberately leaves that global as the store currency so the served HTML is byte-identical for every anonymous visitor, which is exactly what makes the page cacheable. So the label, and only the label, comes out in the store currency.

This is really an upstream WooCommerce bug — the component has the correct `currency` prop in hand and simply doesn't pass it to `formatPrice`. I'll open a core issue; once that lands, this workaround can go away.

**Why not just set the global.** The obvious fix — have cache mode set `wcSettings.currency` to the customer currency — is the one thing we can't do: it re-breaks cacheability, since the HTML would differ per visitor. Setting it client-side instead doesn't work either: `SITE_CURRENCY` is snapshotted when the settings module is evaluated, so a mutation after our REST config fetch is both too late and racing block hydration.

**What this does instead.** Once the async renderer's config lands, it rewrites those labels from the already-correct **visible** prices sitting next to them. The block markup doesn't expose the raw amounts, but it does render both ends of the range in the right currency, so there's nothing to re-convert — it's a re-assembly, not a second conversion, which also means it can't drift from the visible price.

Three details worth a reviewer's attention:

- **The template string comes from JS, not PHP.** `__( 'Price between %1$s and %2$s', 'woocommerce' )` is a blocks-JS string, so its translation lives in a JS `.json` catalog and *not* in WooCommerce's `.mo`. Reading it from PHP (as the existing `srText` config does for the `wc_price` strings) would have returned English on every translated store — trading a currency bug for a localization bug. Calling it from JS hits the same `wp.i18n` domain data the block itself already loaded.
- **It's idempotent rather than marker-gated.** The existing SSR path marks converted nodes with a class; that doesn't work here because React owns these nodes and re-renders would blow the marker away. Writing only when the text actually differs makes repeat passes free and lets a block re-render get picked up again.
- **Server-rendered prices are untouched.** Anything already annotated with `data-wcpay-sr-type` (Product Collection and friends, which go through `woocommerce_format_price_range`) is explicitly excluded and keeps using the existing path.

**Backward compatibility:** no impact. No PHP signature, hook, filter, option, or REST shape changes — the diff is client-side only, plus one added script dependency (`wp-i18n`, auto-extracted into the asset file). The new method only ever runs in cache-optimized mode with no active session, and only when the selected currency differs from the store default.

**How can this break?** The label rebuild depends on WooCommerce's block class names (`.wc-block-components-product-price`, `.wc-block-components-product-price__value`) and on the range variant wrapping its prices in an `aria-hidden` span. If upstream renames those, the fix silently stops applying — it degrades to today's behavior rather than breaking anything, and the guards (`values.length < 2`, missing/blank text) bail out instead of writing a malformed label. Covered by six new unit tests, including the sale-price and server-rendered cases that must be left alone.

No screenshots: the change is invisible by definition — it only affects `.screen-reader-text`. See the testing instructions for how to observe it.

#### Testing instructions

> **Which block matters here.** Two different code paths render a price range, and only one of them has the bug:
>
> | Block | Renderer | Range label | Status |
> |---|---|---|---|
> | **Product Collection**, Products by Category, classic shop | PHP (`woocommerce_format_price_range`) | `Price range: X through Y` | Already correct — annotated with `data-wcpay-sr-type="range"`. **Not** what this PR fixes. |
> | **All Products** (and anything using the blocks `ProductPrice` React component) | JS (Store API) | `Price between X and Y` | The bug. Fixed here. |
>
> If you see `Price range: … through …`, you are on the PHP path and the label is already converted. The bug only shows under the `Price between …` wording.

**Setup**

1. Store base currency **USD**. Enable Multi-Currency with **EUR** as an additional currency, and turn on **automatic currency switching** (Settings → Multi-currency).
2. Set the rendering mode to **Optimized for caching** (Multi-currency → Store settings), i.e. `wcpay_multi_currency_rendering_mode = cache`.
3. Create or use a **variable product with a price range** (e.g. $15–$20) — the sample `V-Neck T-Shirt` works.
4. Add an **All Products** block to a page. **It is hidden from the block inserter** — WooCommerce ships it as a legacy block with `"inserter": false` in its `block.json`, so searching for "All Products" in the editor finds nothing. Add it through the editor's **Code editor** view (⋮ → Code editor) by pasting:

   ```html
   <!-- wp:woocommerce/all-products {"columns":3,"rows":1,"orderby":"price_desc"} --><div class="wp-block-woocommerce-all-products wc-block-all-products" data-attributes="{&quot;columns&quot;:3,&quot;rows&quot;:1,&quot;alignButtons&quot;:false,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;orderby&quot;:&quot;price_desc&quot;,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-button&quot;]]}"></div><!-- /wp:woocommerce/all-products -->
   ```

   Switch back to the visual editor and publish. Make sure the grid actually includes the range-priced product (`orderby` / more rows if needed).

**Reproduce / verify**

5. Open that page in a **fresh incognito window** (no WooCommerce session) with geolocation resolving to a EUR country. Locally, the quickest way to force that is a mu-plugin:

   ```php
   add_filter( 'woocommerce_geolocate_ip', fn() => 'DE', 999 );
   add_filter( 'woocommerce_customer_default_location', fn() => 'DE', 999 );
   ```

6. **Disable the browser HTTP cache** (DevTools → Network → *Disable cache*, keep DevTools open). Both `wc/store/v1/products` and `wc/v3/payments/multi-currency/public/config` are sent with `Cache-Control: max-age`, so after flipping any of the settings above a plain reload can replay stale USD responses and it will look like nothing converted.
7. Inspect the range-priced product's price element and find the `<span class="screen-reader-text">` inside `.wc-block-components-product-price`.
8. **Before this PR:** it reads `Price between $14.00 and $19.00` while the visible price reads `14,00 € — 19,00 €`.
   **After this PR:** it reads `Price between 14,00 € and 19,00 €`, matching the visible price.
9. Optionally confirm with a real screen reader (VoiceOver: `Cmd+F5`) or the browser's accessibility panel.

**Regressions to check**

10. Switch the rendering mode back to **Optimized for speed** — the label should still be correct (this path is unchanged).
11. On a store where the selected currency **equals** the store default, the label must be untouched.
12. Check a **sale-priced** product in the same All Products grid — its `Previous price:` / `Discounted price:` labels must be unchanged and in EUR.
13. Check a range-priced product on a **Product Collection** block or a classic shop page in cache mode — the existing `data-wcpay-sr-type="range"` conversion must still apply and read `Price range: 14,00 € through 19,00 €`. This is the path @htdat exercised; it was already correct before this PR and must stay that way.


-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — does not apply; no visual change.

**Changelog:** Added. The change is user-facing for shoppers using assistive technology, so it's worded for a store owner: *"Multi-Currency: in cache-optimized rendering mode, read the price-range screen-reader label of WooCommerce blocks in the customer's currency instead of the store currency."*

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.