### PR TITLE
chore: remove skipped capital loan notice tests

### DIFF
--- a/changelog/dev-remove-dead-capital-loan-notice-tests
+++ b/changelog/dev-remove-dead-capital-loan-notice-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove skipped tests for the capital loan notice that was removed from the deposits overview.

--- a/client/components/deposits-overview/__tests__/index.test.tsx
+++ b/client/components/deposits-overview/__tests__/index.test.tsx
@@ -18,16 +18,11 @@ import {
 	useSelectedCurrencyOverview,
 	useSelectedCurrency,
 } from 'wcpay/overview/hooks';
-import {
-	useDepositIncludesLoan,
-	useDeposits,
-	useAllDepositsOverviews,
-} from 'wcpay/data/deposits';
+import { useDeposits, useAllDepositsOverviews } from 'wcpay/data/deposits';
 import type { CachedDeposit } from 'wcpay/types/deposits';
 import type * as AccountOverview from 'wcpay/types/account-overview';
 
 jest.mock( 'wcpay/data/deposits', () => ( {
-	useDepositIncludesLoan: jest.fn(),
 	useInstantDeposit: jest.fn(),
 	useDeposits: jest.fn(),
 	useAllDepositsOverviews: jest.fn(),
@@ -163,10 +158,6 @@ const createMockNewAccountOverview = (
 	};
 };
 
-const mockUseDepositIncludesLoan =
-	useDepositIncludesLoan as jest.MockedFunction<
-		typeof useDepositIncludesLoan
-	>;
 const mockUseSelectedCurrencyOverview =
 	useSelectedCurrencyOverview as jest.MockedFunction<
 		typeof useSelectedCurrencyOverview
@@ -246,10 +237,6 @@ describe( 'Deposits Overview information', () => {
 			},
 			dateFormat: 'F j, Y',
 		};
-		mockUseDepositIncludesLoan.mockReturnValue( {
-			includesFinancingPayout: false,
-			isLoading: false,
-		} );
 		mockAccount.deposits_blocked = false;
 	} );
 	afterEach( () => {
@@ -388,67 +375,6 @@ describe( 'Deposits Overview information', () => {
 		const { container } = render( <RecentDepositsList deposits={ [] } /> );
 
 		expect( container ).toBeEmptyDOMElement();
-	} );
-
-	// Capital loans notice temporarily disabled, tests skipped until resolved. See #7689.
-	test.skip( 'Renders capital loan notice if deposit includes financing payout', () => {
-		mockUseDepositIncludesLoan.mockReturnValue( {
-			includesFinancingPayout: true,
-			isLoading: false,
-		} );
-		mockDepositOverviews( [ createMockNewAccountOverview( 'eur' ) ] );
-		mockUseSelectedCurrency.mockReturnValue( {
-			selectedCurrency: 'eur',
-			setSelectedCurrency: mockSetSelectedCurrency,
-		} );
-
-		const { getByRole, getByText } = render( <DepositsOverview /> );
-
-		getByText(
-			'deposit will include funds from your WooCommerce Capital loan',
-			{
-				exact: false,
-				ignore: '.a11y-speak-region',
-			}
-		);
-		expect(
-			getByRole( 'link', {
-				name: 'Learn more',
-			} )
-		).toHaveAttribute(
-			'href',
-			'https://woocommerce.com/document/woopayments/stripe-capital/overview/'
-		);
-	} );
-
-	// Capital loans notice temporarily disabled, tests skipped until resolved. See #7689.
-	test.skip( `Doesn't render capital loan notice if deposit does not include financing payout`, () => {
-		mockUseDepositIncludesLoan.mockReturnValue( {
-			includesFinancingPayout: false,
-			isLoading: false,
-		} );
-		mockDepositOverviews( [ createMockNewAccountOverview( 'eur' ) ] );
-		mockUseSelectedCurrency.mockReturnValue( {
-			selectedCurrency: 'eur',
-			setSelectedCurrency: mockSetSelectedCurrency,
-		} );
-
-		const { queryByRole, queryByText } = render( <DepositsOverview /> );
-
-		expect(
-			queryByText(
-				'payout will include funds from your WooCommerce Capital loan',
-				{
-					exact: false,
-					ignore: '.a11y-speak-region',
-				}
-			)
-		).toBeFalsy();
-		expect(
-			queryByRole( 'link', {
-				name: 'Learn more',
-			} )
-		).toBeFalsy();
 	} );
 
 	test( 'Confirm new account waiting period notice does not show if outside waiting period', () => {


### PR DESCRIPTION
Refs #7689.

#### Changes proposed in this Pull Request

The capital loan notice was removed from the deposits overview in #7656 (November 2023) and its two tests were skipped at the same time. The notice never came back: #7689 was closed without resurfacing it, and nothing in `client/` renders it or calls `useDepositIncludesLoan`. The skipped tests cover a feature that no longer exists.

- Remove the two skipped capital loan notice tests from the deposits overview suite.
- Remove the now-unused `useDepositIncludesLoan` mock wiring from the same file.

The `useDepositIncludesLoan` hook itself is now unused too. I left it in place to keep this PR test-only.

#### Testing instructions

This PR only deletes tests, so CI is the main check.

1. Run the deposits overview Jest suite and confirm it passes with no skipped tests: `npx jest --config tests/js/jest.config.js client/components/deposits-overview`
2. Confirm the notice is not rendered anywhere in source: `grep -rn "Capital loan" client --include="*.tsx" | grep -v __tests__` returns nothing.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
