### PR TITLE
fix: keep comment-style notes out of the compiled changelog

### DIFF
--- a/bin/class-wcpay-changelog-formatter.php
+++ b/bin/class-wcpay-changelog-formatter.php
@@ -188,9 +188,11 @@ class WCPay_Changelog_Formatter extends Parser implements FormatterPlugin {
 
 			foreach ( $entry->getChanges() as $change ) {
 				$text = trim( $change->getContent() );
-				if ( '' !== $text ) {
-					$ret .= $this->bullet . ' ' . $change->getSubheading() . ' ' . $this->separator . ' ' . $text . "\n";
+				// Text starting with "Comment:" is an internal note authored as entry content, so keep it out of the changelog.
+				if ( '' === $text || preg_match( '/^comment:/i', $text ) ) {
+					continue;
 				}
+				$ret .= $this->bullet . ' ' . $change->getSubheading() . ' ' . $this->separator . ' ' . $text . "\n";
 			}
 
 			$ret = trim( $ret ) . "\n\n";

--- a/changelog/dev-check-changelog-comment-in-body
+++ b/changelog/dev-check-changelog-comment-in-body
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Keep entries whose text starts with Comment: out of the compiled changelog, so internal notes authored in the entry body no longer ship in readme.txt.


### PR DESCRIPTION
Follow-up to the 11.1.0 sync review on #12077.

#### Changes proposed in this Pull Request

A changelog entry that puts `Comment:` after the blank line passes `changelogger validate`, because everything after the blank line is entry content. The internal note then compiles into a visible `Dev - Comment: ...` line in the merchant-facing changelog. This shipped in 11.1.0 (removed in 462b0c331) and in at least 11 earlier releases.

- Skip any change whose text starts with `Comment:` (case-insensitive) when `WCPay_Changelog_Formatter` writes the changelog, so a misplaced comment is treated as the comment it was meant to be, however the entry file was authored.

**Note:** `changelogger write` re-formats the whole of `changelog.txt`, so the 12 already-leaked `Dev - Comment:` lines from past releases will also drop out on the next release compile. That cleanup will show as removals in the 11.2.0 release PR diff.

#### Testing instructions

1. Create a malformed entry, one that puts `Comment:` in the body instead of the header:
   ```bash
   printf 'Significance: patch\nType: dev\n\nComment: internal note\n' > changelog/test-malformed
   ```
2. Compile the changelog: `vendor/bin/changelogger write --use-version=99.9.9`
3. Check the new 99.9.9 block in `changelog.txt` does not contain the internal note, and that the historical `Dev - Comment:` lines from past releases are gone.
4. Discard the local changes: `git checkout -- changelog.txt changelog/`

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) - release-time tooling with no test harness precedent; verified with the end-to-end compile step above.
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
