### PR TITLE
Back off errored onboarding and business-types cache entries

### DIFF
--- a/changelog/fix-woopmnt-6394-errored-onboarding-cache-ttl
+++ b/changelog/fix-woopmnt-6394-errored-onboarding-cache-ttl
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Recover onboarding within minutes instead of a week after a transient error, by backing off errored business-types and onboarding-fields cache entries instead of caching the failure for the full week.

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -456,8 +456,11 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 				break;
 			case self::BUSINESS_TYPES_KEY:
 			case self::ONBOARDING_FIELDS_DATA_KEY:
-				// Cache these for a week.
-				$ttl = WEEK_IN_SECONDS;
+				// Cache successful data for a week, but back off quickly on errors so a
+				// single transient failure does not block onboarding for the full week.
+				$ttl = $cache_contents['errored']
+					? $this->get_errored_ttl( $cache_contents['consecutive_errors'] ?? 0 )
+					: WEEK_IN_SECONDS;
 				break;
 			case self::CONNECT_INCENTIVE_KEY:
 				$ttl = $cache_contents['data']['ttl'] ?? HOUR_IN_SECONDS * 6;

--- a/tests/unit/test-class-database-cache.php
+++ b/tests/unit/test-class-database-cache.php
@@ -815,6 +815,50 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider provider_errored_ttl_ladder
+	 */
+	public function test_onboarding_fields_data_errored_entries_use_progressive_backoff( int $consecutive_errors, int $expected_ttl ) {
+		$this->assert_cache_get_respects_ttl(
+			Database_Cache::ONBOARDING_FIELDS_DATA_KEY,
+			[ 'fields' => [] ],
+			true,
+			$expected_ttl,
+			$consecutive_errors
+		);
+	}
+
+	/**
+	 * @dataProvider provider_errored_ttl_ladder
+	 */
+	public function test_business_types_errored_entries_use_progressive_backoff( int $consecutive_errors, int $expected_ttl ) {
+		$this->assert_cache_get_respects_ttl(
+			Database_Cache::BUSINESS_TYPES_KEY,
+			[ 'business_types' => [] ],
+			true,
+			$expected_ttl,
+			$consecutive_errors
+		);
+	}
+
+	public function test_onboarding_fields_data_successful_entries_are_cached_for_a_week() {
+		$this->assert_cache_get_respects_ttl(
+			Database_Cache::ONBOARDING_FIELDS_DATA_KEY,
+			[ 'fields' => [] ],
+			false,
+			WEEK_IN_SECONDS
+		);
+	}
+
+	public function test_business_types_successful_entries_are_cached_for_a_week() {
+		$this->assert_cache_get_respects_ttl(
+			Database_Cache::BUSINESS_TYPES_KEY,
+			[ 'business_types' => [] ],
+			false,
+			WEEK_IN_SECONDS
+		);
+	}
+
 	public function test_errored_write_sets_consecutive_errors_to_one_on_first_failure() {
 		$refreshed = false;
 


### PR DESCRIPTION
Fixes WOOPMNT-6394

#### Changes proposed in this Pull Request

The `wcpay_onboarding_fields_data` and `wcpay_business_types` cache entries used a flat `WEEK_IN_SECONDS` TTL that ignored the `errored` flag. Every other error-prone cache key (`ACCOUNT_KEY`, `CURRENCIES_KEY`, `TRACKING_INFO_KEY`) already routes errored entries through the `get_errored_ttl()` 2/5/10/15-minute backoff ladder; these two were the only outliers.

As a result, a single transient failure to fetch the onboarding fields cached a `null` result for a full week.

**How can this code break?** The change only affects the TTL applied to *errored* entries for these two keys; successful data keeps its one-week TTL. A shorter errored TTL means more frequent retries after a failure, which is the intended behavior and matches the existing keys.

**What are we doing to make sure it doesn't break?** Added unit tests covering the errored backoff ladder and the successful-week TTL for both keys, mirroring the existing `TRACKING_INFO_KEY` coverage.

#### Testing instructions

* None. The change is self-explanatory and contained.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — backend cache TTL change, no UI

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

-------------------

🤖 Spun up by [Claude Code](https://claude.com/claude-code), weighed by human and machine — two kinds of eyes to keep it clean.

