### PR TITLE
Backport WP 7.1 Multi-Currency switcher fix to release/11.0.1

### DIFF
--- a/changelog/fix-wordpress-7.1-compat-for-multicurrency-widget
+++ b/changelog/fix-wordpress-7.1-compat-for-multicurrency-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the currency switcher not rendering on WordPress 7.1 in Storefront breadcrumbs and the wc_get_currency_switcher_markup() template tag.

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -570,12 +570,8 @@ class MultiCurrency {
 	 * @return string The widget markup.
 	 */
 	public function get_switcher_widget_markup( array $instance = [], array $args = [] ): string {
-		/**
-		 * The spl_object_hash function is used here due to we register the widget with an instance of the widget and
-		 * not the class name of the widget. WordPress core takes the instance and passes it through spl_object_hash
-		 * to get a hash and adds that as the widget's name in the $wp_widget_factory->widgets[] array. In order to
-		 * call the_widget, you need to have the name of the widget, so we get the instance and hash to use.
-		 */
+		global $wp_widget_factory;
+
 		ob_start();
 
 		$currency_switcher_widget = $this->get_currency_switcher_widget();
@@ -591,8 +587,14 @@ class MultiCurrency {
 			return ob_get_clean();
 		}
 
+		/*
+		 * WordPress changed instance widget keys from spl_object_hash() to spl_object_id() in 7.1.
+		 * Find the exact registered instance instead of reproducing WordPress's key generation.
+		 */
+		$widget_key = array_search( $currency_switcher_widget, $wp_widget_factory->widgets, true );
+
 		the_widget(
-			spl_object_hash( $currency_switcher_widget ),
+			$widget_key,
 			/**
 			 * Filters the instance settings passed to the currency switcher theme widget.
 			 *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Cherry-pick of #12053 (`bb1e97f03`) onto `release/11.0.1` for the 11.0.1 patch release. The commit is unchanged from what is on `develop`.

WordPress 7.1 changed how the widget factory keys instance-registered widgets, from `spl_object_hash()` to `spl_object_id()`. `get_switcher_widget_markup()` reproduced the old key, so on WP 7.1 `the_widget()` no longer finds the currency switcher and silently renders nothing. This breaks the Storefront breadcrumb switcher and the `wc_get_currency_switcher_markup()` template tag. The fix looks the widget up in the factory with `array_search()` instead, which works from WP 6.0 through 7.1+.

The full analysis, including what is and is not affected and the BC notes, is in #12053.

#### Testing instructions

Automated: `test_get_switcher_widget_markup` (`tests/unit/multi-currency/test-class-multi-currency.php`) exercises the full render path through `the_widget()`. It passes on this branch on WP 7.0 and WP 7.1, and fails on the unpatched release base on WP 7.1.

Manual, on a WP 7.1 site with Multi-currency enabled and two or more currencies:

1. Activate Storefront and tick "Add a currency switcher to the Storefront theme on breadcrumb section" under WooCommerce → Settings → Multi-currency.
2. View the shop page. The switcher should render above the nav, and picking another currency should reload the page with prices in that currency.
3. Regression: repeat on WP 7.0 or current stable, both placements still render.

Full step-by-step instructions are in #12053.

-------------------

- [x] Changelog file is included in the cherry-picked commit.
- [x] Covered with tests — existing `test_get_switcher_widget_markup` fails on WP 7.1 without this fix.
- [x] Tested on mobile (or does not apply)
