### PR TITLE
Keep Multi-Currency inert until it is enabled or WooPayments is configured

### DIFF
--- a/changelog/fix-12060-multi-currency-inert-when-unconfigured
+++ b/changelog/fix-12060-multi-currency-inert-when-unconfigured
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep Multi-Currency inert until the merchant turns it on or configures WooPayments, so it no longer overrides the currency chosen by a third-party currency switcher on an unconfigured store

--- a/includes/class-wc-payments-features.php
+++ b/includes/class-wc-payments-features.php
@@ -34,6 +34,7 @@ class WC_Payments_Features {
 	const AMAZON_PAY_FLAG_NAME                                = '_wcpay_feature_amazon_pay';
 	const MC_CACHE_OPTIMIZED_FLAG_NAME                        = '_wcpay_feature_mc_cache_optimized';
 	const REPORTS_AREA_FLAG_NAME                              = '_wcpay_feature_reports_area';
+	const CUSTOMER_MULTI_CURRENCY_FLAG_NAME                   = '_wcpay_feature_customer_multi_currency';
 
 	/**
 	 * Indicates whether card payments are enabled for this (Stripe) account.
@@ -65,7 +66,29 @@ class WC_Payments_Features {
 	 * @return bool
 	 */
 	public static function is_customer_multi_currency_enabled() {
-		return '1' === get_option( '_wcpay_feature_customer_multi_currency', '1' );
+		return '1' === get_option( self::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '1' );
+	}
+
+	/**
+	 * Returns the customer Multi-Currency preference the merchant saved, if they ever saved one.
+	 *
+	 * `is_customer_multi_currency_enabled()` collapses "never saved" into "enabled", because the
+	 * feature is on by default. Callers that have to tell a saved preference apart from that default
+	 * need the raw three-state value. The option is written in exactly one place — the settings REST
+	 * controller, see `WC_REST_Payments_Settings_Controller::update_is_multi_currency_enabled()` —
+	 * and only ever as '1' or '0', so an absent option reliably means the merchant never saved it.
+	 *
+	 * Note that the settings page posts its whole payload, so saving any unrelated WooPayments
+	 * setting writes this option with whatever value was on screen. A stored '1' therefore records
+	 * that the merchant saved settings while the feature was on; it is not proof of a deliberate
+	 * opt-in.
+	 *
+	 * @return bool|null True or false when the merchant saved the setting, null when they never did.
+	 */
+	public static function get_saved_customer_multi_currency_preference() {
+		$saved_value = get_option( self::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, null );
+
+		return null === $saved_value ? null : '1' === $saved_value;
 	}
 
 	/**

--- a/includes/compat/multi-currency/wc-payments-multi-currency.php
+++ b/includes/compat/multi-currency/wc-payments-multi-currency.php
@@ -27,16 +27,14 @@ function wcpay_multi_currency_onboarding_check() {
 /**
  * Returns the MultiCurrency singleton.
  *
- * Declared unconditionally, on purpose. PHP hoists top-level function declarations at compile time,
- * so the early `return` below never prevented this function from existing, and callers across the
- * plugin and in third-party code — including `MultiCurrency::instance()`, which delegates here —
- * rely on it being available whether or not the module is active.
+ * Declared unconditionally, on purpose: PHP hoists top-level function declarations at compile time,
+ * so the early `return` below never prevented this function from existing, and callers here and in
+ * third-party code rely on it whether or not the module is active.
  *
- * `init_hooks()` stays unconditional. Everything that changes what the store does — the currency and
- * price filters, the currency collections — is registered from `MultiCurrency::init()`, which refuses
- * to run when `MultiCurrency::is_active()` is false. What is left here is the admin screens, the REST
- * routes and a few frontend listeners that no-op on an empty currency list, and a merchant on an
- * unconfigured store still needs those to find and switch the feature on.
+ * `init_hooks()` stays unconditional too. Everything that changes what the store does is registered
+ * from `MultiCurrency::init()`, which refuses to run when `MultiCurrency::is_active()` is false;
+ * what is left here is the admin screens and REST routes an unconfigured store still needs to
+ * switch the feature on.
  *
  * @return WCPay\MultiCurrency\MultiCurrency
  */
@@ -57,13 +55,9 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 	return $instance;
 }
 
-// Unchanged from before: bail out when the merchant turned Multi-Currency off. Reading the saved
-// preference rather than `is_customer_multi_currency_enabled()` keeps the same two outcomes — the
-// helper only ever returns false for a stored '0' — while making it explicit that the never-saved
-// case is decided elsewhere, by `MultiCurrency::is_active()`.
-//
-// This guard is not what keeps the module inert. PHP hoists the function declared above, so callers
-// construct the module whether or not this file returns here.
+// Skip the bootstrap when the merchant saved the setting as off. This is not what keeps the module
+// inert — PHP hoists the function above, so callers construct it whether or not this file returns
+// here. `MultiCurrency::is_active()` is what decides.
 if ( false === WC_Payments_Features::get_saved_customer_multi_currency_preference() && ! wcpay_multi_currency_onboarding_check() ) {
 	return;
 }

--- a/includes/compat/multi-currency/wc-payments-multi-currency.php
+++ b/includes/compat/multi-currency/wc-payments-multi-currency.php
@@ -24,12 +24,19 @@ function wcpay_multi_currency_onboarding_check() {
 	return $is_setup_page;
 }
 
-if ( ! WC_Payments_Features::is_customer_multi_currency_enabled() && ! wcpay_multi_currency_onboarding_check() ) {
-	return;
-}
-
 /**
  * Returns the MultiCurrency singleton.
+ *
+ * Declared unconditionally, on purpose. PHP hoists top-level function declarations at compile time,
+ * so the early `return` below never prevented this function from existing, and callers across the
+ * plugin and in third-party code — including `MultiCurrency::instance()`, which delegates here —
+ * rely on it being available whether or not the module is active.
+ *
+ * `init_hooks()` stays unconditional. Everything that changes what the store does — the currency and
+ * price filters, the currency collections — is registered from `MultiCurrency::init()`, which refuses
+ * to run when `MultiCurrency::is_active()` is false. What is left here is the admin screens, the REST
+ * routes and a few frontend listeners that no-op on an empty currency list, and a merchant on an
+ * unconfigured store still needs those to find and switch the feature on.
  *
  * @return WCPay\MultiCurrency\MultiCurrency
  */
@@ -48,6 +55,17 @@ function WC_Payments_Multi_Currency() { // phpcs:ignore WordPress.NamingConventi
 	}
 
 	return $instance;
+}
+
+// Unchanged from before: bail out when the merchant turned Multi-Currency off. Reading the saved
+// preference rather than `is_customer_multi_currency_enabled()` keeps the same two outcomes — the
+// helper only ever returns false for a stored '0' — while making it explicit that the never-saved
+// case is decided elsewhere, by `MultiCurrency::is_active()`.
+//
+// This guard is not what keeps the module inert. PHP hoists the function declared above, so callers
+// construct the module whether or not this file returns here.
+if ( false === WC_Payments_Features::get_saved_customer_multi_currency_preference() && ! wcpay_multi_currency_onboarding_check() ) {
+	return;
 }
 
 add_action( 'plugins_loaded', 'WC_Payments_Multi_Currency', 12 );

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -243,6 +243,46 @@ class MultiCurrency {
 	}
 
 	/**
+	 * Whether the module may change what the store does on this request.
+	 *
+	 * Multi-Currency is on by default, but "on by default" must not mean "on before the merchant has
+	 * a WooPayments account". A store with WooPayments installed and unconfigured has nothing to
+	 * switch — only its base currency is enabled — yet the module still registered its
+	 * `woocommerce_currency` and price filters and overrode the currency a third-party currency
+	 * switcher had already selected. See #12060.
+	 *
+	 * `WC_Payments_Features::get_saved_customer_multi_currency_preference()` reports three states,
+	 * and each one has an unambiguous answer:
+	 *
+	 * - `false`  the merchant saved the setting as off. Stay inert.
+	 * - `true`   the merchant saved settings while it was on. Run.
+	 * - `null`   the merchant never saved it. Run only once WooPayments is configured.
+	 *
+	 * The Multi-Currency setup flow needs the module before the setting has been written, so it wins
+	 * over all three.
+	 *
+	 * Every entry point has to respect this — the bootstrap in
+	 * `includes/compat/multi-currency/wc-payments-multi-currency.php`, the lazy-initializing getters,
+	 * and any direct caller of `WC_Payments_Multi_Currency()` — so an inert module never registers a
+	 * hook or touches the currency, no matter who asks for it.
+	 *
+	 * @return bool
+	 */
+	public function is_active(): bool {
+		if ( function_exists( 'wcpay_multi_currency_onboarding_check' ) && wcpay_multi_currency_onboarding_check() ) {
+			return true;
+		}
+
+		$saved_preference = WC_Payments_Features::get_saved_customer_multi_currency_preference();
+
+		if ( null !== $saved_preference ) {
+			return $saved_preference;
+		}
+
+		return $this->is_payments_configured();
+	}
+
+	/**
 	 * Initializes this class' WP hooks.
 	 *
 	 * @return void
@@ -299,6 +339,15 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function init() {
+		// The lazy-initializing getters call init() on demand, and any code path can reach them
+		// through WC_Payments_Multi_Currency() regardless of the bootstrap guard. Refuse to
+		// initialize when the module must stay inert, so it never registers the frontend currency
+		// and price hooks on a store that never asked for them.
+		if ( ! $this->is_active() ) {
+			$this->set_inert_state();
+			return;
+		}
+
 		// If the store currency is not in the list of available WooCommerce currencies
 		// (e.g. a custom currency was removed), bail out to avoid fatal errors.
 		// Multi-Currency cannot function without a valid base currency.
@@ -311,10 +360,7 @@ class MultiCurrency {
 					$store_currency
 				)
 			);
-			// Initialize properties to safe defaults so lazy-init getters and
-			// later init-hook callbacks don't re-trigger init() or fatal.
-			$this->available_currencies = [];
-			$this->enabled_currencies   = [];
+			$this->set_inert_state();
 			return;
 		}
 
@@ -540,6 +586,10 @@ class MultiCurrency {
 	 * @return FrontendPrices
 	 */
 	public function get_frontend_prices(): FrontendPrices {
+		if ( null === $this->frontend_prices ) {
+			$this->init();
+		}
+
 		return $this->frontend_prices;
 	}
 
@@ -549,6 +599,10 @@ class MultiCurrency {
 	 * @return FrontendCurrencies
 	 */
 	public function get_frontend_currencies(): FrontendCurrencies {
+		if ( null === $this->frontend_currencies ) {
+			$this->init();
+		}
+
 		return $this->frontend_currencies;
 	}
 
@@ -1777,6 +1831,53 @@ class MultiCurrency {
 		$default[ $default_code ] = $this->enabled_currencies[ $default_code ];
 		unset( $this->enabled_currencies[ $default_code ] );
 		$this->enabled_currencies = array_merge( $default, $this->enabled_currencies );
+	}
+
+	/**
+	 * Whether WooPayments has been configured on this store, with any kind of account.
+	 *
+	 * Reads the local account cache only. `has_account_data()` goes through
+	 * `Database_Cache::get( ACCOUNT_KEY, true )`, which bypasses the expiry check and returns
+	 * whatever is stored, so it never reaches the server. `is_provider_connected()` would: it calls
+	 * `get_cached_account_data()`, which refetches a cold or expired cache and answers false when
+	 * that request fails — a storefront page load must not depend on either. It also only checks for
+	 * an account id, so sandbox, test and live accounts all count, which is what "configured" means
+	 * here.
+	 *
+	 * `has_account_data()` is deliberately not part of `MultiCurrencyAccountInterface`: adding a
+	 * required method to an interface third parties can implement breaks them on load. An
+	 * implementation without it keeps the previous behaviour rather than having Multi-Currency
+	 * switch itself off underneath it.
+	 *
+	 * @return bool
+	 */
+	private function is_payments_configured(): bool {
+		if ( ! method_exists( $this->payments_account, 'has_account_data' ) ) {
+			return true;
+		}
+
+		return (bool) $this->payments_account->has_account_data();
+	}
+
+	/**
+	 * Puts the module into its inert state: no currencies and no hooks, but every getter still
+	 * returns a usable value.
+	 *
+	 * Used when init() must not proceed, so the lazy-initializing getters and later init-hook
+	 * callbacks neither re-trigger init() nor fatal. The frontend price and currency objects are
+	 * still constructed, just without their hooks, because get_frontend_prices() and
+	 * get_frontend_currencies() have non-nullable return types and are reachable from any caller.
+	 *
+	 * `static::$is_initialized` is deliberately left false, so `is_initialized()` keeps reporting
+	 * that Multi-Currency is not running.
+	 *
+	 * @return void
+	 */
+	private function set_inert_state() {
+		$this->available_currencies = [];
+		$this->enabled_currencies   = [];
+		$this->frontend_prices      = $this->frontend_prices ?? new FrontendPrices( $this, $this->compatibility );
+		$this->frontend_currencies  = $this->frontend_currencies ?? new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );
 	}
 
 	/**

--- a/includes/multi-currency/MultiCurrency.php
+++ b/includes/multi-currency/MultiCurrency.php
@@ -63,6 +63,16 @@ class MultiCurrency {
 	protected static $is_initialized = false;
 
 	/**
+	 * Whether init() has already run on this instance, successfully or into an inert state.
+	 *
+	 * Separate from the static $is_initialized, which reports whether Multi-Currency is running
+	 * and is shared by every instance in the process. This one guards re-entry per instance.
+	 *
+	 * @var bool
+	 */
+	private $init_ran = false;
+
+	/**
 	 * Compatibility instance.
 	 *
 	 * @var Compatibility
@@ -246,25 +256,17 @@ class MultiCurrency {
 	 * Whether the module may change what the store does on this request.
 	 *
 	 * Multi-Currency is on by default, but "on by default" must not mean "on before the merchant has
-	 * a WooPayments account". A store with WooPayments installed and unconfigured has nothing to
-	 * switch — only its base currency is enabled — yet the module still registered its
-	 * `woocommerce_currency` and price filters and overrode the currency a third-party currency
-	 * switcher had already selected. See #12060.
+	 * a WooPayments account": an unconfigured store has nothing to switch, yet still registered its
+	 * `woocommerce_currency` and price filters over a third-party currency switcher. See #12060.
 	 *
-	 * `WC_Payments_Features::get_saved_customer_multi_currency_preference()` reports three states,
-	 * and each one has an unambiguous answer:
+	 * The saved preference has three states, each with an unambiguous answer:
 	 *
-	 * - `false`  the merchant saved the setting as off. Stay inert.
-	 * - `true`   the merchant saved settings while it was on. Run.
-	 * - `null`   the merchant never saved it. Run only once WooPayments is configured.
+	 * - `false`  saved as off. Stay inert.
+	 * - `true`   saved as on. Run.
+	 * - `null`   never saved. Run only once WooPayments is configured.
 	 *
-	 * The Multi-Currency setup flow needs the module before the setting has been written, so it wins
-	 * over all three.
-	 *
-	 * Every entry point has to respect this — the bootstrap in
-	 * `includes/compat/multi-currency/wc-payments-multi-currency.php`, the lazy-initializing getters,
-	 * and any direct caller of `WC_Payments_Multi_Currency()` — so an inert module never registers a
-	 * hook or touches the currency, no matter who asks for it.
+	 * The Multi-Currency setup flow needs the module before the setting is written, so it wins over
+	 * all three.
 	 *
 	 * @return bool
 	 */
@@ -339,6 +341,15 @@ class MultiCurrency {
 	 * @return void
 	 */
 	public function init() {
+		// init() runs on the `init` action and lazily from the getters below. A caller that reaches
+		// a getter before `init` fires would otherwise initialize twice, leaving two sets of price
+		// and currency objects hooked at the same priority.
+		if ( $this->init_ran ) {
+			return;
+		}
+
+		$this->init_ran = true;
+
 		// The lazy-initializing getters call init() on demand, and any code path can reach them
 		// through WC_Payments_Multi_Currency() regardless of the bootstrap guard. Refuse to
 		// initialize when the module must stay inert, so it never registers the frontend currency
@@ -1849,6 +1860,12 @@ class MultiCurrency {
 	 * implementation without it keeps the previous behaviour rather than having Multi-Currency
 	 * switch itself off underneath it.
 	 *
+	 * The enabled-currencies option is a second, durable signal. The account cache is wiped by
+	 * `WC_Payments_Account::clear_cache()` — hooked to `woocommerce_woocommerce_payments_updated`,
+	 * so every plugin update — and a storefront request never refreshes it. Without this fallback a
+	 * connected store whose merchant never saved the setting would go inert until something else
+	 * warmed the cache. The option survives that, and is only ever written by a merchant action.
+	 *
 	 * @return bool
 	 */
 	private function is_payments_configured(): bool {
@@ -1856,7 +1873,13 @@ class MultiCurrency {
 			return true;
 		}
 
-		return (bool) $this->payments_account->has_account_data();
+		if ( $this->payments_account->has_account_data() ) {
+			return true;
+		}
+
+		$enabled_currency_codes = get_option( $this->id . '_enabled_currencies', [] );
+
+		return is_array( $enabled_currency_codes ) && ! empty( $enabled_currency_codes );
 	}
 
 	/**
@@ -1876,6 +1899,7 @@ class MultiCurrency {
 	private function set_inert_state() {
 		$this->available_currencies = [];
 		$this->enabled_currencies   = [];
+		$this->default_currency     = new Currency( $this->localization_service, $this->get_store_currency_code() );
 		$this->frontend_prices      = $this->frontend_prices ?? new FrontendPrices( $this, $this->compatibility );
 		$this->frontend_currencies  = $this->frontend_currencies ?? new FrontendCurrencies( $this, $this->localization_service, $this->utils, $this->compatibility );
 	}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -50,6 +50,12 @@ function _manually_load_plugin() {
 	// is not loaded even though it's set during the tests setup.
 	update_option( 'woocommerce_currency', 'USD' );
 
+	// Multi-Currency only initializes for a merchant who saved the setting as on, or for a store
+	// that has WooPayments configured — see MultiCurrency::is_active(). This environment has no
+	// account, so record the saved preference that the Multi-Currency suites assume. Tests that
+	// need the never-saved state delete this option; the per-test transaction restores it.
+	update_option( '_wcpay_feature_customer_multi_currency', '1' );
+
 	// Enable the WCPay Subscriptions feature flag in tests to ensure we can test
 	// subscriptions functionality. Using 'default_option_' filter provides a default
 	// only when the option doesn't exist in the database, allowing tests to override

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -9,6 +9,8 @@ use WCPay\MultiCurrency\Utils;
 use WCPay\MultiCurrency\CachingEnvironment;
 use WCPay\MultiCurrency\Exceptions\InvalidCurrencyException;
 use WCPay\MultiCurrency\Exceptions\InvalidCurrencyRateException;
+use WCPay\MultiCurrency\FrontendCurrencies;
+use WCPay\MultiCurrency\FrontendPrices;
 use WCPay\MultiCurrency\Interfaces\MultiCurrencyAccountInterface;
 use WCPay\MultiCurrency\Interfaces\MultiCurrencyApiClientInterface;
 use WCPay\MultiCurrency\Interfaces\MultiCurrencyCacheInterface;
@@ -159,6 +161,8 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		delete_option( 'wcpay_multi_currency_cache_autodetect_done' );
 		delete_option( 'wcpay_multi_currency_cache_recommendation_dismissed' );
 		delete_option( 'wcpay_multi_currency_store_currency' );
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		unset( $_SERVER['HTTP_REFERER'] );
 
 		parent::tear_down();
 	}
@@ -1836,7 +1840,25 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		}
 	}
 
-	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true, $mock_account = null, $mock_cache = null, $mock_caching_environment = null ) {
+	/**
+	 * Builds an account mock that answers the "is WooPayments configured?" question.
+	 *
+	 * Mocks the concrete class rather than MultiCurrencyAccountInterface on purpose:
+	 * has_account_data() is deliberately absent from the interface, and
+	 * MultiCurrency::is_payments_configured() probes for it with method_exists().
+	 *
+	 * @param bool $has_account_data Whether the local account cache holds an account.
+	 *
+	 * @return WC_Payments_Account|PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function create_mock_account_with_data( bool $has_account_data ) {
+		$mock_account = $this->createMock( WC_Payments_Account::class );
+		$mock_account->method( 'has_account_data' )->willReturn( $has_account_data );
+
+		return $mock_account;
+	}
+
+	private function init_multi_currency( $mock_api_client = null, $wcpay_account_connected = true, $mock_account = null, $mock_cache = null, $mock_caching_environment = null, $run_init = true ) {
 		$this->mock_api_client = $this->createMock( MultiCurrencyApiClientInterface::class );
 
 		$this->mock_account = $mock_account ?? $this->createMock( MultiCurrencyAccountInterface::class );
@@ -1861,7 +1883,10 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 			$mock_caching_environment
 		);
 		$this->multi_currency->init_widgets();
-		$this->multi_currency->init();
+
+		if ( $run_init ) {
+			$this->multi_currency->init();
+		}
 	}
 
 	private function add_mock_order_with_currency_meta( $currency ) {
@@ -1965,6 +1990,118 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertEmpty( $this->multi_currency->get_enabled_currencies() );
 
 		update_option( 'woocommerce_currency', 'USD' );
+	}
+
+	public function test_is_active_is_false_when_the_merchant_saved_the_setting_as_off() {
+		update_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '0' );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ), null, null, false );
+
+		$this->assertFalse( $this->multi_currency->is_active() );
+	}
+
+	public function test_is_active_is_true_when_the_merchant_saved_the_setting_as_on() {
+		update_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '1' );
+
+		// Not configured: a saved preference wins over the configuration check.
+		$this->init_multi_currency( null, false, $this->create_mock_account_with_data( false ), null, null, false );
+
+		$this->assertTrue( $this->multi_currency->is_active() );
+	}
+
+	public function test_is_active_is_false_when_the_setting_was_never_saved_and_woopayments_is_unconfigured() {
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+
+		$this->init_multi_currency( null, false, $this->create_mock_account_with_data( false ), null, null, false );
+
+		$this->assertFalse( $this->multi_currency->is_active() );
+	}
+
+	public function test_is_active_is_true_when_the_setting_was_never_saved_but_woopayments_is_configured() {
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ), null, null, false );
+
+		$this->assertTrue( $this->multi_currency->is_active() );
+	}
+
+	public function test_is_active_is_true_on_the_setup_flow_even_when_the_setting_is_off() {
+		update_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '0' );
+		$_SERVER['HTTP_REFERER'] = admin_url( 'admin.php?page=wc-admin&path=%2Fpayments%2Fmulti-currency-setup' );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ), null, null, false );
+
+		$this->assertTrue( $this->multi_currency->is_active() );
+	}
+
+	public function test_init_registers_no_currency_hooks_when_the_module_is_inactive() {
+		remove_all_filters( 'woocommerce_currency' );
+		update_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '0' );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ) );
+
+		$this->assertSame( [], $this->multi_currency->get_available_currencies() );
+		$this->assertSame( [], $this->multi_currency->get_enabled_currencies() );
+		// Note: is_initialized() is not asserted here. It reads a static flag shared by every
+		// MultiCurrency instance in the process, so an earlier active instance leaves it true.
+		$this->assertFalse( has_filter( 'woocommerce_currency' ) );
+	}
+
+	/**
+	 * The reported scenario: WooPayments installed but never configured, the merchant never touched
+	 * the Multi-Currency setting, and a third-party currency switcher hooked below priority 900.
+	 *
+	 * @see https://github.com/Automattic/woocommerce-payments/issues/12060
+	 */
+	public function test_unconfigured_store_leaves_a_third_party_currency_filter_alone() {
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => 'GBP', 5 );
+
+		$this->init_multi_currency( null, false, $this->create_mock_account_with_data( false ) );
+
+		$this->assertSame( 'GBP', get_woocommerce_currency() );
+	}
+
+	public function test_configured_store_still_asserts_its_currency_over_a_third_party_filter() {
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		remove_all_filters( 'woocommerce_currency' );
+		add_filter( 'woocommerce_currency', fn() => 'GBP', 5 );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ) );
+
+		$this->assertSame( 'USD', get_woocommerce_currency() );
+	}
+
+	public function test_inactive_module_still_reports_the_store_currency() {
+		update_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '0' );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ) );
+
+		$this->assertSame( 'USD', $this->multi_currency->get_default_currency()->get_code() );
+		$this->assertSame( 'USD', $this->multi_currency->get_selected_currency()->get_code() );
+	}
+
+	public function test_frontend_getters_initialize_an_inactive_module_on_first_use() {
+		remove_all_filters( 'woocommerce_currency' );
+		update_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '0' );
+
+		// Nothing has run init() yet: the getters must not return null into their non-nullable types.
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ), null, null, false );
+
+		$this->assertInstanceOf( FrontendCurrencies::class, $this->multi_currency->get_frontend_currencies() );
+		$this->assertInstanceOf( FrontendPrices::class, $this->multi_currency->get_frontend_prices() );
+		$this->assertFalse( has_filter( 'woocommerce_currency' ) );
+	}
+
+	public function test_an_account_implementation_without_has_account_data_keeps_the_previous_behaviour() {
+		// MultiCurrencyAccountInterface does not declare has_account_data(); a third-party
+		// implementation must not be switched off underneath.
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+
+		$this->init_multi_currency( null, false, $this->createMock( MultiCurrencyAccountInterface::class ), null, null, false );
+
+		$this->assertTrue( $this->multi_currency->is_active() );
 	}
 
 	private function mock_theme( $theme ) {

--- a/tests/unit/multi-currency/test-class-multi-currency.php
+++ b/tests/unit/multi-currency/test-class-multi-currency.php
@@ -2011,6 +2011,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 
 	public function test_is_active_is_false_when_the_setting_was_never_saved_and_woopayments_is_unconfigured() {
 		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		delete_option( self::ENABLED_CURRENCIES_OPTION );
 
 		$this->init_multi_currency( null, false, $this->create_mock_account_with_data( false ), null, null, false );
 
@@ -2055,6 +2056,7 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 	 */
 	public function test_unconfigured_store_leaves_a_third_party_currency_filter_alone() {
 		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		delete_option( self::ENABLED_CURRENCIES_OPTION );
 		remove_all_filters( 'woocommerce_currency' );
 		add_filter( 'woocommerce_currency', fn() => 'GBP', 5 );
 
@@ -2094,10 +2096,65 @@ class WCPay_Multi_Currency_Tests extends WCPAY_UnitTestCase {
 		$this->assertFalse( has_filter( 'woocommerce_currency' ) );
 	}
 
+	public function test_is_active_falls_back_to_enabled_currencies_when_the_account_cache_was_cleared() {
+		// clear_cache() runs on every plugin update, and a storefront request never refreshes it.
+		// A connected store must not go inert in that window.
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		update_option( self::ENABLED_CURRENCIES_OPTION, [ 'USD', 'GBP' ] );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( false ), null, null, false );
+
+		$this->assertTrue( $this->multi_currency->is_active() );
+	}
+
+	public function test_is_active_is_false_when_neither_the_account_cache_nor_enabled_currencies_exist() {
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		delete_option( self::ENABLED_CURRENCIES_OPTION );
+
+		$this->init_multi_currency( null, false, $this->create_mock_account_with_data( false ), null, null, false );
+
+		$this->assertFalse( $this->multi_currency->is_active() );
+	}
+
+	public function test_init_does_not_run_twice_when_a_getter_reaches_it_before_the_init_action() {
+		remove_all_filters( 'woocommerce_currency' );
+
+		// A caller reaches a lazy getter first, then the `init` action fires init() again.
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ), null, null, false );
+		$first_frontend_currencies = $this->multi_currency->get_frontend_currencies();
+		$this->multi_currency->init();
+
+		$this->assertSame( $first_frontend_currencies, $this->multi_currency->get_frontend_currencies() );
+		$this->assertCount( 1, $GLOBALS['wp_filter']['woocommerce_currency']->callbacks[900] ?? [] );
+	}
+
+	public function test_inert_module_resolves_the_default_currency_without_re_entering_init() {
+		update_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '0' );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ) );
+
+		// Would loop back into init() on every call if set_inert_state() left this unset.
+		$this->assertSame( 'USD', $this->multi_currency->get_default_currency()->get_code() );
+		$this->assertSame( 'USD', $this->multi_currency->get_default_currency()->get_code() );
+	}
+
+	public function test_inert_module_still_registers_its_admin_and_rest_hooks() {
+		update_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '0' );
+
+		$this->init_multi_currency( null, true, $this->create_mock_account_with_data( true ), null, null, false );
+		$this->multi_currency->init_hooks();
+		$this->multi_currency->init();
+
+		// A merchant on an inert store still needs the screens that switch the feature back on.
+		$this->assertNotFalse( has_action( 'rest_api_init', [ $this->multi_currency, 'init_rest_api' ] ) );
+		$this->assertNotFalse( has_action( 'widgets_init', [ $this->multi_currency, 'init_widgets' ] ) );
+	}
+
 	public function test_an_account_implementation_without_has_account_data_keeps_the_previous_behaviour() {
 		// MultiCurrencyAccountInterface does not declare has_account_data(); a third-party
 		// implementation must not be switched off underneath.
 		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		delete_option( self::ENABLED_CURRENCIES_OPTION );
 
 		$this->init_multi_currency( null, false, $this->createMock( MultiCurrencyAccountInterface::class ), null, null, false );
 

--- a/tests/unit/test-class-wc-payments-features.php
+++ b/tests/unit/test-class-wc-payments-features.php
@@ -95,12 +95,28 @@ class WC_Payments_Features_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_customer_multi_currency_is_enabled_by_default() {
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
 		$this->assertTrue( WC_Payments_Features::is_customer_multi_currency_enabled() );
 	}
 
 	public function test_customer_multi_currency_can_be_disabled() {
 		$this->set_feature_flag_option( '_wcpay_feature_customer_multi_currency', '0' );
 		$this->assertFalse( WC_Payments_Features::is_customer_multi_currency_enabled() );
+	}
+
+	public function test_saved_customer_multi_currency_preference_is_null_when_never_saved() {
+		delete_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME );
+		$this->assertNull( WC_Payments_Features::get_saved_customer_multi_currency_preference() );
+	}
+
+	public function test_saved_customer_multi_currency_preference_reports_a_saved_on() {
+		$this->set_feature_flag_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '1' );
+		$this->assertTrue( WC_Payments_Features::get_saved_customer_multi_currency_preference() );
+	}
+
+	public function test_saved_customer_multi_currency_preference_reports_a_saved_off() {
+		$this->set_feature_flag_option( WC_Payments_Features::CUSTOMER_MULTI_CURRENCY_FLAG_NAME, '0' );
+		$this->assertFalse( WC_Payments_Features::get_saved_customer_multi_currency_preference() );
 	}
 
 	public function test_is_mc_cache_optimized_enabled_by_default() {


### PR DESCRIPTION
Fixes #12060

#### Changes proposed in this Pull Request

Multi-Currency is on by default. On a store where WooPayments is installed but never configured, the module still initialized, registered its `woocommerce_currency` filter at priority 900 and its price filters, and overrode whatever an earlier filter had produced.

With a third-party currency switcher hooked below priority 900 (Aelia hooks at 5), that replaced the shopper's selected currency with the base currency while the third party's converted amounts stayed on the page — shown one currency, charged another. The reporting merchants had never opened WooPayments' settings, so the feature flag was absent and read as on.

`MultiCurrency::is_active()` now decides from the saved preference, and falls back to whether WooPayments is configured when the merchant never saved one:

| `_wcpay_feature_customer_multi_currency` | Multi-Currency |
|---|---|
| `'0'` — saved as off | inert |
| `'1'` — saved as on | active |
| absent — never saved | active only if WooPayments has an account (test or live) |

The Multi-Currency setup flow still wins over all three. "Configured" reads the local account cache via `has_account_data()`, never `is_provider_connected()` — the latter refetches a cold cache and returns false on failure, so a storefront request could trigger a server call or go inert because one failed.

`init_hooks()` stays unconditional. Everything that changes store behaviour is registered from `init()`, so an unconfigured store keeps the admin screens and REST routes it needs to switch the feature on.

**Key commits:**
- Expose the saved Multi-Currency preference as a three-state value (a699095cb)
- Gate initialization on `is_active()` (b61f199ce)

**Alternative considered.** #12066 fixes the same issue by making the priority-900 filter pass its incoming value through when Multi-Currency is idle. That neutralizes the override rather than preventing it, and its `is_enabled()` gate reads `is_customer_multi_currency_enabled()`, which returns true for the never-configured store in this report. The two are complementary: a store that deliberately runs both switchers is not covered here and still needs a pass-through.

**Backward-compatibility impact.** Behaviour change: an unconfigured store with no saved preference no longer gets any Multi-Currency frontend behaviour — including `WC_Payments_Explicit_Price_Formatter`'s currency suffix. That is the point of the fix, but it is the surface to watch. `MultiCurrency::is_active()` and `WC_Payments_Features::get_saved_customer_multi_currency_preference()` are new public API; nothing is renamed or removed. `has_account_data()` is called through `method_exists()` rather than added to `MultiCurrencyAccountInterface`, so third-party implementers do not fatal on load, and one lacking the method keeps the previous behaviour. No hooks, REST routes, option keys or stored meta change. The unit bootstrap now records the preference the Multi-Currency suites assume, since that environment has no account.

#### Testing instructions

_To be added._

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
