### PR TITLE
Sync develop after 11.1.0: version bump + changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,6 @@
 * Update - Clarify where the support phone number appears, mark the field as required, and use one plain validation message.
 * Dev - Add a payment method lifecycle reference doc covering Stripe capability state vs. checkout enablement
 * Dev - Bump WP tested up to version to 7.1 and WC tested up to version to 11.1.0
-* Dev - Comment: Correct development guidance for invalidating the styles cache after plugin updates.
 * Dev - Fix E2E assertions that could not fail: missing awaits, an assertion-free filter test, and swallowed add-payment-method outcomes.
 * Dev - Fix react-hooks/immutability ESLint violations
 * Dev - Fix react-hooks/set-state-in-effect ESLint violations.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,40 @@
 *** WooPayments Changelog ***
 
+= 11.1.0 - 2026-09-02 =
+* Add - Show which risk filters fired when a payment is blocked or held for review, in the order note and the Fraud & Risk meta box.
+* Add - Surface Stripe Radar early fraud warnings in order notes and the Fraud & Risk order metabox.
+* Add - Surface Stripe Radar early fraud warnings in the transaction timeline.
+* Fix - Add an accessible label to the Multi-Currency switcher so screen readers announce it correctly
+* Fix - Avoid a PHP 8 "Undefined array key" warning when computing the cache TTL for a legacy cache entry stored before the errored field existed.
+* Fix - fix: inline notices rendering with a cut-off left border on WordPress 7.1
+* Fix - Fixed merchant-facing documentation links that landed on the wrong page or section, and relabelled two links to match their new destinations.
+* Fix - Fixed the payment details summary labelling a disputed amount as refunded: the withdrawn balance line now reads "Deducted" whenever a dispute moved the money, including when the dispute fee was zero or reversed.
+* Fix - Linked the payment method fee tooltip to the fee section for the WooPayments account's country rather than the store's base country, which differ for Puerto Rico stores and for any store that changes its base country after onboarding.
+* Fix - Link the "View more details" in a fraud-blocked order note to the specific payment intent that was blocked, so repeated blocks on the same order each point to their own transaction.
+* Fix - Prevent a second charge when payment is resubmitted for an order that has already been paid.
+* Fix - Prevent long refund reasons from interrupting refunds.
+* Fix - Re-run the sofort cleanup on stores where the payment method registry re-enabled it.
+* Fix - Recover onboarding within minutes instead of a week after a transient error, by backing off errored business-types and onboarding-fields cache entries instead of caching the failure for the full week.
+* Fix - Send a WooPayments user agent on ExPlat assignment requests so experiment assignments are not filtered out as bot traffic.
+* Fix - Show the evidence response deadline on the order screen when a charge has a dispute that still needs a response alongside one that is under review or lost.
+* Fix - Stop a closing dispute from marking an order completed when the charge still has another dispute open, or when the payment has already been fully refunded
+* Fix - Stop charging the additional Stripe Billing fee on subscription renewals that are not billed through Stripe Billing
+* Fix - Stop counting test-mode WooPayments usage - a test-drive account or test-mode orders - when determining WooPayments incentives eligibility, so trialing WooPayments no longer disqualifies a store from incentives. Stores already disqualified this way get their eligibility re-determined once.
+* Fix - Stopped the dispute details from naming a fee that was never charged: a zero or reversed dispute fee now drops the fee wording instead of showing a $0.00 amount or a dash.
+* Update - Clarify where the support phone number appears, mark the field as required, and use one plain validation message.
+* Dev - Add a payment method lifecycle reference doc covering Stripe capability state vs. checkout enablement
+* Dev - Bump WP tested up to version to 7.1 and WC tested up to version to 11.1.0
+* Dev - Comment: Correct development guidance for invalidating the styles cache after plugin updates.
+* Dev - Fix E2E assertions that could not fail: missing awaits, an assertion-free filter test, and swallowed add-payment-method outcomes.
+* Dev - Fix react-hooks/immutability ESLint violations
+* Dev - Fix react-hooks/set-state-in-effect ESLint violations.
+* Dev - Fix the E2E Action Scheduler helper so it finds the Run link on WordPress 7.1.
+* Dev - Make the subscriptions manage-payments E2E test locate the "Change payment" action by its URL contract instead of its ARIA role.
+* Dev - Make the subscriptions renewal E2E test resilient to Action Scheduler search-box copy changes (fixes the 4.1.0 relabel).
+* Dev - Remove skipped tests for the capital loan notice that was removed from the deposits overview.
+* Dev - Run the PHP test suite against WordPress nightly in the compatibility workflow.
+* Dev - Use a named permission callback for the public multi-currency config REST endpoint.
+
 = 11.0.1 - 2026-08-20 =
 * Fix - Fix the currency switcher not rendering on WordPress 7.1 in Storefront breadcrumbs and the wc_get_currency_switcher_markup() template tag.
 

--- a/changelog/2026-08-19-08-05-04-949708
+++ b/changelog/2026-08-19-08-05-04-949708
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Update the error message incomplete_cvc from Stripe
-
-

--- a/changelog/add-early-fraud-warnings-order-screen
+++ b/changelog/add-early-fraud-warnings-order-screen
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Surface Stripe Radar early fraud warnings in order notes and the Fraud & Risk order metabox.

--- a/changelog/add-early-fraud-warnings-timeline
+++ b/changelog/add-early-fraud-warnings-timeline
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Surface Stripe Radar early fraud warnings in the transaction timeline.

--- a/changelog/add-fraud-ruleset-results-to-order
+++ b/changelog/add-fraud-ruleset-results-to-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Show which risk filters fired when a payment is blocked or held for review, in the order note and the Fraud & Risk meta box.

--- a/changelog/add-release-develop-pr-url-to-slack-notification
+++ b/changelog/add-release-develop-pr-url-to-slack-notification
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Expose develop sync PR URL from release-pr.yml as a workflow output so release-code-freeze.yml can include it in the Slack notification.
-

--- a/changelog/add-wp-nightly-compatibility-job
+++ b/changelog/add-wp-nightly-compatibility-job
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Run the PHP test suite against WordPress nightly in the compatibility workflow.

--- a/changelog/bump-phpstan-2.2.2
+++ b/changelog/bump-phpstan-2.2.2
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Bump phpstan/phpstan from 1.12.32 to 2.2.2.

--- a/changelog/bump-tested-up-to-versions
+++ b/changelog/bump-tested-up-to-versions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Bump WP tested up to version to 7.1 and WC tested up to version to 11.1.0

--- a/changelog/chore-update-phpcs
+++ b/changelog/chore-update-phpcs
@@ -1,3 +1,0 @@
-Significance: patch
-Type: update
-Comment: chore: update wp-coding-standards/wpcs library, not customer-facing

--- a/changelog/dev-correct-styles-cache-guidance
+++ b/changelog/dev-correct-styles-cache-guidance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Comment: Correct development guidance for invalidating the styles cache after plugin updates.

--- a/changelog/dev-remove-dead-capital-loan-notice-tests
+++ b/changelog/dev-remove-dead-capital-loan-notice-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Remove skipped tests for the capital loan notice that was removed from the deposits overview.

--- a/changelog/dev-rename-develop-sync-pr
+++ b/changelog/dev-rename-develop-sync-pr
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Rename the generated develop sync PR to "Sync develop after x.y.z: version bump + changelog" and expand its description, so the title and body both reflect that it carries the version bump as well as the changelog entries.

--- a/changelog/dev-woopmnt-6292-fix-react-hooks-immutability
+++ b/changelog/dev-woopmnt-6292-fix-react-hooks-immutability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix react-hooks/immutability ESLint violations

--- a/changelog/docs-payment-method-lifecycle
+++ b/changelog/docs-payment-method-lifecycle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add a payment method lifecycle reference doc covering Stripe capability state vs. checkout enablement

--- a/changelog/fix-bundle-size-strict-dep-builds
+++ b/changelog/fix-bundle-size-strict-dep-builds
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: CI-only Compressed Size workflow fix; intentionally omitted from the changelog.

--- a/changelog/fix-dispute-closed-order-status
+++ b/changelog/fix-dispute-closed-order-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Stop a closing dispute from marking an order completed when the charge still has another dispute open, or when the payment has already been fully refunded

--- a/changelog/fix-e2e-action-scheduler-run-selector-wp71
+++ b/changelog/fix-e2e-action-scheduler-run-selector-wp71
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix the E2E Action Scheduler helper so it finds the Run link on WordPress 7.1.

--- a/changelog/fix-e2e-test-signal-fixes
+++ b/changelog/fix-e2e-test-signal-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix E2E assertions that could not fail: missing awaits, an assertion-free filter test, and swallowed add-payment-method outcomes.

--- a/changelog/fix-explat-request-user-agent
+++ b/changelog/fix-explat-request-user-agent
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Send a WooPayments user agent on ExPlat assignment requests so experiment assignments are not filtered out as bot traffic.

--- a/changelog/fix-fraud-blocked-note-links-to-intent
+++ b/changelog/fix-fraud-blocked-note-links-to-intent
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Link the "View more details" in a fraud-blocked order note to the specific payment intent that was blocked, so repeated blocks on the same order each point to their own transaction.

--- a/changelog/fix-inline-notice-wp-71-border
+++ b/changelog/fix-inline-notice-wp-71-border
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fix: inline notices rendering with a cut-off left border on WordPress 7.1

--- a/changelog/fix-mccy-currency-switcher-a11y-label
+++ b/changelog/fix-mccy-currency-switcher-a11y-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add an accessible label to the Multi-Currency switcher so screen readers announce it correctly

--- a/changelog/fix-multi-currency-public-config-permission-callback
+++ b/changelog/fix-multi-currency-public-config-permission-callback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Use a named permission callback for the public multi-currency config REST endpoint.

--- a/changelog/fix-multiple-disputes-notice-precedence
+++ b/changelog/fix-multiple-disputes-notice-precedence
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Show the evidence response deadline on the order screen when a charge has a dispute that still needs a response alongside one that is under review or lost.

--- a/changelog/fix-refund-reason-metadata-length
+++ b/changelog/fix-refund-reason-metadata-length
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent long refund reasons from interrupting refunds.

--- a/changelog/fix-sofort-deprecation-migration-version
+++ b/changelog/fix-sofort-deprecation-migration-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Re-run the sofort cleanup on stores where the payment method registry re-enabled it.

--- a/changelog/fix-woopmnt-6313-paid-order-guard
+++ b/changelog/fix-woopmnt-6313-paid-order-guard
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent a second charge when payment is resubmitted for an order that has already been paid.

--- a/changelog/fix-woopmnt-6394-errored-onboarding-cache-ttl
+++ b/changelog/fix-woopmnt-6394-errored-onboarding-cache-ttl
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Recover onboarding within minutes instead of a week after a transient error, by backing off errored business-types and onboarding-fields cache entries instead of caching the failure for the full week.

--- a/changelog/fix-woopmnt-6407-errored-legacy-entry-warning
+++ b/changelog/fix-woopmnt-6407-errored-legacy-entry-warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Avoid a PHP 8 "Undefined array key" warning when computing the cache TTL for a legacy cache entry stored before the errored field existed.

--- a/changelog/perf-onboarding-memoize-field-options
+++ b/changelog/perf-onboarding-memoize-field-options
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Build the onboarding country, business type and MCC option lists once per mount instead of on every render, and stop the business type reorder mutating the shared list. No change in behaviour.

--- a/changelog/remove-wc-tested-up-to-changelog-entry
+++ b/changelog/remove-wc-tested-up-to-changelog-entry
@@ -1,3 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Dev-only WC tested-up-to header bump; intentionally omitted from the changelog.

--- a/changelog/woopmnt-6292-fix-react-hooks-set-state-in-effect
+++ b/changelog/woopmnt-6292-fix-react-hooks-set-state-in-effect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix react-hooks/set-state-in-effect ESLint violations.

--- a/changelog/woopmnt-6320-test-mode-orders-from-test-drive-permanently-destroy-switch
+++ b/changelog/woopmnt-6320-test-mode-orders-from-test-drive-permanently-destroy-switch
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Stop counting test-mode WooPayments usage - a test-drive account or test-mode orders - when determining WooPayments incentives eligibility, so trialing WooPayments no longer disqualifies a store from incentives. Stores already disqualified this way get their eligibility re-determined once.

--- a/changelog/woopmnt-6328-non-subscription-payments-marked-as-wcpay-subscription
+++ b/changelog/woopmnt-6328-non-subscription-payments-marked-as-wcpay-subscription
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Stop charging the additional Stripe Billing fee on subscription renewals that are not billed through Stripe Billing

--- a/changelog/woopmnt-6352-fix-subscriptions-renewal-e2e-test-broken-by-action
+++ b/changelog/woopmnt-6352-fix-subscriptions-renewal-e2e-test-broken-by-action
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Make the subscriptions renewal E2E test resilient to Action Scheduler search-box copy changes (fixes the 4.1.0 relabel).

--- a/changelog/woopmnt-6353-clarify-where-a-support-phone-number-appears
+++ b/changelog/woopmnt-6353-clarify-where-a-support-phone-number-appears
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Clarify where the support phone number appears, mark the field as required, and use one plain validation message.

--- a/changelog/woopmnt-6403
+++ b/changelog/woopmnt-6403
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed merchant-facing documentation links that landed on the wrong page or section, and relabelled two links to match their new destinations.

--- a/changelog/woopmnt-6403-dispute-fee-copy
+++ b/changelog/woopmnt-6403-dispute-fee-copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Stopped the dispute details from naming a fee that was never charged: a zero or reversed dispute fee now drops the fee wording instead of showing a $0.00 amount or a dash.

--- a/changelog/woopmnt-6403-disputed-amount-label
+++ b/changelog/woopmnt-6403-disputed-amount-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed the payment details summary labelling a disputed amount as refunded: the withdrawn balance line now reads "Deducted" whenever a dispute moved the money, including when the dispute fee was zero or reversed.

--- a/changelog/woopmnt-6403-fee-link-account-country
+++ b/changelog/woopmnt-6403-fee-link-account-country
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Linked the payment method fee tooltip to the fee section for the WooPayments account's country rather than the store's base country, which differ for Puerto Rico stores and for any store that changes its base country after onboarding.

--- a/changelog/woopmnt-fix-subscriptions-shopper-change-payment-locator
+++ b/changelog/woopmnt-fix-subscriptions-shopper-change-payment-locator
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Make the subscriptions manage-payments E2E test locate the "Change payment" action by its URL contract instead of its ARIA role.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-payments",
-	"version": "11.0.1",
+	"version": "11.1.0",
 	"main": "webpack.config.js",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,6 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 * Update - Clarify where the support phone number appears, mark the field as required, and use one plain validation message.
 * Dev - Add a payment method lifecycle reference doc covering Stripe capability state vs. checkout enablement
 * Dev - Bump WP tested up to version to 7.1 and WC tested up to version to 11.1.0
-* Dev - Comment: Correct development guidance for invalidating the styles cache after plugin updates.
 * Dev - Fix E2E assertions that could not fail: missing awaits, an assertion-free filter test, and swallowed add-payment-method outcomes.
 * Dev - Fix react-hooks/immutability ESLint violations
 * Dev - Fix react-hooks/set-state-in-effect ESLint violations.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment
 Requires at least: 6.0
 Tested up to: 7.1
 Requires PHP: 7.3
-Stable tag: 11.0.1
+Stable tag: 11.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -86,6 +86,41 @@ You can read our Terms of Service and other policies [here](https://woocommerce.
 4. Manage Disputes
 
 == Changelog ==
+
+= 11.1.0 - 2026-09-02 =
+* Add - Show which risk filters fired when a payment is blocked or held for review, in the order note and the Fraud & Risk meta box.
+* Add - Surface Stripe Radar early fraud warnings in order notes and the Fraud & Risk order metabox.
+* Add - Surface Stripe Radar early fraud warnings in the transaction timeline.
+* Fix - Add an accessible label to the Multi-Currency switcher so screen readers announce it correctly
+* Fix - Avoid a PHP 8 "Undefined array key" warning when computing the cache TTL for a legacy cache entry stored before the errored field existed.
+* Fix - fix: inline notices rendering with a cut-off left border on WordPress 7.1
+* Fix - Fixed merchant-facing documentation links that landed on the wrong page or section, and relabelled two links to match their new destinations.
+* Fix - Fixed the payment details summary labelling a disputed amount as refunded: the withdrawn balance line now reads "Deducted" whenever a dispute moved the money, including when the dispute fee was zero or reversed.
+* Fix - Linked the payment method fee tooltip to the fee section for the WooPayments account's country rather than the store's base country, which differ for Puerto Rico stores and for any store that changes its base country after onboarding.
+* Fix - Link the "View more details" in a fraud-blocked order note to the specific payment intent that was blocked, so repeated blocks on the same order each point to their own transaction.
+* Fix - Prevent a second charge when payment is resubmitted for an order that has already been paid.
+* Fix - Prevent long refund reasons from interrupting refunds.
+* Fix - Re-run the sofort cleanup on stores where the payment method registry re-enabled it.
+* Fix - Recover onboarding within minutes instead of a week after a transient error, by backing off errored business-types and onboarding-fields cache entries instead of caching the failure for the full week.
+* Fix - Send a WooPayments user agent on ExPlat assignment requests so experiment assignments are not filtered out as bot traffic.
+* Fix - Show the evidence response deadline on the order screen when a charge has a dispute that still needs a response alongside one that is under review or lost.
+* Fix - Stop a closing dispute from marking an order completed when the charge still has another dispute open, or when the payment has already been fully refunded
+* Fix - Stop charging the additional Stripe Billing fee on subscription renewals that are not billed through Stripe Billing
+* Fix - Stop counting test-mode WooPayments usage - a test-drive account or test-mode orders - when determining WooPayments incentives eligibility, so trialing WooPayments no longer disqualifies a store from incentives. Stores already disqualified this way get their eligibility re-determined once.
+* Fix - Stopped the dispute details from naming a fee that was never charged: a zero or reversed dispute fee now drops the fee wording instead of showing a $0.00 amount or a dash.
+* Update - Clarify where the support phone number appears, mark the field as required, and use one plain validation message.
+* Dev - Add a payment method lifecycle reference doc covering Stripe capability state vs. checkout enablement
+* Dev - Bump WP tested up to version to 7.1 and WC tested up to version to 11.1.0
+* Dev - Comment: Correct development guidance for invalidating the styles cache after plugin updates.
+* Dev - Fix E2E assertions that could not fail: missing awaits, an assertion-free filter test, and swallowed add-payment-method outcomes.
+* Dev - Fix react-hooks/immutability ESLint violations
+* Dev - Fix react-hooks/set-state-in-effect ESLint violations.
+* Dev - Fix the E2E Action Scheduler helper so it finds the Run link on WordPress 7.1.
+* Dev - Make the subscriptions manage-payments E2E test locate the "Change payment" action by its URL contract instead of its ARIA role.
+* Dev - Make the subscriptions renewal E2E test resilient to Action Scheduler search-box copy changes (fixes the 4.1.0 relabel).
+* Dev - Remove skipped tests for the capital loan notice that was removed from the deposits overview.
+* Dev - Run the PHP test suite against WordPress nightly in the compatibility workflow.
+* Dev - Use a named permission callback for the public multi-currency config REST endpoint.
 
 = 11.0.1 - 2026-08-20 =
 * Fix - Fix the currency switcher not rendering on WordPress 7.1 in Storefront breadcrumbs and the wc_get_currency_switcher_markup() template tag.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -11,7 +11,7 @@
  * WC tested up to: 11.1.0
  * Requires at least: 6.0
  * Requires PHP: 7.4
- * Version: 11.0.1
+ * Version: 11.1.0
  * Requires Plugins: woocommerce
  *
  * @package WooCommerce\Payments


### PR DESCRIPTION
> [!NOTE]
> As the release lead, please approve and merge this PR on release day, once 11.1.0 has shipped. Please don't merge it at code freeze: post-freeze cherry-picks and date changes amend the release changelog, and the version bump should only land on `develop` once the release is out.

Applies the **version bump and changelog entries** from `release/11.1.0` to `develop` so that `develop` stays in sync without a `trunk → develop` merge. Since `trunk` is no longer merged back, this PR is the only thing that brings the 11.1.0 version bump onto `develop`.

Related release PR: #12076
