### PR TITLE
Changelog for develop from version 11.0.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooPayments Changelog ***
 
 = 11.0.1 - 2026-08-20 =
+* Fix - Fix the currency switcher not rendering on WordPress 7.1 in Storefront breadcrumbs and the wc_get_currency_switcher_markup() template tag.
 
 = 11.0.0 - 2026-08-05 =
 * Add - Add A/B/C design variants to the in-app review prompt, assigned per-store via ExPlat (prompt remains disabled pending eligibility criteria)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 *** WooPayments Changelog ***
 
+= 11.0.1 - 2026-08-20 =
+
 = 11.0.0 - 2026-08-05 =
 * Add - Add A/B/C design variants to the in-app review prompt, assigned per-store via ExPlat (prompt remains disabled pending eligibility criteria)
 * Add - Multi-Currency: add the `wcpay_multi_currency_should_output_explicit_price` filter so merchants can force the currency code suffix on totals (e.g. "765 Kč CZK") on or off.

--- a/changelog/fix-wordpress-7.1-compat-for-multicurrency-widget
+++ b/changelog/fix-wordpress-7.1-compat-for-multicurrency-widget
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the currency switcher not rendering on WordPress 7.1 in Storefront breadcrumbs and the wc_get_currency_switcher_markup() template tag.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-payments",
-	"version": "11.0.0",
+	"version": "11.0.1",
 	"main": "webpack.config.js",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 7.3
-Stable tag: 11.0.0
+Stable tag: 11.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -86,6 +86,9 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 4. Manage Disputes
 
 == Changelog ==
+
+= 11.0.1 - 2026-08-20 =
+
 
 = 11.0.0 - 2026-08-05 =
 * Add - Add A/B/C design variants to the in-app review prompt, assigned per-store via ExPlat (prompt remains disabled pending eligibility criteria)

--- a/readme.txt
+++ b/readme.txt
@@ -88,7 +88,7 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 == Changelog ==
 
 = 11.0.1 - 2026-08-20 =
-
+* Fix - Fix the currency switcher not rendering on WordPress 7.1 in Storefront breadcrumbs and the wc_get_currency_switcher_markup() template tag.
 
 = 11.0.0 - 2026-08-05 =
 * Add - Add A/B/C design variants to the in-app review prompt, assigned per-store via ExPlat (prompt remains disabled pending eligibility criteria)

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC tested up to: 11.0.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
- * Version: 11.0.0
+ * Version: 11.0.1
  * Requires Plugins: woocommerce
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
> [!NOTE]
> As the release lead, please approve and merge this PR after the code freeze process is done successfully.

Applies the changelog entries from `release/11.0.1` to `develop` so that `develop` stays in sync without a `trunk → develop` merge.

Related release PR: #12056