### PR TITLE
chore: bump the WP and WC tested up to versions

### DIFF
--- a/changelog/bump-tested-up-to-versions
+++ b/changelog/bump-tested-up-to-versions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Bump WP tested up to version to 7.1 and WC tested up to version to 11.1.0

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
 Requires at least: 6.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.3
 Stable tag: 11.0.1
 License: GPLv2 or later

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
  * WC requires at least: 7.6
- * WC tested up to: 11.0.0
+ * WC tested up to: 11.1.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Version: 11.0.1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WordPress 7.1 was released on Aug 19th, and WooCommerce 11.1.0 is scheduled for Sep 1st, both before the WooPayments 11.1.0 release on Sep 2nd. The tested up to headers need to cover them.

- Bump the WP `Tested up to` header in `readme.txt` from 7.0 to 7.1.
- Bump the `WC tested up to` header in `woocommerce-payments.php` from 11.0.0 to 11.1.0.

Minimum required versions are unchanged, since bumping them is currently paused.

#### Testing instructions

1. Check `readme.txt` shows `Tested up to: 7.1`.
2. Check `woocommerce-payments.php` shows `WC tested up to: 11.1.0`.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (header-only change, no test needed)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
