### PR TITLE
fix: inline notices borders in WP 7.1

### DIFF
--- a/changelog/fix-inline-notice-wp-71-border
+++ b/changelog/fix-inline-notice-wp-71-border
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix: inline notices rendering with a cut-off left border on WordPress 7.1

--- a/client/components/inline-notice/styles.scss
+++ b/client/components/inline-notice/styles.scss
@@ -1,9 +1,5 @@
 .wcpay-inline-notice.components-notice {
 	margin: $gap-large 0;
-	padding: 11px 0 11px 17px;
-	border-left: none;
-	border-radius: 2px;
-	justify-content: flex-start;
 
 	/* Margin exceptions */
 	@at-root .components-modal__header + &,
@@ -29,9 +25,6 @@
 		}
 	}
 	.components-notice__content {
-		margin-top: 2px;
-		margin-bottom: 2px;
-
 		// Ensure links don't wrap across lines, e.g. "Learn (newline) more".
 		a {
 			white-space: nowrap;
@@ -42,18 +35,6 @@
 	}
 	a.wcpay-inline-notice__action {
 		text-decoration: none;
-	}
-	&.is-dismissible {
-		padding-right: 12px;
-	}
-	.components-notice__dismiss {
-		height: 24px;
-		width: 24px;
-		svg {
-			width: 15px;
-			height: 15px;
-			fill: $gray-900;
-		}
 	}
 
 	/* Specific styles for each variant */


### PR DESCRIPTION
Fixes WOOPMNT-6417

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Got DM'd about this.
WP 7.1 restyled core notices: the 4px left border got converted into a full bordered box with a radius.

Dropping our overrides of core's border, radius and padding, so notices render natively on whatever WP is running.

Before:
<img width="1231" height="563" alt="Screenshot 2026-08-25 at 9 14 58 AM" src="https://github.com/user-attachments/assets/d331baa0-6c69-4e7c-9128-b338406c77ed" />


After:
<img width="868" height="221" alt="Screenshot 2026-08-25 at 11 45 04 AM" src="https://github.com/user-attachments/assets/58b7485d-432d-45d0-9217-c64674ee079d" />

Also kept compatibility with older WP versions:
<img width="868" height="201" alt="Screenshot 2026-08-25 at 11 55 52 AM" src="https://github.com/user-attachments/assets/a7259687-05e9-4fd3-8e7f-014e81a9584c" />


#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure you have WP 7.1
- Navigate to the settings page
- The notices should no longer be cut off
- Repeat on WP 7.0 or older: notices keep the accent bar and our colors

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

