### PR TITLE
ci: merge the develop sync PR on release day, not at code freeze

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -154,7 +154,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.create_branch.outputs.trimmed-version }}
           RELEASE_PR_ID: ${{ steps.create-pr-to-trunk.outputs.RELEASE_PR_ID }}
         run: |
-          PR_BODY=$(echo -e "> [!NOTE]\n> As the release lead, please approve and merge this PR after the code freeze process is done successfully.\n\nApplies the **version bump and changelog entries** from \`release/$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge. Since \`trunk\` is no longer merged back, this PR is the only thing that brings the $RELEASE_VERSION version bump onto \`develop\`.\n\nRelated release PR: #${RELEASE_PR_ID}")
+          PR_BODY=$(echo -e "> [!NOTE]\n> As the release lead, please approve and merge this PR on release day, once $RELEASE_VERSION has shipped. Please don't merge it at code freeze: post-freeze cherry-picks and date changes amend the release changelog, and the version bump should only land on \`develop\` once the release is out.\n\nApplies the **version bump and changelog entries** from \`release/$RELEASE_VERSION\` to \`develop\` so that \`develop\` stays in sync without a \`trunk → develop\` merge. Since \`trunk\` is no longer merged back, this PR is the only thing that brings the $RELEASE_VERSION version bump onto \`develop\`.\n\nRelated release PR: #${RELEASE_PR_ID}")
           DEVELOP_PR_URL=$(gh pr create \
             --title "Sync develop after $RELEASE_VERSION: version bump + changelog" \
             --body "$PR_BODY" \

--- a/changelog/fix-sync-pr-merge-timing
+++ b/changelog/fix-sync-pr-merge-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Tell the release lead to merge the develop sync PR on release day, not at code freeze


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The generated develop sync PR tells the release lead to "approve and merge this PR after the code freeze process is done successfully". That's the wrong moment: the changelog it carries is only final once the release ships (post-freeze cherry-picks and date changes amend it), and the version bump shouldn't land on `develop` for a version that isn't released yet. The 11.0.0 retro added the release-day step to the process docs; this aligns the generated note with it.

- Update the sync PR note in `release-pr.yml` to say merge on release day, once the release has shipped, with the reason inline.

The 11.1.0 sync PR (#12077) has been updated by hand to match.

#### Testing instructions

1. Check the note text in `.github/workflows/release-pr.yml`.
2. Compare with #12077's description, which now carries the same wording.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (workflow text change)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
