### PR TITLE
chore: bump the minimum supported WC and WP versions to L-2

### DIFF
--- a/.github/actions/load-version-constants/action.yml
+++ b/.github/actions/load-version-constants/action.yml
@@ -13,5 +13,5 @@ runs:
     - id: vars
       shell: bash
       run: |
-        echo "gutenberg_for_wp_min=13.6.0" >> $GITHUB_OUTPUT
+        echo "gutenberg_for_wp_min=22.3.0" >> $GITHUB_OUTPUT
         echo "gutenberg_for_php_min=22.3.0" >> $GITHUB_OUTPUT

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  WC_MIN_SUPPORTED_VERSION: '7.6.0'
-  WP_MIN_SUPPORTED_VERSION: '6.0'
+  WC_MIN_SUPPORTED_VERSION: '10.9.0'
+  WP_MIN_SUPPORTED_VERSION: '6.9'
   PHP_MIN_SUPPORTED_VERSION: '7.4'
 
 concurrency:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ env:
   E2E_SLACK_TOKEN:               ${{ secrets.E2E_SLACK_TOKEN }}
   E2E_USE_LOCAL_SERVER:          false
   E2E_RESULT_FILEPATH:           'tests/e2e/results.json'
-  WC_MIN_SUPPORTED_VERSION:      '7.6.0'
+  WC_MIN_SUPPORTED_VERSION:      '10.9.0'
   NODE_ENV:                      'test'
   FORCE_E2E_DEPS_SETUP:          true
 

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   WP_VERSION:        latest
-  WC_MIN_SUPPORTED_VERSION: '7.6.0'
+  WC_MIN_SUPPORTED_VERSION: '10.9.0'
   PHP_MIN_SUPPORTED_VERSION: '7.4'
 
 concurrency:

--- a/changelog/chore-bump-min-versions-l2
+++ b/changelog/chore-bump-min-versions-l2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Bump the minimum supported WooCommerce version to 10.9 and the minimum WordPress version to 6.9, following the L-2 support policy.

--- a/docs/version-support-policy.md
+++ b/docs/version-support-policy.md
@@ -1,18 +1,20 @@
 # Version Support Policy
 
-We have officially announced the L-2 version support policy for WooCommerce and WordPress core [since May 2021](https://developer.woocommerce.com/2021/05/12/woocommerce-payments-is-adopting-a-new-version-support-policy/).
+We have officially announced the L-2 version support policy for WooCommerce and WordPress core [since May 2021](https://developer.woocommerce.com/2021/05/12/woocommerce-payments-is-adopting-a-new-version-support-policy/): we support the current major version and the two before it.
 
-However, in the practice, we're really enforcing only WordPress core with the `Requires at least` in [`readme.txt`](https://github.com/Automattic/woocommerce-payments/blob/develop/readme.txt) and [`woocommerce-payments.php`](https://github.com/Automattic/woocommerce-payments/blob/develop/woocommerce-payments.php).
+The minimum supported versions are declared in [`woocommerce-payments.php`](https://github.com/Automattic/woocommerce-payments/blob/develop/woocommerce-payments.php):
 
-For WooCommerce, we are yet to fully support this L-2 policy. The real minimum WooCommerce version can be found on [`woocommerce-payments.php`](https://github.com/Automattic/woocommerce-payments/blob/develop/woocommerce-payments.php) with the `WC requires at least` tag. There are two main reasons for this:
+- `WC requires at least` for WooCommerce.
+- `Requires at least` for WordPress core (also in [`readme.txt`](https://github.com/Automattic/woocommerce-payments/blob/develop/readme.txt)).
 
-- There is no reliable built-in functionality that prevents a merchant from installing the latest version of WooCommerce Payments (WCPay) with an unsupported WooCommerce version. To deal with this issue, we continue loading WCPay if sites have an active WCPay account, but nudge their owners to upgrade WooCommerce. More details in [this PR](https://github.com/Automattic/woocommerce-payments/pull/3010), which is later refactored to `WC_Payments_Dependency_Service`.
-- Some of our internal consumers are also not yet using the latest version of WooCommerce. See paJDYF-3fF-p2#comment-9591
+Both move to L-2 as part of each release.
+
+## How the minimum is enforced
+
+- **Below the minimum, the plugin still loads and takes payments.** The merchant sees a warning notice asking them to update. Version incompatibilities never disable the plugin; only a missing WooCommerce install does. See `WC_Payments_Dependency_Service`.
+- **Updates are gated.** When a new WooPayments version requires a newer WooCommerce version than the site runs, the update is not offered (`WC_Payments_Dependency_Service::gate_plugin_updates()`), and a notice on the plugins screen explains that WooCommerce must be updated first. This mirrors how WordPress core handles updates that require a newer PHP version.
+- **WordPress core enforces the WP minimum.** Sites below `Requires at least` are not offered the update by WordPress itself.
 
 ## What does this policy mean for contributors?
 
-As a contributor to WCPay, you would be mindful when adding new features and functions to your PRs as your code needs to work within proper ranges of WordPress and WooCommerce versions. Although we have [a CI workflow](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/compatibility.yml) to check the compatibility between WCPay and these ranges, it's still good for contributors to be aware of this policy.
-
-## When will WCPay fully support L-2 for WooCommerce core?
-
-We have no ETA for this yet, and you're recommended to check the current minimum WooCommerce version in the code at the moment of writing your code. That said, we're working on a few approaches to reduce the gap between the real minimum supported version and the L-2 version. paJDYF-3fF-p2
+Your code needs to work across the supported WooCommerce and WordPress range (L, L-1, L-2). The [compatibility CI workflow](https://github.com/Automattic/woocommerce-payments/blob/develop/.github/workflows/compatibility.yml) tests against the declared minimums; keep its `WC_MIN_SUPPORTED_VERSION` and `WP_MIN_SUPPORTED_VERSION` values in sync with the plugin headers when the floor moves.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooPayments: Integrated WooCommerce Payments ===
 Contributors: woocommerce, automattic
 Tags: woocommerce payments, apple pay, credit card, google pay, payment, payment gateway
-Requires at least: 6.0
+Requires at least: 6.9
 Tested up to: 7.1
 Requires PHP: 7.3
 Stable tag: 11.0.1

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -7,9 +7,9 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-payments
  * Domain Path: /languages
- * WC requires at least: 7.6
+ * WC requires at least: 10.9
  * WC tested up to: 11.1.0
- * Requires at least: 6.0
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 11.0.1
  * Requires Plugins: woocommerce


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With below-minimum WooCommerce versions no longer disabling the plugin and incompatible updates no longer offered (#12078), the `WC requires at least` header can track the announced L-2 policy again. This PR moves the floors.

- Bump `WC requires at least` from 7.6 to 10.9 (L-2 of the current 11.1).
- Bump `Requires at least` from 6.0 to 6.9 in the plugin header and `readme.txt`. WC 10.8+ already requires WP 6.9, and WordPress core enforces this header natively.
- Move the CI minimum-version floors (`compatibility.yml`, `php-lint-test.yml`, `e2e-test.yml`) with the headers, and raise the Gutenberg version paired with the WP minimum to one that supports WP 6.9.
- Rewrite `docs/version-support-policy.md` to describe the new model.

**Notes**

- This PR must merge after #12078. Without the gating in place, a bumped header would disable the plugin on stores below the new minimum.
- I think the exact header values are a release decision, so I'm happy to adjust them. The header should represent L-2 at the release that ships it.

#### Testing instructions

1. Confirm the compatibility CI workflow passes with the new floors (WC 10.9.0, WP 6.9).
2. On a site with WooCommerce 10.9 or newer, confirm the plugin activates and works as usual.
3. On a site below WooCommerce 10.9, confirm the below-minimum warning notice from #12078 appears and the plugin keeps working.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
