### PR TITLE
Stop Multi-Currency overriding third-party currency switchers when it is idle or disabled

### DIFF
--- a/changelog/fix-12060-multi-currency-respect-third-party-currency-filters
+++ b/changelog/fix-12060-multi-currency-respect-third-party-currency-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop Multi-Currency from overriding the currency selected by a third-party currency switcher while it has nothing to switch, and keep the module inert when the feature is disabled

--- a/includes/compat/multi-currency/wc-payments-multi-currency.php
+++ b/includes/compat/multi-currency/wc-payments-multi-currency.php
@@ -24,12 +24,16 @@ function wcpay_multi_currency_onboarding_check() {
 	return $is_setup_page;
 }
 
-if ( ! WC_Payments_Features::is_customer_multi_currency_enabled() && ! wcpay_multi_currency_onboarding_check() ) {
-	return;
-}
-
 /**
  * Returns the MultiCurrency singleton.
+ *
+ * This function is declared unconditionally, on purpose: PHP hoists top-level function declarations
+ * at compile time, so the early `return` below never prevented it from existing, and callers across
+ * the plugin and in third-party code — including `MultiCurrency::instance()`, which delegates here —
+ * rely on it being available whether or not the feature is enabled. When the module is disabled
+ * (see `MultiCurrency::is_enabled()`), the instance is inert: it registers no hooks, and
+ * `MultiCurrency::init()` refuses to initialize, so its getters return empty collections and the
+ * store currency.
  *
  * @return WCPay\MultiCurrency\MultiCurrency
  */
@@ -44,10 +48,17 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 			WC_Payments::get_localization_service(),
 			WC_Payments::get_database_cache()
 		);
-		$instance->init_hooks();
+
+		if ( WCPay\MultiCurrency\MultiCurrency::is_enabled() ) {
+			$instance->init_hooks();
+		}
 	}
 
 	return $instance;
+}
+
+if ( ! WCPay\MultiCurrency\MultiCurrency::is_enabled() ) {
+	return;
 }
 
 add_action( 'plugins_loaded', 'WC_Payments_Multi_Currency', 12 );

--- a/includes/compat/multi-currency/wc-payments-multi-currency.php
+++ b/includes/compat/multi-currency/wc-payments-multi-currency.php
@@ -57,7 +57,11 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 	return $instance;
 }
 
-if ( ! WCPay\MultiCurrency\MultiCurrency::is_enabled() ) {
+// Deliberately class-free: this file is included on every request of every store, and referencing
+// MultiCurrency here would autoload it even where the feature is off, fataling during an old/new file
+// mix while a manual update is in progress. This is the same predicate as MultiCurrency::is_enabled();
+// keep the two in sync.
+if ( ! WC_Payments_Features::is_customer_multi_currency_enabled() && ! wcpay_multi_currency_onboarding_check() ) {
 	return;
 }
 

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -186,16 +186,34 @@ class FrontendCurrencies {
 	/**
 	 * Returns the currency code to be used by WooCommerce.
 	 *
+	 * Runs on the `woocommerce_currency` filter at priority 900, after WooCommerce and any other
+	 * plugin filtering the currency. Multi-Currency only asserts its own currency when it is actually
+	 * switching, i.e. when the selected currency differs from the store currency. When it is idle —
+	 * including when a compatibility rule asks for the store currency — it leaves the value produced by
+	 * the earlier filters untouched, so a third-party currency switcher that hooks at a lower priority
+	 * keeps working alongside an idle Multi-Currency module. Every other formatting filter in this class
+	 * already follows the same rule by comparing against the store currency before overriding.
+	 *
+	 * @param string $currency The currency code produced by the filter chain so far. Defaults to empty
+	 *                         for direct calls, in which case the store currency is used as the fallback.
+	 *
 	 * @return string The code of the currency to be used.
 	 */
-	public function get_woocommerce_currency(): string {
+	public function get_woocommerce_currency( $currency = '' ): string {
+		$filtered_currency = is_string( $currency ) && '' !== $currency ? $currency : $this->get_store_currency()->get_code();
+
 		if ( $this->compatibility->should_return_store_currency() ) {
-			return $this->get_store_currency()->get_code();
+			return $filtered_currency;
 		}
 
 		if ( empty( $this->woocommerce_currency ) ) {
 			$this->woocommerce_currency = $this->get_selected_currency_code();
 		}
+
+		if ( $this->woocommerce_currency === $this->get_store_currency()->get_code() ) {
+			return $filtered_currency;
+		}
+
 		return $this->woocommerce_currency;
 	}
 

--- a/includes/multi-currency/FrontendCurrencies.php
+++ b/includes/multi-currency/FrontendCurrencies.php
@@ -66,6 +66,13 @@ class FrontendCurrencies {
 	private $woocommerce_currency;
 
 	/**
+	 * Whether WooPayments has an explicit shopper or compatibility currency selection.
+	 *
+	 * @var bool|null
+	 */
+	private $has_explicit_currency_selection;
+
+	/**
 	 * Price Decimal Separator cache.
 	 *
 	 * @var array
@@ -132,10 +139,11 @@ class FrontendCurrencies {
 	 * @return void
 	 */
 	public function selected_currency_changed() {
-		$this->selected_currency_code   = null;
-		$this->price_decimal_separators = [];
-		$this->woocommerce_currency     = null;
-		$this->store_currency           = null;
+		$this->selected_currency_code          = null;
+		$this->price_decimal_separators        = [];
+		$this->woocommerce_currency            = null;
+		$this->has_explicit_currency_selection = null;
+		$this->store_currency                  = null;
 	}
 
 	/**
@@ -187,31 +195,35 @@ class FrontendCurrencies {
 	 * Returns the currency code to be used by WooCommerce.
 	 *
 	 * Runs on the `woocommerce_currency` filter at priority 900, after WooCommerce and any other
-	 * plugin filtering the currency. Multi-Currency only asserts its own currency when it is actually
-	 * switching, i.e. when the selected currency differs from the store currency. When it is idle —
-	 * including when a compatibility rule asks for the store currency — it leaves the value produced by
-	 * the earlier filters untouched, so a third-party currency switcher that hooks at a lower priority
-	 * keeps working alongside an idle Multi-Currency module. Every other formatting filter in this class
-	 * already follows the same rule by comparing against the store currency before overriding.
+	 * plugin filtering the currency. Multi-Currency only asserts its own currency when the shopper
+	 * or a compatibility rule has an explicit selection. When it is idle, it leaves the value
+	 * produced by the earlier filters untouched, so a third-party currency switcher that hooks at a
+	 * lower priority keeps working alongside an idle Multi-Currency module.
 	 *
-	 * @param string $currency The currency code produced by the filter chain so far. Defaults to empty
-	 *                         for direct calls, in which case the store currency is used as the fallback.
+	 * The WordPress filter supplies its current currency as an undeclared argument.
+	 * Reading it at runtime keeps the public zero-argument signature compatible with subclasses.
 	 *
 	 * @return string The code of the currency to be used.
 	 */
-	public function get_woocommerce_currency( $currency = '' ): string {
-		$filtered_currency = is_string( $currency ) && '' !== $currency ? $currency : $this->get_store_currency()->get_code();
+	public function get_woocommerce_currency(): string {
+		$currency = func_num_args() > 0 ? func_get_arg( 0 ) : '';
 
 		if ( $this->compatibility->should_return_store_currency() ) {
-			return $filtered_currency;
+			return $this->get_store_currency()->get_code();
 		}
 
 		if ( empty( $this->woocommerce_currency ) ) {
-			$this->woocommerce_currency = $this->get_selected_currency_code();
+			$explicit_currency                     = $this->multi_currency->get_explicit_selected_currency();
+			$this->has_explicit_currency_selection = null !== $explicit_currency;
+			$this->woocommerce_currency            = ( $explicit_currency ?? $this->get_store_currency() )->get_code();
 		}
 
-		if ( $this->woocommerce_currency === $this->get_store_currency()->get_code() ) {
-			return $filtered_currency;
+		if (
+			false === $this->has_explicit_currency_selection
+			&& is_string( $currency )
+			&& '' !== $currency
+		) {
+			return $currency;
 		}
 
 		return $this->woocommerce_currency;

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -381,9 +381,8 @@ class MultiCurrency {
 		$user_settings = new UserSettings( $this );
 		new Analytics( $this, $this->settings_service );
 
-		$this->frontend_prices     = new FrontendPrices( $this, $this->compatibility );
-		$this->frontend_currencies = new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );
-		$this->tracking            = new Tracking( $this );
+		$this->build_frontend_objects();
+		$this->tracking = new Tracking( $this );
 
 		// Init all the hooks.
 		$admin_notices->init_hooks();
@@ -1859,8 +1858,8 @@ class MultiCurrency {
 	 * Used when init() must not proceed, so lazy-initializing getters and later init-hook
 	 * callbacks neither re-trigger init() nor fatal. default_currency is assigned so
 	 * get_default_currency() short-circuits. The frontend price and currency objects are
-	 * constructed without their hooks (and not replaced if they already exist), because
-	 * get_frontend_prices() and get_frontend_currencies() have non-nullable return types.
+	 * constructed without their hooks, because get_frontend_prices() and
+	 * get_frontend_currencies() have non-nullable return types.
 	 *
 	 * @return void
 	 */
@@ -1868,8 +1867,20 @@ class MultiCurrency {
 		$this->available_currencies = [];
 		$this->enabled_currencies   = [];
 		$this->default_currency     = new Currency( $this->localization_service, $this->get_store_currency_code() );
-		$this->frontend_prices      = $this->frontend_prices ?? new FrontendPrices( $this, $this->compatibility );
-		$this->frontend_currencies  = $this->frontend_currencies ?? new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );
+		$this->build_frontend_objects();
+	}
+
+	/**
+	 * Constructs the frontend price and currency objects, without registering their hooks.
+	 *
+	 * Shared by the full initialization and the inert state so the two cannot drift. Objects that
+	 * already exist are kept: callers may be holding a reference obtained through the getters.
+	 *
+	 * @return void
+	 */
+	private function build_frontend_objects() {
+		$this->frontend_prices     = $this->frontend_prices ?? new FrontendPrices( $this, $this->compatibility );
+		$this->frontend_currencies = $this->frontend_currencies ?? new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -202,6 +202,15 @@ class MultiCurrency {
 	 */
 	protected $simulation_params = [];
 
+	/**
+	 * Whether init() has already run for this instance.
+	 *
+	 * Separate from the static $is_initialized, which reports whether Multi-Currency is running
+	 * and is shared by every instance in the process. This one guards re-entry per instance.
+	 *
+	 * @var bool
+	 */
+	private $init_ran = false;
 
 	/**
 	 * Class constructor.
@@ -318,6 +327,15 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function init() {
+		// init() runs on the `init` action and lazily from the getters below. A caller that reaches
+		// a getter before `init` fires would otherwise initialize twice, leaving two sets of price
+		// and currency objects hooked at the same priority.
+		if ( $this->init_ran ) {
+			return;
+		}
+
+		$this->init_ran = true;
+
 		// The lazy-initializing getters call init() on demand, and any code path can reach them through
 		// WC_Payments_Multi_Currency() regardless of the feature flag. Refuse to initialize when the module
 		// is disabled, so a disabled module never registers the frontend currency and price hooks.
@@ -827,19 +845,32 @@ class MultiCurrency {
 	}
 
 	/**
+	 * Gets an explicit shopper or compatibility currency selection, if one exists.
+	 *
+	 * Unlike get_selected_currency(), this does not fall back to the store currency. Null means
+	 * Multi-Currency has nothing of its own to assert, so a third-party `woocommerce_currency`
+	 * filter should be left alone.
+	 *
+	 * @return Currency|null
+	 */
+	public function get_explicit_selected_currency(): ?Currency {
+		$multi_currency_code = $this->compatibility->override_selected_currency();
+		$currency_code       = $multi_currency_code ? $multi_currency_code : $this->get_stored_currency_code();
+
+		if ( null === $currency_code || '' === $currency_code ) {
+			return null;
+		}
+
+		return $this->get_enabled_currencies()[ $currency_code ] ?? null;
+	}
+
+	/**
 	 * Gets the user selected currency, or `$default_currency` if is not set.
 	 *
 	 * @return Currency
 	 */
 	public function get_selected_currency(): Currency {
-		$multi_currency_code = $this->compatibility->override_selected_currency();
-		$currency_code       = $multi_currency_code ? $multi_currency_code : $this->get_stored_currency_code();
-
-		if ( null === $currency_code ) {
-			return $this->get_default_currency();
-		}
-
-		return $this->get_enabled_currencies()[ $currency_code ] ?? $this->get_default_currency();
+		return $this->get_explicit_selected_currency() ?? $this->get_default_currency();
 	}
 
 	/**
@@ -1826,17 +1857,19 @@ class MultiCurrency {
 	 * returns a usable value.
 	 *
 	 * Used when init() must not proceed, so lazy-initializing getters and later init-hook
-	 * callbacks neither re-trigger init() nor fatal. The frontend price and currency objects are
-	 * still constructed, just without their hooks, because get_frontend_prices() and
-	 * get_frontend_currencies() have non-nullable return types and are reachable from any caller.
+	 * callbacks neither re-trigger init() nor fatal. default_currency is assigned so
+	 * get_default_currency() short-circuits. The frontend price and currency objects are
+	 * constructed without their hooks (and not replaced if they already exist), because
+	 * get_frontend_prices() and get_frontend_currencies() have non-nullable return types.
 	 *
 	 * @return void
 	 */
 	private function set_inert_state() {
 		$this->available_currencies = [];
 		$this->enabled_currencies   = [];
-		$this->frontend_prices      = new FrontendPrices( $this, $this->compatibility );
-		$this->frontend_currencies  = new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );
+		$this->default_currency     = new Currency( $this->localization_service, $this->get_store_currency_code() );
+		$this->frontend_prices      = $this->frontend_prices ?? new FrontendPrices( $this, $this->compatibility );
+		$this->frontend_currencies  = $this->frontend_currencies ?? new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -243,6 +243,25 @@ class MultiCurrency {
 	}
 
 	/**
+	 * Whether the Multi-Currency module may initialize on this request.
+	 *
+	 * True when the customer multi-currency feature is enabled, or when the merchant is going through the
+	 * Multi-Currency setup flow, which needs the module before the feature is switched on. Everything that
+	 * boots the module — the `plugins_loaded` bootstrap, the lazy-initializing getters, and direct callers of
+	 * `WC_Payments_Multi_Currency()` — must respect this, so a disabled module never registers hooks or
+	 * touches the currency, no matter who asks for it.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled(): bool {
+		if ( WC_Payments_Features::is_customer_multi_currency_enabled() ) {
+			return true;
+		}
+
+		return function_exists( 'wcpay_multi_currency_onboarding_check' ) && wcpay_multi_currency_onboarding_check();
+	}
+
+	/**
 	 * Initializes this class' WP hooks.
 	 *
 	 * @return void
@@ -299,6 +318,14 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function init() {
+		// The lazy-initializing getters call init() on demand, and any code path can reach them through
+		// WC_Payments_Multi_Currency() regardless of the feature flag. Refuse to initialize when the module
+		// is disabled, so a disabled module never registers the frontend currency and price hooks.
+		if ( ! static::is_enabled() ) {
+			$this->set_inert_state();
+			return;
+		}
+
 		// If the store currency is not in the list of available WooCommerce currencies
 		// (e.g. a custom currency was removed), bail out to avoid fatal errors.
 		// Multi-Currency cannot function without a valid base currency.
@@ -311,10 +338,7 @@ class MultiCurrency {
 					$store_currency
 				)
 			);
-			// Initialize properties to safe defaults so lazy-init getters and
-			// later init-hook callbacks don't re-trigger init() or fatal.
-			$this->available_currencies = [];
-			$this->enabled_currencies   = [];
+			$this->set_inert_state();
 			return;
 		}
 
@@ -540,6 +564,10 @@ class MultiCurrency {
 	 * @return FrontendPrices
 	 */
 	public function get_frontend_prices(): FrontendPrices {
+		if ( null === $this->frontend_prices ) {
+			$this->init();
+		}
+
 		return $this->frontend_prices;
 	}
 
@@ -549,6 +577,10 @@ class MultiCurrency {
 	 * @return FrontendCurrencies
 	 */
 	public function get_frontend_currencies(): FrontendCurrencies {
+		if ( null === $this->frontend_currencies ) {
+			$this->init();
+		}
+
 		return $this->frontend_currencies;
 	}
 
@@ -1787,6 +1819,24 @@ class MultiCurrency {
 	private function set_default_currency() {
 		$available_currencies   = $this->get_available_currencies();
 		$this->default_currency = $available_currencies[ $this->get_store_currency_code() ] ?? null;
+	}
+
+	/**
+	 * Puts the module into its inert state: no currencies, no hooks, but every getter still
+	 * returns a usable value.
+	 *
+	 * Used when init() must not proceed, so lazy-initializing getters and later init-hook
+	 * callbacks neither re-trigger init() nor fatal. The frontend price and currency objects are
+	 * still constructed, just without their hooks, because get_frontend_prices() and
+	 * get_frontend_currencies() have non-nullable return types and are reachable from any caller.
+	 *
+	 * @return void
+	 */
+	private function set_inert_state() {
+		$this->available_currencies = [];
+		$this->enabled_currencies   = [];
+		$this->frontend_prices      = new FrontendPrices( $this, $this->compatibility );
+		$this->frontend_currencies  = new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -850,17 +850,32 @@ class MultiCurrency {
 	 * Multi-Currency has nothing of its own to assert, so a third-party `woocommerce_currency`
 	 * filter should be left alone.
 	 *
+	 * A compatibility override always counts. A stored session or user-meta code only counts when
+	 * more than one currency is enabled: with a single currency nothing could have been selected,
+	 * so a stored code is stale state (an old `?currency=` link, meta from a time the store had more
+	 * currencies), not a choice to assert over other plugins' filters.
+	 *
 	 * @return Currency|null
 	 */
 	public function get_explicit_selected_currency(): ?Currency {
-		$multi_currency_code = $this->compatibility->override_selected_currency();
-		$currency_code       = $multi_currency_code ? $multi_currency_code : $this->get_stored_currency_code();
+		$enabled_currencies = $this->get_enabled_currencies();
+		$override_code      = $this->compatibility->override_selected_currency();
 
-		if ( null === $currency_code || '' === $currency_code ) {
+		if ( $override_code ) {
+			return $enabled_currencies[ $override_code ] ?? null;
+		}
+
+		if ( count( $enabled_currencies ) < 2 ) {
 			return null;
 		}
 
-		return $this->get_enabled_currencies()[ $currency_code ] ?? null;
+		$stored_code = $this->get_stored_currency_code();
+
+		if ( null === $stored_code || '' === $stored_code ) {
+			return null;
+		}
+
+		return $enabled_currencies[ $stored_code ] ?? null;
 	}
 
 	/**

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -151,6 +151,45 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WCPAY_UnitTestCase 
 		$this->assertSame( 'GBP', apply_filters( 'woocommerce_currency', 'USD' ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
 	}
 
+	public function test_get_woocommerce_currency_passes_through_a_second_filtered_currency_when_idle() {
+		$this->mock_multi_currency
+			->expects( $this->once() )
+			->method( 'get_explicit_selected_currency' )
+			->willReturn( null );
+		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
+
+		$this->assertSame( 'GBP', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
+		$this->assertSame( 'CAD', $this->frontend_currencies->get_woocommerce_currency( 'CAD' ) );
+	}
+
+	public function test_get_woocommerce_currency_reuses_an_explicit_selection_on_a_second_call() {
+		$this->mock_multi_currency
+			->expects( $this->once() )
+			->method( 'get_explicit_selected_currency' )
+			->willReturn( new Currency( $this->localization_service, Currency_Code::EURO ) );
+		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
+
+		$this->assertSame( 'EUR', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
+		$this->assertSame( 'EUR', $this->frontend_currencies->get_woocommerce_currency( 'CAD' ) );
+	}
+
+	public function test_get_woocommerce_currency_re_resolves_after_selected_currency_changed() {
+		$this->mock_multi_currency
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_explicit_selected_currency' )
+			->willReturnOnConsecutiveCalls(
+				new Currency( $this->localization_service, Currency_Code::EURO ),
+				new Currency( $this->localization_service, Currency_Code::POUND_STERLING )
+			);
+		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
+
+		$this->assertSame( 'EUR', $this->frontend_currencies->get_woocommerce_currency( 'USD' ) );
+
+		$this->frontend_currencies->selected_currency_changed();
+
+		$this->assertSame( 'GBP', $this->frontend_currencies->get_woocommerce_currency( 'USD' ) );
+	}
+
 	public function test_get_price_decimals_returns_num_decimals() {
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'BHD' ) );
 

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -119,6 +119,46 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WCPAY_UnitTestCase 
 		$this->assertSame( 'USD', $this->frontend_currencies->get_woocommerce_currency() );
 	}
 
+	public function test_get_woocommerce_currency_passes_through_filtered_currency_when_not_switching() {
+		// The selected currency is the store currency: Multi-Currency is idle and must leave the filter chain alone.
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'USD' ) );
+		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
+
+		$this->assertSame( 'GBP', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
+	}
+
+	public function test_get_woocommerce_currency_returns_store_currency_when_not_switching_and_nothing_was_filtered() {
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'USD' ) );
+		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
+
+		$this->assertSame( 'USD', $this->frontend_currencies->get_woocommerce_currency() );
+	}
+
+	public function test_get_woocommerce_currency_passes_through_filtered_currency_when_store_currency_is_requested() {
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'EUR' ) );
+		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( true );
+
+		$this->assertSame( 'GBP', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
+	}
+
+	public function test_get_woocommerce_currency_overrides_filtered_currency_when_switching() {
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'EUR' ) );
+		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
+
+		$this->assertSame( 'EUR', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
+	}
+
+	public function test_woocommerce_currency_filter_keeps_value_from_earlier_filters_when_not_switching() {
+		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'USD' ) );
+		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
+
+		// A third-party currency switcher hooked below Multi-Currency's priority.
+		add_filter( 'woocommerce_currency', fn() => 'GBP', 5 );
+
+		// Run the filter chain as WooCommerce does, starting from the store currency.
+		$this->assertSame( 'GBP', apply_filters( 'woocommerce_currency', 'USD' ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
+	}
+
 	public function test_get_price_decimals_returns_num_decimals() {
 		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'BHD' ) );
 

--- a/tests/unit/multi-currency/test-class-frontend-currencies.php
+++ b/tests/unit/multi-currency/test-class-frontend-currencies.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Constants\Currency_Code;
 use WCPay\MultiCurrency\Currency;
 use WCPay\MultiCurrency\Compatibility;
 use WCPay\MultiCurrency\FrontendCurrencies;
@@ -106,50 +107,41 @@ class WCPay_Multi_Currency_Frontend_Currencies_Tests extends WCPAY_UnitTestCase 
 	}
 
 	public function test_get_woocommerce_currency_returns_selected_currency() {
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'EUR' ) );
+		$this->mock_multi_currency->method( 'get_explicit_selected_currency' )->willReturn( new Currency( $this->localization_service, Currency_Code::EURO ) );
 		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
 
 		$this->assertSame( 'EUR', $this->frontend_currencies->get_woocommerce_currency() );
 	}
 
 	public function test_get_woocommerce_currency_returns_store_currency() {
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'EUR' ) );
 		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( true );
 
-		$this->assertSame( 'USD', $this->frontend_currencies->get_woocommerce_currency() );
+		$this->assertSame( 'USD', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
 	}
 
 	public function test_get_woocommerce_currency_passes_through_filtered_currency_when_not_switching() {
-		// The selected currency is the store currency: Multi-Currency is idle and must leave the filter chain alone.
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'USD' ) );
+		$this->mock_multi_currency->method( 'get_explicit_selected_currency' )->willReturn( null );
 		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
 
 		$this->assertSame( 'GBP', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
 	}
 
 	public function test_get_woocommerce_currency_returns_store_currency_when_not_switching_and_nothing_was_filtered() {
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'USD' ) );
+		$this->mock_multi_currency->method( 'get_explicit_selected_currency' )->willReturn( null );
 		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
 
 		$this->assertSame( 'USD', $this->frontend_currencies->get_woocommerce_currency() );
 	}
 
-	public function test_get_woocommerce_currency_passes_through_filtered_currency_when_store_currency_is_requested() {
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'EUR' ) );
-		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( true );
-
-		$this->assertSame( 'GBP', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
-	}
-
 	public function test_get_woocommerce_currency_overrides_filtered_currency_when_switching() {
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'EUR' ) );
+		$this->mock_multi_currency->method( 'get_explicit_selected_currency' )->willReturn( new Currency( $this->localization_service, Currency_Code::EURO ) );
 		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
 
 		$this->assertSame( 'EUR', $this->frontend_currencies->get_woocommerce_currency( 'GBP' ) );
 	}
 
 	public function test_woocommerce_currency_filter_keeps_value_from_earlier_filters_when_not_switching() {
-		$this->mock_multi_currency->method( 'get_selected_currency' )->willReturn( new Currency( $this->localization_service, 'USD' ) );
+		$this->mock_multi_currency->method( 'get_explicit_selected_currency' )->willReturn( null );
 		$this->mock_compatibility->method( 'should_return_store_currency' )->willReturn( false );
 
 		// A third-party currency switcher hooked below Multi-Currency's priority.

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\MultiCurrency\FrontendCurrencies;
+use WCPay\MultiCurrency\FrontendPrices;
 use WCPay\MultiCurrency\Utils;
 use WCPay\MultiCurrency\CachingEnvironment;
 use WCPay\MultiCurrency\Exceptions\InvalidCurrencyException;
@@ -158,6 +160,8 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		delete_option( 'wcpay_multi_currency_rendering_mode' );
 		delete_option( 'wcpay_multi_currency_cache_autodetect_done' );
 		delete_option( 'wcpay_multi_currency_cache_recommendation_dismissed' );
+		delete_option( '_wcpay_feature_customer_multi_currency' );
+		unset( $_SERVER['HTTP_REFERER'] );
 		delete_option( 'wcpay_multi_currency_store_currency' );
 
 		parent::tear_down();
@@ -1836,7 +1840,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		}
 	}
 
-	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true, $mock_account = null, $mock_cache = null, $mock_caching_environment = null ) {
+	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true, $mock_account = null, $mock_cache = null, $mock_caching_environment = null, $run_init = true ) {
 		$this->mock_api_client = $this->createMock( MultiCurrencyApiClientInterface::class );
 
 		$this->mock_account = $mock_account ?? $this->createMock( MultiCurrencyAccountInterface::class );
@@ -1861,7 +1865,9 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 			$mock_caching_environment
 		);
 		$this->multi_currency->init_widgets();
-		$this->multi_currency->init();
+		if ( $run_init ) {
+			$this->multi_currency->init();
+		}
 	}
 
 	private function add_mock_order_with_currency_meta( $currency ) {
@@ -1977,6 +1983,73 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 		$this->assertSame( [ 'USD' ], array_keys( $this->multi_currency->get_enabled_currencies() ) );
 		$this->assertSame( 'GBP', get_woocommerce_currency() );
+	}
+
+	public function test_init_does_not_initialize_when_feature_is_disabled() {
+		remove_all_filters( 'woocommerce_currency' );
+		update_option( '_wcpay_feature_customer_multi_currency', '0' );
+
+		$this->init_multi_currency();
+
+		$this->assertSame( [], $this->multi_currency->get_available_currencies() );
+		$this->assertSame( [], $this->multi_currency->get_enabled_currencies() );
+		$this->assertFalse( has_filter( 'woocommerce_currency' ) );
+	}
+
+	public function test_uninitialized_module_still_reports_store_currency_as_default_and_selected() {
+		update_option( '_wcpay_feature_customer_multi_currency', '0' );
+
+		$this->init_multi_currency();
+
+		$this->assertSame( 'USD', $this->multi_currency->get_default_currency()->get_code() );
+		$this->assertSame( 'USD', $this->multi_currency->get_selected_currency()->get_code() );
+	}
+
+	public function test_uninitialized_module_still_exposes_frontend_objects_without_their_hooks() {
+		remove_all_filters( 'woocommerce_currency' );
+		update_option( '_wcpay_feature_customer_multi_currency', '0' );
+
+		$this->init_multi_currency();
+
+		$this->assertInstanceOf( FrontendCurrencies::class, $this->multi_currency->get_frontend_currencies() );
+		$this->assertInstanceOf( FrontendPrices::class, $this->multi_currency->get_frontend_prices() );
+		$this->assertFalse( has_filter( 'woocommerce_currency' ) );
+	}
+
+	public function test_frontend_getters_initialize_a_disabled_module_on_first_use() {
+		remove_all_filters( 'woocommerce_currency' );
+		update_option( '_wcpay_feature_customer_multi_currency', '0' );
+
+		// Nothing has run init() yet: the getters must not return null into their non-nullable return types.
+		$this->init_multi_currency( null, true, null, null, null, false );
+
+		$this->assertInstanceOf( FrontendCurrencies::class, $this->multi_currency->get_frontend_currencies() );
+		$this->assertInstanceOf( FrontendPrices::class, $this->multi_currency->get_frontend_prices() );
+		$this->assertFalse( has_filter( 'woocommerce_currency' ) );
+	}
+
+	public function test_init_initializes_during_setup_when_feature_is_disabled() {
+		update_option( '_wcpay_feature_customer_multi_currency', '0' );
+		$_SERVER['HTTP_REFERER'] = admin_url( 'admin.php?page=wc-admin&path=%2Fpayments%2Fmulti-currency-setup' );
+
+		$this->init_multi_currency();
+
+		$this->assertNotEmpty( $this->multi_currency->get_enabled_currencies() );
+	}
+
+	public function test_is_enabled_follows_the_customer_multi_currency_feature_flag() {
+		update_option( '_wcpay_feature_customer_multi_currency', '0' );
+		$this->assertFalse( MultiCurrency::is_enabled() );
+
+		update_option( '_wcpay_feature_customer_multi_currency', '1' );
+		$this->assertTrue( MultiCurrency::is_enabled() );
+	}
+
+	public function test_is_enabled_is_true_during_setup_when_feature_is_disabled() {
+		update_option( '_wcpay_feature_customer_multi_currency', '0' );
+		$_SERVER['HTTP_REFERER'] = admin_url( 'admin.php?page=wc-admin&path=%2Fpayments%2Fmulti-currency-setup' );
+
+		$this->assertTrue( MultiCurrency::is_enabled() );
 	}
 
 	private function mock_theme( $theme ) {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -412,6 +412,24 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertNull( $this->multi_currency->get_explicit_selected_currency() );
 	}
 
+	public function test_get_explicit_selected_currency_ignores_stored_code_when_only_store_currency_is_enabled() {
+		// Not connected: only the store currency is enabled, so nothing could have been selected.
+		$this->init_multi_currency( null, false );
+		WC()->session->set( MultiCurrency::CURRENCY_SESSION_KEY, Currency_Code::UNITED_STATES_DOLLAR );
+
+		$this->assertSame( [ 'USD' ], array_keys( $this->multi_currency->get_enabled_currencies() ) );
+		$this->assertNull( $this->multi_currency->get_explicit_selected_currency() );
+	}
+
+	public function test_get_explicit_selected_currency_honours_stored_store_currency_with_two_enabled_currencies() {
+		update_option( self::ENABLED_CURRENCIES_OPTION, [ Currency_Code::UNITED_STATES_DOLLAR, Currency_Code::POUND_STERLING ] );
+		$this->init_multi_currency();
+		WC()->session->set( MultiCurrency::CURRENCY_SESSION_KEY, Currency_Code::UNITED_STATES_DOLLAR );
+
+		$this->assertSame( [ 'USD', 'GBP' ], array_keys( $this->multi_currency->get_enabled_currencies() ) );
+		$this->assertSame( 'USD', $this->multi_currency->get_explicit_selected_currency()->get_code() );
+	}
+
 	public function test_get_selected_currency_does_not_trigger_null_offset_deprecation_without_stored_currency() {
 		// Regression test for WOOPMNT-6238. With no currency stored for the user or
 		// session, the resolved currency code is null. Subscripting the enabled
@@ -2004,6 +2022,16 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		WC()->session->set( MultiCurrency::CURRENCY_SESSION_KEY, Currency_Code::UNITED_STATES_DOLLAR );
 
 		$this->assertSame( 'USD', get_woocommerce_currency() );
+	}
+
+	public function test_stored_store_currency_does_not_override_filtered_currency_when_only_store_currency_is_enabled() {
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => Currency_Code::POUND_STERLING, 5 );
+		// Not connected: a stored code on a one-currency store is stale state, not a shopper's choice.
+		$this->init_multi_currency( null, false );
+		WC()->session->set( MultiCurrency::CURRENCY_SESSION_KEY, Currency_Code::UNITED_STATES_DOLLAR );
+
+		$this->assertSame( 'GBP', get_woocommerce_currency() );
 	}
 
 	public function test_compatibility_store_currency_override_overrides_filtered_currency() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -5,6 +5,7 @@
  * @package WooCommerce\Payments\Tests
  */
 
+use WCPay\Constants\Currency_Code;
 use WCPay\MultiCurrency\FrontendCurrencies;
 use WCPay\MultiCurrency\FrontendPrices;
 use WCPay\MultiCurrency\Utils;
@@ -146,6 +147,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		WC()->session->__unset( MultiCurrency::CURRENCY_SESSION_KEY );
 		remove_all_filters( 'wcpay_multi_currency_apply_charm_only_to_products' );
 		remove_all_filters( 'wcpay_multi_currency_available_currencies' );
+		remove_all_filters( 'wcpay_multi_currency_override_selected_currency' );
 		remove_all_filters( 'woocommerce_currency' );
 		remove_all_filters( 'woocommerce_geolocate_ip' );
 		remove_all_filters( 'stylesheet' );
@@ -398,6 +400,16 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function test_get_selected_currency_returns_default_currency_for_empty_session_and_user() {
 		$this->assertSame( get_woocommerce_currency(), $this->multi_currency->get_selected_currency()->get_code() );
+	}
+
+	public function test_get_explicit_selected_currency_returns_null_for_empty_session_and_user() {
+		$this->assertNull( $this->multi_currency->get_explicit_selected_currency() );
+	}
+
+	public function test_get_explicit_selected_currency_returns_null_for_invalid_session_currency() {
+		WC()->session->set( MultiCurrency::CURRENCY_SESSION_KEY, 'UNSUPPORTED_CURRENCY' );
+
+		$this->assertNull( $this->multi_currency->get_explicit_selected_currency() );
 	}
 
 	public function test_get_selected_currency_does_not_trigger_null_offset_deprecation_without_stored_currency() {
@@ -1985,6 +1997,34 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertSame( 'GBP', get_woocommerce_currency() );
 	}
 
+	public function test_explicit_store_currency_selection_overrides_filtered_currency() {
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => Currency_Code::POUND_STERLING, 5 );
+		$this->init_multi_currency();
+		WC()->session->set( MultiCurrency::CURRENCY_SESSION_KEY, Currency_Code::UNITED_STATES_DOLLAR );
+
+		$this->assertSame( 'USD', get_woocommerce_currency() );
+	}
+
+	public function test_compatibility_store_currency_override_overrides_filtered_currency() {
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => Currency_Code::POUND_STERLING, 5 );
+		add_filter( 'wcpay_multi_currency_override_selected_currency', fn() => Currency_Code::UNITED_STATES_DOLLAR );
+		$this->init_multi_currency();
+
+		$this->assertSame( 'USD', get_woocommerce_currency() );
+	}
+
+	public function test_filtered_woocommerce_currency_survives_empty_logged_in_user_selection() {
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => Currency_Code::POUND_STERLING, 5 );
+		wp_set_current_user( self::LOGGED_IN_USER_ID );
+		delete_user_meta( self::LOGGED_IN_USER_ID, MultiCurrency::CURRENCY_META_KEY );
+		$this->init_multi_currency();
+
+		$this->assertSame( 'GBP', get_woocommerce_currency() );
+	}
+
 	public function test_init_does_not_initialize_when_feature_is_disabled() {
 		remove_all_filters( 'woocommerce_currency' );
 		update_option( '_wcpay_feature_customer_multi_currency', '0' );
@@ -2014,6 +2054,21 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertInstanceOf( FrontendCurrencies::class, $this->multi_currency->get_frontend_currencies() );
 		$this->assertInstanceOf( FrontendPrices::class, $this->multi_currency->get_frontend_prices() );
 		$this->assertFalse( has_filter( 'woocommerce_currency' ) );
+	}
+
+	public function test_get_default_currency_on_disabled_module_does_not_rebuild_frontend_objects() {
+		update_option( '_wcpay_feature_customer_multi_currency', '0' );
+
+		$this->init_multi_currency();
+
+		$frontend_currencies = $this->multi_currency->get_frontend_currencies();
+		$frontend_prices     = $this->multi_currency->get_frontend_prices();
+
+		$this->multi_currency->get_default_currency();
+		$this->multi_currency->get_default_currency();
+
+		$this->assertSame( $frontend_currencies, $this->multi_currency->get_frontend_currencies() );
+		$this->assertSame( $frontend_prices, $this->multi_currency->get_frontend_prices() );
 	}
 
 	public function test_frontend_getters_initialize_a_disabled_module_on_first_use() {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -1967,6 +1967,18 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		update_option( 'woocommerce_currency', 'USD' );
 	}
 
+	public function test_filtered_woocommerce_currency_survives_when_only_store_currency_is_enabled() {
+		remove_all_filters( 'woocommerce_currency' );
+		// A third-party currency switcher picks the visitor currency at a low priority.
+		add_filter( 'woocommerce_currency', fn() => 'GBP', 5 );
+
+		// Not connected: Multi-Currency has only the store currency available, so it has nothing to switch.
+		$this->init_multi_currency( null, false );
+
+		$this->assertSame( [ 'USD' ], array_keys( $this->multi_currency->get_enabled_currencies() ) );
+		$this->assertSame( 'GBP', get_woocommerce_currency() );
+	}
+
 	private function mock_theme( $theme ) {
 		add_filter(
 			'stylesheet',


### PR DESCRIPTION
Fixes #12060

#### Changes proposed in this Pull Request

Since 11.0, stores that use a third-party currency switcher alongside WooPayments can show a shopper an amount converted by that switcher but labelled — and then charged — in the store currency. The reporter's example: a 90 EUR product switched to CAD displays as CAD 117, and the order goes through as 117 EUR.

**What is actually going on.** `FrontendCurrencies::get_woocommerce_currency()` runs on the `woocommerce_currency` filter at priority 900, took no argument, and returned Multi-Currency's own selected currency regardless of what earlier filters had produced — even when Multi-Currency had only the store currency enabled and nothing to switch. That has been true for years, but it was invisible: Multi-Currency derived its own base currency from the already-filtered `get_woocommerce_currency()`, so it echoed the third-party currency straight back. #11902 correctly re-pinned the base currency to the raw `woocommerce_currency` option (a visitor switching currency must not rewrite the store's base-currency option and invalidate the shared rate cache). The echo stopped, and the pre-existing override became a money bug. It only bites switchers hooked below priority 900 — the Aelia Currency Switcher filters at priority 5; FOX Currency Switcher and WPExperts' WC Currency Switcher hook at 9999 and were never affected.

Two things let that reach merchants who never opted into WooPayments Multi-Currency. The feature has been on by default since it went GA in #2552 — that is unchanged here and not a regression; it is a product question, not a bug fix. And the "feature disabled → `return`" guard in `wc-payments-multi-currency.php` never prevented `WC_Payments_Multi_Currency()` from being declared, because PHP hoists top-level function declarations at compile time. Any caller — `Fraud_Risk_Tools::get_formatted_converted_amount()`, `WC_Payments_Order_Service::get_order_amount()`, or third-party code using `MultiCurrency::instance()` — constructed the module, and the first lazy getter ran `init()` in full and registered the frontend hooks with the setting explicitly off. That is why the reporter's merchants saw the bug with the Multi-Currency checkbox unticked.

**The fix, #11902 untouched:**

- `FrontendCurrencies::get_woocommerce_currency()` now reads the filter's incoming value (via `func_get_arg`, so the declared signature is unchanged and subclass overrides keep working on PHP 8) and only overrides it when Multi-Currency has an **explicit selection** of its own: a compatibility override, or a stored session/user-meta currency validated against the enabled currencies — resolved by the new `MultiCurrency::get_explicit_selected_currency()`. With no explicit selection it passes the earlier filters' value through: that value is the chain *without* Multi-Currency. The `should_return_store_currency()` branch keeps returning the store currency, as its public contract documents (FedEx, UPS and the non-Store-API REST default all produce that flag). A stored selection only counts when more than one currency is enabled: on a single-currency store nothing could have been selected, so a stale `?currency=` link or leftover user meta is state, not a choice, and must not re-arm the override on exactly the stores this fixes. Every other formatting filter in the class already compares against the store currency before overriding; this brings the currency filter in line with them. (f737817c1, 9e6d585ca, 02d8e5086)
- `MultiCurrency::is_enabled()` — true when the feature flag is on or the merchant is on the Multi-Currency setup flow, which needs the module before the flag is switched on. `init()` refuses to initialize when it is false (and is now guarded against re-entry per instance) and puts the module into an inert state — empty currency collections, a store-currency default, the frontend objects constructed without their hooks — the same shape the existing invalid-store-currency bail-out uses, so lazy getters, `is_initialized()`-guarded callers and the unguarded callers above all keep working. `get_frontend_prices()` / `get_frontend_currencies()` lazily call `init()` like their siblings — on a disabled store nothing else triggered it, so reaching them first was a `TypeError`. The factory still returns an instance but no longer registers hooks when disabled, and its declaration now sits above the early `return` with a docblock saying why — the code now says what PHP was doing all along. The file-scope guard stays class-free on purpose: the file loads on every request, and autoloading `MultiCurrency` there would fatal during an old/new file mix mid-update. (082340891, 79f718bec, 6f642fad1)

**Alternative considered.** Gating `frontend_prices`/`frontend_currencies` hook registration on `has_additional_currencies_enabled()` also fixes the reported case, but it drops per-order currency formatting for historical orders in since-disabled currencies, does not fix the connected-account case where Multi-Currency is enabled but idle, and is defeated on exactly the affected stores: unticking the checkbox writes the feature flag to `0` but leaves `wcpay_multi_currency_enabled_currencies` populated.

**Not addressed, deliberately.** Two switchers both actively converting (WooPayments MC switched to GBP *and* Aelia switched to GBP) still double-convert; that configuration cannot be made coherent from this side. The default-on feature flag is left as is. Two residual cases are unchanged from `develop` and documented in the blast-radius comment below: a non-Store-API REST request without an admin referer that carries a third-party switcher's session still gets the store currency (the REST default-to-store-currency override), and on a genuinely multi-currency store a shopper who explicitly picks the store currency in WooPayments still overrides another switcher (by design — that store runs two switchers on purpose).

**Backward-compatibility impact.** `FrontendCurrencies::get_woocommerce_currency()` keeps its exact signature (`(): string`); it reads the filter argument at runtime, so subclasses that override it are unaffected and direct zero-argument callers get the previous return values. `MultiCurrency::is_enabled()` and `MultiCurrency::get_explicit_selected_currency()` are new public API; `get_selected_currency()` returns exactly what it did before. `WC_Payments_Multi_Currency()` and `MultiCurrency::instance()` still always return an instance; when the feature is off it no longer initializes or registers hooks, but `get_frontend_currencies()` / `get_frontend_prices()` now lazily initialize like the other getters and return their objects (hook-less), so nothing that dereferences them on a disabled store fatals — before this PR that was a `TypeError` whenever they were the first getter called — code that relied on a disabled module initializing anyway was relying on the bug. Behaviour change: an idle Multi-Currency no longer forces the store currency over other `woocommerce_currency` filters, and a stored selection on a single-currency store no longer counts; stores without another switcher see no difference because the incoming value there *is* the store currency. The `wcpay_multi_currency_should_return_store_currency` and `wcpay_multi_currency_override_selected_currency` filters keep their documented meaning. No hooks, REST routes, option keys or stored meta change.

#### Testing instructions

Unit tests — 24 new tests, all watched fail before the fix:

* `docker compose exec -u www-data wordpress bash -c "cd /var/www/html/wp-content/plugins/woocommerce-payments && vendor/bin/phpunit --configuration phpunit.xml.dist --filter 'WCPay_Multi_Currency_Frontend_Currencies_Tests|WCPay_Multi_Currency_Tests'"`

Manual — the reported scenario, without needing a real switcher. Store currency USD, a simple product priced $18.00, WooPayments installed and **not** connected, Multi-Currency setting left untouched (defaults to enabled).

- Add a temporary MU plugin that plays a third-party switcher hooked below priority 900 and converts the price, e.g. `wp-content/mu-plugins/fake-switcher.php`:
  ```php
  <?php
  add_filter( 'woocommerce_currency', fn() => 'GBP', 5 );
  add_filter( 'woocommerce_product_get_price', fn( $price ) => $price * 0.75, 5 );
  ```
- Open the product page on the storefront.
- [ ] Before this PR: the price reads **$13.50** — the GBP amount with the USD symbol. With this PR: **£13.50**.
- Add the product to the cart and check `GET /wp-json/wc/store/v1/cart`.
- [ ] Before: `currency_code` is `USD`. After: `GBP`.
- Place an order with an offline gateway (e.g. Cash on delivery).
- [ ] Before: the order is created in USD for 13.50. After: GBP 13.50.

Manual — feature explicitly disabled, module booted by a caller (the path the reporter's merchants hit):

- Keep the MU plugin above. Disable Multi-Currency: WooPayments → Settings → Advanced settings → untick "Enable Multi-Currency", or `wp option update _wcpay_feature_customer_multi_currency 0`. Then append to the MU plugin:
  ```php
  add_action( 'plugins_loaded', fn() => WC_Payments_Multi_Currency()->get_enabled_currencies(), 20 );
  ```
- Reload the product page.
- [ ] Before this PR: **$13.50** again — the disabled module initialized and re-registered its priority-900 filter. After: **£13.50**.

Manual — a stale selection on a single-currency store does not re-arm the override:

- Back to the first setup (feature enabled, not connected), MU plugin from the first step in place. Visit `/?currency=USD` once (WooPayments stores it in the session), then reload the product page.
- [ ] Before `02d8e5086`: **$13.50**. After: **£13.50**.

Manual — genuine Multi-Currency switching is unchanged:

- Remove the MU plugin, connect a test account, enable Multi-Currency with GBP as an extra currency (manual rate, e.g. 0.5), and switch with `?currency=GBP`.
- [ ] The product shows **£9.00**, exactly as before this PR.

Verified locally against the real plugins as well — full matrix (pre-#11902 / `develop` / this branch × nine scenarios, storefront, Store API, REST, FedEx and UPS backtraces) in [this comment](https://github.com/Automattic/woocommerce-payments/pull/12066#issuecomment-5439336867): Aelia Currency Switcher 5.3.5 (priority 5 — was broken, now fixed), FOX Currency Switcher 2.5.1 and WPExperts' WC Currency Switcher 2.0.5 (priority 9999 — unaffected before and after), FedEx 4.7.1 and UPS 3.9.13 (the store-currency compatibility branch is what Aelia's own shipping-rate conversion expects), USPS, Royal Mail, Canada Post and Australia Post (out of the blast radius).

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

