### PR TITLE
MultiCurrency Widget: use `$wp_widget_factory->get_widget_key` over `spl_object_hash` for identifying the widget in get_switcher_widget_markup method

### DIFF
--- a/changelog/fix-wordpress-7.1-compat-for-multicurrency-widget
+++ b/changelog/fix-wordpress-7.1-compat-for-multicurrency-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the currency switcher not rendering on WordPress 7.1 in Storefront breadcrumbs and the wc_get_currency_switcher_markup() template tag.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -570,12 +570,8 @@ class MultiCurrency {
 	 * @return string The widget markup.
 	 */
 	public function get_switcher_widget_markup( array $instance = [], array $args = [] ): string {
-		/**
-		 * The spl_object_hash function is used here due to we register the widget with an instance of the widget and
-		 * not the class name of the widget. WordPress core takes the instance and passes it through spl_object_hash
-		 * to get a hash and adds that as the widget's name in the $wp_widget_factory->widgets[] array. In order to
-		 * call the_widget, you need to have the name of the widget, so we get the instance and hash to use.
-		 */
+		global $wp_widget_factory;
+
 		ob_start();
 
 		$currency_switcher_widget = $this->get_currency_switcher_widget();
@@ -591,8 +587,17 @@ class MultiCurrency {
 			return ob_get_clean();
 		}
 
+		/*
+		 * We register the currency switcher with a widget instance rather than a class name, so WordPress stores it
+		 * in $wp_widget_factory->widgets[] under a generated key rather than under its class name. the_widget()
+		 * expects that key, so we ask the factory for it instead of recomputing it ourselves: WordPress 7.1 changed
+		 * the key from spl_object_hash() to spl_object_id(). WP_Widget_Factory::get_widget_key() has returned the
+		 * current key since WordPress 5.8, whichever way it is generated.
+		 */
+		$widget_key = $wp_widget_factory->get_widget_key( $currency_switcher_widget->id_base );
+
 		the_widget(
-			spl_object_hash( $currency_switcher_widget ),
+			$widget_key,
 			/**
 			 * Filters the instance settings passed to the currency switcher theme widget.
 			 *

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -588,13 +588,10 @@ class MultiCurrency {
 		}
 
 		/*
-		 * We register the currency switcher with a widget instance rather than a class name, so WordPress stores it
-		 * in $wp_widget_factory->widgets[] under a generated key rather than under its class name. the_widget()
-		 * expects that key, so we ask the factory for it instead of recomputing it ourselves: WordPress 7.1 changed
-		 * the key from spl_object_hash() to spl_object_id(). WP_Widget_Factory::get_widget_key() has returned the
-		 * current key since WordPress 5.8, whichever way it is generated.
+		 * WordPress changed instance widget keys from spl_object_hash() to spl_object_id() in 7.1.
+		 * Find the exact registered instance instead of reproducing WordPress's key generation.
 		 */
-		$widget_key = $wp_widget_factory->get_widget_key( $currency_switcher_widget->id_base );
+		$widget_key = array_search( $currency_switcher_widget, $wp_widget_factory->widgets, true );
 
 		the_widget(
 			$widget_key,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`get_switcher_widget_markup()` renders the legacy currency switcher by calling `the_widget()` with a key it derives itself: `spl_object_hash( $currency_switcher_widget )`. That works because we register the switcher with an *instance* (`register_widget( $this->currency_switcher_widget )`), so `WP_Widget_Factory::register()` stores it under a generated key rather than under its class name — and until now that key was the object hash.

**WordPress 7.1 changes that key to `spl_object_id()`** ([changeset 62408](https://core.trac.wordpress.org/changeset/62408/), [#58291](https://core.trac.wordpress.org/ticket/58291)) — an int rather than a 32-char hash. `the_widget()`'s `isset( $wp_widget_factory->widgets[ $widget ] )` guard then misses, `_doing_it_wrong()` fires, and the function returns without rendering.

This is already in 7.1 RC, so it lands on every store that updates.

What breaks, concretely — both callers of `get_switcher_widget_markup()`:

- `wc_get_currency_switcher_markup()`, the public template tag themes use to place the switcher.
- `StorefrontIntegration`, which injects the switcher above the Storefront nav via `woocommerce_breadcrumb_defaults`.

What does **not** break: a switcher placed in a sidebar through the widgets screen, and the Currency Switcher block. Sidebar rendering goes through `WP_Widget::_register()` → `wp_register_sidebar_widget()`, and `WP_Widget_Factory::_register_widgets()` uses the array keys only to iterate — it never looks a widget up by key. So this is silent disappearance on the two paths above, not a fatal or a full outage.

The fix looks the widget up in the factory instead of reproducing core's key generation: `array_search( $currency_switcher_widget, $wp_widget_factory->widgets, true )` returns whatever key core filed our exact instance under. That keeps the switcher working on 6.0 through 7.1+ from a single code path, which matters because we support back to WP 6.0 — swapping `spl_object_hash()` for `spl_object_id()` would just move the breakage onto every store below 7.1.

*How can this code break?* If the switcher isn't registered in `$wp_widget_factory` — e.g. something unhooked `widgets_init` — `array_search()` returns `false`, which `the_widget()` rejects via its `isset()` guard: it trips `_doing_it_wrong()` and renders nothing, exactly as the unpatched code does today for an unregistered widget. We search for the exact instance rather than asking `get_widget_key( $id_base )` because the factory can hold several widgets sharing an `id_base`: `WP_Widget_Factory::_register_widgets()` only dedupes those registered before `widgets_init` runs, so anything registered afterwards accumulates — as the test suite does each time it re-initialises `MultiCurrency` — and `get_widget_key()` would return the first match, which may be a stale instance bound to a different `MultiCurrency`.

#### Testing instructions

Automated: `test_get_switcher_widget_markup()` (`tests/unit/multi-currency/test-class-multi-currency.php`) asserts the fully rendered switcher markup, so on WP 7.1 it fails on `develop` and passes with this branch. It is currently the *only* test that exercises the `the_widget()` lookup end to end — `test_get_switcher_widget_markup_when_widget_instance_is_null()` returns before reaching it, `test-class-storefront-integration.php` only asserts filter registration and never calls `modify_breadcrumb_defaults()`, and `test-class-currency-switcher-widget.php` calls `widget()` directly, bypassing `the_widget()`.

Note that CI will not show the failure yet: `php-lint-test.yml` pins `WP_VERSION: latest`, and `compatibility.yml`'s matrix is `wordpress: ["latest"]` plus min `6.0`, with no beta/RC entry. It only turns red once 7.1 is released. Reproduce locally with `WP_VERSION=trunk` (or a 7.1 RC).

Manual, on a WP 7.1 RC site with Multi-currency enabled and **two or more** currencies (with one enabled currency every path bails out early and renders nothing regardless of this bug):

1. Activate the **Storefront** theme (a Storefront child theme also works — `StorefrontIntegration` is only constructed when the stylesheet or template is `storefront`).
2. Under **WooCommerce → Settings → Multi-currency**, tick *"Add a currency switcher to the Storefront theme on breadcrumb section."* (option `wcpay_multi_currency_enable_storefront_switcher`; note it defaults to off, despite the comment above the check in `StorefrontIntegration`).
3. View a page where WooCommerce renders breadcrumbs — shop, a product, a category. Expected: switcher above the nav. On `develop` it is missing; with this branch it is back.
4. Without switching themes, call `echo wc_get_currency_switcher_markup();` from a snippet or template. Expected: markup. On `develop`: empty string.
5. Regression-check WP 6.0 and current stable — both paths still render.
6. Regression-check the two unaffected paths on 7.1 — the switcher widget placed in a sidebar, and the Currency Switcher block.

With `WP_DEBUG` on you will also see the `_doing_it_wrong()` notice — *"Widgets need to be registered using `register_widget()`, before they can be displayed"* — which confirms you are hitting this failure rather than the one-currency bail-out.

-------------------

- [] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests — existing `test_get_switcher_widget_markup()` fails on WP 7.1 without this fix
- [x] Tested on mobile (or does not apply)
