### PR TITLE
fix(e2e): find the Action Scheduler Run link on WordPress 7.1

### DIFF
--- a/changelog/fix-e2e-action-scheduler-run-selector-wp71
+++ b/changelog/fix-e2e-action-scheduler-run-selector-wp71
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix the E2E Action Scheduler helper so it finds the Run link on WordPress 7.1.

--- a/tests/e2e/utils/merchant.ts
+++ b/tests/e2e/utils/merchant.ts
@@ -431,8 +431,9 @@ export const disablePaymentMethods = async (
 
 export const ensureOrderIsProcessed = async ( page: Page, orderId: string ) => {
 	await navigation.goToActionScheduler( page, 'pending', orderId );
+	// The hook cell is a td before WP 7.1 and a th from WP 7.1, so match it by class.
 	await page.$eval(
-		'td:has-text("wc-admin_import_orders") a:has-text("Run")',
+		'.column-hook:has-text("wc-admin_import_orders") a:has-text("Run")',
 		( el: HTMLLinkElement ) => el.click()
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Every `WC 7.7.0 | merchant` job in the E2E Tests - All workflow has failed since WordPress 7.1 was released on 19 August. WP 7.1 changed `WP_List_Table` to render the primary column as a `<th scope="row">` cell instead of a `<td>`, so the `td:has-text(...)` selector in `ensureOrderIsProcessed` no longer finds the Action Scheduler "Run" link.

- Match the hook cell by its `column-hook` class instead of the element tag, which works on both the old and new markup.

Only `ensureOrderIsProcessed` used a `td`-based selector; I checked the rest of the suite for the same pattern.

#### Testing instructions

1. Verified against real Action Scheduler admin pages from WP 7.0.2 and WP 7.1 (WC 7.7.0 + Action Scheduler 4.1.0): the old selector matches on 7.0.2 only, the new one matches exactly one element on both.
2. After merge, check the `WC - 7.7.0 | PHP - 7.4 | wcpay - merchant` job in the next scheduled E2E Tests - All run goes green.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
