### PR TITLE
fix: keep the Payments Overview rendering when the settings request fails

### DIFF
--- a/changelog/fix-woopmnt-6426-overview-settings-guard
+++ b/changelog/fix-woopmnt-6426-overview-settings-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the Payments Overview page crashing when the settings request fails.

--- a/client/overview/__tests__/index.test.js
+++ b/client/overview/__tests__/index.test.js
@@ -12,6 +12,7 @@ import { select } from '@wordpress/data';
 import OverviewPage from '../';
 import { getTasks } from '../task-list/tasks';
 import { getQuery } from '@woocommerce/navigation';
+import { useGetSettings } from 'wcpay/data/settings';
 
 const settingsMock = {
 	enabled_payment_method_ids: [ 'foo', 'bar' ],
@@ -141,6 +142,15 @@ describe( 'Overview page', () => {
 		};
 		getQuery.mockReturnValue( {} );
 		getTasks.mockReturnValue( [] );
+		useGetSettings.mockReturnValue( {
+			enabled_payment_method_ids: [ 'foo', 'bar' ],
+		} );
+	} );
+
+	it( 'Renders even when the settings request has failed', () => {
+		useGetSettings.mockReturnValue( {} );
+
+		expect( () => render( <OverviewPage /> ) ).not.toThrow();
 	} );
 
 	it( 'Skips rendering task list when there are no tasks', () => {

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -145,9 +145,10 @@ const OverviewPage = () => {
 
 	const activeAccountFees = Object.entries( wcpaySettings.accountFees )
 		.map( ( [ key, value ] ) => {
+			// The settings can be empty when the request fails; don't crash the page.
 			const isPaymentMethodEnabled =
 				! settingsIsLoading &&
-				settings.enabled_payment_method_ids.filter(
+				( settings.enabled_payment_method_ids ?? [] ).filter(
 					( enabledMethod ) => {
 						return enabledMethod === key;
 					}


### PR DESCRIPTION
Fixes WOOPMNT-6426

#### Changes proposed in this Pull Request

When the settings request fails, the whole Payments → Overview page crashes with `TypeError: Cannot read properties of undefined (reading 'filter')`. The `activeAccountFees` computation reads `settings.enabled_payment_method_ids` guarded only by `settingsIsLoading`, and a failed request leaves the array undefined with loading false. This was surfaced by API rate limiting during 11.1.0 release pre-testing.

- Default the enabled payment method list to an empty array, so the page renders and the fee discount info simply stays hidden until settings load.
- Add a regression test rendering the Overview with empty settings.

#### Testing instructions

1. Run `pnpm run test:js -- client/overview` and check the "Renders even when the settings request has failed" test passes.
2. **Manual repro:** open Payments → Overview on a connected store and check it renders. In the browser devtools Network tab, add a request-blocking pattern for `*payments%2Fsettings*` (the wc-admin settings fetch) and reload the page.
3. Without this change the page crashes with the TypeError in the console; with it, the page renders normally without the fee discount details.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : 'QA Testing Not Applicable'
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
