### PR TITLE
Restore spacing in dispute readiness checklist rows

### DIFF
--- a/changelog/fix-dispute-readiness-checklist-spacing
+++ b/changelog/fix-dispute-readiness-checklist-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore spacing in the dispute readiness checklist.

--- a/client/overview/dispute-readiness/style.scss
+++ b/client/overview/dispute-readiness/style.scss
@@ -45,6 +45,10 @@
 	.woocommerce-task-list__item {
 		grid-template-columns: 72px minmax( 0, 1fr ) 24px;
 
+		.woocommerce-task-list__item-text {
+			padding: $gap 0;
+		}
+
 		&::before {
 			background: transparent;
 		}


### PR DESCRIPTION
Fixes [WOOPMNT-6434](https://linear.app/a8c/issue/WOOPMNT-6434/restore-woopayments-dispute-readiness-checklist-spacing).

#### Changes proposed in this Pull Request

WooCommerce experimental `TaskItem` 4.0 removed its default text padding while adding the in-progress layout. This compressed the dispute readiness checklist from WooPayments 11.0 onwards.

- Restore 16px vertical padding using the existing `$gap` spacing token.
- Scope the override to the dispute readiness checklist.
- Keep the existing `CollapsibleList` and `TaskItem` components.
- Leave the global experimental package stylesheet excluded.

**Before**

![Checklist rows before the spacing fix](https://github.com/user-attachments/assets/d72b8471-317e-4b8e-80b7-7909785131c7)

**After**

![Checklist rows after the spacing fix](https://github.com/user-attachments/assets/a824d108-81ed-4139-a438-7fac325f8fc1)

**Compatibility**

The override is safe with older WooCommerce versions that already supply this padding because it replaces the same CSS property rather than adding to it. No public APIs, hooks, stored data, multisite behaviour, or install paths change.

#### Testing instructions

1. Build the client with `pnpm run build:client`.
2. On a store with a connected WooPayments account, make sure the dispute readiness card is enabled and not dismissed:
   ```bash
   wp option update _wcpay_feature_dispute_readiness_overview 1
   wp option delete wcpay_dispute_readiness_card_dismissed
   ```
3. Go to **Payments → Overview**.
4. Confirm completed and incomplete checklist rows have consistent vertical spacing.
5. Confirm status icons remain vertically aligned with each row.
6. Confirm incomplete rows leave clear space around the **Fix it** button.
7. Repeat at a narrow viewport and confirm the rows wrap without horizontal overflow.

Automated checks:

- `pnpm exec stylelint client/overview/dispute-readiness/style.scss`
- `pnpm run test:js -- --runInBand client/overview/dispute-readiness/__tests__/index.test.tsx`
- `pnpm run build`
- Chrome verification at desktop and mobile widths, with no console errors

The spacing is verified in a browser because Jest does not compute SCSS layout.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
