### PR TITLE
feat: make below-minimum WC versions safe and gate incompatible updates

### DIFF
--- a/changelog/feat-version-support-gating
+++ b/changelog/feat-version-support-gating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Keep WooPayments running with a warning notice when the installed WooCommerce version is below the minimum supported one, instead of partially disabling the plugin.

--- a/changelog/feat-version-support-gating
+++ b/changelog/feat-version-support-gating
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Keep WooPayments running with a warning notice when the installed WooCommerce version is below the minimum supported one, instead of partially disabling the plugin.
+Keep WooPayments running with a warning notice when the installed WooCommerce version is below the minimum supported one, and stop offering updates that require a newer WooCommerce version.

--- a/includes/class-wc-payments-dependency-service.php
+++ b/includes/class-wc-payments-dependency-service.php
@@ -32,6 +32,15 @@ class WC_Payments_Dependency_Service {
 		self::WOOADMIN_NOT_FOUND,
 	];
 
+	const UPDATE_WC_REQUIREMENT_TRANSIENT = 'wcpay_update_wc_requirement';
+
+	/**
+	 * Details of an update offer withheld by gate_plugin_updates() during this request, or null.
+	 *
+	 * @var array|null
+	 */
+	private $gated_update;
+
 	/**
 	 * Initializes this class's WP hooks.
 	 *
@@ -39,6 +48,8 @@ class WC_Payments_Dependency_Service {
 	 */
 	public function init_hooks() {
 		add_filter( 'admin_notices', [ $this, 'display_admin_notices' ] );
+		add_filter( 'site_transient_update_plugins', [ $this, 'gate_plugin_updates' ] );
+		add_action( 'after_plugin_row_' . plugin_basename( WCPAY_PLUGIN_FILE ), [ $this, 'display_gated_update_row_notice' ] );
 	}
 
 	/**
@@ -63,6 +74,135 @@ class WC_Payments_Dependency_Service {
 	 */
 	public function get_blocking_dependencies() {
 		return array_values( array_intersect( $this->get_invalid_dependencies(), self::BLOCKING_DEPENDENCIES ) );
+	}
+
+	/**
+	 * Withholds the plugin update offer when the offered version requires a newer
+	 * WooCommerce version than the one installed. Mirrors how WordPress core keeps
+	 * updates requiring a newer PHP version away from incompatible sites.
+	 *
+	 * @param mixed $transient Value of the update_plugins site transient.
+	 *
+	 * @return mixed The (possibly modified) transient value.
+	 */
+	public function gate_plugin_updates( $transient ) {
+		$plugin_file = plugin_basename( WCPAY_PLUGIN_FILE );
+
+		if ( ! is_object( $transient ) || empty( $transient->response[ $plugin_file ] ) || ! defined( 'WC_VERSION' ) ) {
+			return $transient;
+		}
+
+		$update      = $transient->response[ $plugin_file ];
+		$new_version = $update->new_version ?? null;
+
+		if ( ! $new_version ) {
+			return $transient;
+		}
+
+		$required_wc_version = $this->get_wc_version_required_by( $new_version );
+
+		// Fail open: without a known requirement, leave the offer alone.
+		if ( ! $required_wc_version || version_compare( WC_VERSION, $required_wc_version, '>=' ) ) {
+			return $transient;
+		}
+
+		// Moving the offer to no_update hides the update badge and keeps auto-updates away.
+		unset( $transient->response[ $plugin_file ] );
+		$transient->no_update[ $plugin_file ] = $update;
+
+		$this->gated_update = [
+			'new_version' => $new_version,
+			'wc_requires' => $required_wc_version,
+		];
+
+		return $transient;
+	}
+
+	/**
+	 * Returns the "WC requires at least" header of the given released plugin version,
+	 * fetched from the WordPress.org plugin repository and cached for 12 hours.
+	 *
+	 * @param string $version Version of WooPayments to look up.
+	 *
+	 * @return string|null The minimum required WooCommerce version, or null when unknown.
+	 */
+	public function get_wc_version_required_by( $version ) {
+		$cached = get_transient( self::UPDATE_WC_REQUIREMENT_TRANSIENT );
+
+		if ( is_array( $cached ) && ( $cached['version'] ?? null ) === $version ) {
+			return $cached['wc_requires'];
+		}
+
+		// Only fetch in admin or cron contexts, where update checks belong.
+		if ( ! is_admin() && ! wp_doing_cron() ) {
+			return null;
+		}
+
+		$response = wp_remote_get(
+			'https://plugins.svn.wordpress.org/woocommerce-payments/tags/' . rawurlencode( $version ) . '/woocommerce-payments.php',
+			[ 'timeout' => 5 ]
+		);
+
+		$wc_requires = null;
+
+		if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
+			$matched     = preg_match( '/^[ \t\/*#@]*WC requires at least:[ \t]*([0-9][0-9.]*)/mi', wp_remote_retrieve_body( $response ), $matches );
+			$wc_requires = $matched ? $matches[1] : null;
+		}
+
+		// Cache failures for a shorter time so a transient network error does not stick.
+		$expiration = null === $wc_requires ? HOUR_IN_SECONDS : 12 * HOUR_IN_SECONDS;
+		set_transient(
+			self::UPDATE_WC_REQUIREMENT_TRANSIENT,
+			[
+				'version'     => $version,
+				'wc_requires' => $wc_requires,
+			],
+			$expiration
+		);
+
+		return $wc_requires;
+	}
+
+	/**
+	 * Renders a plugins-screen row notice when an update offer was withheld
+	 * because the site's WooCommerce version is too old. Called on the
+	 * after_plugin_row_{$plugin_file} action.
+	 *
+	 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+	 *
+	 * @return void
+	 */
+	public function display_gated_update_row_notice( $plugin_file ) {
+		if ( null === $this->gated_update || ! defined( 'WC_VERSION' ) ) {
+			return;
+		}
+
+		$colspan = 4;
+		if ( function_exists( '_get_list_table' ) ) {
+			$colspan = _get_list_table( 'WP_Plugins_List_Table' )->get_column_count();
+		}
+
+		$is_active = function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_file );
+
+		$message = sprintf(
+			/* translators: %1: WooPayments, %2: new WooPayments version number, %3: WooCommerce, %4: WC version required by the new version, %5: currently installed WC version */
+			__( '%1$s %2$s is available, but it requires %3$s %4$s or greater (you are using %5$s). Update %3$s to receive new versions of %1$s, including security fixes.', 'woocommerce-payments' ),
+			'WooPayments',
+			$this->gated_update['new_version'],
+			'WooCommerce',
+			$this->gated_update['wc_requires'],
+			WC_VERSION
+		);
+
+		printf(
+			'<tr class="plugin-update-tr %1$s" id="%2$s-update" data-slug="%2$s" data-plugin="%3$s"><td colspan="%4$d" class="plugin-update colspanchange"><div class="update-message notice inline notice-warning notice-alt"><p>%5$s</p></div></td></tr>',
+			$is_active ? 'active' : 'inactive',
+			'woocommerce-payments',
+			esc_attr( $plugin_file ),
+			(int) $colspan,
+			esc_html( $message )
+		);
 	}
 
 	/**

--- a/includes/class-wc-payments-dependency-service.php
+++ b/includes/class-wc-payments-dependency-service.php
@@ -9,7 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-use WCPay\Database_Cache;
 
 /**
  * Validates dependencies (core, plugins, versions) for WCPAY
@@ -25,6 +24,15 @@ class WC_Payments_Dependency_Service {
 	const DEV_ASSETS_NOT_BUILT  = 'dev_assets_not_built';
 
 	/**
+	 * Dependencies that prevent the plugin from loading at all. The other
+	 * (version) dependencies only produce a warning notice.
+	 */
+	const BLOCKING_DEPENDENCIES = [
+		self::WOOCORE_NOT_FOUND,
+		self::WOOADMIN_NOT_FOUND,
+	];
+
+	/**
 	 * Initializes this class's WP hooks.
 	 *
 	 * @return void
@@ -34,9 +42,10 @@ class WC_Payments_Dependency_Service {
 	}
 
 	/**
-	 * Checks if all the dependencies needed to run WooPayments are present
+	 * Checks if the dependencies needed to load WooPayments are present.
+	 * Version incompatibilities do not block loading; they only produce a warning notice.
 	 *
-	 * @return bool True if all required dependencies are met.
+	 * @return bool True if all blocking dependencies are met.
 	 */
 	public function has_valid_dependencies() {
 
@@ -44,7 +53,16 @@ class WC_Payments_Dependency_Service {
 			return true;
 		}
 
-		return empty( $this->get_invalid_dependencies( true ) );
+		return empty( $this->get_blocking_dependencies() );
+	}
+
+	/**
+	 * Returns the invalid dependencies that prevent the plugin from loading.
+	 *
+	 * @return array of invalid dependencies as string constants.
+	 */
+	public function get_blocking_dependencies() {
+		return array_values( array_intersect( $this->get_invalid_dependencies(), self::BLOCKING_DEPENDENCIES ) );
 	}
 
 	/**
@@ -66,30 +84,34 @@ class WC_Payments_Dependency_Service {
 
 		$invalid_dependencies = $this->get_invalid_dependencies();
 
-		if ( ! empty( $invalid_dependencies ) ) {
-			WC_Payments::display_admin_error( $this->get_notice_for_invalid_dependency( $invalid_dependencies[0] ) );
+		if ( empty( $invalid_dependencies ) ) {
+			return;
 		}
+
+		$blocking_dependencies = array_values( array_intersect( $invalid_dependencies, self::BLOCKING_DEPENDENCIES ) );
+
+		if ( ! empty( $blocking_dependencies ) ) {
+			WC_Payments::display_admin_error( $this->get_notice_for_invalid_dependency( $blocking_dependencies[0] ) );
+			return;
+		}
+
+		WC_Payments::display_admin_notice( $this->get_notice_for_invalid_dependency( $invalid_dependencies[0] ), 'notice-warning' );
 	}
 
 	/**
 	 * Returns an array of invalid dependencies
 	 *
-	 * @param bool $check_account_connection - if should bypass dependency version validation when an account is connected.
-	 *
 	 * @return array of invalid dependencies as string constants.
 	 */
-	public function get_invalid_dependencies( bool $check_account_connection = false ) {
+	public function get_invalid_dependencies() {
 
 		$invalid_dependencies = [];
-
-		// Either ignore the account connection check or check if there's a cached account connection.
-		$ignore_when_account_is_connected = $check_account_connection && self::has_cached_account_connection();
 
 		if ( ! $this->is_woo_core_active() ) {
 			$invalid_dependencies[] = self::WOOCORE_NOT_FOUND;
 		}
 
-		if ( ! $ignore_when_account_is_connected && ! $this->is_woo_core_version_compatible() ) {
+		if ( ! $this->is_woo_core_version_compatible() ) {
 			$invalid_dependencies[] = self::WOOCORE_INCOMPATIBLE;
 		}
 
@@ -97,11 +119,11 @@ class WC_Payments_Dependency_Service {
 			$invalid_dependencies[] = self::WOOADMIN_NOT_FOUND;
 		}
 
-		if ( ! $ignore_when_account_is_connected && ! $this->is_wc_admin_version_compatible() ) {
+		if ( ! $this->is_wc_admin_version_compatible() ) {
 			$invalid_dependencies[] = self::WOOADMIN_INCOMPATIBLE;
 		}
 
-		if ( ! $ignore_when_account_is_connected && ! $this->is_wp_version_compatible() ) {
+		if ( ! $this->is_wp_version_compatible() ) {
 			$invalid_dependencies[] = self::WP_INCOMPATIBLE;
 		}
 
@@ -225,8 +247,8 @@ class WC_Payments_Dependency_Service {
 			case self::WOOCORE_INCOMPATIBLE:
 				$error_message = WC_Payments_Utils::esc_interpolated_html(
 					sprintf(
-						/* translators: %1: WooPayments, %2: current WooCommerce Payment version, %3: WooCommerce, %4: required WC version number, %5: currently installed WC version number */
-						__( '%1$s %2$s requires <strong>%3$s %4$s</strong> or greater to be installed (you are using %5$s). ', 'woocommerce-payments' ),
+						/* translators: %1: WooPayments, %2: current WooCommerce Payment version, %3: WooCommerce, %4: minimum supported WC version number, %5: currently installed WC version number */
+						__( '%1$s %2$s supports <strong>%3$s %4$s</strong> or greater (you are using %5$s). Some features may not work as expected until you update. ', 'woocommerce-payments' ),
 						'WooPayments',
 						WCPAY_VERSION_NUMBER,
 						'WooCommerce',
@@ -271,8 +293,8 @@ class WC_Payments_Dependency_Service {
 			case self::WOOADMIN_INCOMPATIBLE:
 				$error_message = WC_Payments_Utils::esc_interpolated_html(
 					sprintf(
-						/* translators: %1: WooPayments, %2: WooCommerce Admin, %3: required WC-Admin version number, %4: currently installed WC-Admin version number */
-						__( '%1$s requires <strong>%2$s %3$s</strong> or greater to be installed (you are using %4$s).', 'woocommerce-payments' ),
+						/* translators: %1: WooPayments, %2: WooCommerce Admin, %3: minimum supported WC-Admin version number, %4: currently installed WC-Admin version number */
+						__( '%1$s supports <strong>%2$s %3$s</strong> or greater (you are using %4$s).', 'woocommerce-payments' ),
 						'WooPayments',
 						'WooCommerce Admin',
 						WCPAY_MIN_WC_ADMIN_VERSION,
@@ -293,8 +315,8 @@ class WC_Payments_Dependency_Service {
 			case self::WP_INCOMPATIBLE:
 				$error_message = WC_Payments_Utils::esc_interpolated_html(
 					sprintf(
-						/* translators: %1: WooPayments, %2: required WP version number, %3: currently installed WP version number */
-						__( '%1$s requires <strong>WordPress %2$s</strong> or greater (you are using %3$s).', 'woocommerce-payments' ),
+						/* translators: %1: WooPayments, %2: minimum supported WP version number, %3: currently installed WP version number */
+						__( '%1$s supports <strong>WordPress %2$s</strong> or greater (you are using %3$s). Some features may not work as expected until you update.', 'woocommerce-payments' ),
 						'WooPayments',
 						$wp_version,
 						get_bloginfo( 'version' )
@@ -335,15 +357,5 @@ class WC_Payments_Dependency_Service {
 	private static function is_at_plugin_install_page() {
 		$cur_screen = get_current_screen();
 		return $cur_screen && 'update' === $cur_screen->id && 'plugins' === $cur_screen->parent_base;
-	}
-
-	/**
-	 * Check if the current WCPay Account has cache data.
-	 *
-	 * @return bool True if the cache data exists in wp_options.
-	 */
-	private static function has_cached_account_connection(): bool {
-		$account_data = get_option( Database_Cache::ACCOUNT_KEY );
-		return isset( $account_data['data'] ) && is_array( $account_data['data'] ) && ! empty( $account_data['data'] );
 	}
 }

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -138,6 +138,13 @@ class WC_Payments {
 	private static $dependency_service;
 
 	/**
+	 * Whether init() passed the dependency check and registered the full feature set.
+	 *
+	 * @var bool
+	 */
+	private static $initialized = false;
+
+	/**
 	 * Instance of WC_Payments_Fraud_Service, created in init function
 	 *
 	 * @var WC_Payments_Fraud_Service
@@ -370,6 +377,8 @@ class WC_Payments {
 		if ( false === self::$dependency_service->has_valid_dependencies() ) {
 			return;
 		}
+
+		self::$initialized = true;
 
 		add_action( 'admin_init', [ __CLASS__, 'add_woo_admin_notes' ] );
 		add_action( 'admin_init', [ __CLASS__, 'remove_deprecated_notes' ] );
@@ -900,6 +909,15 @@ class WC_Payments {
 	public static function add_post_kyc_activation_email( array $email_classes ): array {
 		$email_classes['WC_Payments_Email_Post_Kyc_Activation'] = include __DIR__ . '/emails/class-wc-payments-email-post-kyc-activation.php';
 		return $email_classes;
+	}
+
+	/**
+	 * Whether init() passed the dependency check and registered the full feature set.
+	 *
+	 * @return bool
+	 */
+	public static function is_initialized(): bool {
+		return self::$initialized;
 	}
 
 	/**

--- a/tests/unit/test-class-wc-payments-dependency-service.php
+++ b/tests/unit/test-class-wc-payments-dependency-service.php
@@ -17,6 +17,23 @@ class WC_Payments_Dependency_Service_Test extends WCPAY_UnitTestCase {
 		parent::set_up();
 
 		$this->dependency_service = new WC_Payments_Dependency_Service();
+		delete_transient( WC_Payments_Dependency_Service::UPDATE_WC_REQUIREMENT_TRANSIENT );
+	}
+
+	/**
+	 * Builds a mock update_plugins transient offering the given version of this plugin.
+	 *
+	 * @param string $new_version Version to offer.
+	 *
+	 * @return object
+	 */
+	private function build_update_transient( $new_version ) {
+		return (object) [
+			'response'  => [
+				plugin_basename( WCPAY_PLUGIN_FILE ) => (object) [ 'new_version' => $new_version ],
+			],
+			'no_update' => [],
+		];
 	}
 
 	public function test_get_invalid_dependencies() {
@@ -150,6 +167,120 @@ class WC_Payments_Dependency_Service_Test extends WCPAY_UnitTestCase {
 
 		$this->assertStringContainsString( 'notice-error', $result );
 		$this->assertStringContainsString( 'to be installed and active', $result );
+	}
+
+	public function test_gate_plugin_updates_withholds_incompatible_offer() {
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'gate_plugin_updates' ] )
+			->getMock();
+		$dependency_service->method( 'get_wc_version_required_by' )->willReturn( '99.0' );
+
+		$transient = $dependency_service->gate_plugin_updates( $this->build_update_transient( '99.9.9' ) );
+
+		$this->assertArrayNotHasKey( plugin_basename( WCPAY_PLUGIN_FILE ), $transient->response );
+		$this->assertArrayHasKey( plugin_basename( WCPAY_PLUGIN_FILE ), $transient->no_update );
+	}
+
+	public function test_gate_plugin_updates_keeps_compatible_offer() {
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'gate_plugin_updates' ] )
+			->getMock();
+		$dependency_service->method( 'get_wc_version_required_by' )->willReturn( '0.1' );
+
+		$transient = $dependency_service->gate_plugin_updates( $this->build_update_transient( '99.9.9' ) );
+
+		$this->assertArrayHasKey( plugin_basename( WCPAY_PLUGIN_FILE ), $transient->response );
+		$this->assertArrayNotHasKey( plugin_basename( WCPAY_PLUGIN_FILE ), $transient->no_update );
+	}
+
+	public function test_gate_plugin_updates_fails_open_when_requirement_unknown() {
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'gate_plugin_updates' ] )
+			->getMock();
+		$dependency_service->method( 'get_wc_version_required_by' )->willReturn( null );
+
+		$transient = $dependency_service->gate_plugin_updates( $this->build_update_transient( '99.9.9' ) );
+
+		$this->assertArrayHasKey( plugin_basename( WCPAY_PLUGIN_FILE ), $transient->response );
+	}
+
+	public function test_gate_plugin_updates_ignores_transient_without_an_offer() {
+		$transient = (object) [
+			'response'  => [],
+			'no_update' => [],
+		];
+
+		$this->assertSame( $transient, $this->dependency_service->gate_plugin_updates( $transient ) );
+		$this->assertFalse( $this->dependency_service->gate_plugin_updates( false ) );
+	}
+
+	public function test_get_wc_version_required_by_fetches_and_caches_the_header() {
+		set_current_screen( 'plugins' );
+
+		$request_count = 0;
+		$fake_response = function ( $preempt, $parsed_args, $url ) use ( &$request_count ) {
+			++$request_count;
+			$this->assertStringContainsString( 'plugins.svn.wordpress.org/woocommerce-payments/tags/99.9.9/', $url );
+			return [
+				'response' => [ 'code' => 200 ],
+				'body'     => '<?php
+/**
+ * Plugin Name: WooPayments
+ * WC requires at least: 9.9
+ * Version: 99.9.9
+ */
+',
+			];
+		};
+		add_filter( 'pre_http_request', $fake_response, 10, 3 );
+
+		$this->assertEquals( '9.9', $this->dependency_service->get_wc_version_required_by( '99.9.9' ) );
+		$this->assertEquals( '9.9', $this->dependency_service->get_wc_version_required_by( '99.9.9' ) );
+		$this->assertEquals( 1, $request_count, 'The second lookup should be served from the cached transient.' );
+
+		remove_filter( 'pre_http_request', $fake_response );
+		set_current_screen( 'front' );
+	}
+
+	public function test_get_wc_version_required_by_returns_null_on_fetch_failure() {
+		set_current_screen( 'plugins' );
+
+		$fake_response = function () {
+			return new WP_Error( 'http_request_failed', 'timeout' );
+		};
+		add_filter( 'pre_http_request', $fake_response );
+
+		$this->assertNull( $this->dependency_service->get_wc_version_required_by( '99.9.9' ) );
+
+		remove_filter( 'pre_http_request', $fake_response );
+		set_current_screen( 'front' );
+	}
+
+	public function test_display_gated_update_row_notice_renders_after_gating() {
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'gate_plugin_updates', 'display_gated_update_row_notice' ] )
+			->getMock();
+		$dependency_service->method( 'get_wc_version_required_by' )->willReturn( '99.0' );
+
+		$dependency_service->gate_plugin_updates( $this->build_update_transient( '99.9.9' ) );
+
+		ob_start();
+		$dependency_service->display_gated_update_row_notice( plugin_basename( WCPAY_PLUGIN_FILE ) );
+		$result = ob_get_clean();
+
+		$this->assertStringContainsString( 'requires WooCommerce 99.0 or greater', $result );
+	}
+
+	public function test_display_gated_update_row_notice_renders_nothing_without_a_gated_update() {
+		ob_start();
+		$this->dependency_service->display_gated_update_row_notice( plugin_basename( WCPAY_PLUGIN_FILE ) );
+		$result = ob_get_clean();
+
+		$this->assertSame( '', $result );
 	}
 
 	public function test_display_admin_notices() {

--- a/tests/unit/test-class-wc-payments-dependency-service.php
+++ b/tests/unit/test-class-wc-payments-dependency-service.php
@@ -62,6 +62,96 @@ class WC_Payments_Dependency_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertContains( WC_Payments_Dependency_Service::WP_INCOMPATIBLE, $invalid_deps );
 	}
 
+	public function test_get_invalid_dependencies_ignores_cached_account_connection() {
+		update_option( WCPay\Database_Cache::ACCOUNT_KEY, [ 'data' => [ 'account_id' => 'acct_123' ] ] );
+
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'get_invalid_dependencies' ] )
+			->getMock();
+
+		$dependency_service->method( 'is_woo_core_active' )->willReturn( true );
+		$dependency_service->method( 'is_woo_core_version_compatible' )->willReturn( false );
+		$dependency_service->method( 'is_wc_admin_enabled' )->willReturn( true );
+		$dependency_service->method( 'is_wc_admin_version_compatible' )->willReturn( true );
+		$dependency_service->method( 'is_wp_version_compatible' )->willReturn( true );
+
+		// The removed second argument used to skip version checks for connected accounts.
+		$invalid_deps = $dependency_service->get_invalid_dependencies( true );
+
+		$this->assertEquals( [ 'woocore_outdated' ], $invalid_deps );
+
+		delete_option( WCPay\Database_Cache::ACCOUNT_KEY );
+	}
+
+	public function test_get_blocking_dependencies_excludes_version_incompatibilities() {
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'get_blocking_dependencies', 'get_invalid_dependencies' ] )
+			->getMock();
+
+		$dependency_service->method( 'is_woo_core_active' )->willReturn( true );
+		$dependency_service->method( 'is_woo_core_version_compatible' )->willReturn( false );
+		$dependency_service->method( 'is_wc_admin_enabled' )->willReturn( true );
+		$dependency_service->method( 'is_wc_admin_version_compatible' )->willReturn( false );
+		$dependency_service->method( 'is_wp_version_compatible' )->willReturn( false );
+
+		$this->assertEquals( [], $dependency_service->get_blocking_dependencies() );
+	}
+
+	public function test_get_blocking_dependencies_includes_missing_woo_core() {
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'get_blocking_dependencies', 'get_invalid_dependencies' ] )
+			->getMock();
+
+		$dependency_service->method( 'is_woo_core_active' )->willReturn( false );
+		$dependency_service->method( 'is_woo_core_version_compatible' )->willReturn( true );
+		$dependency_service->method( 'is_wc_admin_enabled' )->willReturn( true );
+		$dependency_service->method( 'is_wc_admin_version_compatible' )->willReturn( true );
+		$dependency_service->method( 'is_wp_version_compatible' )->willReturn( true );
+
+		$this->assertEquals( [ 'woocore_disabled' ], $dependency_service->get_blocking_dependencies() );
+	}
+
+	public function test_display_admin_notices_renders_version_incompatibility_as_warning() {
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'display_admin_notices' ] )
+			->getMock();
+
+		$dependency_service->method( 'are_assets_built' )->willReturn( true );
+		$dependency_service
+			->method( 'get_invalid_dependencies' )
+			->willReturn( [ WC_Payments_Dependency_Service::WOOCORE_INCOMPATIBLE ] );
+
+		ob_start();
+		$dependency_service->display_admin_notices();
+		$result = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-warning', $result );
+		$this->assertStringNotContainsString( 'notice-error', $result );
+	}
+
+	public function test_display_admin_notices_renders_blocking_dependency_as_error() {
+		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setConstructorArgs( [] )
+			->setMethodsExcept( [ 'display_admin_notices' ] )
+			->getMock();
+
+		$dependency_service->method( 'are_assets_built' )->willReturn( true );
+		$dependency_service
+			->method( 'get_invalid_dependencies' )
+			->willReturn( [ WC_Payments_Dependency_Service::WOOCORE_INCOMPATIBLE, WC_Payments_Dependency_Service::WOOCORE_NOT_FOUND ] );
+
+		ob_start();
+		$dependency_service->display_admin_notices();
+		$result = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-error', $result );
+		$this->assertStringContainsString( 'to be installed and active', $result );
+	}
+
 	public function test_display_admin_notices() {
 
 		// Create a partial mock, leaving out the method under test.

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -163,6 +163,15 @@ function wcpay_init() {
 	require_once WCPAY_ABSPATH . '/includes/class-wc-payments.php';
 	require_once WCPAY_ABSPATH . '/includes/class-wc-payments-payment-request-session.php';
 	WC_Payments::init();
+
+	/**
+	 * Stop when WC_Payments could not initialize: the components below rely on its services.
+	 * Check https://github.com/Automattic/woocommerce-payments/issues/7147
+	 */
+	if ( ! WC_Payments::is_initialized() ) {
+		return;
+	}
+
 	/**
 	 * Needs to be loaded as soon as possible
 	 * Check https://github.com/Automattic/woocommerce-payments/issues/4759


### PR DESCRIPTION
Fixes #7147.

#### Changes proposed in this Pull Request

Our `WC requires at least` header has been stuck at 7.6 since September 2023 because bumping it could disable the plugin on stores below the new minimum, and in the worst case fatal them (the 6.4.1 incident). This PR makes a bump safe. The bump itself follows in #12079.

**1. A WooCommerce version below the minimum no longer disables the plugin**

- Version incompatibilities (WC, WC Admin, WP) now only show a warning notice. The plugin loads and keeps taking payments.
- Only a missing WooCommerce or disabled WC Admin still blocks `WC_Payments::init()`, and `wcpay_init()` now stops cleanly when that happens. This removes the half-loaded state behind #7147.
- The cached-account bypass in `WC_Payments_Dependency_Service` is removed, as nothing needs it now.

**2. Updates that require a newer WooCommerce version are not offered**

- `gate_plugin_updates()` filters `site_transient_update_plugins` and hides the offer when the new version needs a newer WooCommerce than the site runs.
- The new version's requirement is read from its tagged plugin file on WordPress.org and cached for 12 hours. Any failure fails open, so an update is never withheld by mistake.
- A notice on the plugins screen explains that WooCommerce must be updated first, like WordPress core does for updates needing a newer PHP version.

**Notes**

- The gate only works going forward. Older plugin versions still see update offers, but part 1 turns the outcome into a warning instead of a fatal.
- A store kept below the minimum stops receiving updates, including security fixes, because WordPress.org only serves one stable version. The notice tells the merchant how to resume them.
- BC impact: `has_valid_dependencies()` now ignores version incompatibilities and `get_invalid_dependencies()` loses its `$check_account_connection` parameter (PHP ignores extra arguments, so existing callers keep working). The new public methods and the `wcpay_update_wc_requirement` transient are additive. No hooks changed.

**Prior art**

- WordPress.org already gates updates this way for the requirements it knows about: its update API withholds an offer when the site's WordPress or PHP version doesn't meet the new version's `Requires at least` / `Requires PHP`. I verified this against the live API, where a site reporting WP 6.8 gets no WooCommerce 11.0.1 offer and a WP 6.9 site does. This PR applies the same model to a header the API can't see.
- The plugin dependencies feature in WordPress 6.5 (`Requires Plugins`) deliberately shipped [without version constraints](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/) and only gates activation, so there is no platform mechanism for plugin-to-plugin version requirements.
- Plugins with a parent dependency generally don't gate their own updates and rely on runtime notices instead. Elementor Pro is the best-known example of where that leads: elementor/elementor#14576 has been open since 2021 because updating Pro past the free plugin breaks sites.
- Filtering `site_transient_update_plugins` is itself a standard mechanism. The WooCommerce.com marketplace updater and licensed-plugin updaters use the same filter.

#### Testing instructions

**Below the minimum, the plugin keeps working**

1. In `woocommerce-payments.php`, temporarily set `WC requires at least: 99.0`. This simulates a store below the floor without downgrading WooCommerce.
2. Reload wp-admin. Confirm the site does not fatal, WooPayments stays active, and an amber warning notice (not an error) asks you to update WooCommerce.

   ![Below-minimum warning notice](https://raw.githubusercontent.com/wiki/Automattic/woocommerce-payments/pr-testing-images/pr-12078-below-minimum-warning-notice.png)
3. Place an order with a test card (4242 4242 4242 4242). Confirm the payment succeeds and the order reaches Processing.

   ![Order received below the minimum](https://raw.githubusercontent.com/wiki/Automattic/woocommerce-payments/pr-testing-images/pr-12078-below-minimum-order-received.png)
4. Revert the header change.

**Update gating**

1. If your environment runs a plugin that disables update checks (the Docker env has "Disable All WordPress Updates"), deactivate it first.
2. Seed a fake requirement and update offer:
   ```
   wp eval 'set_transient( WC_Payments_Dependency_Service::UPDATE_WC_REQUIREMENT_TRANSIENT, [ "version" => "99.9.9", "wc_requires" => "99.0" ], HOUR_IN_SECONDS );'
   wp eval '$f = plugin_basename( WCPAY_PLUGIN_FILE ); $t = get_site_transient( "update_plugins" ); if ( ! is_object( $t ) ) { $t = (object) [ "no_update" => [] ]; } $t->response[ $f ] = (object) [ "slug" => "woocommerce-payments", "plugin" => $f, "new_version" => "99.9.9", "package" => "" ]; set_site_transient( "update_plugins", $t );'
   ```
3. Go to Plugins. Confirm WooPayments shows no update badge, and a row notice explains the new version requires a newer WooCommerce.

   ![Gated update row notice](https://raw.githubusercontent.com/wiki/Automattic/woocommerce-payments/pr-testing-images/pr-12078-update-gated-row-notice.png)
4. Make the offered version compatible and reload Plugins. The normal update row comes back (fail open works the same way if you delete the requirement transient instead).
   ```
   wp eval 'set_transient( WC_Payments_Dependency_Service::UPDATE_WC_REQUIREMENT_TRANSIENT, [ "version" => "99.9.9", "wc_requires" => "1.0" ], HOUR_IN_SECONDS );'
   ```

   ![Update offered when compatible](https://raw.githubusercontent.com/wiki/Automattic/woocommerce-payments/pr-testing-images/pr-12078-update-offered-when-compatible.png)
5. Clean up:
   ```
   wp eval 'delete_transient( WC_Payments_Dependency_Service::UPDATE_WC_REQUIREMENT_TRANSIENT ); delete_site_transient( "update_plugins" );'
   ```

**Optional: real requirement lookup**

1. Confirm the live WordPress.org lookup parses a released version's header:
   ```
   wp eval 'add_filter( "wp_doing_cron", "__return_true" ); var_dump( ( new WC_Payments_Dependency_Service() )->get_wc_version_required_by( "11.0.1" ) );'
   ```
   It should print `string(3) "7.6"`.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
