### PR TITLE
Match readme.txt changelog spacing to trunk

### DIFF
--- a/changelog/fix-readme-changelog-spacing-drift
+++ b/changelog/fix-readme-changelog-spacing-drift
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Whitespace-only sync of readme.txt with trunk to quiet the drift check, no entry needed.

--- a/changelog/fix-readme-changelog-spacing-drift
+++ b/changelog/fix-readme-changelog-spacing-drift
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Whitespace-only sync of readme.txt with trunk to quiet the drift check, no entry needed.

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 = 11.0.1 - 2026-08-20 =
 * Fix - Fix the currency switcher not rendering on WordPress 7.1 in Storefront breadcrumbs and the wc_get_currency_switcher_markup() template tag.
 
+
 = 11.0.0 - 2026-08-05 =
 * Add - Add A/B/C design variants to the in-app review prompt, assigned per-store via ExPlat (prompt remains disabled pending eligibility criteria)
 * Add - Multi-Currency: add the `wcpay_multi_currency_should_output_explicit_price` filter so merchants can force the currency code suffix on totals (e.g. "765 Kč CZK") on or off.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The weekly release-files drift check compares `trunk` and `develop` byte for byte, and a single blank line difference in `readme.txt`'s 11.0.1 changelog block keeps it alerting (see [the alert](https://a8c.slack.com/archives/CGGCLBN58/p1787230002932489)). This adds the blank line back on `develop` so the file matches the released one on `trunk` exactly.

#### Testing instructions

`git diff origin/trunk origin/develop -- readme.txt` is empty once this merges. The change is whitespace only.

-------------------

- [x] Changelog entry not needed (whitespace only).
- [x] Covered with tests (not applicable, whitespace only).
- [x] Tested on mobile (or does not apply)
