### PR TITLE
ci: add a WP nightly job to the compatibility workflow

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -74,6 +74,38 @@ jobs:
           echo "matrix={\"woocommerce\":[\"beta\"],\"wordpress\":[\"latest\"],\"gutenberg\":[\"latest\"],\"php\":$PHP_VERSIONS}" >> $GITHUB_OUTPUT
 
   # a dedicated job, as allowed to fail
+  compatibility-wordpress-nightly:
+    name: Environment - WP nightly
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        woocommerce: [ 'latest' ]
+        wordpress: [ 'nightly' ]
+        gutenberg: [ 'latest' ]
+        php: [ '7.4' ]
+    env:
+      WP_VERSION: ${{ matrix.wordpress }}
+      WC_VERSION: ${{ matrix.woocommerce }}
+      GUTENBERG_VERSION: ${{ matrix.gutenberg }}
+    steps:
+      # clone the repository
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # enable dependencies caching
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/composer/
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.json') }}-${{ hashFiles('composer.lock') }}
+      # setup PHP, but without debug extensions for reasonable performance
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer
+          coverage: none
+      # run CI checks
+      - run: bash bin/run-ci-tests.bash
+
+  # a dedicated job, as allowed to fail
   compatibility-woocommerce-beta:
     name: Environment - WC beta
     needs: generate-wc-compat-beta-matrix

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,7 +1,11 @@
 name: Compatibility - WC, WP and PHP
 
 on:
-  pull_request
+  pull_request:
+  # Also run on a schedule so WC beta and WP nightly breakage is caught in quiet weeks
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
 
 env:
   WC_MIN_SUPPORTED_VERSION: '7.6.0'

--- a/changelog/add-wp-nightly-compatibility-job
+++ b/changelog/add-wp-nightly-compatibility-job
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Run the PHP test suite against WordPress nightly in the compatibility workflow, to catch breaking WordPress changes before they are released.

--- a/changelog/add-wp-nightly-compatibility-job
+++ b/changelog/add-wp-nightly-compatibility-job
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Run the PHP test suite against WordPress nightly in the compatibility workflow, to catch breaking WordPress changes before they are released.
+Run the PHP test suite against WordPress nightly in the compatibility workflow.

--- a/docs/test-matrix.md
+++ b/docs/test-matrix.md
@@ -33,7 +33,7 @@ All test suites, CI workflows, and release processes are owned and maintained by
 | 15 | [ESLint + CSS Lint](#15-eslint--css-lint) | Linting | WooPayments | PR, merge_group | Yes | No |
 | 16 | [TypeScript](#16-typescript) | Type Checking | WooPayments | PR, merge_group | Yes | No |
 | 17 | [PHP Compatibility](#17-php-compatibility) | Compatibility | WooPayments | PR | Yes | No |
-| 18 | [WC/WP Compatibility](#18-wcwp-compatibility) | Compatibility | WooPayments | PR | Partial | No |
+| 18 | [WC/WP Compatibility](#18-wcwp-compatibility) | Compatibility | WooPayments | PR, daily schedule | Partial | No |
 | 19 | [Changelog Check](#19-changelog-check) | Process | WooPayments | PR (develop, release/*) | Yes | No |
 | 20 | [Bundle Size](#20-bundle-size) | Performance | WooPayments | PR | Yes | No |
 | | **Release Testing** | | | | | |
@@ -414,8 +414,8 @@ Validates PHP version compatibility using `bin/phpcs-compat.sh`.
 |-------|-------|
 | **Category** | Compatibility |
 | **CI Workflow** | `compatibility.yml` |
-| **Trigger** | `pull_request` |
-| **Required** | Partial (main matrix required, beta allowed to fail) |
+| **Trigger** | `pull_request`, daily `schedule`, `workflow_dispatch` |
+| **Required** | Partial (main matrix required, beta and WP nightly allowed to fail) |
 | **Status** | Active |
 
 **Main matrix (required):**
@@ -427,6 +427,8 @@ Validates PHP version compatibility using `bin/phpcs-compat.sh`.
 | 7.6.0 | 6.0 | 13.6.0 | 7.4 |
 
 **Beta matrix (allowed to fail):** WC beta x PHP 7.4, 8.0, 8.1.
+
+**WP nightly (allowed to fail):** WC latest x WP nightly x PHP 7.4.
 
 ---
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The compatibility workflow tests the current stable and minimum supported WordPress versions, so nothing runs against a WordPress release before it ships. The WP 7.1 widget factory change that broke the Multi-Currency switcher (#12053) was caught by manual RC testing rather than CI, even though an existing unit test fails under WP 7.1 with the old code.

- Add a dedicated `Environment - WP nightly` job that runs the PHP test suite against the WordPress nightly build on every PR, mirroring the existing WC beta job.
- The job is not a required check, matching how the WC beta job is treated.

`bin/install-wp-tests.sh` already supports `WP_VERSION=nightly`, so no script changes are needed.

#### Testing instructions

1. Check the `Environment - WP nightly` job in this PR's checks. It should install WordPress nightly and run the full PHP suite.
2. Confirm the existing compatibility jobs still pass unchanged.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
