### PR TITLE
Guard the errored read in get_ttl for legacy cache entries

### DIFF
--- a/changelog/fix-woopmnt-6407-errored-legacy-entry-warning
+++ b/changelog/fix-woopmnt-6407-errored-legacy-entry-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid a PHP 8 "Undefined array key" warning when computing the cache TTL for a legacy cache entry stored before the errored field existed.

--- a/includes/class-database-cache.php
+++ b/includes/class-database-cache.php
@@ -423,11 +423,16 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 	 * @return integer The cache TTL.
 	 */
 	private function get_ttl( string $key, array $cache_contents ): int {
+		// Legacy cache entries written before the `errored` field existed do not carry the key,
+		// and get() reaches get_ttl() (via is_expired) without guaranteeing it. Default to false so
+		// the reads below cannot emit a PHP 8 "Undefined array key" warning.
+		$errored = $cache_contents['errored'] ?? false;
+
 		switch ( $key ) {
 			case self::ACCOUNT_KEY:
 				if ( is_admin() ) {
 					// Fetches triggered from the admin panel should be more frequent.
-					if ( $cache_contents['errored'] ) {
+					if ( $errored ) {
 						// Progressive backoff on repeated errors (2/5/10/15 min).
 						$ttl = $this->get_errored_ttl( $cache_contents['consecutive_errors'] ?? 0 );
 					} else {
@@ -442,7 +447,7 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 			case self::CURRENCIES_KEY:
 				if ( defined( 'DOING_CRON' ) || is_admin() || Utils::is_admin_api_request() ) {
 					// Fetches triggered from the admin panel should be more frequent.
-					if ( $cache_contents['errored'] ) {
+					if ( $errored ) {
 						// Progressive backoff on repeated errors (2/5/10/15 min).
 						$ttl = $this->get_errored_ttl( $cache_contents['consecutive_errors'] ?? 0 );
 					} else {
@@ -458,7 +463,7 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 			case self::ONBOARDING_FIELDS_DATA_KEY:
 				// Cache successful data for a week, but back off quickly on errors so a
 				// single transient failure does not block onboarding for the full week.
-				$ttl = $cache_contents['errored']
+				$ttl = $errored
 					? $this->get_errored_ttl( $cache_contents['consecutive_errors'] ?? 0 )
 					: WEEK_IN_SECONDS;
 				break;
@@ -471,12 +476,12 @@ class Database_Cache implements MultiCurrencyCacheInterface {
 				$ttl = $cache_contents['data'] ? DAY_IN_SECONDS * 90 : HOUR_IN_SECONDS;
 				break;
 			case self::TRACKING_INFO_KEY:
-				$ttl = $cache_contents['errored']
+				$ttl = $errored
 					? $this->get_errored_ttl( $cache_contents['consecutive_errors'] ?? 0 )
 					: MONTH_IN_SECONDS;
 				break;
 			case self::ADDRESS_AUTOCOMPLETE_JWT_KEY:
-				if ( $cache_contents['errored'] ) {
+				if ( $errored ) {
 					// Retry quickly after a transient failure so address autocomplete recovers promptly.
 					$ttl = 2 * MINUTE_IN_SECONDS;
 				} else {

--- a/tests/unit/test-class-database-cache.php
+++ b/tests/unit/test-class-database-cache.php
@@ -816,6 +816,29 @@ class Database_Cache_Test extends WCPAY_UnitTestCase {
 	}
 
 	/**
+	 * A legacy cache entry written before the `errored` field existed must resolve without a
+	 * PHP 8 "Undefined array key" warning. With convertWarningsToExceptions enabled, an unguarded
+	 * read of the missing key would throw here.
+	 */
+	public function test_get_ttl_handles_legacy_entry_without_errored_key() {
+		update_option(
+			Database_Cache::BUSINESS_TYPES_KEY,
+			[
+				'data'    => [ 'business_types' => [] ],
+				'fetched' => time(),
+			],
+			'no'
+		);
+
+		$this->assertSame(
+			[ 'business_types' => [] ],
+			$this->database_cache->get( Database_Cache::BUSINESS_TYPES_KEY )
+		);
+
+		delete_option( Database_Cache::BUSINESS_TYPES_KEY );
+	}
+
+	/**
 	 * @dataProvider provider_errored_ttl_ladder
 	 */
 	public function test_onboarding_fields_data_errored_entries_use_progressive_backoff( int $consecutive_errors, int $expected_ttl ) {


### PR DESCRIPTION
Fixes WOOPMNT-6407

#### Changes proposed in this Pull Request

`get_ttl()` reads `$cache_contents['errored']` directly, but the `get()` → `is_expired()` → `get_ttl()` path does not guarantee the key is present. A cache entry written before the `errored` field existed (i.e. from before the upgrade) therefore emits a PHP 8 `Undefined array key` warning when read, until the entry is rewritten. It's log noise only — the value still coerces to `false` and resolves the correct TTL.

Normalize the read once at the top of `get_ttl()` (`$errored = $cache_contents['errored'] ?? false`) and use it for every key. This also covers the pre-existing `ACCOUNT` / `CURRENCIES` / `TRACKING_INFO` / `ADDRESS_AUTOCOMPLETE` arms that share the same unguarded read. `should_refresh_cache()` already guards via `array_key_exists()` and `write_to_cache()` assigns the key, so both are intentionally left unchanged.

#### Testing instructions

- On PHP 8+, seed a `wcpay_business_types_data` (or `wcpay_onboarding_fields_data`) option with `data` and `fetched` but no `errored` key, then read it via the cache.
- [ ] Confirm no `Undefined array key "errored"` warning is emitted and the value resolves normally.

*

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — backend cache logic, no UI

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows), if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.

-------------------

🤖 Written by [Claude Code](https://claude.com/claude-code), read once by a human and once by a machine — a quiet fix, twice checked.
