### PR TITLE
test(e2e): fix assertions that could not fail

### DIFF
--- a/changelog/fix-e2e-test-signal-fixes
+++ b/changelog/fix-e2e-test-signal-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix E2E assertions that could not fail: missing awaits, an assertion-free filter test, and swallowed add-payment-method outcomes.

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-manage-payments.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-manage-payments.spec.ts
@@ -37,7 +37,9 @@ const navigateToSubscriptionDetails = async (
 		} )
 	).toBeVisible();
 
-	await page.getByText( 'Choose a new payment method' ).isVisible();
+	await expect(
+		page.getByText( 'Choose a new payment method' )
+	).toBeVisible();
 };
 
 describeif( shouldRunSubscriptionsTests )(
@@ -76,7 +78,7 @@ describeif( shouldRunSubscriptionsTests )(
 			await page
 				.locator( changePaymentMethodButtonSelector )
 				.first()
-				.click( { noWaitAfter: true } );
+				.click();
 
 			await expect(
 				page.getByText( 'Payment method updated.' )
@@ -92,7 +94,7 @@ describeif( shouldRunSubscriptionsTests )(
 			await page
 				.locator( changePaymentMethodButtonSelector )
 				.first()
-				.click( { noWaitAfter: true } );
+				.click();
 
 			await expect(
 				page.getByText( 'Payment method updated.' )

--- a/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts
+++ b/tests/e2e/specs/subscriptions/shopper/shopper-subscriptions-purchase-no-signup-fee.spec.ts
@@ -55,7 +55,7 @@ describeif( shouldRunSubscriptionsTests )(
 				const card = config.cards.basic;
 				await fillCardDetails( shopperPage, card );
 				await placeOrder( shopperPage );
-				expect(
+				await expect(
 					shopperPage.getByRole( 'heading', {
 						name: 'Order received',
 					} )

--- a/tests/e2e/specs/wcpay/merchant/merchant-admin-deposits.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-admin-deposits.spec.ts
@@ -18,7 +18,7 @@ test.describe( 'Merchant deposits', () => {
 			.locator( '.woocommerce-table__table.is-loading' )
 			.waitFor( { state: 'hidden' } );
 
-		expect(
+		await expect(
 			page.getByRole( 'heading', {
 				name: 'Payout history',
 			} )
@@ -54,9 +54,12 @@ test.describe( 'Merchant deposits', () => {
 		await page.evaluate( () => {
 			window.scrollTo( 0, 0 );
 		} );
-		// TODO: This visual regression test is not flaky, but we should revisit the approach.
-		// await expect(
-		// 	page.locator( '.woocommerce-filters' ).last()
-		// ).toHaveScreenshot();
+
+		// Apply the filter and confirm it drives the filtered list via the URL query.
+		await page.getByRole( 'link', { name: 'Filter', exact: true } ).click();
+		await expect( page ).toHaveURL( /status_is=/ );
+		await expect(
+			page.locator( '.woocommerce-table__table.is-loading' )
+		).toHaveCount( 0 );
 	} );
 } );

--- a/tests/e2e/specs/wcpay/merchant/merchant-admin-disputes.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-admin-disputes.spec.ts
@@ -23,7 +23,7 @@ test.describe( 'Merchant disputes', () => {
 		).toHaveCount( 0 );
 
 		// .nth( 1 ) defines the second instance of the Disputes heading, which is in the table.
-		expect(
+		await expect(
 			page.getByRole( 'heading', { name: 'Disputes' } ).nth( 1 )
 		).toBeVisible();
 	} );

--- a/tests/e2e/specs/wcpay/merchant/merchant-multi-currency-widget.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-multi-currency-widget.spec.ts
@@ -89,35 +89,29 @@ test.describe( 'Multi-currency widget setup', () => {
 			await merchantPage
 				.getByRole( 'checkbox', { name: 'Display flags' } )
 				.check();
-			expect(
-				await merchantPage
-					.getByRole( 'checkbox', { name: 'Display flags' } )
-					.isChecked()
-			).toBeTruthy();
+			await expect(
+				merchantPage.getByRole( 'checkbox', { name: 'Display flags' } )
+			).toBeChecked();
 		} );
 
 		await test.step( 'checks display currency symbols', async () => {
 			await merchantPage
 				.getByRole( 'checkbox', { name: 'Display currency symbols' } )
 				.check();
-			expect(
-				await merchantPage
-					.getByRole( 'checkbox', {
-						name: 'Display currency symbols',
-					} )
-					.isChecked()
-			).toBeTruthy();
+			await expect(
+				merchantPage.getByRole( 'checkbox', {
+					name: 'Display currency symbols',
+				} )
+			).toBeChecked();
 		} );
 
 		await test.step( 'checks border', async () => {
 			await merchantPage
 				.getByRole( 'checkbox', { name: 'Border' } )
 				.check();
-			expect(
-				await merchantPage
-					.getByRole( 'checkbox', { name: 'Border' } )
-					.isChecked()
-			).toBeTruthy();
+			await expect(
+				merchantPage.getByRole( 'checkbox', { name: 'Border' } )
+			).toBeChecked();
 		} );
 
 		await test.step( 'updates border radius', async () => {

--- a/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.ts
+++ b/tests/e2e/specs/wcpay/shopper/shopper-checkout-failures.spec.ts
@@ -167,7 +167,7 @@ test.describe(
 				'p#Field-numberError'
 			);
 
-			expect( numberErrorText ).toHaveText(
+			await expect( numberErrorText ).toHaveText(
 				'Your card number is invalid.'
 			);
 		} );

--- a/tests/e2e/utils/shopper.ts
+++ b/tests/e2e/utils/shopper.ts
@@ -680,7 +680,8 @@ export const addSavedCard = async (
 	// Wait for one of the expected outcomes:
 	//  - 3DS modal appears (Stripe iframe)
 	//  - Success notice
-	//  - Error notice (e.g., too soon after previous)
+	//  - Error notice (declined card, too soon after previous, generic failure)
+	//  - Card validation error inside the Stripe iframe (form never submits)
 	//  - Redirect back to Payment methods page
 	const threeDSFrame = page.locator(
 		'body > div > iframe[name^="__privateStripeFrame"]'
@@ -688,12 +689,11 @@ export const addSavedCard = async (
 	const successNotice = page.getByText(
 		'Payment method successfully added.'
 	);
-	const tooSoonNotice = page.getByText(
-		'You cannot add a new payment method so soon after the previous one.'
-	);
-	const genericError = page.getByText(
-		"We're not able to add this payment method. Please refresh the page and try again."
-	);
+	const errorNotice = page.getByRole( 'alert' ).first();
+	const inlineCardError = page
+		.frameLocator( 'iframe[title="Secure payment input frame"]' )
+		.getByRole( 'alert' )
+		.first();
 	const methodsHeading = page.getByRole( 'heading', {
 		name: 'Payment methods',
 	} );
@@ -701,12 +701,12 @@ export const addSavedCard = async (
 	await Promise.race( [
 		threeDSFrame.waitFor( { state: 'visible', timeout: 20000 } ),
 		successNotice.waitFor( { state: 'visible', timeout: 20000 } ),
-		tooSoonNotice.waitFor( { state: 'visible', timeout: 20000 } ),
-		genericError.waitFor( { state: 'visible', timeout: 20000 } ),
+		errorNotice.waitFor( { state: 'visible', timeout: 20000 } ),
+		inlineCardError.waitFor( { state: 'visible', timeout: 20000 } ),
 		methodsHeading.waitFor( { state: 'visible', timeout: 20000 } ),
 	] ).catch( () => {
 		throw new Error(
-			'Adding a payment method produced none of the expected outcomes: no 3DS modal, success notice, error notice, or redirect to the Payment methods page.'
+			'Adding a payment method produced none of the expected outcomes: no 3DS modal, success notice, error notice, inline card error, or redirect to the Payment methods page.'
 		);
 	} );
 };

--- a/tests/e2e/utils/shopper.ts
+++ b/tests/e2e/utils/shopper.ts
@@ -705,7 +705,9 @@ export const addSavedCard = async (
 		genericError.waitFor( { state: 'visible', timeout: 20000 } ),
 		methodsHeading.waitFor( { state: 'visible', timeout: 20000 } ),
 	] ).catch( () => {
-		/* ignore and let the caller continue; downstream assertions will catch real issues */
+		throw new Error(
+			'Adding a payment method produced none of the expected outcomes: no 3DS modal, success notice, error notice, or redirect to the Payment methods page.'
+		);
 	} );
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

An audit of the E2E suite found tests whose checks cannot fail, so a real regression could pass CI. This PR restores their signal without changing what they cover.

- Await four floating assertions (`merchant-admin-disputes`, `merchant-admin-deposits`, `shopper-subscriptions-purchase-no-signup-fee`, `shopper-checkout-failures`). Without `await`, the test ends before the check settles and always passes.
- Add a real assertion to the payouts advanced-filter test: apply the filter and check it lands in the URL query. Its previous assertion was commented out.
- Throw from the add-payment-method helper when none of its expected outcomes appear, instead of continuing and failing somewhere unrelated.
- Assert the change-payment form is visible instead of discarding an `isVisible()` result, and drop `noWaitAfter` from submits that trigger a redirect.
- Replace one-shot `isChecked()` checks with retrying `toBeChecked()` in the multi-currency widget spec.

Audit follow-ups are tracked in WOOPMNT-6377.

#### Testing instructions

1. Check the E2E jobs on this PR pass. The awaited assertions now gate their tests, so a green run is the main check.
2. Locally, run the touched merchant specs: `pnpm run test:e2e tests/e2e/specs/wcpay/merchant/merchant-admin-disputes.spec.ts tests/e2e/specs/wcpay/merchant/merchant-admin-deposits.spec.ts`.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
