### PR TITLE
fix: prevent checkout fatal from a stale store_api_draft_order id

### DIFF
--- a/changelog/fix-woopay-direct-checkout-stale-draft-order-fatal
+++ b/changelog/fix-woopay-direct-checkout-stale-draft-order-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error during checkout when the session points at a WooPay direct checkout draft order that no longer exists.

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -69,13 +69,24 @@ class WC_Payments_WooPay_Direct_Checkout {
 		$draft_order_id = absint( WC()->session->get( 'store_api_draft_order' ) );
 		$draft_order    = $draft_order_id ? wc_get_order( $draft_order_id ) : false;
 
-		// The session can outlive the draft order it points at: the daily
-		// `woocommerce_cleanup_draft_orders` action deletes stale draft orders while the
-		// customer session persists. Under HPOS a reused post ID can even make the stale
-		// pointer resolve to a non-order object, so guard with an instance check rather than
-		// a truthiness check. When the pointer is stale, discard it and fall through to
-		// normal order creation instead of fataling on a call to set_status() on false.
-		if ( ! $draft_order instanceof WC_Order ) {
+		// Only resume the session's draft order when it is genuinely the customer's current,
+		// resumable order, mirroring WooCommerce core's own validity check
+		// (WooCommerce\StoreApi\Utilities\DraftOrderTrait::is_valid_draft_order()): it must be a
+		// checkout-draft, or an unpaid order that still matches the current cart. Anything else is
+		// discarded so checkout falls through to normal order creation rather than resuming the
+		// wrong order — or fataling. This covers a pointer left dangling by the daily
+		// `woocommerce_cleanup_draft_orders` cleanup (where wc_get_order() returns false), a
+		// trashed order, and a stale order that no longer matches the cart.
+		$cart      = WC()->cart;
+		$cart_hash = $cart instanceof WC_Cart ? $cart->get_cart_hash() : '';
+
+		$is_resumable_draft_order = $draft_order instanceof WC_Order
+			&& (
+				$draft_order->has_status( 'checkout-draft' )
+				|| ( $draft_order->needs_payment() && $draft_order->has_cart_hash( $cart_hash ) )
+			);
+
+		if ( ! $is_resumable_draft_order ) {
 			WC()->session->set( 'store_api_draft_order', null );
 			return $order_id;
 		}

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -55,7 +55,7 @@ class WC_Payments_WooPay_Direct_Checkout {
 	 */
 	public function maybe_use_store_api_draft_order_id( $order_id ) {
 		// Only apply this filter during the checkout request.
-		$is_checkout = defined( 'WOOCOMMERCE_CHECKOUT' ) && WOOCOMMERCE_CHECKOUT;
+		$is_checkout = $this->is_checkout_request();
 		// Only apply this filter if the order ID is not already defined.
 		$is_already_defined_order_id = ! empty( $order_id );
 		// Only apply this filter if the session doesn't already have an order_awaiting_payment.
@@ -137,6 +137,19 @@ class WC_Payments_WooPay_Direct_Checkout {
 		);
 
 		wp_enqueue_script( 'WCPAY_WOOPAY_DIRECT_CHECKOUT' );
+	}
+
+	/**
+	 * Whether the current request is a (classic) checkout request.
+	 *
+	 * Extracted so it can be overridden in tests without defining the global
+	 * `WOOCOMMERCE_CHECKOUT` constant (which cannot be undefined and would leak
+	 * into other test classes).
+	 *
+	 * @return bool
+	 */
+	protected function is_checkout_request(): bool {
+		return defined( 'WOOCOMMERCE_CHECKOUT' ) && WOOCOMMERCE_CHECKOUT;
 	}
 
 	/**

--- a/includes/class-wc-payments-woopay-direct-checkout.php
+++ b/includes/class-wc-payments-woopay-direct-checkout.php
@@ -67,8 +67,20 @@ class WC_Payments_WooPay_Direct_Checkout {
 		}
 
 		$draft_order_id = absint( WC()->session->get( 'store_api_draft_order' ) );
+		$draft_order    = $draft_order_id ? wc_get_order( $draft_order_id ) : false;
+
+		// The session can outlive the draft order it points at: the daily
+		// `woocommerce_cleanup_draft_orders` action deletes stale draft orders while the
+		// customer session persists. Under HPOS a reused post ID can even make the stale
+		// pointer resolve to a non-order object, so guard with an instance check rather than
+		// a truthiness check. When the pointer is stale, discard it and fall through to
+		// normal order creation instead of fataling on a call to set_status() on false.
+		if ( ! $draft_order instanceof WC_Order ) {
+			WC()->session->set( 'store_api_draft_order', null );
+			return $order_id;
+		}
+
 		// Set the order status to "pending" payment, so that it can be resumed.
-		$draft_order = wc_get_order( $draft_order_id );
 		$draft_order->set_status( 'pending' );
 		$draft_order->save();
 

--- a/tests/unit/test-class-wc-payments-woopay-direct-checkout.php
+++ b/tests/unit/test-class-wc-payments-woopay-direct-checkout.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * These tests make assertions against class WC_Payments_WooPay_Direct_Checkout.
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+use WCPay\WooPay\WooPay_Utilities;
+
+/**
+ * WC_Payments_WooPay_Direct_Checkout_Test class.
+ */
+class WC_Payments_WooPay_Direct_Checkout_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Payments_WooPay_Direct_Checkout
+	 */
+	private $direct_checkout;
+
+	public function set_up() {
+		parent::set_up();
+
+		// The filter only runs during checkout; the class returns early otherwise.
+		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
+			define( 'WOOCOMMERCE_CHECKOUT', true );
+		}
+
+		$this->direct_checkout = new WC_Payments_WooPay_Direct_Checkout( $this->createMock( WooPay_Utilities::class ) );
+
+		WC()->session->set( 'store_api_draft_order', null );
+		WC()->session->set( 'order_awaiting_payment', null );
+	}
+
+	public function tear_down() {
+		WC()->session->set( 'store_api_draft_order', null );
+		WC()->session->set( 'order_awaiting_payment', null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * A session pointing at a draft order that no longer exists must not fatal:
+	 * the stale pointer is discarded and checkout falls through to normal order creation.
+	 */
+	public function test_stale_draft_order_id_is_discarded_without_fatal() {
+		$non_existent_order_id = 999999999;
+		WC()->session->set( 'store_api_draft_order', $non_existent_order_id );
+
+		$result = $this->direct_checkout->maybe_use_store_api_draft_order_id( 0 );
+
+		$this->assertSame( 0, $result );
+		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
+		$this->assertNull( WC()->session->get( 'order_awaiting_payment' ) );
+	}
+
+	/**
+	 * Under HPOS a reused post ID can make the stale pointer resolve to a non-order post
+	 * (e.g. a media attachment). wc_get_order() returns false for such a post, and the
+	 * instance check must keep checkout from fataling on set_status().
+	 */
+	public function test_draft_order_id_resolving_to_non_order_post_is_discarded_without_fatal() {
+		$attachment_id = self::factory()->post->create( [ 'post_type' => 'attachment' ] );
+		WC()->session->set( 'store_api_draft_order', $attachment_id );
+
+		$result = $this->direct_checkout->maybe_use_store_api_draft_order_id( 0 );
+
+		$this->assertSame( 0, $result );
+		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
+		$this->assertNull( WC()->session->get( 'order_awaiting_payment' ) );
+	}
+
+	/**
+	 * A valid draft order is still resumed: its status is set to pending and the session
+	 * pointer is moved from store_api_draft_order to order_awaiting_payment.
+	 */
+	public function test_valid_draft_order_is_resumed() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'checkout-draft' );
+		$order->save();
+
+		WC()->session->set( 'store_api_draft_order', $order->get_id() );
+
+		$result = $this->direct_checkout->maybe_use_store_api_draft_order_id( 0 );
+
+		$this->assertSame( 0, $result );
+		$this->assertSame( 'pending', wc_get_order( $order->get_id() )->get_status() );
+		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
+		$this->assertEquals( $order->get_id(), WC()->session->get( 'order_awaiting_payment' ) );
+	}
+}

--- a/tests/unit/test-class-wc-payments-woopay-direct-checkout.php
+++ b/tests/unit/test-class-wc-payments-woopay-direct-checkout.php
@@ -9,13 +9,6 @@ use WCPay\WooPay\WooPay_Utilities;
 
 /**
  * WC_Payments_WooPay_Direct_Checkout_Test class.
- *
- * Runs in a separate process because these tests define the `WOOCOMMERCE_CHECKOUT`
- * constant, which cannot be undefined once set. Isolation keeps it from leaking into
- * other test classes (several code paths, e.g. customer creation, branch on it).
- *
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
  */
 class WC_Payments_WooPay_Direct_Checkout_Test extends WCPAY_UnitTestCase {
 
@@ -29,14 +22,14 @@ class WC_Payments_WooPay_Direct_Checkout_Test extends WCPAY_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// The filter only runs during checkout; the class returns early otherwise.
-		// Safe to define here: the class runs in a separate process (see class docblock),
-		// so the constant does not leak into other test classes.
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
-		$this->direct_checkout = new WC_Payments_WooPay_Direct_Checkout( $this->createMock( WooPay_Utilities::class ) );
+		// The filter only runs during checkout. Rather than define the global
+		// WOOCOMMERCE_CHECKOUT constant (which cannot be undefined and would leak into other
+		// test classes), stub is_checkout_request() to report a checkout request.
+		$this->direct_checkout = $this->getMockBuilder( WC_Payments_WooPay_Direct_Checkout::class )
+			->setConstructorArgs( [ $this->createMock( WooPay_Utilities::class ) ] )
+			->onlyMethods( [ 'is_checkout_request' ] )
+			->getMock();
+		$this->direct_checkout->method( 'is_checkout_request' )->willReturn( true );
 
 		WC()->session->set( 'store_api_draft_order', null );
 		WC()->session->set( 'order_awaiting_payment', null );

--- a/tests/unit/test-class-wc-payments-woopay-direct-checkout.php
+++ b/tests/unit/test-class-wc-payments-woopay-direct-checkout.php
@@ -9,6 +9,13 @@ use WCPay\WooPay\WooPay_Utilities;
 
 /**
  * WC_Payments_WooPay_Direct_Checkout_Test class.
+ *
+ * Runs in a separate process because these tests define the `WOOCOMMERCE_CHECKOUT`
+ * constant, which cannot be undefined once set. Isolation keeps it from leaking into
+ * other test classes (several code paths, e.g. customer creation, branch on it).
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class WC_Payments_WooPay_Direct_Checkout_Test extends WCPAY_UnitTestCase {
 
@@ -23,6 +30,8 @@ class WC_Payments_WooPay_Direct_Checkout_Test extends WCPAY_UnitTestCase {
 		parent::set_up();
 
 		// The filter only runs during checkout; the class returns early otherwise.
+		// Safe to define here: the class runs in a separate process (see class docblock),
+		// so the constant does not leak into other test classes.
 		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
 			define( 'WOOCOMMERCE_CHECKOUT', true );
 		}
@@ -88,5 +97,24 @@ class WC_Payments_WooPay_Direct_Checkout_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'pending', wc_get_order( $order->get_id() )->get_status() );
 		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
 		$this->assertEquals( $order->get_id(), WC()->session->get( 'order_awaiting_payment' ) );
+	}
+
+	/**
+	 * A trashed order still resolves to a WC_Order, but is not a resumable draft, so it must be
+	 * discarded rather than resumed. Guards against the "just trashed" case raised in review.
+	 */
+	public function test_trashed_order_is_discarded_and_not_resumed() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'checkout-draft' );
+		$order->save();
+		$order->get_data_store()->delete( $order, [ 'force_delete' => false ] ); // Trash, not force-delete.
+
+		WC()->session->set( 'store_api_draft_order', $order->get_id() );
+
+		$result = $this->direct_checkout->maybe_use_store_api_draft_order_id( 0 );
+
+		$this->assertSame( 0, $result );
+		$this->assertNull( WC()->session->get( 'store_api_draft_order' ) );
+		$this->assertNull( WC()->session->get( 'order_awaiting_payment' ) );
 	}
 }


### PR DESCRIPTION
Fixes #12071

#### Changes proposed in this Pull Request

`WC_Payments_WooPay_Direct_Checkout::maybe_use_store_api_draft_order_id()` called `set_status()` on the result of `wc_get_order()` without checking it returned an order, so a session pointing at a draft order that no longer exists fataled.

The pointer goes stale through an entirely routine sequence: a shopper reaches Store API checkout (a draft order is created and its ID stored in the session as `store_api_draft_order`), doesn't complete, the daily `woocommerce_cleanup_draft_orders` action later deletes that draft order, and the shopper returns and checks out on the same session — dereferencing a dead ID.

What makes it nasty is *where* it happens: the `woocommerce_create_order` filter fires outside `WC_Checkout::process_checkout()`'s try/catch, so nothing is caught, nothing is logged, no order is created, and the shopper gets a generic error over an **HTTP 200 with an empty body**. From the merchant's side that's indistinguishable from a front-end, payment-method, or caching problem — the reporter took six failed checkouts to find it.

#### Testing instructions

1. On a store with WooPay Direct Checkout enabled and the Cart/Checkout blocks (Store API) active.
2. Reach checkout as a customer so a draft order is created and `store_api_draft_order` is set in the session.
3. Delete that draft order (or wait for `woocommerce_cleanup_draft_orders`).
4. Attempt to check out on the same session.
   - **Before:** fatal error — HTTP 200, empty body, generic error message, nothing logged.
   - **After:** the stale pointer is discarded and checkout proceeds with a new order.

> ⚠️ **WooCommerce version note for step 2.** WooCommerce **10.8.0** deferred Store API draft-order creation to place-order time, so on WC ≥ 10.8 (e.g. 11.x) simply landing on the blocks checkout no longer creates a draft order — you get one by *submitting* a checkout that then doesn't complete. On WC < 10.8 (e.g. 10.7) the draft is created on hydration, so landing on the checkout page is enough. Either way the fatal is the same; the version only changes how the `store_api_draft_order` gets created in step 2.

Unit tests: `vendor/bin/phpunit --filter 'WC_Payments_WooPay_Direct_Checkout_Test'` — covers the stale-id, non-order-post (HPOS ID reuse), and valid-draft-order paths.

**Changelog:** added (user-facing) — prevents a silent checkout failure, so a store-owner-readable `fix` entry is warranted.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file — added a `fix` / patch entry. (Added by hand: `pnpm run changelog:add` errored on a local corepack/Node issue, unrelated to this change.)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply) — does not apply (backend-only checkout guard).

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows), if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.
