### PR TITLE
fix: fall back to our own copy of user preferences

### DIFF
--- a/changelog/fix-woopmnt-6433-user-preferences-fallback
+++ b/changelog/fix-woopmnt-6433-user-preferences-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Keep WooPayments table column and notice preferences saved when WooCommerce does not send the user's preference data to the browser.

--- a/client/globals.d.ts
+++ b/client/globals.d.ts
@@ -147,6 +147,7 @@ declare global {
 		dateFormat: string;
 		timeFormat: string;
 		formattedStoreAddress: string;
+		userPreferences: Record< string, string >;
 	};
 
 	const wooPaymentsPaymentMethodDefinitions: Record<

--- a/client/hooks/__tests__/use-wcpay-user-preferences.test.ts
+++ b/client/hooks/__tests__/use-wcpay-user-preferences.test.ts
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { useUserPreferences } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { useWcpayUserPreferences } from '../use-wcpay-user-preferences';
+
+jest.mock( '@woocommerce/data', () => ( {
+	useUserPreferences: jest.fn(),
+} ) );
+
+const mockUseUserPreferences = useUserPreferences as jest.MockedFunction<
+	typeof useUserPreferences
+>;
+
+const updateUserPreferences = jest.fn();
+
+declare const global: {
+	wcpaySettings: {
+		userPreferences?: Record< string, string >;
+	};
+};
+
+/**
+ * Stand in for what WooCommerce Admin hands us, which carries only the preferences it
+ * managed to read.
+ *
+ * @param preferences Decoded preferences WooCommerce Admin resolved.
+ */
+const mockLivePreferences = ( preferences: Record< string, unknown > ) => {
+	mockUseUserPreferences.mockReturnValue( {
+		isRequesting: false,
+		updateUserPreferences,
+		...preferences,
+	} as unknown as ReturnType< typeof useUserPreferences > );
+};
+
+/**
+ * Stand in for the raw values we render into the page ourselves.
+ *
+ * @param preferences Raw stored values.
+ */
+const mockRenderedPreferences = ( preferences: Record< string, string > ) => {
+	global.wcpaySettings = {
+		...global.wcpaySettings,
+		userPreferences: preferences,
+	};
+};
+
+/**
+ * Render the hook and expose the merged bag, whose names are only known at runtime.
+ */
+const renderPreferences = () => {
+	const { result } = renderHook( () => useWcpayUserPreferences() );
+
+	return result.current as unknown as Record< string, unknown > &
+		ReturnType< typeof useUserPreferences >;
+};
+
+describe( 'useWcpayUserPreferences', () => {
+	const originalSettings = global.wcpaySettings;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		global.wcpaySettings = { ...originalSettings };
+	} );
+
+	afterAll( () => {
+		global.wcpaySettings = originalSettings;
+	} );
+
+	it( 'falls back to the rendered values when WooCommerce Admin resolved none', () => {
+		mockLivePreferences( {} );
+		mockRenderedPreferences( {
+			wc_payments_payouts_hidden_columns: '["date","status"]',
+		} );
+
+		expect(
+			renderPreferences().wc_payments_payouts_hidden_columns
+		).toEqual( [ 'date', 'status' ] );
+	} );
+
+	it( 'prefers the value WooCommerce Admin resolved over the rendered one', () => {
+		mockLivePreferences( {
+			wc_payments_payouts_hidden_columns: [ 'amount' ],
+		} );
+		mockRenderedPreferences( {
+			wc_payments_payouts_hidden_columns: '["date","status"]',
+		} );
+
+		expect(
+			renderPreferences().wc_payments_payouts_hidden_columns
+		).toEqual( [ 'amount' ] );
+	} );
+
+	it( 'keeps a cleared value rather than falling back to the rendered one', () => {
+		mockLivePreferences( { wc_payments_payouts_hidden_columns: '' } );
+		mockRenderedPreferences( {
+			wc_payments_payouts_hidden_columns: '["date","status"]',
+		} );
+
+		expect( renderPreferences().wc_payments_payouts_hidden_columns ).toBe(
+			''
+		);
+	} );
+
+	it( 'decodes rendered values the way WooCommerce Admin does', () => {
+		mockLivePreferences( {} );
+		mockRenderedPreferences( {
+			json_object: '{"perPage":25}',
+			json_number: '1750000000',
+			plain_string: 'yes',
+			unset: '',
+		} );
+
+		expect( renderPreferences() ).toEqual(
+			expect.objectContaining( {
+				json_object: { perPage: 25 },
+				json_number: 1750000000,
+				plain_string: 'yes',
+				unset: '',
+			} )
+		);
+	} );
+
+	it( 'passes through everything else the WooCommerce Admin hook returns', () => {
+		mockLivePreferences( {} );
+		mockRenderedPreferences( {} );
+
+		const preferences = renderPreferences();
+
+		expect( preferences.isRequesting ).toBe( false );
+		expect( preferences.updateUserPreferences ).toBe(
+			updateUserPreferences
+		);
+	} );
+
+	it( 'copes with no rendered values at all', () => {
+		mockLivePreferences( {
+			wc_payments_payouts_hidden_columns: [ 'fee' ],
+		} );
+		delete global.wcpaySettings.userPreferences;
+
+		expect(
+			renderPreferences().wc_payments_payouts_hidden_columns
+		).toEqual( [ 'fee' ] );
+	} );
+} );

--- a/client/hooks/use-persisted-table-column-visibility.ts
+++ b/client/hooks/use-persisted-table-column-visibility.ts
@@ -2,11 +2,15 @@
  * External dependencies
  */
 import { useMemo } from 'react';
-import { useUserPreferences } from '@woocommerce/data';
 import type { TableCardColumn } from '@woocommerce/components';
 
 /**
- * Type for user preferences returned from useUserPreferences hook.
+ * Internal dependencies
+ */
+import { useWcpayUserPreferences } from 'wcpay/hooks/use-wcpay-user-preferences';
+
+/**
+ * Type for user preferences returned from the user preferences hook.
  *
  * These preference keys are defined and managed in:
  *
@@ -28,7 +32,7 @@ interface UserPreferences {
  * Hook to manage column visibility for a TableCard component.
  *
  * This hook is used to manage the visibility of columns in a TableCard component.
- * It uses the `@woocommerce/data` `useUserPreferences` hook to get the user's preferences and store them in the `wp_usermeta` table.
+ * It uses the `useWcpayUserPreferences` hook to get the user's preferences and store them in the `wp_usermeta` table.
  */
 export const usePersistedColumnVisibility = <
 	ColumnType extends TableCardColumn
@@ -61,7 +65,7 @@ export const usePersistedColumnVisibility = <
 	 */
 	columnsToDisplay: ColumnType[];
 } => {
-	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
+	const { updateUserPreferences, ...userPrefs } = useWcpayUserPreferences();
 
 	// If returned value is undefined or empty string, use default visibility value.
 	const userPrefHiddenColumns =

--- a/client/hooks/use-wcpay-user-preferences.ts
+++ b/client/hooks/use-wcpay-user-preferences.ts
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import { useUserPreferences } from '@woocommerce/data';
+
+type UserPreferencesHookResult = ReturnType< typeof useUserPreferences >;
+
+/**
+ * Decode a raw `woocommerce_meta` value.
+ *
+ * Mirrors WooCommerce Admin's own decoding so both sources yield the same shape: values are
+ * stored as JSON, except the ones that were written as plain strings such as `yes` or `no`.
+ *
+ * @param value Raw stored value.
+ * @return The decoded value, or an empty string when nothing is stored.
+ */
+const decodePreference = ( value: string | undefined ): unknown => {
+	if ( ! value || value.length === 0 ) {
+		return '';
+	}
+
+	try {
+		return JSON.parse( value );
+	} catch ( e ) {
+		return value;
+	}
+};
+
+/**
+ * Read the current user's WooPayments preferences.
+ *
+ * WooCommerce Admin builds the user payload that backs `useUserPreferences` without booting the
+ * REST API, so the field holding these preferences is missing on stores where nothing else boots
+ * it. Every preference then reads back empty even though it saved correctly, which looks to a
+ * merchant like their hidden columns and dismissed notices never stick.
+ *
+ * Saved values still reach the browser through our own settings, so fall back to those. A live
+ * value always wins, which keeps a write made during this page visit ahead of the copy that was
+ * rendered with the page.
+ *
+ * @return The same shape as `useUserPreferences`, with missing values filled in.
+ */
+export const useWcpayUserPreferences = (): UserPreferencesHookResult => {
+	const { isRequesting, updateUserPreferences, ...livePreferences } =
+		useUserPreferences();
+
+	const renderedPreferences = useMemo( () => {
+		const raw =
+			typeof wcpaySettings === 'undefined'
+				? undefined
+				: wcpaySettings.userPreferences;
+
+		return Object.entries( raw ?? {} ).reduce< Record< string, unknown > >(
+			( decoded, [ name, value ] ) => {
+				decoded[ name ] = decodePreference( value );
+				return decoded;
+			},
+			{}
+		);
+	}, [] );
+
+	const preferences = Object.entries(
+		livePreferences as Record< string, unknown >
+	).reduce< Record< string, unknown > >(
+		( merged, [ name, value ] ) => {
+			if ( undefined !== value ) {
+				merged[ name ] = value;
+			}
+			return merged;
+		},
+		{ ...renderedPreferences }
+	);
+
+	// The preference names are only known at runtime, so the merged bag can't be inferred.
+	return {
+		...preferences,
+		isRequesting,
+		updateUserPreferences,
+	} as UserPreferencesHookResult;
+};

--- a/client/reports/feedback-survey/hooks.ts
+++ b/client/reports/feedback-survey/hooks.ts
@@ -3,12 +3,12 @@
  */
 import { useCallback, useState } from 'react';
 import apiFetch from '@wordpress/api-fetch';
-import { useUserPreferences } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import { NAMESPACE } from 'wcpay/data/constants';
+import { useWcpayUserPreferences } from 'wcpay/hooks/use-wcpay-user-preferences';
 import type { ReportFeedbackRating } from './tracks';
 
 interface SubmitFeedbackParams {
@@ -16,7 +16,7 @@ interface SubmitFeedbackParams {
 	rating: ReportFeedbackRating;
 }
 
-interface UserPreferences extends ReturnType< typeof useUserPreferences > {
+interface UserPreferences extends ReturnType< typeof useWcpayUserPreferences > {
 	wc_payments_reports_feedback_dismissed?: number;
 }
 
@@ -46,7 +46,7 @@ export const useReportFeedbackState = () => {
 	const {
 		updateUserPreferences,
 		wc_payments_reports_feedback_dismissed: dismissedAt,
-	} = useUserPreferences() as UserPreferences;
+	} = useWcpayUserPreferences() as UserPreferences;
 
 	const dismiss = () =>
 		updateUserPreferences( {

--- a/client/reports/fees/use-fees-user-prefs.ts
+++ b/client/reports/fees/use-fees-user-prefs.ts
@@ -4,12 +4,12 @@
  * External dependencies
  */
 import { useCallback, useEffect, useRef } from 'react';
-import { useUserPreferences } from '@woocommerce/data';
 import type { View, ViewTable } from '@wordpress/dataviews/wp';
 
 /**
  * Internal dependencies
  */
+import { useWcpayUserPreferences } from 'wcpay/hooks/use-wcpay-user-preferences';
 import {
 	feesViewUserMetaKey,
 	getFeesTableFields,
@@ -43,7 +43,7 @@ interface UseFeesUserPrefsResult {
 }
 
 export const useFeesUserPrefs = (): UseFeesUserPrefsResult => {
-	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
+	const { updateUserPreferences, ...userPrefs } = useWcpayUserPreferences();
 	const prefs = userPrefs as unknown as Record< string, unknown >;
 	const rawPersisted = prefs[ feesViewUserMetaKey ] as
 		| PersistedFeesView

--- a/includes/admin/class-wc-payments-admin.php
+++ b/includes/admin/class-wc-payments-admin.php
@@ -1071,6 +1071,7 @@ class WC_Payments_Admin {
 			'woopayFontRules'                    => WC_Payments_Styles_Cache::get_woopay_font_rules(),
 			'dateFormat'                         => wc_date_format(),
 			'timeFormat'                         => get_option( 'time_format' ),
+			'userPreferences'                    => $this->get_user_preferences(),
 			'formattedStoreAddress'              => WC()->countries->get_formatted_address(
 				[
 					'address_1' => get_option( 'woocommerce_store_address', '' ),
@@ -1108,6 +1109,36 @@ class WC_Payments_Admin {
 		 * @since 7.8.0
 		 */
 		return apply_filters( 'wcpay_plugins_page_js_settings', $plugins_page_settings );
+	}
+
+	/**
+	 * Get the current user's WooPayments preferences to be sent to JS.
+	 *
+	 * These live in `woocommerce_meta` on the user, which WooCommerce Admin normally hands to
+	 * the browser inside its own `currentUserData` payload. That payload is built without
+	 * booting the REST API, so on stores where nothing else boots it the WooCommerce-registered
+	 * fields are missing and every preference reads back empty. Shipping our own copy keeps the
+	 * values available regardless.
+	 *
+	 * Values are passed through exactly as stored; the client decodes them the same way
+	 * WooCommerce Admin does.
+	 *
+	 * @return array Map of preference name to raw stored value, empty when there is no user.
+	 */
+	private function get_user_preferences(): array {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id ) {
+			return [];
+		}
+
+		$preferences = [];
+
+		foreach ( WC_Payments::add_user_data_fields( [] ) as $field ) {
+			$preferences[ $field ] = get_user_meta( $user_id, 'woocommerce_admin_' . $field, true );
+		}
+
+		return $preferences;
 	}
 
 	/**

--- a/tests/unit/admin/test-class-wc-payments-admin.php
+++ b/tests/unit/admin/test-class-wc-payments-admin.php
@@ -845,6 +845,65 @@ class WC_Payments_Admin_Test extends WCPAY_UnitTestCase {
 		}
 	}
 
+	public function test_get_user_preferences_returns_every_declared_field() {
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, 'woocommerce_admin_wc_payments_payouts_hidden_columns', '["date"]' );
+
+		$preferences = $this->get_user_preferences();
+
+		$this->assertSame(
+			[
+				'wc_payments_overview_inbox_last_read',
+				'wc_payments_transactions_hidden_columns',
+				'wc_payments_transactions_blocked_hidden_columns',
+				'wc_payments_transactions_risk_review_hidden_columns',
+				'wc_payments_transactions_uncaptured_hidden_columns',
+				'wc_payments_payouts_hidden_columns',
+				'wc_payments_disputes_hidden_columns',
+				'wc_payments_documents_hidden_columns',
+				'wc_payments_reports_fees_view',
+				'wc_payments_review_prompt_dismissed',
+				'wc_payments_review_prompt_maybe_later',
+				'wc_payments_reports_feedback_dismissed',
+			],
+			array_keys( $preferences )
+		);
+		$this->assertSame( '["date"]', $preferences['wc_payments_payouts_hidden_columns'] );
+
+		wp_set_current_user( 0 );
+	}
+
+	public function test_get_user_preferences_keeps_fields_with_nothing_stored() {
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$preferences = $this->get_user_preferences();
+
+		$this->assertArrayHasKey( 'wc_payments_payouts_hidden_columns', $preferences );
+		$this->assertSame( '', $preferences['wc_payments_payouts_hidden_columns'] );
+
+		wp_set_current_user( 0 );
+	}
+
+	public function test_get_user_preferences_returns_nothing_without_a_user() {
+		wp_set_current_user( 0 );
+
+		$this->assertSame( [], $this->get_user_preferences() );
+	}
+
+	/**
+	 * Calls the private method under test.
+	 *
+	 * @return array
+	 */
+	private function get_user_preferences(): array {
+		$method = new ReflectionMethod( WC_Payments_Admin::class, 'get_user_preferences' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->payments_admin );
+	}
+
 	/**
 	 * Returns an object mocking what we need from \WP_Screen.
 	 *


### PR DESCRIPTION
Fixes WOOPMNT-6433

#### Changes proposed in this Pull Request

On some stores, WooPayments preferences might never save.
Hide a column, refresh the page, and the column is back again. Same for the Fees report layout and the reports feedback notice.

They *are* saving. The problem is the "reading" of the preference.

We read them through WooCommerce's `useUserPreferences`, which gets its data from a blob WooCommerce renders into the page. WooCommerce builds that blob without booting the REST API, so the field holding these preferences only lands in it if something else booted REST first. Until WooCommerce 11.0 a Jetpack status preload always did. [#65505](https://github.com/woocommerce/woocommerce/pull/65505) removed it for performance, leaving the Analytics preload as the only trigger - and Analytics is a setting merchants can switch off.

So, with WooCommerce 11.0 or newer (with Analytics disabled), no preferences reach the browser.

This renders our own copy of the values alongside the rest of our settings and falls back to it. A live value always wins, so anything saved during the visit stays ahead of the copy that shipped with the page.

#### Considerations

The obvious fix is four lines: call WooCommerce's own field registration before it builds the blob. But that means depending on `Automattic\WooCommerce\Internal\Admin\WCAdminUser`, and `Internal` is not a stability guarantee.

The real fix belongs in WooCommerce and is about three lines there. This is a workaround, and the tradeoff is a second source of truth: our copy has to decode values the same way WooCommerce does. If WooCommerce ever changes that encoding, the two drift silently — wrong values rather than a crash, which is harder to notice than the bug being fixed. The decoder carries a pointer to the upstream function it mirrors, and a test pins the behaviour. Delete this once WooCommerce ships a fix and our version floor clears it.

Backward compatibility: additive only. One new key in `wcpaySettings`, one new private method, no signature or hook changes.

#### Testing instructions

Needs **WooCommerce 11.0 or newer**.

**Reproduce on `develop` first**

* **WooCommerce > Settings > Advanced > Features** — untick **WooCommerce Analytics**, save
* Go to **Payments > Transactions**, open the columns menu (gear icon), untick a couple of columns
* Reload — the columns are back. Nothing stuck.

**Then verify the fix**

* Check out this branch, rebuild the client assets, leave Analytics **off**
* Hide some columns on Transactions, reload — they stay hidden
* Same on Payouts, Disputes and Documents
* **Payments > Reports > Fees** — change the columns or rows-per-page, reload — the view shape holds
* Dismiss the feedback notice on a report, reload — it stays dismissed

**Then check the normal configuration still works**

* Re-tick **WooCommerce Analytics**, save
* Repeat any of the above — behaviour is unchanged
* Change a preference, reload, change it back — no stale values from the page copy

Remember to leave **WooCommerce Analytics** ticked when you're done — it is on by default.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX6K5MNvVahunXNLhTRdGb
