### PR TITLE
Run deprecated inbox note cleanup during plugin updates

### DIFF
--- a/changelog/fix-wccom-2823-run-deprecated-note-cleanup-on-update
+++ b/changelog/fix-wccom-2823-run-deprecated-note-cleanup-on-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove a deprecated inbox note during the plugin update process.

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -372,7 +372,6 @@ class WC_Payments {
 		}
 
 		add_action( 'admin_init', [ __CLASS__, 'add_woo_admin_notes' ] );
-		add_action( 'admin_init', [ __CLASS__, 'remove_deprecated_notes' ] );
 		add_action( 'init', [ __CLASS__, 'install_actions' ] );
 
 		// Invalidate styles cache and recompute WooPay appearance when theme or styles change.
@@ -745,6 +744,7 @@ class WC_Payments {
 		require_once __DIR__ . '/migrations/class-allowed-payment-request-button-sizes-update.php';
 		require_once __DIR__ . '/migrations/class-update-service-data-from-server.php';
 		require_once __DIR__ . '/migrations/class-additional-payment-methods-admin-notes-removal.php';
+		require_once __DIR__ . '/migrations/class-qualitative-feedback-admin-note-removal.php';
 		require_once __DIR__ . '/migrations/class-link-woopay-mutual-exclusion-handler.php';
 		require_once __DIR__ . '/migrations/class-gateway-settings-sync.php';
 		require_once __DIR__ . '/migrations/class-delete-active-woopay-webhook.php';
@@ -761,6 +761,7 @@ class WC_Payments {
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Allowed_Payment_Request_Button_Sizes_Update( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Update_Service_Data_From_Server( self::get_account_service() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Additional_Payment_Methods_Admin_Notes_Removal(), 'maybe_migrate' ] );
+		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Qualitative_Feedback_Admin_Note_Removal(), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Link_WooPay_Mutual_Exclusion_Handler( self::get_gateway() ), 'maybe_migrate' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ new \WCPay\Migrations\Gateway_Settings_Sync( self::get_gateway(), self::get_payment_gateway_map() ), 'maybe_sync' ] );
 		add_action( 'woocommerce_woocommerce_payments_updated', [ '\WCPay\Migrations\Delete_Active_WooPay_Webhook', 'maybe_delete' ] );

--- a/includes/migrations/class-qualitative-feedback-admin-note-removal.php
+++ b/includes/migrations/class-qualitative-feedback-admin-note-removal.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Class Qualitative_Feedback_Admin_Note_Removal
+ *
+ * @package WooCommerce\Payments
+ */
+
+namespace WCPay\Migrations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Removes the deprecated qualitative feedback admin note during plugin update.
+ *
+ * @since 11.1.0
+ */
+class Qualitative_Feedback_Admin_Note_Removal {
+
+	/**
+	 * Version in which this migration was introduced.
+	 *
+	 * @var string
+	 */
+	const VERSION_SINCE = '11.1.0';
+
+	/**
+	 * Only execute the migration if it was not applied yet.
+	 */
+	public function maybe_migrate() {
+		$previous_version = get_option( 'woocommerce_woocommerce_payments_version' );
+		if ( version_compare( self::VERSION_SINCE, $previous_version, '>' ) ) {
+			$this->migrate();
+		}
+	}
+
+	/**
+	 * Removes the deprecated note.
+	 */
+	private function migrate() {
+		\WC_Payments::remove_deprecated_notes();
+	}
+}

--- a/includes/migrations/class-qualitative-feedback-admin-note-removal.php
+++ b/includes/migrations/class-qualitative-feedback-admin-note-removal.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Removes the deprecated qualitative feedback admin note during plugin update.
  *
- * @since 11.1.0
+ * @since 11.2.0
  */
 class Qualitative_Feedback_Admin_Note_Removal {
 
@@ -21,7 +21,7 @@ class Qualitative_Feedback_Admin_Note_Removal {
 	 *
 	 * @var string
 	 */
-	const VERSION_SINCE = '11.1.0';
+	const VERSION_SINCE = '11.2.0';
 
 	/**
 	 * Only execute the migration if it was not applied yet.

--- a/tests/unit/migrations/test-class-qualitative-feedback-admin-note-removal.php
+++ b/tests/unit/migrations/test-class-qualitative-feedback-admin-note-removal.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Class Qualitative_Feedback_Admin_Note_Removal_Test
+ *
+ * @package WooCommerce\Payments\Tests
+ */
+
+namespace WCPay\Migrations;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use WC_Data_Store;
+use WC_Payments_Notes_Qualitative_Feedback;
+use WCPAY_UnitTestCase;
+
+/**
+ * WCPay\Migrations\Qualitative_Feedback_Admin_Note_Removal unit tests.
+ */
+class Qualitative_Feedback_Admin_Note_Removal_Test extends WCPAY_UnitTestCase {
+
+	/**
+	 * @var Qualitative_Feedback_Admin_Note_Removal
+	 */
+	private $migration;
+
+	public function set_up() {
+		parent::set_up();
+
+		require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-qualitative-feedback.php';
+
+		$this->migration = new Qualitative_Feedback_Admin_Note_Removal();
+		Notes::delete_notes_with_name( WC_Payments_Notes_Qualitative_Feedback::NOTE_NAME );
+	}
+
+	public function tear_down() {
+		Notes::delete_notes_with_name( WC_Payments_Notes_Qualitative_Feedback::NOTE_NAME );
+		delete_option( 'woocommerce_woocommerce_payments_version' );
+
+		parent::tear_down();
+	}
+
+	public function test_it_removes_the_note_when_upgrading_from_an_older_version() {
+		update_option( 'woocommerce_woocommerce_payments_version', '11.0.0' );
+		$this->create_deprecated_note();
+
+		$this->migration->maybe_migrate();
+
+		$this->assertSame( [], $this->get_deprecated_note_ids() );
+	}
+
+	public function test_it_removes_the_note_through_the_plugin_update_hook() {
+		update_option( 'woocommerce_woocommerce_payments_version', '10.9.0' );
+		$this->create_deprecated_note();
+
+		\WC_Payments::install_actions();
+
+		$this->assertSame( [], $this->get_deprecated_note_ids() );
+	}
+
+	public function test_it_removes_the_note_when_the_stored_version_is_missing() {
+		delete_option( 'woocommerce_woocommerce_payments_version' );
+		$this->create_deprecated_note();
+
+		$this->migration->maybe_migrate();
+
+		$this->assertSame( [], $this->get_deprecated_note_ids() );
+	}
+
+	/**
+	 * @dataProvider versions_without_applying_migration_provider
+	 */
+	public function test_it_keeps_the_note_when_the_migration_was_already_applied( string $stored_wcpay_version ) {
+		update_option( 'woocommerce_woocommerce_payments_version', $stored_wcpay_version );
+		$this->create_deprecated_note();
+
+		$this->migration->maybe_migrate();
+
+		$this->assertNotSame( [], $this->get_deprecated_note_ids() );
+	}
+
+	public function versions_without_applying_migration_provider() {
+		return [
+			'same version'  => [ Qualitative_Feedback_Admin_Note_Removal::VERSION_SINCE ],
+			'newer version' => [ '11.2.0' ],
+		];
+	}
+
+	private function create_deprecated_note() {
+		$note = new Note();
+		$note->set_name( WC_Payments_Notes_Qualitative_Feedback::NOTE_NAME );
+		$note->save();
+	}
+
+	private function get_deprecated_note_ids() {
+		return ( WC_Data_Store::load( 'admin-note' ) )->get_notes_with_name( WC_Payments_Notes_Qualitative_Feedback::NOTE_NAME );
+	}
+}

--- a/tests/unit/migrations/test-class-qualitative-feedback-admin-note-removal.php
+++ b/tests/unit/migrations/test-class-qualitative-feedback-admin-note-removal.php
@@ -40,7 +40,7 @@ class Qualitative_Feedback_Admin_Note_Removal_Test extends WCPAY_UnitTestCase {
 	}
 
 	public function test_it_removes_the_note_when_upgrading_from_an_older_version() {
-		update_option( 'woocommerce_woocommerce_payments_version', '11.0.0' );
+		update_option( 'woocommerce_woocommerce_payments_version', '11.1.0' );
 		$this->create_deprecated_note();
 
 		$this->migration->maybe_migrate();
@@ -81,7 +81,7 @@ class Qualitative_Feedback_Admin_Note_Removal_Test extends WCPAY_UnitTestCase {
 	public function versions_without_applying_migration_provider() {
 		return [
 			'same version'  => [ Qualitative_Feedback_Admin_Note_Removal::VERSION_SINCE ],
-			'newer version' => [ '11.2.0' ],
+			'newer version' => [ '11.3.0' ],
 		];
 	}
 

--- a/tests/unit/test-class-wc-payments.php
+++ b/tests/unit/test-class-wc-payments.php
@@ -42,6 +42,10 @@ class WC_Payments_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 10, $install_actions_priority );
 	}
 
+	public function test_it_does_not_clean_up_deprecated_notes_on_admin_init() {
+		$this->assertFalse( has_action( 'admin_init', [ WC_Payments::class, 'remove_deprecated_notes' ] ) );
+	}
+
 	public function test_it_calls_upgrade_hook_during_upgrade() {
 		update_option( 'woocommerce_woocommerce_payments_version', '1.0.0' );
 


### PR DESCRIPTION
Related to WCCOM-2823.

Alternative to #12024.

#### Changes proposed in this Pull Request

The deprecated qualitative feedback inbox note is now removed once during the WooPayments update process. It no longer causes repeated WooCommerce Admin note queries on each admin page load.

The migration runs for stores that upgrade from a version before `11.1.0`. Stores that already have `11.1.0` or a newer version do not run it. This gives the cleanup a transition release before we remove it in a later update.

`WC_Payments::remove_deprecated_notes()` stays public and keeps its existing behavior. This preserves backward compatibility for direct callers. No public method signature, hook name, hook argument, or option key changes. The migration uses site-scoped data, but multisite was not tested.

#### Testing instructions

1. Start the WooPayments PHP test environment.
2. Run:

   ```bash
   pnpm run test:php --filter '^(WC_Payments_Test|WCPay\\Migrations\\Qualitative_Feedback_Admin_Note_Removal_Test)'
   ```

3. Confirm that all 44 tests and 155 assertions pass.
4. Confirm that the migration tests cover these cases:
   - an older or missing stored version removes the note;
   - the real plugin update hook removes the note;
   - the same or a newer stored version keeps the note;
   - `admin_init` no longer registers the recurring cleanup.

The changed PHP files also pass PHPCS and PHPStan. This change has no UI or mobile effect.

#### Deployment validation

After release, check PHP error logs for `Qualitative_Feedback_Admin_Note_Removal` errors. Spot-check one updated store and confirm that the deprecated qualitative feedback note is absent. A rollback does not restore a note that the migration already removed.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (does not apply: no UI change)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
