### PR TITLE
Add a default failure reason to the timeline

### DIFF
--- a/changelog/codex-fix-null-refund-failure-reason
+++ b/changelog/codex-fix-null-refund-failure-reason
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevented canceled refunds from showing an undefined failure reason.

--- a/client/payment-details/timeline/__tests__/map-events.test.js
+++ b/client/payment-details/timeline/__tests__/map-events.test.js
@@ -182,6 +182,21 @@ describe( 'mapTimelineEvents', () => {
 		).toMatchSnapshot();
 	} );
 
+	test( 'formats refund_failed events without a failure reason', () => {
+		const events = mapTimelineEvents( [
+			{
+				datetime: 1585859207,
+				type: 'refund_failed',
+				failure_reason: null,
+				amount_refunded: '100',
+			},
+		] );
+
+		expect( events[ 0 ].headline ).toBe(
+			'$1.00 USD refund was attempted but failed due to an unknown reason.'
+		);
+	} );
+
 	test( 'formats actionable early_fraud_warning events', () => {
 		expect(
 			mapTimelineEvents(

--- a/client/payment-details/timeline/map-events.js
+++ b/client/payment-details/timeline/map-events.js
@@ -513,6 +513,8 @@ const getRefundFailureReason = ( event ) => {
 				'the card being lost or stolen.',
 				'woocommerce-payments'
 			);
+		default:
+			return __( 'an unknown reason.', 'woocommerce-payments' );
 	}
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Canceled refund events can omit `failure_reason`. The transaction timeline then showed merchants that a refund “failed due to undefined.” This change uses neutral fallback text for missing or unknown values. Known failure reasons keep their current text.

This is the client compatibility part of a companion server timeline correction. Legacy refund totals and transaction status handling remain separate follow-up work.

#### Testing instructions

* Run `pnpm run test:js -- client/payment-details/timeline/__tests__/map-events.test.js --runInBand` with Node 24.
* Confirm that 59 tests and 38 snapshots pass.
* Confirm that the null-reason test renders “failed due to an unknown reason.”

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : QA Testing Not Applicable
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
