### PR TITLE
Clarify where the support phone number appears

### DIFF
--- a/changelog/woopmnt-6353-clarify-where-a-support-phone-number-appears
+++ b/changelog/woopmnt-6353-clarify-where-a-support-phone-number-appears
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Clarify where the support phone number appears, mark the field as required, and use one plain validation message.

--- a/client/settings/support-phone-input/__tests__/support-phone-input.test.js
+++ b/client/settings/support-phone-input/__tests__/support-phone-input.test.js
@@ -25,6 +25,13 @@ jest.mock( 'wcpay/data/settings', () => ( {
 const waitForPhoneInputReady = () =>
 	screen.findByRole( 'combobox', { name: /:\s*\+/ } );
 
+const LABEL = 'Support phone number (required)';
+const ERROR_MESSAGE =
+	'A support phone number is required. Please enter a valid phone number.';
+const HELP_TEXT =
+	// eslint-disable-next-line max-len
+	"This number may appear on customer bank statements and in-person purchase receipts, but not in order emails. Use a number you're comfortable sharing publicly.";
+
 describe( 'SupportPhoneInput', () => {
 	beforeEach( () => {
 		useAccountBusinessSupportPhone.mockReturnValue( [
@@ -32,11 +39,20 @@ describe( 'SupportPhoneInput', () => {
 			jest.fn(),
 		] );
 		useGetSavingError.mockReturnValue( null );
+		useTestModeOnboarding.mockReturnValue( false );
 		window.wcpaySettings = {
 			accountStatus: {
 				country: 'US',
 			},
 		};
+	} );
+
+	it( 'explains where the number is exposed', async () => {
+		render( <SupportPhoneInput /> );
+
+		await waitForPhoneInputReady();
+
+		expect( screen.getByText( HELP_TEXT ) ).toBeInTheDocument();
 	} );
 
 	it( 'updates phone input', async () => {
@@ -50,7 +66,7 @@ describe( 'SupportPhoneInput', () => {
 		await waitForPhoneInputReady();
 
 		const newPhone = '+12377778888';
-		fireEvent.change( screen.getByLabelText( 'Support phone number' ), {
+		fireEvent.change( screen.getByLabelText( LABEL ), {
 			target: { value: newPhone },
 		} );
 
@@ -74,7 +90,7 @@ describe( 'SupportPhoneInput', () => {
 		// Mock that the phone number input is set to empty.
 		useAccountBusinessSupportPhone.mockReturnValue( [ '', jest.fn() ] );
 
-		fireEvent.change( screen.getByLabelText( 'Support phone number' ), {
+		fireEvent.change( screen.getByLabelText( LABEL ), {
 			target: { value: '' },
 		} );
 
@@ -83,9 +99,7 @@ describe( 'SupportPhoneInput', () => {
 			expect(
 				container.querySelector( '.components-notice.is-error' )
 					.textContent
-			).toMatch(
-				/Support phone number cannot be empty once it has been set before, please specify\./
-			)
+			).toMatch( ERROR_MESSAGE )
 		);
 	} );
 
@@ -100,7 +114,7 @@ describe( 'SupportPhoneInput', () => {
 			expect(
 				container.querySelector( '.components-notice.is-error' )
 					.textContent
-			).toMatch( /Support phone number cannot be empty\./ )
+			).toMatch( ERROR_MESSAGE )
 		);
 	} );
 
@@ -118,7 +132,7 @@ describe( 'SupportPhoneInput', () => {
 			expect(
 				container.querySelector( '.components-notice.is-error' )
 					.textContent
-			).toMatch( /Please enter a valid phone number\./ )
+			).toMatch( ERROR_MESSAGE )
 		);
 	} );
 
@@ -146,7 +160,7 @@ describe( 'SupportPhoneInput', () => {
 			'+6580800000',
 			'+6580900000',
 		] ) {
-			fireEvent.change( screen.getByLabelText( 'Support phone number' ), {
+			fireEvent.change( screen.getByLabelText( LABEL ), {
 				target: { value },
 			} );
 			await waitFor( () =>
@@ -179,7 +193,7 @@ describe( 'SupportPhoneInput', () => {
 			'+85271234567',
 			'+85281234567',
 		] ) {
-			fireEvent.change( screen.getByLabelText( 'Support phone number' ), {
+			fireEvent.change( screen.getByLabelText( LABEL ), {
 				target: { value },
 			} );
 			await waitFor( () =>

--- a/client/settings/support-phone-input/index.js
+++ b/client/settings/support-phone-input/index.js
@@ -3,7 +3,7 @@
  */
 import { BaseControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -24,29 +24,17 @@ const SupportPhoneInput = ( { setInputValid } ) => {
 		useGetSavingError()?.data?.details?.account_business_support_phone
 			?.message;
 
-	const currentPhone = useRef( supportPhone ).current;
-	const isEmptyPhoneValid = supportPhone === '' && currentPhone === '';
 	const isTestModeOnboarding = useTestModeOnboarding();
 	const isTestPhoneValid =
 		isTestModeOnboarding && supportPhone === '+10000000000';
 
 	const [ isPhoneValid, setPhoneValidity ] = useState( true );
-	if ( supportPhone === '' ) {
-		supportPhoneError = __(
-			'Support phone number cannot be empty.',
-			'woocommerce-payments'
-		);
-	}
-	if ( ! isTestPhoneValid && ! isPhoneValid && ! isEmptyPhoneValid ) {
-		supportPhoneError = __(
-			'Please enter a valid phone number.',
-			'woocommerce-payments'
-		);
-	}
 
-	if ( supportPhone === '' && currentPhone !== '' ) {
+	// Empty, never set, and invalid numbers all share one message: the merchant
+	// only ever needs to know that a valid number is required.
+	if ( supportPhone === '' || ( ! isTestPhoneValid && ! isPhoneValid ) ) {
 		supportPhoneError = __(
-			'Support phone number cannot be empty once it has been set before, please specify.',
+			'A support phone number is required. Please enter a valid phone number.',
 			'woocommerce-payments'
 		);
 	}
@@ -57,7 +45,10 @@ const SupportPhoneInput = ( { setInputValid } ) => {
 		}
 	}, [ supportPhoneError, setInputValid ] );
 
-	const labelText = __( 'Support phone number', 'woocommerce-payments' );
+	const labelText = __(
+		'Support phone number (required)',
+		'woocommerce-payments'
+	);
 	return (
 		<>
 			{ supportPhoneError && (
@@ -70,7 +61,8 @@ const SupportPhoneInput = ( { setInputValid } ) => {
 				help={
 					<>
 						{ __(
-							'This may be visible on receipts, invoices, and automated emails from your store.',
+							// eslint-disable-next-line max-len
+							"This number may appear on customer bank statements and in-person purchase receipts, but not in order emails. Use a number you're comfortable sharing publicly.",
 							'woocommerce-payments'
 						) }
 						{ isTestModeOnboarding && (

--- a/client/settings/support-phone-input/index.js
+++ b/client/settings/support-phone-input/index.js
@@ -30,8 +30,6 @@ const SupportPhoneInput = ( { setInputValid } ) => {
 
 	const [ isPhoneValid, setPhoneValidity ] = useState( true );
 
-	// Empty, never set, and invalid numbers all share one message: the merchant
-	// only ever needs to know that a valid number is required.
 	if ( supportPhone === '' || ( ! isTestPhoneValid && ! isPhoneValid ) ) {
 		supportPhoneError = __(
 			'A support phone number is required. Please enter a valid phone number.',

--- a/client/settings/transactions/__tests__/index.test.js
+++ b/client/settings/transactions/__tests__/index.test.js
@@ -172,7 +172,7 @@ describe( 'Settings - Transactions', () => {
 	it( 'display support email and phone inputs', async () => {
 		render( <Transactions /> );
 		expect(
-			screen.getByLabelText( 'Support phone number' )
+			screen.getByLabelText( 'Support phone number (required)' )
 		).toBeInTheDocument();
 		expect( screen.getByLabelText( 'Support email' ) ).toBeInTheDocument();
 	} );


### PR DESCRIPTION
Fixes WOOPMNT-6353

#### Changes proposed in this Pull Request

The help text under Payments → Settings → Transactions told merchants their support phone number "may be visible on receipts, invoices, and automated emails from your store." For an online-only store that is wrong on all three counts. The field feeds Stripe's `business_profile.support_phone`, which banks surface on customer statements and card readers print on in-person receipts. It never reaches the store's order emails or invoices.

A merchant who had put in a personal number read that literally and tried to clear the field, which is blocked on purpose: with no merchant number set, banks receive the platform's support number instead. The block was also explained by three different error strings depending on how the field got into a bad state, so it read as three different problems rather than one requirement.

- The help text now says where the number really appears, and suggests using a number the merchant is comfortable sharing publicly. The `(+1 0000000000 can be used for test accounts)` line is unchanged.
- The label reads `Support phone number (required)`, so the constraint is visible before the merchant runs into it.
- The empty, never-set, and invalid cases all show one message: `A support phone number is required. Please enter a valid phone number.`

Save is still blocked on an empty or invalid number, exactly as before.

Copy is design-approved.

#### Testing instructions

1. Go to Payments → Settings. Scroll to Transactions → Customer support.
2. Confirm the label reads `SUPPORT PHONE NUMBER (REQUIRED)`, and the help text below the input reads "This number may appear on customer bank statements and in-person purchase receipts, but not in order emails. Use a number you're comfortable sharing publicly."
3. On a test-mode account, confirm the `(+1 0000000000 can be used for test accounts)` line still sits below that.
4. Clear the field. Confirm one error appears above it, "A support phone number is required. Please enter a valid phone number.", and Save changes is disabled.
5. Type a partial number such as `12345`. Confirm you get the same message, not a separate "Please enter a valid phone number."
6. Type a valid number. Confirm the error clears and Save changes re-enables.
7. Confirm the Support email field above is unchanged, help text included.

#### Screenshots

<img width="563" height="172" alt="image" src="https://github.com/user-attachments/assets/a77999b0-3e75-4103-aa89-21b81cb26f39" />

<img width="576" height="250" alt="image" src="https://github.com/user-attachments/assets/4b28311e-0496-4e17-82d8-56f5ccc2023c" />

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — does not apply (copy change)

**Post merge**

- [ ] Link to testing instructions from release testing doc: _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update critical flows and testing instructions for critical flows, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.

