### PR TITLE
Fix merchant-facing documentation links, dispute fee copy, and the disputed-amount label

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We currently support the following variables:
 
 ## Test account setup
 
-For setting up a test account follow [these instructions](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/).
+For setting up a test account follow [these instructions](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/).
 
 You will need an externally accessible URL to set up the plugin. You can use ngrok for this.
 

--- a/changelog/woopmnt-6403
+++ b/changelog/woopmnt-6403
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed merchant-facing documentation links that resolved but landed on the wrong page or section

--- a/changelog/woopmnt-6403
+++ b/changelog/woopmnt-6403
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fixed merchant-facing documentation links that resolved but landed on the wrong page or section
+Fixed merchant-facing documentation links that landed on the wrong page or section, and relabelled two links to match their new destinations.

--- a/changelog/woopmnt-6403-dispute-fee-copy
+++ b/changelog/woopmnt-6403-dispute-fee-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stopped the dispute details from naming a fee that was never charged: a zero or reversed dispute fee now drops the fee wording instead of showing a $0.00 amount or a dash.

--- a/changelog/woopmnt-6403-disputed-amount-label
+++ b/changelog/woopmnt-6403-disputed-amount-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed the payment details summary labelling a disputed amount as refunded: the withdrawn balance line now reads "Deducted" whenever a dispute moved the money, including when the dispute fee was zero or reversed.

--- a/changelog/woopmnt-6403-fee-link-account-country
+++ b/changelog/woopmnt-6403-fee-link-account-country
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Linked the payment method fee tooltip to the fee section for the WooPayments account's country rather than the store's base country, which differ for Puerto Rico stores and for any store that changes its base country after onboarding.

--- a/client/components/account-details/account-fees/__tests__/index.test.js
+++ b/client/components/account-details/account-fees/__tests__/index.test.js
@@ -139,8 +139,6 @@ describe( 'AccountFees', () => {
 	} );
 
 	test( 'renders discounted non-USD base fee', () => {
-		global.wcpaySettings.connect.country = 'GB';
-
 		const { container: accountFees } = renderAccountFees( [
 			{
 				payment_method: 'card',

--- a/client/components/account-details/account-fees/__tests__/index.test.js
+++ b/client/components/account-details/account-fees/__tests__/index.test.js
@@ -139,7 +139,7 @@ describe( 'AccountFees', () => {
 	} );
 
 	test( 'renders discounted non-USD base fee', () => {
-		global.wcpaySettings.connect.country = 'UK';
+		global.wcpaySettings.connect.country = 'GB';
 
 		const { container: accountFees } = renderAccountFees( [
 			{

--- a/client/components/sandbox-mode-switch-to-live-notice/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/index.tsx
@@ -251,7 +251,7 @@ const SandboxModeSwitchToLiveNotice: React.FC< Props > = ( {
 														<Link
 															href={
 																// eslint-disable-next-line max-len
-																'https://woocommerce.com/document/woopayments/startup-guide/#sign-up-process'
+																'https://woocommerce.com/document/woopayments/startup-guide/#signup-process'
 															}
 															target="_blank"
 															rel="noreferrer"

--- a/client/components/sandbox-mode-switch-to-live-notice/index.tsx
+++ b/client/components/sandbox-mode-switch-to-live-notice/index.tsx
@@ -91,7 +91,7 @@ const SandboxModeSwitchToLiveNotice: React.FC< Props > = ( {
 																'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/'
 															}
 															target="_blank"
-															rel="noreferrer"
+															rel="noreferrer noopener"
 															type="external"
 															onClick={ () =>
 																recordEvent(

--- a/client/components/test-mode-notice/__tests__/__snapshots__/index.test.tsx.snap
+++ b/client/components/test-mode-notice/__tests__/__snapshots__/index.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`Test mode notification Returns valid component for overview page 1`] = 
        All transactions will be simulated. 
       <a
         class="components-external-link"
-        href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/"
+        href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/"
         rel="external noreferrer noopener"
         target="_blank"
       >

--- a/client/components/test-mode-notice/index.tsx
+++ b/client/components/test-mode-notice/index.tsx
@@ -102,7 +102,7 @@ const getNoticeContent = (
 									// @ts-expect-error: children is provided when interpolating the component
 									<ExternalLink
 										href={
-											'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/'
+											'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/'
 										}
 										onClick={ () =>
 											recordEvent(
@@ -134,7 +134,7 @@ const getNoticeContent = (
 								// @ts-expect-error: children is provided when interpolating the component
 								<ExternalLink
 									href={
-										'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/'
+										'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/'
 									}
 									onClick={ () =>
 										recordEvent(
@@ -173,7 +173,7 @@ const getNoticeContent = (
 									// @ts-expect-error: children is provided when interpolating the component
 									<ExternalLink
 										href={
-											'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/'
+											'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/'
 										}
 									/>
 								),

--- a/client/connect-account-page/strings.tsx
+++ b/client/connect-account-page/strings.tsx
@@ -85,7 +85,7 @@ export default {
 				// Link content is in the format string above. Consider disabling jsx-a11y/anchor-has-content.
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
 				<a
-					href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/"
+					href="https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/"
 					target="_blank"
 					rel="noreferrer"
 				/>

--- a/client/deposits/details/index.tsx
+++ b/client/deposits/details/index.tsx
@@ -346,7 +346,7 @@ export const DepositDetails: React.FC< DepositDetailsProps > = ( {
 									components: {
 										learnMoreLink: (
 											// @ts-expect-error: children is provided when interpolating the component
-											<ExternalLink href="https://woocommerce.com/document/woopayments/payouts/instant-payouts/#transactions" />
+											<ExternalLink href="https://woocommerce.com/document/woopayments/payouts/instant-payouts/#request-an-instant-payout" />
 										),
 									},
 								} ) }

--- a/client/disputes/__tests__/utils.test.ts
+++ b/client/disputes/__tests__/utils.test.ts
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { isDueWithin, isInquiry, isVisaComplianceDispute } from '../utils';
+import {
+	getDisputeFeeAmount,
+	isDueWithin,
+	isInquiry,
+	isVisaComplianceDispute,
+} from '../utils';
 import type { Dispute } from 'wcpay/types/disputes';
 
 describe( 'isDueWithin', () => {
@@ -179,5 +184,85 @@ describe( 'isVisaComplianceDispute', () => {
 
 	test( 'returns false if dispute is undefined', () => {
 		expect( isVisaComplianceDispute( undefined as any ) ).toBe( false );
+	} );
+} );
+
+describe( 'getDisputeFeeAmount', () => {
+	const disputeFeeRow = {
+		amount: -5000,
+		currency: 'usd',
+		fee: 1500,
+		reporting_category: 'dispute',
+	};
+
+	describe( 'when the server annotates effective_fee', () => {
+		test( 'returns the annotated fee', () => {
+			expect(
+				getDisputeFeeAmount( {
+					balance_transactions: [],
+					effective_fee: { amount: 1500, currency: 'usd' },
+				} )
+			).toEqual( { amount: 1500, currency: 'usd' } );
+		} );
+
+		test( 'returns undefined when the fee was reversed', () => {
+			expect(
+				getDisputeFeeAmount( {
+					balance_transactions: [ disputeFeeRow ],
+					effective_fee: null,
+				} )
+			).toBeUndefined();
+		} );
+
+		test( 'returns undefined when the fee is zero', () => {
+			// A $0.00 fee is no fee. Returning it would let callers render
+			// "the $0.00 fee has been deducted from your account".
+			expect(
+				getDisputeFeeAmount( {
+					balance_transactions: [],
+					effective_fee: { amount: 0, currency: 'usd' },
+				} )
+			).toBeUndefined();
+		} );
+	} );
+
+	describe( 'when falling back to balance_transactions', () => {
+		test( 'returns the dispute row fee', () => {
+			expect(
+				getDisputeFeeAmount( {
+					balance_transactions: [ disputeFeeRow ],
+				} )
+			).toEqual( { amount: 1500, currency: 'usd' } );
+		} );
+
+		test( 'returns undefined when a reversal row is present', () => {
+			expect(
+				getDisputeFeeAmount( {
+					balance_transactions: [
+						disputeFeeRow,
+						{
+							amount: 5000,
+							currency: 'usd',
+							fee: -1500,
+							reporting_category: 'dispute_reversal',
+						},
+					],
+				} )
+			).toBeUndefined();
+		} );
+
+		test( 'returns undefined when no dispute row is present', () => {
+			expect(
+				getDisputeFeeAmount( { balance_transactions: [] } )
+			).toBeUndefined();
+		} );
+
+		test( 'returns undefined when the dispute row fee is zero', () => {
+			expect(
+				getDisputeFeeAmount( {
+					balance_transactions: [ { ...disputeFeeRow, fee: 0 } ],
+				} )
+			).toBeUndefined();
+		} );
 	} );
 } );

--- a/client/disputes/__tests__/utils.test.ts
+++ b/client/disputes/__tests__/utils.test.ts
@@ -214,6 +214,18 @@ describe( 'getDisputeFeeAmount', () => {
 			).toBeUndefined();
 		} );
 
+		test( 'returns undefined when the amount is malformed', () => {
+			// Would otherwise reach the currency formatter and render "$NaN".
+			expect(
+				getDisputeFeeAmount( {
+					balance_transactions: [],
+					effective_fee: {
+						currency: 'usd',
+					} as unknown as { amount: number; currency: string },
+				} )
+			).toBeUndefined();
+		} );
+
 		test( 'returns undefined when the fee is zero', () => {
 			// A $0.00 fee is no fee. Returning it would let callers render
 			// "the $0.00 fee has been deducted from your account".

--- a/client/disputes/__tests__/utils.test.ts
+++ b/client/disputes/__tests__/utils.test.ts
@@ -239,14 +239,6 @@ describe( 'getDisputeFeeAmount', () => {
 	} );
 
 	describe( 'when falling back to balance_transactions', () => {
-		test( 'returns the dispute row fee', () => {
-			expect(
-				getDisputeFeeAmount( {
-					balance_transactions: [ disputeFeeRow ],
-				} )
-			).toEqual( { amount: 1500, currency: 'usd' } );
-		} );
-
 		test( 'returns undefined when a reversal row is present', () => {
 			expect(
 				getDisputeFeeAmount( {
@@ -260,12 +252,6 @@ describe( 'getDisputeFeeAmount', () => {
 						},
 					],
 				} )
-			).toBeUndefined();
-		} );
-
-		test( 'returns undefined when no dispute row is present', () => {
-			expect(
-				getDisputeFeeAmount( { balance_transactions: [] } )
 			).toBeUndefined();
 		} );
 

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -160,9 +160,11 @@ export const getDisputeFeeAmount = (
 
 	// A zero fee is no fee. Callers phrase this as "the %s fee has been
 	// deducted from your account", which is false at $0.00 — the same
-	// copy/reality mismatch as a reversed fee.
-	return fee && fee.amount !== 0
-		? { amount: fee.amount, currency: fee.currency }
+	// copy/reality mismatch as a reversed fee. The finite check keeps a
+	// malformed amount from reaching the currency formatter and rendering
+	// as "$NaN".
+	return fee && Number.isFinite( fee.amount ) && fee.amount !== 0
+		? fee
 		: undefined;
 };
 

--- a/client/disputes/utils.ts
+++ b/client/disputes/utils.ts
@@ -133,8 +133,8 @@ const getDisputeDeductedBalanceTransaction = (
 };
 
 /**
- * Returns the effective dispute fee as a raw `{ amount, currency }` pair if it
- * exists and the deduction has not been reversed.
+ * Returns the effective dispute fee as a raw `{ amount, currency }` pair if a
+ * non-zero fee exists and the deduction has not been reversed.
  *
  * Prefers the server-computed `dispute.effective_fee` when present.
  * Falls back to inspecting `balance_transactions` directly for responses
@@ -146,29 +146,29 @@ const getDisputeDeductedBalanceTransaction = (
 export const getDisputeFeeAmount = (
 	dispute: Pick< Dispute, 'balance_transactions' | 'effective_fee' >
 ): { amount: number; currency: string } | undefined => {
-	// Server-computed path: effective_fee is explicitly null when the fee
-	// was reversed, an object when it's still effective.
+	let fee: { amount: number; currency: string } | undefined;
+
 	if ( dispute.effective_fee !== undefined ) {
-		if ( dispute.effective_fee === null ) {
-			return undefined;
-		}
-		return {
-			amount: dispute.effective_fee.amount,
-			currency: dispute.effective_fee.currency,
-		};
+		// Server-computed: an object while the fee is effective, explicitly
+		// null once it has been reversed.
+		fee = dispute.effective_fee ?? undefined;
+	} else {
+		// Legacy fallback.
+		const row = getDisputeDeductedBalanceTransaction( dispute );
+		fee = row ? { amount: row.fee, currency: row.currency } : undefined;
 	}
 
-	// Legacy fallback.
-	const disputeFee = getDisputeDeductedBalanceTransaction( dispute );
-	if ( ! disputeFee ) {
-		return undefined;
-	}
-	return { amount: disputeFee.fee, currency: disputeFee.currency };
+	// A zero fee is no fee. Callers phrase this as "the %s fee has been
+	// deducted from your account", which is false at $0.00 — the same
+	// copy/reality mismatch as a reversed fee.
+	return fee && fee.amount !== 0
+		? { amount: fee.amount, currency: fee.currency }
+		: undefined;
 };
 
 /**
- * Returns the dispute fee formatted as a currency string if it exists
- * and the deduction has not been reversed.
+ * Returns the dispute fee formatted as a currency string if a non-zero fee
+ * exists and the deduction has not been reversed.
  */
 export const getDisputeFeeFormatted = (
 	dispute: Pick< Dispute, 'balance_transactions' | 'effective_fee' >,

--- a/client/onboarding/steps/embedded-kyc.tsx
+++ b/client/onboarding/steps/embedded-kyc.tsx
@@ -119,7 +119,7 @@ const EmbeddedKyc: React.FC< Props > = ( {
 								// @ts-expect-error: children is provided when interpolating the component
 								<ExternalLink
 									href={
-										'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/'
+										'https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/'
 									}
 								/>
 							),

--- a/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-awaiting-response-details.test.tsx
@@ -362,6 +362,56 @@ describe( 'DisputeAwaitingResponseDetails - Visa Compliance', () => {
 		);
 	} );
 
+	test( 'Accept dispute modal names the fee that will be forfeited', async () => {
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ getBaseDispute() }
+				customer={ getBaseBillingDetails() }
+				chargeCreated={ 1693453017 }
+				onIssueRefund={ mockOnIssueRefund }
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: /Accept dispute/i } )
+		);
+
+		// The copy is split by an <em>, so assert on the dialog's text.
+		expect( screen.getByRole( 'dialog' ).textContent ).toContain(
+			'The disputed amount and the $15.00 dispute fee will not be returned to you.'
+		);
+	} );
+
+	test( 'Accept dispute modal drops the fee clause when no fee was charged', async () => {
+		// Previously rendered as "the - dispute fee will not be returned to
+		// you" at the moment the merchant is about to forfeit funds.
+		const dispute = { ...getBaseDispute(), effective_fee: null };
+
+		renderWithContext(
+			<DisputeAwaitingResponseDetails
+				dispute={ dispute }
+				customer={ getBaseBillingDetails() }
+				chargeCreated={ 1693453017 }
+				onIssueRefund={ mockOnIssueRefund }
+				paymentMethod="card"
+				bankName="Chase Bank"
+			/>
+		);
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: /Accept dispute/i } )
+		);
+
+		const modalText = screen.getByRole( 'dialog' ).textContent ?? '';
+
+		expect( modalText ).toContain(
+			'The disputed amount will not be returned to you.'
+		);
+		expect( modalText ).not.toContain( 'dispute fee' );
+	} );
+
 	test( 'Accept dispute button works correctly for Visa compliance disputes', async () => {
 		const dispute = getBaseDispute();
 		const customer = getBaseBillingDetails();

--- a/client/payment-details/dispute-details/__tests__/dispute-resolution-footer.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-resolution-footer.test.tsx
@@ -82,6 +82,14 @@ const getBaseDispute = ( overrides = {} ): Dispute => ( {
 	...overrides,
 } );
 
+// The module factory's implementation is not restored between tests, so a
+// `mockReturnValueOnce` that the component stops consuming would otherwise
+// surface as a failure in whichever test runs next.
+beforeEach( () => {
+	( getDisputeFeeFormatted as jest.Mock ).mockReset();
+	( getDisputeFeeFormatted as jest.Mock ).mockReturnValue( '$15.00' );
+} );
+
 describe( 'DisputeResolutionFooter - Under Review Status', () => {
 	it( 'renders under review footer with bank name for regular disputes', () => {
 		const dispute = getBaseDispute( { status: 'under_review' } );
@@ -405,7 +413,10 @@ describe( 'DisputeResolutionFooter - Lost Status', () => {
 		expect( screen.getByText( /\$15\.00 fee/i ) ).toBeInTheDocument();
 	} );
 
-	it( 'omits the fee sentence when the dispute fee was reversed or never charged', () => {
+	// getDisputeFeeFormatted returns undefined for a reversed fee, a missing
+	// fee, and a zero fee alike (see client/disputes/__tests__/utils.test.ts);
+	// this covers what the footer does with that answer.
+	it( 'omits the fee sentence when there is no dispute fee', () => {
 		( getDisputeFeeFormatted as jest.Mock ).mockReturnValueOnce(
 			undefined
 		);

--- a/client/payment-details/dispute-details/__tests__/dispute-resolution-footer.test.tsx
+++ b/client/payment-details/dispute-details/__tests__/dispute-resolution-footer.test.tsx
@@ -10,6 +10,7 @@ import { render, screen } from '@testing-library/react';
 import DisputeResolutionFooter from '../dispute-resolution-footer';
 import type { Dispute } from 'wcpay/types/disputes';
 import type { Charge } from 'wcpay/types/charges';
+import { getDisputeFeeFormatted } from 'wcpay/disputes/utils';
 
 // Mock date formatting utility
 jest.mock( 'wcpay/utils/date-time', () => ( {
@@ -402,6 +403,39 @@ describe( 'DisputeResolutionFooter - Lost Status', () => {
 		);
 
 		expect( screen.getByText( /\$15\.00 fee/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits the fee sentence when the dispute fee was reversed or never charged', () => {
+		( getDisputeFeeFormatted as jest.Mock ).mockReturnValueOnce(
+			undefined
+		);
+
+		const dispute = getBaseDispute( {
+			status: 'lost',
+			metadata: {
+				__evidence_submitted_at: '1693453017',
+				__dispute_closed_at: '1693453017',
+			},
+		} );
+
+		render(
+			<DisputeResolutionFooter dispute={ dispute } bankName={ null } />
+		);
+
+		expect( screen.queryByText( /fee has been deducted/i ) ).toBeNull();
+		expect(
+			screen.getByText(
+				/The disputed amount has been returned to your customer/i
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', {
+				name: /Learn more about disputed amounts/i,
+			} )
+		).toHaveAttribute(
+			'href',
+			'https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#amounts'
+		);
 	} );
 
 	it( 'renders link to view dispute details for submitted disputes', () => {

--- a/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
+++ b/client/payment-details/dispute-details/dispute-awaiting-response-details.tsx
@@ -126,6 +126,8 @@ function getAcceptDisputeProps( {
 	>;
 	isDisputeAcceptRequestPending: boolean;
 } ): AcceptDisputeProps {
+	const disputeFeeFormatted = getDisputeFeeFormatted( dispute, true );
+
 	return {
 		acceptButtonLabel: __( 'Accept dispute', 'woocommerce-payments' ),
 		acceptButtonTracksEvent: 'wcpay_dispute_accept_modal_view',
@@ -134,14 +136,23 @@ function getAcceptDisputeProps( {
 			{
 				icon: <Icon icon={ backup } size={ 24 } />,
 				description: createInterpolateElement(
-					sprintf(
-						/* translators: %s: dispute fee, <em>: emphasis HTML element. */
-						__(
-							'Accepting the dispute marks it as <em>Lost</em>. The disputed amount and the %s dispute fee will not be returned to you.',
-							'woocommerce-payments'
-						),
-						getDisputeFeeFormatted( dispute, true ) ?? '-'
-					),
+					// Drop the fee clause entirely when no fee was charged,
+					// rather than telling a merchant about a "-" fee at the
+					// moment they are about to forfeit funds.
+					disputeFeeFormatted
+						? sprintf(
+								/* translators: %s: dispute fee, <em>: emphasis HTML element. */
+								__(
+									'Accepting the dispute marks it as <em>Lost</em>. The disputed amount and the %s dispute fee will not be returned to you.',
+									'woocommerce-payments'
+								),
+								disputeFeeFormatted
+						  )
+						: /* translators: <em>: emphasis HTML element. */
+						  __(
+								'Accepting the dispute marks it as <em>Lost</em>. The disputed amount will not be returned to you.',
+								'woocommerce-payments'
+						  ),
 					{
 						em: <em />,
 					}

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -91,7 +91,7 @@ const DisputeUnderReviewFooter: React.FC< {
 						  ) }{ ' ' }
 					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#monitor-status">
 						{ __(
-							'Learn more about the dispute process.',
+							'Learn more about monitoring dispute status.',
 							'woocommerce-payments'
 						) }
 					</ExternalLink>

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -229,7 +229,7 @@ const DisputeLostFooter: React.FC< {
 } > = ( { dispute, bankName } ) => {
 	const isSubmitted = !! dispute.metadata.__evidence_submitted_at;
 	const isAccepted = dispute.metadata.__closed_by_merchant === '1';
-	const disputeFeeFormatted = getDisputeFeeFormatted( dispute, true ) ?? '-';
+	const disputeFeeFormatted = getDisputeFeeFormatted( dispute, true );
 
 	const closedDateFormatted = dispute.metadata.__dispute_closed_at
 		? formatDateTimeFromTimestamp(
@@ -296,20 +296,37 @@ const DisputeLostFooter: React.FC< {
 					{ createInterpolateElement( messagePrefix, {
 						strong: <strong />,
 					} ) }{ ' ' }
-					{ sprintf(
-						/* Translators: %1$s – the formatted dispute fee amount */
-						__(
-							'The %1$s fee has been deducted from your account, and the disputed amount has been returned to your customer.',
-							'woocommerce-payments'
-						),
-						disputeFeeFormatted
-					) }{ ' ' }
-					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#fees">
-						{ __(
-							'Learn more about dispute fees.',
-							'woocommerce-payments'
-						) }
-					</ExternalLink>
+					{ disputeFeeFormatted ? (
+						<>
+							{ sprintf(
+								/* Translators: %1$s – the formatted dispute fee amount */
+								__(
+									'The %1$s fee has been deducted from your account, and the disputed amount has been returned to your customer.',
+									'woocommerce-payments'
+								),
+								disputeFeeFormatted
+							) }{ ' ' }
+							<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#fees">
+								{ __(
+									'Learn more about dispute fees.',
+									'woocommerce-payments'
+								) }
+							</ExternalLink>
+						</>
+					) : (
+						<>
+							{ __(
+								'The disputed amount has been returned to your customer.',
+								'woocommerce-payments'
+							) }{ ' ' }
+							<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#amounts">
+								{ __(
+									'Learn more about disputed amounts.',
+									'woocommerce-payments'
+								) }
+							</ExternalLink>
+						</>
+					) }
 				</FlexItem>
 
 				{ isSubmitted && (

--- a/client/payment-details/dispute-details/dispute-resolution-footer.tsx
+++ b/client/payment-details/dispute-details/dispute-resolution-footer.tsx
@@ -89,7 +89,7 @@ const DisputeUnderReviewFooter: React.FC< {
 									strong: <strong />,
 								}
 						  ) }{ ' ' }
-					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/">
+					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#monitor-status">
 						{ __(
 							'Learn more about the dispute process.',
 							'woocommerce-payments'
@@ -179,7 +179,7 @@ const DisputeWonFooter: React.FC< {
 									strong: <strong />,
 								}
 						  ) }{ ' ' }
-					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/">
+					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/preventing-disputes/">
 						{ __(
 							'Learn more about preventing disputes.',
 							'woocommerce-payments'
@@ -304,9 +304,9 @@ const DisputeLostFooter: React.FC< {
 						),
 						disputeFeeFormatted
 					) }{ ' ' }
-					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/">
+					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#fees">
 						{ __(
-							'Learn more about preventing disputes.',
+							'Learn more about dispute fees.',
 							'woocommerce-payments'
 						) }
 					</ExternalLink>
@@ -380,7 +380,7 @@ const InquiryUnderReviewFooter: React.FC< {
 							strong: <strong />,
 						}
 					) }{ ' ' }
-					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/">
+					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#inquiries">
 						{ __( 'Learn more.', 'woocommerce-payments' ) }
 					</ExternalLink>
 				</FlexItem>
@@ -435,7 +435,7 @@ const InquiryClosedFooter: React.FC< {
 						),
 						closedDateFormatted
 					) }{ ' ' }
-					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/">
+					<ExternalLink href="https://woocommerce.com/document/woopayments/fraud-and-disputes/preventing-disputes/">
 						{ __(
 							'Learn more about preventing disputes.',
 							'woocommerce-payments'

--- a/client/payment-details/order-details/__tests__/__snapshots__/index.test.tsx.snap
+++ b/client/payment-details/order-details/__tests__/__snapshots__/index.test.tsx.snap
@@ -472,7 +472,7 @@ exports[`Order details page should match the snapshot - Charge without payment i
               You must 
               <a
                 class="components-external-link"
-                href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
+                href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-payments"
                 rel="external noreferrer noopener"
                 target="_blank"
               >

--- a/client/payment-details/summary/__tests__/__snapshots__/index.test.js.snap
+++ b/client/payment-details/summary/__tests__/__snapshots__/index.test.js.snap
@@ -424,7 +424,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders ca
             You must 
             <a
               class="components-external-link"
-              href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
+              href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-payments"
               rel="external noreferrer noopener"
               target="_blank"
             >
@@ -919,7 +919,7 @@ exports[`PaymentDetailsSummary capture notification and fraud buttons renders th
             You must 
             <a
               class="components-external-link"
-              href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders"
+              href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-payments"
               rel="external noreferrer noopener"
               target="_blank"
             >
@@ -5530,7 +5530,7 @@ exports[`PaymentDetailsSummary renders the information of a dispute-reversal cha
              
             <a
               class="components-external-link"
-              href="https://woocommerce.com/document/woopayments/fraud-and-disputes/"
+              href="https://woocommerce.com/document/woopayments/fraud-and-disputes/preventing-disputes/"
               rel="external noreferrer noopener"
               target="_blank"
             >

--- a/client/payment-details/summary/__tests__/index.test.js
+++ b/client/payment-details/summary/__tests__/index.test.js
@@ -870,6 +870,78 @@ describe( 'PaymentDetailsSummary', () => {
 		expect( screen.queryByText( /Refunded:/i ) ).not.toBeInTheDocument();
 	} );
 
+	test( 'labels a refund on a charge with an inquiry as refunded', () => {
+		// An inquiry withdraws nothing, so the only money that moved is the
+		// customer refund. The label must not follow the mere presence of a
+		// dispute record.
+		const charge = getBaseCharge();
+		charge.amount_refunded = 1000;
+		charge.refunds = {
+			data: [
+				{
+					amount: 1000,
+					currency: 'usd',
+					balance_transaction: {
+						amount: -1000,
+						currency: 'usd',
+						fee: 0,
+					},
+				},
+			],
+		};
+		charge.disputed = true;
+		charge.dispute = getBaseDispute();
+		charge.dispute.status = 'warning_needs_response';
+		charge.dispute.balance_transactions = [];
+
+		renderCharge( charge );
+
+		expect( screen.getByText( /Refunded:/i ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Deducted:/i ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'labels a refund on a charge with a won dispute as refunded', () => {
+		// The dispute rows net to zero, so nothing was deducted; the refund is
+		// the only withdrawal.
+		const charge = getBaseCharge();
+		charge.amount_refunded = 1000;
+		charge.refunds = {
+			data: [
+				{
+					amount: 1000,
+					currency: 'usd',
+					balance_transaction: {
+						amount: -1000,
+						currency: 'usd',
+						fee: 0,
+					},
+				},
+			],
+		};
+		charge.disputed = true;
+		charge.dispute = getBaseDispute();
+		charge.dispute.status = 'won';
+		charge.dispute.balance_transactions = [
+			{
+				amount: -2000,
+				currency: 'usd',
+				fee: 1500,
+				reporting_category: 'dispute',
+			},
+			{
+				amount: 2000,
+				currency: 'usd',
+				fee: -1500,
+				reporting_category: 'dispute_reversal',
+			},
+		];
+
+		renderCharge( charge );
+
+		expect( screen.getByText( /Refunded:/i ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Deducted:/i ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'renders the fee breakdown tooltip of a disputed charge', async () => {
 		const charge = {
 			...getBaseCharge(),

--- a/client/payment-details/summary/__tests__/index.test.js
+++ b/client/payment-details/summary/__tests__/index.test.js
@@ -848,6 +848,28 @@ describe( 'PaymentDetailsSummary', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
+	test( 'labels a zero-fee dispute as deducted, not refunded', () => {
+		// The label keys on the dispute, not the dispute fee: the disputed
+		// amount left the account as a deduction whether or not a fee rode
+		// along with it.
+		const charge = getBaseCharge();
+		charge.disputed = true;
+		charge.dispute = getBaseDispute();
+		charge.dispute.balance_transactions = [
+			{
+				amount: -2000,
+				currency: 'usd',
+				fee: 0,
+				reporting_category: 'dispute',
+			},
+		];
+
+		renderCharge( charge );
+
+		expect( screen.getByText( /Deducted:/i ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Refunded:/i ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'renders the fee breakdown tooltip of a disputed charge', async () => {
 		const charge = {
 			...getBaseCharge(),

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -345,9 +345,11 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 			( fee ): fee is { amount: number; currency: string } => !! fee
 		);
 	const disputeFeeTotal = _.sumBy( disputeFeeAmounts, 'amount' );
-	// Settlement currency, not the first fee-bearing dispute's: which dispute
-	// sits at index 0 shifts as the list is filtered, and the rest of the
-	// breakdown is already denominated in `balance.currency`.
+	// Every dispute fee on a charge is already denominated in the settlement
+	// currency, so reading it off `balance.currency` rather than off whichever
+	// dispute happens to sit at index 0 changes nothing rendered — it just
+	// states the denomination the rest of the breakdown uses instead of
+	// relying on the two agreeing by construction.
 	const disputeFee = disputeFeeAmounts.length
 		? formatCurrency( disputeFeeTotal, balance.currency )
 		: undefined;

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -917,7 +917,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 							{
 								a: (
 									// @ts-expect-error: children is provided when interpolating the component
-									<ExternalLink href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-orders" />
+									<ExternalLink href="https://woocommerce.com/document/woopayments/settings-guide/authorize-and-capture/#capturing-authorized-payments" />
 								),
 							}
 						) }{ ' ' }

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -511,7 +511,12 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 								{ balance.refunded ? (
 									<p>
 										{ `${
-											disputeFee
+											// Disputed money left the account
+											// as a deduction, not a refund —
+											// keyed on the dispute itself
+											// because the fee can be zero or
+											// reversed.
+											disputes.length
 												? __(
 														'Deducted',
 														'woocommerce-payments'

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -27,6 +27,7 @@ import {
 import {
 	canUseFeeBreakdownData,
 	getChargeAmounts,
+	isChargeDisputed,
 	getChargeDisputes,
 	getDisputeOrdinals,
 	getChargeStatus,
@@ -351,6 +352,19 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 		? formatCurrency( disputeFeeTotal, balance.currency )
 		: undefined;
 
+	// The withdrawn-balance line folds refunds and dispute deductions together
+	// (see getChargeAmounts). Call it "Deducted" only when a dispute actually
+	// moved money: an inquiry withdraws nothing, and a won dispute's rows net
+	// back to zero, so in both cases a refund is the only withdrawal.
+	const disputeWithdrawnAmount = isChargeDisputed( charge )
+		? _.sumBy(
+				disputes.flatMap(
+					( dispute ) => dispute.balance_transactions ?? []
+				),
+				'amount'
+		  )
+		: 0;
+
 	// Refunding is blocked while any single dispute blocks it, so the menu is
 	// only refundable when every dispute is.
 	const isDisputeRefundable = disputes.every( ( dispute ) =>
@@ -514,12 +528,7 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 								{ balance.refunded ? (
 									<p>
 										{ `${
-											// Disputed money left the account
-											// as a deduction, not a refund —
-											// keyed on the dispute itself
-											// because the fee can be zero or
-											// reversed.
-											disputes.length
+											disputeWithdrawnAmount !== 0
 												? __(
 														'Deducted',
 														'woocommerce-payments'

--- a/client/payment-details/summary/index.tsx
+++ b/client/payment-details/summary/index.tsx
@@ -344,8 +344,11 @@ const PaymentDetailsSummary: React.FC< PaymentDetailsSummaryProps > = ( {
 			( fee ): fee is { amount: number; currency: string } => !! fee
 		);
 	const disputeFeeTotal = _.sumBy( disputeFeeAmounts, 'amount' );
+	// Settlement currency, not the first fee-bearing dispute's: which dispute
+	// sits at index 0 shifts as the list is filtered, and the rest of the
+	// breakdown is already denominated in `balance.currency`.
 	const disputeFee = disputeFeeAmounts.length
-		? formatCurrency( disputeFeeTotal, disputeFeeAmounts[ 0 ].currency )
+		? formatCurrency( disputeFeeTotal, balance.currency )
 		: undefined;
 
 	// Refunding is blocked while any single dispute blocks it, so the menu is

--- a/client/settings/payment-methods-list/use-payment-method-availability.tsx
+++ b/client/settings/payment-methods-list/use-payment-method-availability.tsx
@@ -23,7 +23,7 @@ import { getAdminUrl } from 'wcpay/utils';
 
 const documentationTypeMap = {
 	DEFAULT:
-		'https://woocommerce.com/document/woopayments/payment-methods/additional-payment-methods/#method-cant-be-enabled',
+		'https://woocommerce.com/document/woopayments/payment-methods/local-payment-methods/#method-cant-be-enabled',
 	BNPLS: 'https://woocommerce.com/document/woopayments/payment-methods/buy-now-pay-later/#contact-support',
 	DELAYED_APPROVAL:
 		'https://woocommerce.com/document/woopayments/payment-methods/local-payment-methods/#approval-delays',

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -102,7 +102,7 @@ const DepositsDescription = () => {
 			</p>
 			<ExternalLink href="https://woocommerce.com/document/woopayments/payouts/payout-schedule/">
 				{ __(
-					'Learn more about pending schedules',
+					'Learn more about payout schedules',
 					'woocommerce-payments'
 				) }
 			</ExternalLink>

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -27,7 +27,12 @@ jest.mock( 'multi-currency/interface/functions', () => ( {
 
 declare const global: {
 	wcpaySettings: {
-		connect: {
+		// The fee link keys on the account country; `connect.country` is the
+		// store base country and is here so tests can make the two diverge.
+		accountStatus?: {
+			country: string;
+		};
+		connect?: {
 			country: string;
 		};
 		dateFormat?: string;
@@ -282,10 +287,10 @@ describe( 'Account fees utility functions', () => {
 
 	describe( 'formatMethodFeesTooltip()', () => {
 		beforeAll( () => {
-			global.wcpaySettings = { connect: { country: 'US' } };
+			global.wcpaySettings = { accountStatus: { country: 'US' } };
 		} );
 		afterAll( () => {
-			global.wcpaySettings = { connect: { country: '' } };
+			global.wcpaySettings = { accountStatus: { country: '' } };
 		} );
 
 		it( 'displays base percentage and fixed fee - no custom fee nor discount', () => {
@@ -358,7 +363,7 @@ describe( 'Account fees utility functions', () => {
 		const renderTooltipForCountry = ( country: string ) => {
 			global.wcpaySettings = {
 				...global.wcpaySettings,
-				connect: { country },
+				accountStatus: { country },
 			};
 
 			return render(
@@ -398,8 +403,8 @@ describe( 'Account fees utility functions', () => {
 			);
 		} );
 
-		it( 'links a merchant in an unmapped country to the fees page with no anchor', () => {
-			const { container } = renderTooltipForCountry( 'PR' );
+		it( 'links an account in an unmapped country to the fees page with no anchor', () => {
+			const { container } = renderTooltipForCountry( 'BR' );
 
 			expect(
 				within( container ).getByRole( 'link', {
@@ -412,12 +417,43 @@ describe( 'Account fees utility functions', () => {
 		} );
 
 		it( 'drops the "in your country" promise for an unmapped country', () => {
-			const { container } = renderTooltipForCountry( 'PR' );
+			const { container } = renderTooltipForCountry( 'BR' );
 
 			expect(
 				container.querySelector( '.wcpay-fees-tooltip__hint-text' )
 					?.textContent
 			).toMatch( /Learn more.* about WooPayments Fees$/ );
+		} );
+
+		it( 'follows the account country when the store base country differs', () => {
+			// The fees rendered above the link come from the account, so the
+			// link has to describe the account's country. A store that changed
+			// its base country after onboarding would otherwise read one
+			// country's rates under a link promising another's.
+			global.wcpaySettings = {
+				...global.wcpaySettings,
+				connect: { country: 'GB' },
+				accountStatus: { country: 'US' },
+			};
+
+			const { container } = render(
+				formatMethodFeesTooltip(
+					mockAccountFees( {
+						percentage_rate: 0.123,
+						fixed_rate: 456.78,
+						currency: 'USD',
+					} )
+				)
+			);
+
+			expect(
+				within( container ).getByRole( 'link', {
+					name: /Learn more/i,
+				} )
+			).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/woopayments/fees/#united-states'
+			);
 		} );
 
 		it( 'treats an Object.prototype member as an unmapped country', () => {

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -344,6 +344,37 @@ describe( 'Account fees utility functions', () => {
 		} );
 	} );
 
+	describe( 'formatMethodFeesTooltip() country fee links', () => {
+		afterEach( () => {
+			global.wcpaySettings = { connect: { country: '' } };
+		} );
+
+		const renderTooltipForCountry = ( country: string ) => {
+			global.wcpaySettings = { connect: { country } };
+
+			return render(
+				formatMethodFeesTooltip(
+					mockAccountFees( {
+						percentage_rate: 0.123,
+						fixed_rate: 456.78,
+						currency: 'USD',
+					} )
+				)
+			);
+		};
+
+		it( 'links a merchant in an unmapped country to the fees page with no anchor', () => {
+			const { container } = renderTooltipForCountry( 'PR' );
+
+			expect(
+				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )
+			).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/woopayments/fees/'
+			);
+		} );
+	} );
+
 	describe( 'getDiscountBadgeText()', () => {
 		beforeAll( () => {
 			global.wcpaySettings = {

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -363,6 +363,28 @@ describe( 'Account fees utility functions', () => {
 			);
 		};
 
+		it( 'links a United Kingdom merchant to the united-kingdom fee section', () => {
+			const { container } = renderTooltipForCountry( 'GB' );
+
+			expect(
+				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )
+			).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/woopayments/fees/#united-kingdom'
+			);
+		} );
+
+		it( 'links a Swedish merchant to the sweden fee section', () => {
+			const { container } = renderTooltipForCountry( 'SE' );
+
+			expect(
+				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )
+			).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/woopayments/fees/#sweden'
+			);
+		} );
+
 		it( 'links a merchant in an unmapped country to the fees page with no anchor', () => {
 			const { container } = renderTooltipForCountry( 'PR' );
 

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -456,6 +456,39 @@ describe( 'Account fees utility functions', () => {
 			);
 		} );
 
+		it( 'still offers the fees page when the account country is unknown', () => {
+			// The cached account can carry fees while erroring out of a
+			// status, leaving no country. Fees are on screen, so the link
+			// that explains them should be too.
+			global.wcpaySettings = {
+				...global.wcpaySettings,
+				accountStatus: undefined,
+			};
+
+			const { container } = render(
+				formatMethodFeesTooltip(
+					mockAccountFees( {
+						percentage_rate: 0.123,
+						fixed_rate: 456.78,
+						currency: 'USD',
+					} )
+				)
+			);
+
+			expect(
+				within( container ).getByRole( 'link', {
+					name: /Learn more/i,
+				} )
+			).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/woopayments/fees/'
+			);
+			expect(
+				container.querySelector( '.wcpay-fees-tooltip__hint-text' )
+					?.textContent
+			).toMatch( /Learn more.* about WooPayments Fees$/ );
+		} );
+
 		it( 'treats an Object.prototype member as an unmapped country', () => {
 			// A bare bracket lookup walks the prototype chain and would
 			// interpolate a function into the URL fragment.

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -3,7 +3,7 @@
  */
 import { sprintf } from '@wordpress/i18n';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -376,7 +376,9 @@ describe( 'Account fees utility functions', () => {
 			const { container } = renderTooltipForCountry( 'GB' );
 
 			expect(
-				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )
+				within( container ).getByRole( 'link', {
+					name: /Learn more/i,
+				} )
 			).toHaveAttribute(
 				'href',
 				'https://woocommerce.com/document/woopayments/fees/#united-kingdom'
@@ -387,7 +389,9 @@ describe( 'Account fees utility functions', () => {
 			const { container } = renderTooltipForCountry( 'SE' );
 
 			expect(
-				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )
+				within( container ).getByRole( 'link', {
+					name: /Learn more/i,
+				} )
 			).toHaveAttribute(
 				'href',
 				'https://woocommerce.com/document/woopayments/fees/#sweden'
@@ -398,7 +402,9 @@ describe( 'Account fees utility functions', () => {
 			const { container } = renderTooltipForCountry( 'PR' );
 
 			expect(
-				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )
+				within( container ).getByRole( 'link', {
+					name: /Learn more/i,
+				} )
 			).toHaveAttribute(
 				'href',
 				'https://woocommerce.com/document/woopayments/fees/'
@@ -420,7 +426,9 @@ describe( 'Account fees utility functions', () => {
 			const { container } = renderTooltipForCountry( 'constructor' );
 
 			expect(
-				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )
+				within( container ).getByRole( 'link', {
+					name: /Learn more/i,
+				} )
 			).toHaveAttribute(
 				'href',
 				'https://woocommerce.com/document/woopayments/fees/'

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -416,15 +416,6 @@ describe( 'Account fees utility functions', () => {
 			);
 		} );
 
-		it( 'drops the "in your country" promise for an unmapped country', () => {
-			const { container } = renderTooltipForCountry( 'BR' );
-
-			expect(
-				container.querySelector( '.wcpay-fees-tooltip__hint-text' )
-					?.textContent
-			).toMatch( /Learn more.* about WooPayments Fees$/ );
-		} );
-
 		it( 'follows the account country when the store base country differs', () => {
 			// The fees rendered above the link come from the account, so the
 			// link has to describe the account's country. A store that changed
@@ -487,21 +478,6 @@ describe( 'Account fees utility functions', () => {
 				container.querySelector( '.wcpay-fees-tooltip__hint-text' )
 					?.textContent
 			).toMatch( /Learn more.* about WooPayments Fees$/ );
-		} );
-
-		it( 'treats an Object.prototype member as an unmapped country', () => {
-			// A bare bracket lookup walks the prototype chain and would
-			// interpolate a function into the URL fragment.
-			const { container } = renderTooltipForCountry( 'constructor' );
-
-			expect(
-				within( container ).getByRole( 'link', {
-					name: /Learn more/i,
-				} )
-			).toHaveAttribute(
-				'href',
-				'https://woocommerce.com/document/woopayments/fees/'
-			);
 		} );
 	} );
 

--- a/client/utils/__tests__/account-fees.test.tsx
+++ b/client/utils/__tests__/account-fees.test.tsx
@@ -345,12 +345,21 @@ describe( 'Account fees utility functions', () => {
 	} );
 
 	describe( 'formatMethodFeesTooltip() country fee links', () => {
+		let originalWcpaySettings: typeof global.wcpaySettings;
+
+		beforeEach( () => {
+			originalWcpaySettings = global.wcpaySettings;
+		} );
+
 		afterEach( () => {
-			global.wcpaySettings = { connect: { country: '' } };
+			global.wcpaySettings = originalWcpaySettings;
 		} );
 
 		const renderTooltipForCountry = ( country: string ) => {
-			global.wcpaySettings = { connect: { country } };
+			global.wcpaySettings = {
+				...global.wcpaySettings,
+				connect: { country },
+			};
 
 			return render(
 				formatMethodFeesTooltip(
@@ -387,6 +396,28 @@ describe( 'Account fees utility functions', () => {
 
 		it( 'links a merchant in an unmapped country to the fees page with no anchor', () => {
 			const { container } = renderTooltipForCountry( 'PR' );
+
+			expect(
+				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )
+			).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/woopayments/fees/'
+			);
+		} );
+
+		it( 'drops the "in your country" promise for an unmapped country', () => {
+			const { container } = renderTooltipForCountry( 'PR' );
+
+			expect(
+				container.querySelector( '.wcpay-fees-tooltip__hint-text' )
+					?.textContent
+			).toMatch( /Learn more.* about WooPayments Fees$/ );
+		} );
+
+		it( 'treats an Object.prototype member as an unmapped country', () => {
+			// A bare bracket lookup walks the prototype chain and would
+			// interpolate a function into the URL fragment.
+			const { container } = renderTooltipForCountry( 'constructor' );
 
 			expect(
 				container.querySelector( '.wcpay-fees-tooltip__hint-text a' )

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -214,39 +214,38 @@ export const formatMethodFeesTooltip = (
 					{ getFeeDescriptionString( total ) }
 				</div>
 			</div>
-			{ country ? (
-				<div className="wcpay-fees-tooltip__hint-text">
-					<span>
-						{ interpolateComponents( {
-							mixedString: feeDocsSlug
-								? sprintf(
-										/* translators: %s: WooPayments */
-										__(
-											'{{linkToStripePage}}Learn more{{/linkToStripePage}} about %s Fees in your country',
-											'woocommerce-payments'
-										),
-										'WooPayments'
-								  )
-								: sprintf(
-										/* translators: %s: WooPayments */
-										__(
-											'{{linkToStripePage}}Learn more{{/linkToStripePage}} about %s Fees',
-											'woocommerce-payments'
-										),
-										'WooPayments'
-								  ),
-							components: {
-								linkToStripePage: (
-									// @ts-expect-error: children is provided when interpolating the component
-									<ExternalLink href={ feeDocsUrl } />
-								),
-							},
-						} ) }
-					</span>
-				</div>
-			) : (
-				''
-			) }
+			{ /* No country gate: an account whose country is unknown still gets
+			     the un-anchored fees page, the same as a country the page has
+			     no section for. Fees are on screen either way. */ }
+			<div className="wcpay-fees-tooltip__hint-text">
+				<span>
+					{ interpolateComponents( {
+						mixedString: feeDocsSlug
+							? sprintf(
+									/* translators: %s: WooPayments */
+									__(
+										'{{linkToStripePage}}Learn more{{/linkToStripePage}} about %s Fees in your country',
+										'woocommerce-payments'
+									),
+									'WooPayments'
+							  )
+							: sprintf(
+									/* translators: %s: WooPayments */
+									__(
+										'{{linkToStripePage}}Learn more{{/linkToStripePage}} about %s Fees',
+										'woocommerce-payments'
+									),
+									'WooPayments'
+							  ),
+						components: {
+							linkToStripePage: (
+								// @ts-expect-error: children is provided when interpolating the component
+								<ExternalLink href={ feeDocsUrl } />
+							),
+						},
+					} ) }
+				</span>
+			</div>
 		</div>
 	);
 };

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -63,7 +63,13 @@ const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 };
 
 const getStripeFeeSectionUrl = ( country: string ): string => {
-	return `${ countryFeeStripeDocsBaseLink }#${ countryFeeStripeDocsSectionNumbers[ country ] }`;
+	const section = countryFeeStripeDocsSectionNumbers[ country ];
+
+	// Fall back to the un-anchored fees page rather than emitting
+	// "#undefined" for a country the map does not cover.
+	return section
+		? `${ countryFeeStripeDocsBaseLink }#${ section }`
+		: countryFeeStripeDocsBaseLink;
 };
 
 const getFeeDescriptionString = (
@@ -186,9 +192,9 @@ export const formatMethodFeesTooltip = (
 			wcpaySettings.connect.country ? (
 				<div className="wcpay-fees-tooltip__hint-text">
 					<span>
-						{ countryFeeStripeDocsSectionNumbers.hasOwnProperty(
+						{ countryFeeStripeDocsSectionNumbers[
 							wcpaySettings.connect.country
-						)
+						]
 							? interpolateComponents( {
 									mixedString: sprintf(
 										/* translators: %s: WooPayments */

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -151,12 +151,11 @@ export const formatMethodFeesTooltip = (
 		return fee.fixed_rate > 0.0 || fee.percentage_rate > 0.0;
 	};
 
-	// The account country, not `connect.country` (the store base country): these
-	// are separate facts that only usually agree, and the fees above this link
-	// come from the account. A store that changes its base country after
-	// onboarding — or a Puerto Rico store, whose account is created as US —
-	// would otherwise be shown one country's rates under a link promising
-	// another's.
+	// The fees above this link come from the Stripe account, so the link has to
+	// describe the account's country. `connect.country` is the store base
+	// country — a separate setting that only usually agrees, since it can be
+	// edited after onboarding and a Puerto Rico store's account is created
+	// as US.
 	const country = wcpaySettings?.accountStatus?.country;
 	// Un-anchored fees page for a country the page has no section for, rather
 	// than a "#undefined" fragment.

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -19,9 +19,12 @@ import { BaseFee, DiscountFee, FeeStructure } from 'wcpay/types/fees';
 import { createInterpolateElement } from '@wordpress/element';
 import PAYMENT_METHOD_IDS from 'constants/payment-method';
 
-const countryFeeStripeDocsBaseLink =
+const countryFeeDocsBaseLink =
 	'https://woocommerce.com/document/woopayments/fees/';
-const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
+
+// Keyed on the store base country; values are the fees page's URL fragment
+// slugs, not section numbers.
+const countryFeeDocsSectionSlugs: Record< string, string > = {
 	AE: 'united-arab-emirates',
 	AU: 'australia',
 	AT: 'austria',
@@ -71,15 +74,18 @@ const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	// fees page instead.
 };
 
-const getStripeFeeSectionUrl = ( country: string ): string => {
-	const section = countryFeeStripeDocsSectionNumbers[ country ];
-
-	// Fall back to the un-anchored fees page rather than emitting
-	// "#undefined" for a country the map does not cover.
-	return section
-		? `${ countryFeeStripeDocsBaseLink }#${ section }`
-		: countryFeeStripeDocsBaseLink;
-};
+/**
+ * The fees page's fragment slug for a store's base country, if the page has a
+ * section for it.
+ *
+ * `hasOwnProperty` rather than a bare lookup: a bare lookup walks the
+ * prototype chain, so a country of `constructor` or `toString` would resolve
+ * to a function and read as a mapped country.
+ */
+const getCountryFeeDocsSlug = ( country: string ): string | undefined =>
+	Object.prototype.hasOwnProperty.call( countryFeeDocsSectionSlugs, country )
+		? countryFeeDocsSectionSlugs[ country ]
+		: undefined;
 
 const getFeeDescriptionString = (
 	fee: BaseFee,
@@ -146,6 +152,14 @@ export const formatMethodFeesTooltip = (
 		return fee.fixed_rate > 0.0 || fee.percentage_rate > 0.0;
 	};
 
+	const country = wcpaySettings?.connect?.country;
+	// Un-anchored fees page for a country the page has no section for, rather
+	// than a "#undefined" fragment.
+	const feeDocsSlug = country ? getCountryFeeDocsSlug( country ) : undefined;
+	const feeDocsUrl = feeDocsSlug
+		? `${ countryFeeDocsBaseLink }#${ feeDocsSlug }`
+		: countryFeeDocsBaseLink;
+
 	return (
 		<div className={ 'wcpay-fees-tooltip' }>
 			<div>
@@ -196,59 +210,34 @@ export const formatMethodFeesTooltip = (
 					{ getFeeDescriptionString( total ) }
 				</div>
 			</div>
-			{ wcpaySettings &&
-			wcpaySettings.connect &&
-			wcpaySettings.connect.country ? (
+			{ country ? (
 				<div className="wcpay-fees-tooltip__hint-text">
 					<span>
-						{ countryFeeStripeDocsSectionNumbers[
-							wcpaySettings.connect.country
-						]
-							? interpolateComponents( {
-									mixedString: sprintf(
+						{ interpolateComponents( {
+							mixedString: feeDocsSlug
+								? sprintf(
 										/* translators: %s: WooPayments */
 										__(
 											'{{linkToStripePage}}Learn more{{/linkToStripePage}} about %s Fees in your country',
 											'woocommerce-payments'
 										),
 										'WooPayments'
-									),
-									components: {
-										linkToStripePage: (
-											// @ts-expect-error: children is provided when interpolating the component
-											<ExternalLink
-												href={ getStripeFeeSectionUrl(
-													wcpaySettings.connect
-														.country
-												) }
-											/>
-										),
-									},
-							  } )
-							: interpolateComponents( {
-									mixedString: sprintf(
+								  )
+								: sprintf(
 										/* translators: %s: WooPayments */
 										__(
-											'{{linkToStripePage /}} about %s Fees',
+											'{{linkToStripePage}}Learn more{{/linkToStripePage}} about %s Fees',
 											'woocommerce-payments'
 										),
 										'WooPayments'
-									),
-									components: {
-										linkToStripePage: (
-											<ExternalLink
-												href={
-													countryFeeStripeDocsBaseLink
-												}
-											>
-												{ __(
-													'Learn more',
-													'woocommerce-payments'
-												) }
-											</ExternalLink>
-										),
-									},
-							  } ) }
+								  ),
+							components: {
+								linkToStripePage: (
+									// @ts-expect-error: children is provided when interpolating the component
+									<ExternalLink href={ feeDocsUrl } />
+								),
+							},
+						} ) }
 					</span>
 				</div>
 			) : (

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -152,10 +152,10 @@ export const formatMethodFeesTooltip = (
 	};
 
 	// The fees above this link come from the Stripe account, so the link has to
-	// describe the account's country. `connect.country` is the store base
-	// country — a separate setting that only usually agrees, since it can be
-	// edited after onboarding and a Puerto Rico store's account is created
-	// as US.
+	// describe the account's country. Not `connect.country` — that namespace is
+	// the onboarding form's data (country, availableCountries, availableStates),
+	// where the store address is the only country signal available because no
+	// account exists yet.
 	const country = wcpaySettings?.accountStatus?.country;
 	// Un-anchored fees page for a country the page has no section for, rather
 	// than a "#undefined" fragment.

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -22,8 +22,9 @@ import PAYMENT_METHOD_IDS from 'constants/payment-method';
 const countryFeeDocsBaseLink =
 	'https://woocommerce.com/document/woopayments/fees/';
 
-// Keyed on the store base country; values are the fees page's URL fragment
-// slugs, not section numbers.
+// Keyed on the Stripe account country — the same account the fees in this
+// tooltip come from. Values are the fees page's URL fragment slugs, not
+// section numbers.
 const countryFeeDocsSectionSlugs: Record< string, string > = {
 	AE: 'united-arab-emirates',
 	AU: 'australia',
@@ -63,19 +64,17 @@ const countryFeeDocsSectionSlugs: Record< string, string > = {
 	GB: 'united-kingdom',
 	US: 'united-states',
 	RO: 'romania',
-	// PR (Puerto Rico) is intentionally absent. This map is keyed on the
-	// store base country, but PR is not selectable during Stripe account
-	// signup, so a PR store's account is created as US while its base
-	// country stays PR — the two diverge. The fees page also has no Puerto
-	// Rico section; its only PR line sits inside the US section, noting
-	// that PR-issued cards trigger the international payment fee. Mapping
-	// PR to 'united-states' would paper over that divergence and assert
-	// rates the docs do not support, so PR merchants get the un-anchored
-	// fees page instead.
+	// PR (Puerto Rico) needs no entry. It is a supported *store* country but
+	// is not selectable during Stripe account signup, so a Puerto Rico store's
+	// account is created as US and this lookup resolves to 'united-states' —
+	// which is the section describing the rates that account is actually
+	// charged. The fees page has no Puerto Rico section to point at anyway;
+	// its only PR line sits inside the US section, noting that PR-issued cards
+	// trigger the international payment fee.
 };
 
 /**
- * The fees page's fragment slug for a store's base country, if the page has a
+ * The fees page's fragment slug for an account's country, if the page has a
  * section for it.
  *
  * `hasOwnProperty` rather than a bare lookup: a bare lookup walks the
@@ -152,7 +151,13 @@ export const formatMethodFeesTooltip = (
 		return fee.fixed_rate > 0.0 || fee.percentage_rate > 0.0;
 	};
 
-	const country = wcpaySettings?.connect?.country;
+	// The account country, not `connect.country` (the store base country): these
+	// are separate facts that only usually agree, and the fees above this link
+	// come from the account. A store that changes its base country after
+	// onboarding — or a Puerto Rico store, whose account is created as US —
+	// would otherwise be shown one country's rates under a link promising
+	// another's.
+	const country = wcpaySettings?.accountStatus?.country;
 	// Un-anchored fees page for a country the page has no section for, rather
 	// than a "#undefined" fragment.
 	const feeDocsSlug = country ? getCountryFeeDocsSlug( country ) : undefined;

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -51,9 +51,6 @@ const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	NZ: 'new-zealand',
 	PL: 'poland',
 	PT: 'portugal',
-	// Puerto Rico has no section of its own; its fees are covered by the
-	// United States section.
-	PR: 'united-states',
 	SG: 'singapore',
 	SI: 'slovenia',
 	SK: 'slovakia',

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -60,6 +60,12 @@ const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	GB: 'united-kingdom',
 	US: 'united-states',
 	RO: 'romania',
+	// PR (Puerto Rico) is intentionally absent. The fees page has no Puerto
+	// Rico section, and its only PR line sits inside the US section stating
+	// that PR-issued cards trigger the international payment fee — so
+	// mapping PR to 'united-states' would assert rates the docs do not
+	// support. Unmapped merchants get the un-anchored fees page instead.
+	// Revisit if a Puerto Rico section is ever added.
 };
 
 const getStripeFeeSectionUrl = ( country: string ): string => {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -60,12 +60,15 @@ const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	GB: 'united-kingdom',
 	US: 'united-states',
 	RO: 'romania',
-	// PR (Puerto Rico) is intentionally absent. The fees page has no Puerto
-	// Rico section, and its only PR line sits inside the US section stating
-	// that PR-issued cards trigger the international payment fee — so
-	// mapping PR to 'united-states' would assert rates the docs do not
-	// support. Unmapped merchants get the un-anchored fees page instead.
-	// Revisit if a Puerto Rico section is ever added.
+	// PR (Puerto Rico) is intentionally absent. This map is keyed on the
+	// store base country, but PR is not selectable during Stripe account
+	// signup, so a PR store's account is created as US while its base
+	// country stays PR — the two diverge. The fees page also has no Puerto
+	// Rico section; its only PR line sits inside the US section, noting
+	// that PR-issued cards trigger the international payment fee. Mapping
+	// PR to 'united-states' would paper over that divergence and assert
+	// rates the docs do not support, so PR merchants get the un-anchored
+	// fees page instead.
 };
 
 const getStripeFeeSectionUrl = ( country: string ): string => {

--- a/client/utils/account-fees.tsx
+++ b/client/utils/account-fees.tsx
@@ -51,13 +51,16 @@ const countryFeeStripeDocsSectionNumbers: Record< string, string > = {
 	NZ: 'new-zealand',
 	PL: 'poland',
 	PT: 'portugal',
+	// Puerto Rico has no section of its own; its fees are covered by the
+	// United States section.
+	PR: 'united-states',
 	SG: 'singapore',
 	SI: 'slovenia',
 	SK: 'slovakia',
-	SW: 'sweden',
+	SE: 'sweden',
 	ES: 'spain',
 	CH: 'switzerland',
-	UK: 'united-kingdom',
+	GB: 'united-kingdom',
 	US: 'united-states',
 	RO: 'romania',
 };

--- a/client/utils/charge/index.ts
+++ b/client/utils/charge/index.ts
@@ -199,27 +199,31 @@ export const canUseFeeBreakdownData = ( charge: Charge ): boolean => {
  * @return {ChargeAmounts} An object, containing the `currency`, `amount`, `net`, `fee`, and `refunded` amounts in Stripe format (*100).
  */
 export const getChargeAmounts = ( charge: Charge ): ChargeAmounts => {
-	// FEE_BREAKDOWN_FORK_PATCH: remove when envelope is the only path.
-	// `balance.fee` below must represent the *full* Stripe deduction in
-	// store currency (pre-tax fee + tax), because the downstream
-	// `net = amount - fee - refunded` needs to absorb BOTH components to
-	// match `totals.net.amount` — and that formula has to stay in charge
-	// of later-arriving customer-refunds and dispute adjustments, which
-	// the envelope doesn't cover. Using only `totals.fee.amount` here
-	// (pre-tax) would drop the tax from the net calculation.
+	// FEE_BREAKDOWN_FORK_PATCH: remove the legacy branch when the envelope
+	// is the only path. The two branches answer the same question from
+	// different sources — the envelope reports the charge's current state,
+	// the legacy path reconstructs it from balance transactions — and they
+	// derive opposite fields: the envelope is handed `net` and works out
+	// `refunded`, the legacy path accumulates `refunded` and works out
+	// `net`. A change to either needs checking against the other.
 	const breakdown = charge.fee_breakdown_v1;
 	if (
 		canUseFeeBreakdownData( charge ) &&
 		breakdown?.totals?.net &&
 		breakdown.totals.gross
 	) {
-		// Envelope is authoritative for the charge's *current* state:
-		// the server has already folded customer-refunds, dispute fees,
-		// and dispute balance adjustments into `totals.fee` / `totals.net`.
-		// No client-side subtraction needed. `refunded` is derived for
-		// backward compatibility with consumers that still read it.
-		// Prefer the server-pre-summed fee_plus_tax; fall back to fee+tax
-		// for older servers.
+		// Envelope is authoritative for the charge's *current* state: the
+		// server has already folded customer-refunds, dispute fees, and
+		// dispute balance adjustments into `totals.fee` / `totals.net`, so
+		// there is no client-side subtraction here. `refunded` is derived
+		// for backward compatibility with consumers that still read it.
+		//
+		// `totalFee` has to be the full Stripe deduction — fee plus tax,
+		// not `totals.fee.amount` alone — because it is both what we report
+		// as the fee and what gets subtracted to derive `refunded`. Dropping
+		// the tax would understate the first and overstate the second.
+		// Prefer the server-pre-summed `fee_plus_tax`; fall back to
+		// fee + tax for older servers.
 		const totalFee =
 			breakdown.totals.fee_plus_tax?.amount ??
 			breakdown.totals.fee.amount + ( breakdown.totals.tax?.amount ?? 0 );

--- a/includes/admin/class-wc-payments-admin-settings.php
+++ b/includes/admin/class-wc-payments-admin-settings.php
@@ -155,7 +155,7 @@ class WC_Payments_Admin_Settings {
 					printf(
 						/* translators: %s: URL to learn more */
 						esc_html__( 'Provide additional details about your business so you can begin accepting real payments. %1$sLearn more%2$s', 'woocommerce-payments' ),
-						'<a href="' . esc_url( 'https://woocommerce.com/document/woopayments/startup-guide/#sign-up-process' ) . '" target="_blank" rel="noreferrer noopener">',
+						'<a href="' . esc_url( 'https://woocommerce.com/document/woopayments/startup-guide/#signup-process' ) . '" target="_blank" rel="noreferrer noopener">',
 						'</a>'
 					);
 				} else {
@@ -236,7 +236,7 @@ class WC_Payments_Admin_Settings {
 						esc_html__( 'To begin accepting real payments you will need to first %1$sreset your account%2$s and, then, provide additional details about your business. %3$sLearn more%4$s', 'woocommerce-payments' ),
 						'<a href="' . esc_url( 'https://woocommerce.com/document/woopayments/startup-guide/#resetting' ) . '" target="_blank" rel="noreferrer noopener">',
 						'</a>',
-						'<a href="' . esc_url( 'https://woocommerce.com/document/woopayments/startup-guide/#sign-up-process' ) . '" target="_blank" rel="noreferrer noopener">',
+						'<a href="' . esc_url( 'https://woocommerce.com/document/woopayments/startup-guide/#signup-process' ) . '" target="_blank" rel="noreferrer noopener">',
 						'</a>',
 					);
 				} else {

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -303,7 +303,7 @@ class WC_Payments_Apple_Pay_Registration {
 		$learn_more_text = WC_Payments_Utils::esc_interpolated_html(
 			__( '<a>Learn more</a>.', 'woocommerce-payments' ),
 			[
-				'a' => '<a href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay/#domain-registration" target="_blank">',
+				'a' => '<a href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay/#button-does-not-appear" target="_blank">',
 			]
 		);
 

--- a/includes/class-wc-payments-apple-pay-registration.php
+++ b/includes/class-wc-payments-apple-pay-registration.php
@@ -303,7 +303,7 @@ class WC_Payments_Apple_Pay_Registration {
 		$learn_more_text = WC_Payments_Utils::esc_interpolated_html(
 			__( '<a>Learn more</a>.', 'woocommerce-payments' ),
 			[
-				'a' => '<a href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay/#button-does-not-appear" target="_blank">',
+				'a' => '<a href="https://woocommerce.com/document/woopayments/payment-methods/apple-pay/#button-does-not-appear" target="_blank" rel="noreferrer noopener">',
 			]
 		);
 

--- a/includes/core/class-mode.php
+++ b/includes/core/class-mode.php
@@ -95,7 +95,7 @@ class Mode {
 		 *
 		 * @since 0.8.2
 		 *
-		 * @see https://woocommerce.com/document/woopayments/testing-and-troubleshooting/sandbox-mode/
+		 * @see https://woocommerce.com/document/woopayments/testing-and-troubleshooting/test-accounts/
 		 * @param bool $dev_mode Whether to enter WooPayments in dev mode.
 		 */
 		$this->dev_mode = (bool) apply_filters( 'wcpay_dev_mode', $dev_mode );

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel these subscriptions%2$s prior to deactivating %3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank" rel="noreferrer noopener">',
+								'<a href="https://woocommerce.com/document/subscriptions/customers-view/suspend-cancel-or-remove-an-item/#how-to-cancel-a-subscription-as-a-store-manager" target="_blank" rel="noreferrer noopener">',
 								'</a>',
 								'Woo Subscriptions'
 							);

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel these subscriptions%2$s prior to deactivating %3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank">',
+								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank" rel="noreferrer noopener">',
 								'</a>',
 								'Woo Subscriptions'
 							);

--- a/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
+++ b/includes/subscriptions/templates/html-subscriptions-plugin-notice.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel these subscriptions%2$s prior to deactivating %3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
+								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank">',
 								'</a>',
 								'Woo Subscriptions'
 							);

--- a/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel all subscriptions%2$s prior to deactivating %3$s. ', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank" rel="noreferrer noopener">',
+								'<a href="https://woocommerce.com/document/subscriptions/customers-view/suspend-cancel-or-remove-an-item/#how-to-cancel-a-subscription-as-a-store-manager" target="_blank" rel="noreferrer noopener">',
 								'</a>',
 								'WooPayments'
 							);

--- a/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel all subscriptions%2$s prior to deactivating %3$s. ', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank">',
+								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank" rel="noreferrer noopener">',
 								'</a>',
 								'WooPayments'
 							);

--- a/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-wcpay-deactivate-warning.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel all subscriptions%2$s prior to deactivating %3$s. ', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
+								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank">',
 								'</a>',
 								'WooPayments'
 							);

--- a/includes/subscriptions/templates/html-woo-payments-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-woo-payments-deactivate-warning.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel these subscriptions%2$s prior to deactivating %3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#cancel-or-suspend-subscription" target="_blank">',
+								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank">',
 								'</a>',
 								'WooPayments'
 							);

--- a/includes/subscriptions/templates/html-woo-payments-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-woo-payments-deactivate-warning.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel these subscriptions%2$s prior to deactivating %3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank" rel="noreferrer noopener">',
+								'<a href="https://woocommerce.com/document/subscriptions/customers-view/suspend-cancel-or-remove-an-item/#how-to-cancel-a-subscription-as-a-store-manager" target="_blank" rel="noreferrer noopener">',
 								'</a>',
 								'WooPayments'
 							);

--- a/includes/subscriptions/templates/html-woo-payments-deactivate-warning.php
+++ b/includes/subscriptions/templates/html-woo-payments-deactivate-warning.php
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								// translators: $1 $2 placeholders are opening and closing HTML link tags, linking to documentation. $3 is WooPayments.
 								esc_html__( 'If you do not want these subscriptions to continue to be billed, you should %1$scancel these subscriptions%2$s prior to deactivating %3$s.', 'woocommerce-payments' ),
-								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank">',
+								'<a href="https://woocommerce.com/document/subscriptions/statuses/#cancelled-subscription-status" target="_blank" rel="noreferrer noopener">',
 								'</a>',
 								'WooPayments'
 							);


### PR DESCRIPTION
Fixes WOOPMNT-6403

#### Changes proposed in this Pull Request

A merchant reported that a WooPayments link about dispute fees led to a page with nothing about those fees. That prompted an audit of every documentation link a merchant can see or click from the plugin: 132 occurrences across 76 files, 79 unique URLs, 40 unique pages.

**Nothing 404s.** All 132 links return HTTP 200, which is exactly why no link checker ever caught this. The failure mode is different and invisible to automated checking: links that resolve fine but land somewhere that does not answer the question the surrounding copy just raised.

Every destination below was verified against the live documentation, including checking that each fragment actually exists in the target page's anchor set after redirects.

**1. Dispute resolution footer — five links, all pointing at the same hub page**

All five links in `dispute-resolution-footer.tsx` pointed at the bare `fraud-and-disputes/` index page. The word "fee" appears zero times on it, so the original report was literally accurate. Three were also labelled "Learn more about preventing disputes" despite a dedicated `preventing-disputes/` page existing.

| Preceding copy (abridged) | Old target | New target |
|---|---|---|
| "The customer's bank is currently reviewing the evidence you submitted on X..." | `fraud-and-disputes/` | `managing-disputes/#monitor-status` |
| "Good news — you've won this dispute!..." | `fraud-and-disputes/` | `preventing-disputes/` |
| **"The $X fee has been deducted from your account..."** | `fraud-and-disputes/` | `managing-disputes/#fees` |
| "You submitted evidence for this inquiry on X..." | `fraud-and-disputes/` | `managing-disputes/#inquiries` |
| "This inquiry was closed on X." | `fraud-and-disputes/` | `preventing-disputes/` |

The dispute-lost link (row 3) is the reported bug. Its label also changes from "Learn more about preventing disputes." to "Learn more about dispute fees." so the text matches where it now goes.

**2. Anchors that do not exist on their target page**

The page loads, the merchant lands at the top, and nothing signals that the intended section was missed.

| Location | Old | New |
|---|---|---|
| `class-wc-payments-admin-settings.php` (x2), `sandbox-mode-switch-to-live-notice/index.tsx` | `startup-guide/#sign-up-process` | `#signup-process` |
| `payment-details/summary/index.tsx` | `authorize-and-capture/#capturing-authorized-orders` | `#capturing-authorized-payments` |
| `class-wc-payments-apple-pay-registration.php` | `apple-pay/#domain-registration` | `#button-does-not-appear` |
| `deposits/details/index.tsx` | `instant-payouts/#transactions` | `#request-an-instant-payout` |

For Apple Pay, the page has no domain-registration section, but the domain registration retry steps do exist inside the section anchored `#button-does-not-appear`. That is where a merchant who just hit a verification failure needs to land. Adding a properly named anchor to the doc would be the better long-term fix.

For instant payouts, there is no `#transactions` anchor. The explanation does exist as a note inside `#request-an-instant-payout`: "Instant payouts are defined by the payout amount and are not linked to specific transactions. As a result, transaction details for instant payouts are unavailable."

**3. Fee tooltip country codes that could never match**

`client/utils/account-fees.tsx` builds per-country fee links from a country code supplied by `WC()->countries->get_base_country()`. Two of its 38 keys are not valid country codes:

- `SW` for Sweden, which is `SE`
- `UK` for the United Kingdom, which is `GB`

WooCommerce core's country list (`i18n/countries.php`) has no `SW` or `UK` key at all, so `get_base_country()` can never return either. This plugin's own `Country_Code` constants agree (`SWEDEN = 'SE'`, `UNITED_KINGDOM = 'GB'`). The other 36 keys are all valid ISO 3166-1 alpha-2 codes, so these are two isolated typos rather than an alternate scheme.

A `hasOwnProperty` guard made the failure silent: instead of a broken URL, UK and Swedish merchants fell through to the generic "Learn more about WooPayments Fees" link on the page top, never reaching their country's fee section. Both `#united-kingdom` and `#sweden` exist and work. Both keys have been wrong since they were introduced (`UK` in #5299, `SW` in #6350), so this has never worked for either market.

**The map was also keyed on the wrong country.** The tooltip renders the *Stripe account's* fee schedule but chose its documentation section from `WC()->countries->get_base_country()` — the *store* setting. Those are separate facts that only usually agree, and nothing reconciled them.

Where they diverge the failure is silent. 38 of the 39 supported countries are mapped, so a base country that is wrong for the account still resolves to a confident anchor instead of falling back. A store with base country `GB` on a `US` account lists "2.9% + $0.30" directly above a link to the United Kingdom section, which quotes pounds. Two realistic routes there — a Puerto Rico store, and any store that edits its base country after onboarding, since a Stripe account's country cannot follow it.

The lookup now reads `wcpaySettings.accountStatus.country`, which already serves as the country of record for VAT, phone formatting, payment method details and the transactions list. Where the two agree — nearly every merchant — nothing changes; the tooltip snapshots are unchanged, which is the evidence for that.

Puerto Rico therefore needs no map entry. `PR` is not selectable during Stripe signup, so a Puerto Rico store's account is created as United States and the lookup resolves to `#united-states` — the section describing the rates that account is actually charged.

One narrow trade-off: `get_account_status_data()` falls back to `Country_Code::UNITED_STATES` when `$account['country']` is absent, so an account missing that field would claim US rates where it previously used the real base country. It requires a Stripe account field that should always be present to be missing. Conversely, an account country with no fees section now correctly declines to claim one — verified with a `BR` account on a `US` base country, which falls back to the un-anchored page instead of asserting `#united-states`.

The lookup itself was restructured. `getStripeFeeSectionUrl()` previously produced `.../fees/#undefined` for any unmapped country and was safe only because its single call site pre-checked the map first — safety that lived at the caller, which also left the function's own fallback unreachable and untested. The tooltip now resolves the slug once through `getCountryFeeDocsSlug()`, and both the `href` and the surrounding copy read from that one result, so the un-anchored fallback is the live path for an unmapped country. That is what the Puerto Rico test exercises.

Two details ride along with that lookup. It goes through `Object.prototype.hasOwnProperty.call()`, so a country value matching an `Object.prototype` member cannot resolve to a function and be interpolated into the fragment. And the map is renamed `countryFeeDocsSectionSlugs`: it holds URL slugs, not the section numbers its old name claimed, which is an odd thing to leave lying in a PR premised on names matching their destinations.

**4. Stale slugs that currently work only via redirect**

Normalised so the codebase matches the real information architecture, and so a dropped redirect surfaces instead of silently breaking:

- `testing-and-troubleshooting/sandbox-mode/` to `test-accounts/` (7 occurrences, including `README.md` and a `@see` docblock)
- `payment-methods/additional-payment-methods/` to `local-payment-methods/` (1 occurrence; the `#method-cant-be-enabled` fragment survives the rename)

**5. Copy fix**

"Learn more about pending schedules" in the settings payouts panel reworded to "Learn more about payout schedules". The linked page has no "pending schedules" concept at all: it has pending funds and payout schedules as separate ideas. Text only, the URL is unchanged.

**6. Subscription deactivation modals — a dead anchor outside the WooPayments doc tree**

Three deactivation warnings (`html-wcpay-deactivate-warning.php`, `html-woo-payments-deactivate-warning.php`, `html-subscriptions-plugin-notice.php`) linked "cancel all subscriptions" to `subscriptions/store-manager-guide/#cancel-or-suspend-subscription`. That anchor does not exist. The page it lands on is titled "Subscriptions General Settings" and contains no cancellation instructions at all — its only two "cancel" mentions are an incidental role-settings aside and a shortcode `status` argument.

This matters more than the usual wrong-anchor case: it is the exact moment a merchant is told that Stripe Billing subscriptions will keep charging customers off-site if they get this wrong.

These three templates load through `wc_get_template()`, so a site that has copied them into its theme keeps the old anchor until it re-syncs. That is the normal template-override contract and not something this change can reach.

All three now point at `subscriptions/customers-view/suspend-cancel-or-remove-an-item/#how-to-cancel-a-subscription-as-a-store-manager`, which carries the step-by-step instructions under a heading that names the task. `subscriptions/statuses/#cancelled-subscription-status` was rejected — live and on-topic, but it defines what the status means rather than telling a store manager how to cancel, which is the same failure mode this branch exists to remove. `#customer-suspensions` was rejected too: it documents a setting capping how many times a *customer* may suspend their own subscription.

**7. Dispute copy that names a fee which was never charged**

Repointing the dispute-fee link at `#fees` in change 1 makes an existing mismatch louder: the label promises exactly the thing that did not happen. Three surfaces make that claim, in two different ways.

`getDisputeFeeFormatted()` returns `undefined` when the dispute fee was reversed or never charged (`client/types/disputes.d.ts` documents this case). Separately, it returned a formatted `"$0.00"` for a fee of zero — and `"$0.00"` is truthy, so a zero fee sailed through every "do we have a fee?" check in the codebase.

| Surface | Before | After |
|---|---|---|
| Dispute-lost footer, no fee | "The **-** fee has been deducted from your account…" | "The disputed amount has been returned to your customer." → `#amounts` |
| Dispute-lost footer, zero fee | "The **$0.00** fee has been deducted from your account…" | same as above |
| Accept-dispute modal, no or zero fee | "The disputed amount and the **-** dispute fee will not be returned to you." | "The disputed amount will not be returned to you." |
| Fee breakdown tooltip, zero fee | "Dispute fee **$0.00**" row | tooltip hidden (`Total fees` already equalled `Transaction fee`) |

The accept-modal one is the worst of these: a merchant reads it at the moment they are about to forfeit funds.

Rather than guard each surface, the zero case is handled once in `getDisputeFeeAmount()`, alongside the reversal rule that already lives there — a zero fee is no fee. All three consumers inherit one answer instead of each deciding what `$0.00` means. Change 8 covers why that needed care.

**8. Payment summary — "Deducted" vs "Refunded", and proof the numbers did not move**

Treating a zero fee as no fee is a behaviour change to a helper that money-adjacent code reads, so it also corrects a label there.

The payment summary labels the withdrawn balance line "Deducted" for a dispute and "Refunded" for a refund, and picked between them by testing the derived dispute *fee*. That proxy only held while every dispute carried a fee. On `develop` today, a dispute whose fee was **reversed** already renders "**Refunded**: -$50.00" for money that left the account as a dispute deduction — a pre-existing mislabel this PR also fixes.

The label now mirrors what `getChargeAmounts()` actually folds into `balance.refunded`: the dispute balance transactions are summed behind the same `isChargeDisputed` gate, and the line reads "Deducted" only when that sum is non-zero. Testing merely whether a dispute *record* exists is not enough — an inquiry has no balance transactions and a won dispute's rows net back to zero, so on either of those a plain customer refund is the only withdrawal and must still read "Refunded".

To be sure nothing else moved, the same fixtures were rendered against a `develop` build and a branch build of the same store, and every figure compared:

| Scenario | Amount line | Fees | Net | `develop` vs branch |
|---|---|---|---|---|
| fee 1500 | Deducted -$50.00 | -$16.75 | -$16.75 | identical |
| fee 0 | Deducted -$50.00 | -$1.75 | -$1.75 | identical |
| reversed, no offset row | -$50.00 | -$16.75 | -$16.75 | **label fixed**, amounts identical |
| reversed + `dispute_reversal` row | (no line) | -$1.75 | $48.25 | identical |
| 2 disputes, 1500 + 1500 | Deducted -$100.00 | -$31.75 | -$81.75 | identical |
| 2 disputes, 1500 + 0 | Deducted -$100.00 | -$16.75 | -$66.75 | identical |
| 2 disputes, 0 + 0 | Deducted -$100.00 | -$1.75 | -$51.75 | identical |
| refunded **and** zero-fee disputed | Deducted -$40.00 | -$1.75 | $8.25 | identical |
| refunded **and** inquiry (no withdrawal) | Refunded -$10.00 | -$1.75 | $38.25 | identical |
| refunded **and** won dispute (rows net to zero) | Refunded -$10.00 | -$1.75 | $38.25 | identical |
| refunded only (control) | Refunded -$10.00 | -$1.75 | $38.25 | identical |

**No monetary figure changes in any scenario.** The structural reason: `getChargeAmounts()` — which produces `Fees`, `Net` and the withdrawn amount — is untouched by this PR and reads `dispute.balance_transactions` directly, never through `getDisputeFeeAmount()`. `getDisputeFeeAmount()` has exactly three consumers, all listed in change 7.

Besides the corrected label, the only other differences are cosmetic and both improvements: the zero-fee breakdown tooltip is hidden (its "Dispute fee $0.00" row was a no-op — `Total fees` already equalled `Transaction fee`, and `develop` already hid the tooltip for reversed fees), and the `1500 + 0` case now reads "Dispute fee $15.00" rather than "Dispute fee**s** $15.00", since only one of the two disputes actually carried a fee.

Two smaller corrections to the same code path. The breakdown total took its currency from `disputeFeeAmounts[0].currency` and now reads `balance.currency`. Nothing rendered changes — every dispute fee on a charge is denominated in the settlement currency, so the two always agree — but the breakdown now states the denomination it uses rather than depending on that agreement. And the zero-fee guard now also rejects a non-finite amount, so a malformed `effective_fee` renders nothing rather than "The **$NaN** fee has been deducted from your account".

**9. `rel="noreferrer noopener"` on the anchors this PR edits**

The five external anchors changed in changes 2 and 6 emitted `target="_blank"` with no `rel` (or, in the sandbox notice, a bare `rel="noreferrer"`), while `class-wc-payments-admin-settings.php` — edited three lines away in change 2 — emits `rel="noreferrer noopener"` on every link. Modern browsers imply `noopener` for `target="_blank"`, so the practical exposure is referrer leakage on older engines; the reason to fix it is that the inconsistency was being reintroduced on the exact lines under edit. Verified to survive `WC_Payments_Utils::esc_interpolated_html()`, which rebuilds the tag. Untouched anchors elsewhere in those files still lack `rel` and are left alone.

The dispute recommendations card links outside `/woopayments/` deliberately per RiskOps review, so it is left as-is.

**How this could break:** most of this is string literals in UI copy, where the risk is a typo in a URL producing a link that resolves worse than before — mitigated by verifying every destination and fragment against the live docs, and by the snapshot tests that assert the rendered `href` values.

The exception is change 7's zero-fee rule, which is real logic in a helper that money-adjacent code reads. If it were wrong, a merchant could see an incorrect figure rather than merely an unhelpful link. That is why change 8 compares every rendered figure against a `develop` build rather than reasoning about it.

**Backward compatibility:** no public API surface changes. No hooks, class or method signatures, REST routes, option keys, or stored meta are touched.

One behaviour change is worth calling out explicitly: `getDisputeFeeAmount()` in `client/disputes/utils.ts` now returns `undefined` for a zero fee as well as a reversed one. It is a client-side TypeScript module rather than part of the plugin's PHP extensibility surface, and its three consumers all ship in this repo (listed in change 7). No figure rendered to a merchant changes as a result; change 8 has the comparison.

Seven translatable strings are new or changed, retiring four previously translated ones:

| New or changed string | Replaces |
|---|---|
| "Learn more about dispute fees." | "Learn more about preventing disputes." |
| "Learn more about monitoring dispute status." | "Learn more about the dispute process." |
| "Learn more about payout schedules" | "Learn more about pending schedules" |
| `{{linkToStripePage}}Learn more{{/linkToStripePage}} about %s Fees` | `{{linkToStripePage /}} about %s Fees` |
| "Learn more about disputed amounts." | — new |
| "The disputed amount has been returned to your customer." | — new |
| "Accepting the dispute marks it as \<em>Lost\</em>. The disputed amount will not be returned to you." | — new |

All seven need translation, so merchants on translated locales see English until translations land. That is normal for a copy change, not a break. The fee-tooltip string changes form only — the self-closing placeholder becomes a wrapping one so both tooltip branches can share a single component map — and renders identically in English.

#### Testing instructions

The substance of this change is where each link goes, so most verification is checking destinations rather than reaching every UI state.

**1. Verify the destinations (main check)**

Open each new URL and confirm it scrolls to a section that answers the adjacent copy. Anchors that do not exist fail silently by landing at the top of the page, which is the entire bug class here, so watch for that specifically.

- `woocommerce.com/document/woopayments/fraud-and-disputes/managing-disputes/#fees` should land on "Dispute fees"
- `.../managing-disputes/#monitor-status` should land on "Monitor the dispute status"
- `.../managing-disputes/#inquiries` should land on "Inquiries"
- `.../fraud-and-disputes/preventing-disputes/` should be the preventing disputes page
- `.../startup-guide/#signup-process` should land on "The WooPayments signup process"
- `.../settings-guide/authorize-and-capture/#capturing-authorized-payments` should land on "Capturing authorized payments"
- `.../payment-methods/apple-pay/#button-does-not-appear` should land on the section containing the domain registration retry steps
- `.../payouts/instant-payouts/#request-an-instant-payout` should land on the section whose note explains that transaction details are unavailable
- `.../fees/#united-kingdom` and `.../fees/#sweden` should land on those country sections
- `.../managing-disputes/#amounts` should land on "Disputed amounts"
- `.../subscriptions/statuses/#cancelled-subscription-status` should land on "Cancelled Subscription Status"

**2. Fee tooltip (the country code fix)**

1. On a store whose WooPayments account country is United Kingdom, go to Payments > Settings and hover the fee tooltip.
2. Before this change the hint reads "Learn more about WooPayments Fees" and links to the fees page top. After, it should read "Learn more about WooPayments Fees in your country" and link to `.../fees/#united-kingdom`.
3. Repeat with Sweden, expecting `#sweden`.
4. Sanity check an already-working country such as Germany to confirm no regression.
5. The link now follows the **account** country, not the store base country. To see that, change WooCommerce > Settings > General > Country/Region to a different supported country and reload: the fee rates and the link should stay on the account's country rather than following the store setting.

**3. Dispute footers and the fee copy**

The five footers correspond to dispute states: under review, won, lost, inquiry under review, inquiry closed. The lost-dispute footer is the one from the original report.

1. On a payment details page for a **lost dispute with a fee**, confirm the copy reads "The $X fee has been deducted from your account…" followed by "Learn more about dispute fees.", linking to `managing-disputes/#fees`. The summary's withdrawn line should read "Deducted: …".
2. For a lost dispute whose **fee was reversed or is zero**, confirm the copy reads only "The disputed amount has been returned to your customer." with "Learn more about disputed amounts." → `#amounts`, and no `$0.00` or `-` anywhere. The summary line should still read "**Deducted**" — on `develop` the reversed case reads "Refunded", which is the mislabel change 8 fixes.
3. On an **under-review** dispute, the link should read "Learn more about monitoring dispute status." → `#monitor-status`.
4. On a dispute **awaiting response**, click "Accept dispute" and read the modal. With a fee it names the amount; with no fee or a zero fee the fee clause is absent entirely rather than showing a `-`.

These states are easiest to reach by varying the dispute payload rather than driving real disputes: `effective_fee` set to `{ amount: 0 }`, to `null`, or omitted with a zero-fee balance transaction, cover the three no-fee routes.

**4. Automated**

- `pnpm run test:js` passes: 374 suites, 3653 tests, 340 snapshots. Three snapshot files change, five `href` values between them, and nothing else.
- **17 new tests**, covering the `GB` and `SE` fee-section hrefs, the un-anchored fallback and its copy for an unmapped country, the `Object.prototype` lookup guard, `getDisputeFeeAmount()` across both the annotated and legacy paths (fee present, reversed, zero, absent), the accept-dispute modal with and without a fee, the no-fee footer, a malformed fee amount, the fee link following the account country when the store base country differs, and the withdrawn-balance label across a zero-fee chargeback, an inquiry plus refund, and a won dispute plus refund.
- Every added test was mutation-checked — the thing it covers was broken to confirm the test notices. Four that did not were removed: three restated coverage other tests already provide, and one guarded the country lookup against an `Object.prototype` member, which a Stripe ISO-3166 alpha-2 code cannot be.
- Every documentation URL the branch adds — 15 unique, 12 of them anchored — was re-verified against the live pages by fetching each one and asserting the fragment appears in that page's `id` set. All 15 resolve.
- `pnpm run lint:js` reports 0 errors, and no warnings in any file touched here.
- `pnpm run lint:php` passes, and PHPCS is clean on all four changed PHP files.
- PHP unit tests covering the touched subscription and Apple Pay classes pass: 324 tests, 831 assertions.

**5. Browser verification**

Every claim above about rendered output was checked in a real `wp-admin` against the built bundle, not only in unit tests: the four dispute-fee states, the under-review link label, the `GB` and `PR` fee tooltips, and the four PHP anchors rendered through their templates (including through `esc_interpolated_html()`). The `develop`-vs-branch comparison in change 8 was produced the same way — same fixtures, same store, only the built bundle swapped.

**Merge note:** #12045 adds a Klarna loss-reason line to `DisputeLostFooter` at the same place the fee/no-fee ternary in change 7 lands, so whichever merges second will conflict there. Keep the Klarna line as a single statement *before* the ternary so it covers both the fee and no-fee branches, rather than duplicating it into each arm.

#### Known limitations and follow-ups

Two destinations are the best available rather than the right one, because the anchor a merchant needs does not exist in the docs:

- **Apple Pay `#button-does-not-appear`** — the domain-registration retry steps really are in this section, but at the bottom, after six checks about browsers, devices, HTTPS, and guest-checkout settings. A merchant who just saw "Apple Pay domain verification failed" lands on content that does not match the error. Every other anchor on that page (`#troubleshooting`, `#other-issues`, …) lands further from the steps, so this stays. A dedicated anchor for domain-verification failures needs a docs request.
- **Subscriptions — bulk cancellation** — the destination now documents cancelling a subscription, but one at a time; no woocommerce.com page covers cancelling in bulk, which is what a merchant deactivating the plugin actually needs. Worth noting: the woocommerce.com Stripe Billing FAQ carries the identical dead `store-manager-guide/#cancel-or-suspend-subscription` link inside its `#deactivate-woopayments-plugin` section, so the plugin inherited this from the docs and the root fix belongs with the docs team.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) — existing snapshot tests assert the rendered `href` values, plus 17 new tests covering the fee-section links, the unmapped-country fallback and its guard, `getDisputeFeeAmount()` across every fee state, the accept-dispute modal, the no-fee footer, and the zero-fee "Deducted" label.
- [x] Tested on mobile (or does not apply) — does not apply.

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.






