### PR TITLE
fix: show complete dispute summary in overview task

### DIFF
--- a/changelog/fix-woopmnt-6439-dispute-summary-task
+++ b/changelog/fix-woopmnt-6439-dispute-summary-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show complete dispute counts, currency totals, and response deadlines in the Payments Overview task.

--- a/client/data/disputes/__tests__/hooks.test.ts
+++ b/client/data/disputes/__tests__/hooks.test.ts
@@ -1,0 +1,55 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useDisputes } from '../hooks';
+
+jest.mock( '@wordpress/data' );
+
+describe( 'Dispute data hooks', () => {
+	const getDisputes = jest.fn().mockReturnValue( [] );
+	const isResolving = jest.fn().mockReturnValue( false );
+	const hasFinishedResolution = jest.fn().mockReturnValue( false );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( useSelect as jest.Mock ).mockImplementation( ( callback ) =>
+			callback( () => ( {
+				getDisputes,
+				isResolving,
+				hasFinishedResolution,
+			} ) )
+		);
+	} );
+
+	it( 'does not resolve dispute rows when loading is disabled', () => {
+		const result = useDisputes(
+			{ filter: 'awaiting_response', per_page: '1' },
+			false
+		);
+
+		expect( result ).toEqual( { disputes: [], isLoading: false } );
+		expect( getDisputes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stays loading during the first explicitly enabled resolution', () => {
+		const result = useDisputes(
+			{ filter: 'awaiting_response', per_page: '1' },
+			true
+		);
+
+		expect( result ).toEqual( { disputes: [], isLoading: true } );
+		expect( getDisputes ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				filter: 'awaiting_response',
+				perPage: '1',
+			} )
+		);
+	} );
+} );

--- a/client/data/disputes/__tests__/hooks.test.ts
+++ b/client/data/disputes/__tests__/hooks.test.ts
@@ -38,6 +38,26 @@ describe( 'Dispute data hooks', () => {
 		expect( getDisputes ).not.toHaveBeenCalled();
 	} );
 
+	it( 'uses the existing loading behavior when shouldLoad is omitted', () => {
+		const result = useDisputes( {
+			filter: 'awaiting_response',
+			per_page: '1',
+		} );
+
+		expect( result ).toEqual( { disputes: [], isLoading: false } );
+		expect( getDisputes ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				filter: 'awaiting_response',
+				perPage: '1',
+			} )
+		);
+		expect( isResolving ).toHaveBeenCalledWith(
+			'getDisputes',
+			expect.any( Array )
+		);
+		expect( hasFinishedResolution ).not.toHaveBeenCalled();
+	} );
+
 	it( 'stays loading during the first explicitly enabled resolution', () => {
 		const result = useDisputes(
 			{ filter: 'awaiting_response', per_page: '1' },

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -90,23 +90,27 @@ export const useDisputeEvidence = (): {
 	return { updateDispute };
 };
 
-export const useDisputes = ( {
-	paged,
-	per_page: perPage,
-	store_currency_is: storeCurrencyIs,
-	match,
-	date_before: dateBefore,
-	date_after: dateAfter,
-	date_between: dateBetween,
-	filter,
-	status_is: statusIs,
-	status_is_not: statusIsNot,
-	orderby: orderBy,
-	order,
-}: Query ): CachedDisputes =>
+export const useDisputes = (
+	{
+		paged,
+		per_page: perPage,
+		store_currency_is: storeCurrencyIs,
+		match,
+		date_before: dateBefore,
+		date_after: dateAfter,
+		date_between: dateBetween,
+		filter,
+		status_is: statusIs,
+		status_is_not: statusIsNot,
+		orderby: orderBy,
+		order,
+	}: Query,
+	shouldLoad?: boolean
+): CachedDisputes =>
 	useSelect(
 		( select ) => {
-			const { getDisputes, isResolving } = select( STORE_NAME );
+			const { getDisputes, isResolving, hasFinishedResolution } =
+				select( STORE_NAME );
 
 			const query = {
 				paged: Number.isNaN( parseInt( paged ?? '', 10 ) )
@@ -131,9 +135,16 @@ export const useDisputes = ( {
 				order: order || 'desc',
 			};
 
+			if ( shouldLoad === false ) {
+				return { disputes: [], isLoading: false };
+			}
+
 			return {
 				disputes: getDisputes( query ),
-				isLoading: isResolving( 'getDisputes', [ query ] ),
+				isLoading:
+					isResolving( 'getDisputes', [ query ] ) ||
+					( shouldLoad === true &&
+						! hasFinishedResolution( 'getDisputes', [ query ] ) ),
 			};
 		},
 		[
@@ -149,6 +160,7 @@ export const useDisputes = ( {
 			statusIsNot,
 			orderBy,
 			order,
+			shouldLoad,
 		]
 	);
 

--- a/client/data/disputes/hooks.ts
+++ b/client/data/disputes/hooks.ts
@@ -20,6 +20,11 @@ import type { ChargeDispute } from 'wcpay/types/charges';
 import type { ApiError } from 'wcpay/types/errors';
 import { STORE_NAME } from './store';
 
+const emptyCachedDisputes: CachedDisputes = {
+	disputes: [],
+	isLoading: false,
+};
+
 /**
  * Returns the dispute object, error object, and loading state.
  * Fetches the dispute object if it is not already cached.
@@ -109,6 +114,10 @@ export const useDisputes = (
 ): CachedDisputes =>
 	useSelect(
 		( select ) => {
+			if ( shouldLoad === false ) {
+				return emptyCachedDisputes;
+			}
+
 			const { getDisputes, isResolving, hasFinishedResolution } =
 				select( STORE_NAME );
 
@@ -134,10 +143,6 @@ export const useDisputes = (
 				orderBy: orderBy || 'created',
 				order: order || 'desc',
 			};
-
-			if ( shouldLoad === false ) {
-				return { disputes: [], isLoading: false };
-			}
 
 			return {
 				disputes: getDisputes( query ),

--- a/client/overview/__tests__/index.test.js
+++ b/client/overview/__tests__/index.test.js
@@ -157,39 +157,49 @@ describe( 'Overview page', () => {
 		} );
 	} );
 
-	it( 'requests dispute rows and summary with the awaiting response filter', () => {
+	it( 'does not load dispute rows before the summary finds one dispute', () => {
 		render( <OverviewPage /> );
 
-		expect( useDisputes ).toHaveBeenCalledWith( {
-			filter: 'awaiting_response',
-			per_page: 50,
-		} );
 		expect( useDisputesSummary ).toHaveBeenCalledWith( {
 			filter: 'awaiting_response',
 		} );
+		expect( useDisputes ).toHaveBeenCalledWith(
+			{
+				filter: 'awaiting_response',
+				per_page: 1,
+			},
+			false
+		);
 	} );
 
-	it( 'passes the dispute summary and loading state to the task builder', () => {
-		const activeDisputes = [ { dispute_id: 'dp_1' } ];
+	it( 'loads and passes one dispute when the summary count is one', () => {
+		const activeDispute = { dispute_id: 'dp_1', charge_id: 'ch_1' };
 		const activeDisputesSummary = {
-			count: 51,
-			amount_by_currency: { usd: 51000 },
+			count: 1,
+			amount_by_currency: { usd: 1000 },
 			earliest_due_by: '2023-02-01 23:59:59',
 		};
 		useDisputes.mockReturnValue( {
-			disputes: activeDisputes,
-			isLoading: false,
+			disputes: [ activeDispute ],
+			isLoading: true,
 		} );
 		useDisputesSummary.mockReturnValue( {
 			disputesSummary: activeDisputesSummary,
-			isLoading: true,
+			isLoading: false,
 		} );
 
 		render( <OverviewPage /> );
 
+		expect( useDisputes ).toHaveBeenCalledWith(
+			{
+				filter: 'awaiting_response',
+				per_page: 1,
+			},
+			true
+		);
 		expect( getTasks ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				activeDisputes,
+				activeDispute,
 				activeDisputesSummary,
 				activeDisputesSummaryIsLoading: true,
 			} )

--- a/client/overview/__tests__/index.test.js
+++ b/client/overview/__tests__/index.test.js
@@ -13,6 +13,7 @@ import OverviewPage from '../';
 import { getTasks } from '../task-list/tasks';
 import { getQuery } from '@woocommerce/navigation';
 import { useGetSettings } from 'wcpay/data/settings';
+import { useDisputes, useDisputesSummary } from 'wcpay/data/disputes';
 
 const settingsMock = {
 	enabled_payment_method_ids: [ 'foo', 'bar' ],
@@ -77,6 +78,10 @@ jest.mock( 'wcpay/data/disputes', () => ( {
 	useDisputes: jest
 		.fn()
 		.mockReturnValue( { disputes: [], isLoading: false } ),
+	useDisputesSummary: jest.fn().mockReturnValue( {
+		disputesSummary: {},
+		isLoading: false,
+	} ),
 } ) );
 jest.mock( 'wcpay/data/pm-promotions', () => ( {
 	usePmPromotions: jest
@@ -145,6 +150,50 @@ describe( 'Overview page', () => {
 		useGetSettings.mockReturnValue( {
 			enabled_payment_method_ids: [ 'foo', 'bar' ],
 		} );
+		useDisputes.mockReturnValue( { disputes: [], isLoading: false } );
+		useDisputesSummary.mockReturnValue( {
+			disputesSummary: {},
+			isLoading: false,
+		} );
+	} );
+
+	it( 'requests dispute rows and summary with the awaiting response filter', () => {
+		render( <OverviewPage /> );
+
+		expect( useDisputes ).toHaveBeenCalledWith( {
+			filter: 'awaiting_response',
+			per_page: 50,
+		} );
+		expect( useDisputesSummary ).toHaveBeenCalledWith( {
+			filter: 'awaiting_response',
+		} );
+	} );
+
+	it( 'passes the dispute summary and loading state to the task builder', () => {
+		const activeDisputes = [ { dispute_id: 'dp_1' } ];
+		const activeDisputesSummary = {
+			count: 51,
+			amount_by_currency: { usd: 51000 },
+			earliest_due_by: '2023-02-01 23:59:59',
+		};
+		useDisputes.mockReturnValue( {
+			disputes: activeDisputes,
+			isLoading: false,
+		} );
+		useDisputesSummary.mockReturnValue( {
+			disputesSummary: activeDisputesSummary,
+			isLoading: true,
+		} );
+
+		render( <OverviewPage /> );
+
+		expect( getTasks ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				activeDisputes,
+				activeDisputesSummary,
+				activeDisputesSummaryIsLoading: true,
+			} )
+		);
 	} );
 
 	it( 'Renders even when the settings request has failed', () => {

--- a/client/overview/__tests__/index.test.js
+++ b/client/overview/__tests__/index.test.js
@@ -201,7 +201,7 @@ describe( 'Overview page', () => {
 			expect.objectContaining( {
 				activeDispute,
 				activeDisputesSummary,
-				activeDisputesSummaryIsLoading: true,
+				activeDisputeTaskIsLoading: true,
 			} )
 		);
 	} );

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -97,23 +97,29 @@ const OverviewPage = () => {
 		useState( false );
 	const settings = useGetSettings();
 
-	const { disputes: activeDisputes } = useDisputes( {
-		filter: 'awaiting_response',
-		per_page: 50,
-	} );
 	const {
 		disputesSummary: activeDisputesSummary,
 		isLoading: activeDisputesSummaryIsLoading,
 	} = useDisputesSummary( {
 		filter: 'awaiting_response',
 	} );
+	const shouldLoadSingleDispute = activeDisputesSummary?.count === 1;
+	const { disputes: activeDisputes, isLoading: activeDisputesIsLoading } =
+		useDisputes(
+			{
+				filter: 'awaiting_response',
+				per_page: 1,
+			},
+			shouldLoadSingleDispute
+		);
 
 	const tasksUnsorted = getTasks( {
 		showUpdateDetailsTask,
 		wpcomReconnectUrl,
-		activeDisputes,
+		activeDispute: activeDisputes[ 0 ],
 		activeDisputesSummary,
-		activeDisputesSummaryIsLoading,
+		activeDisputesSummaryIsLoading:
+			activeDisputesSummaryIsLoading || activeDisputesIsLoading,
 	} );
 	const tasks =
 		Array.isArray( tasksUnsorted ) && tasksUnsorted.sort( taskSort );

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -27,7 +27,7 @@ import InboxNotifications from './inbox-notifications';
 import TaskList from './task-list';
 import { getTasks, taskSort } from './task-list/tasks';
 import DisputeReadinessCard from './dispute-readiness';
-import { useDisputes } from 'wcpay/data/disputes';
+import { useDisputes, useDisputesSummary } from 'wcpay/data/disputes';
 import { useGetSettings, useSettings } from 'wcpay/data/settings';
 import SandboxModeSwitchToLiveNotice from 'wcpay/components/sandbox-mode-switch-to-live-notice';
 import './style.scss';
@@ -101,11 +101,19 @@ const OverviewPage = () => {
 		filter: 'awaiting_response',
 		per_page: 50,
 	} );
+	const {
+		disputesSummary: activeDisputesSummary,
+		isLoading: activeDisputesSummaryIsLoading,
+	} = useDisputesSummary( {
+		filter: 'awaiting_response',
+	} );
 
 	const tasksUnsorted = getTasks( {
 		showUpdateDetailsTask,
 		wpcomReconnectUrl,
 		activeDisputes,
+		activeDisputesSummary,
+		activeDisputesSummaryIsLoading,
 	} );
 	const tasks =
 		Array.isArray( tasksUnsorted ) && tasksUnsorted.sort( taskSort );

--- a/client/overview/index.js
+++ b/client/overview/index.js
@@ -118,7 +118,7 @@ const OverviewPage = () => {
 		wpcomReconnectUrl,
 		activeDispute: activeDisputes[ 0 ],
 		activeDisputesSummary,
-		activeDisputesSummaryIsLoading:
+		activeDisputeTaskIsLoading:
 			activeDisputesSummaryIsLoading || activeDisputesIsLoading,
 	} );
 	const tasks =

--- a/client/overview/task-list/__tests__/tasks.test.js
+++ b/client/overview/task-list/__tests__/tasks.test.js
@@ -419,7 +419,7 @@ describe( 'getTasks()', () => {
 					key: 'dispute-resolution-task-summary',
 					completed: false,
 					level: 1,
-					title: 'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD',
+					title: 'Respond to 3 active disputes',
 					content: 'Respond today by 6:59 PM',
 					actionLabel: 'See disputes',
 				} ),
@@ -473,7 +473,7 @@ describe( 'getTasks()', () => {
 					key: 'dispute-resolution-task-summary',
 					completed: false,
 					level: 1,
-					title: 'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD',
+					title: 'Respond to 3 active disputes',
 					content: 'By Feb 1, 2023 – 6 days left to respond',
 					actionLabel: 'See disputes',
 				} ),
@@ -541,42 +541,24 @@ describe( 'getDisputeResolutionTask()', () => {
 		);
 	} );
 
-	it( 'shows two summary totals with stable ISO currency codes', () => {
+	it( 'does not show totals for multiple summary currencies', () => {
 		const task = getDisputeResolutionTask( {
 			count: 3,
 			amount_by_currency: { usd: 2000, eur: 1000 },
 			earliest_due_by: nextWeekDeadline,
 		} );
 
-		expect( task?.title ).toBe(
-			'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD'
-		);
+		expect( task?.title ).toBe( 'Respond to 3 active disputes' );
 	} );
 
-	it( 'honors the explicit price setting for two summary totals', () => {
-		global.wcpaySettings.shouldUseExplicitPrice = false;
-
-		const task = getDisputeResolutionTask( {
-			count: 3,
-			amount_by_currency: { usd: 2000, eur: 1000 },
-			earliest_due_by: nextWeekDeadline,
-		} );
-
-		expect( task?.title ).toBe(
-			'Respond to 3 active disputes for totals of €10.00 and $20.00'
-		);
-	} );
-
-	it( 'shows a currency count instead of totals for three currencies', () => {
+	it( 'keeps the same title for three or more summary currencies', () => {
 		const task = getDisputeResolutionTask( {
 			count: 3,
 			amount_by_currency: { usd: 1000, eur: 1000, gbp: 1000 },
 			earliest_due_by: nextWeekDeadline,
 		} );
 
-		expect( task?.title ).toBe(
-			'Respond to 3 active disputes in 3 currencies'
-		);
+		expect( task?.title ).toBe( 'Respond to 3 active disputes' );
 		expect( task?.title ).not.toContain( '$' );
 		expect( task?.title ).not.toContain( '€' );
 		expect( task?.title ).not.toContain( '£' );

--- a/client/overview/task-list/__tests__/tasks.test.js
+++ b/client/overview/task-list/__tests__/tasks.test.js
@@ -320,18 +320,14 @@ describe( 'getTasks()', () => {
 		);
 	} );
 
-	it( 'should not include the dispute resolution task if no active disputes', () => {
-		const activeDisputes = [];
-		const actual = getTasks( {
-			activeDisputes,
-		} );
+	it( 'should not include the dispute resolution task without a summary', () => {
+		const actual = getTasks( {} );
 
 		expect( actual ).toEqual( [] );
 	} );
 
 	it( 'does not include the dispute task while its summary is loading', () => {
 		const actual = getTasks( {
-			activeDisputes: [ mockActiveDisputes[ 0 ] ],
 			activeDisputesSummary: {
 				count: 1,
 				amount_by_currency: { usd: 1000 },
@@ -343,28 +339,15 @@ describe( 'getTasks()', () => {
 		expect( actual ).toEqual( [] );
 	} );
 
-	it( 'uses the row fallback after an old-server summary finishes loading', () => {
-		const actual = getTasks( {
-			activeDisputes: [ mockActiveDisputes[ 0 ] ],
-			activeDisputesSummary: { count: 1 },
-			activeDisputesSummaryIsLoading: false,
-		} );
-
-		expect( actual ).toEqual(
-			expect.arrayContaining( [
-				expect.objectContaining( {
-					key: 'dispute-resolution-task-dp_1',
-					title: 'Respond to a dispute for $10.00 – Last day',
-				} ),
-			] )
-		);
-	} );
-
 	it( 'should not include the dispute resolution task if dispute due_by > 7 days', () => {
 		// Set Date.now to - 7 days to reduce urgency of disputes.
 		Date.now = jest.fn( () => new Date( '2023-01-24T08:00:00.000Z' ) );
 		const actual = getTasks( {
-			activeDisputes: mockActiveDisputes,
+			activeDisputesSummary: {
+				count: 3,
+				amount_by_currency: { usd: 2000, eur: 1000 },
+				earliest_due_by: '2023-02-01 23:59:59',
+			},
 		} );
 
 		expect( actual ).toEqual( [] );
@@ -372,7 +355,12 @@ describe( 'getTasks()', () => {
 
 	it( 'should include the dispute resolution task with 1 urgent dispute', () => {
 		const actual = getTasks( {
-			activeDisputes: [ mockActiveDisputes[ 0 ] ],
+			activeDispute: mockActiveDisputes[ 0 ],
+			activeDisputesSummary: {
+				count: 1,
+				amount_by_currency: { usd: 1000 },
+				earliest_due_by: '2023-02-01 23:59:59',
+			},
 		} );
 
 		expect( actual ).toEqual(
@@ -393,7 +381,12 @@ describe( 'getTasks()', () => {
 		// Set Date.now to - 5 days to reduce urgency of dispute.
 		Date.now = jest.fn( () => new Date( '2023-01-27T08:00:00.000Z' ) );
 		const actual = getTasks( {
-			activeDisputes: [ mockActiveDisputes[ 0 ] ],
+			activeDispute: mockActiveDisputes[ 0 ],
+			activeDisputesSummary: {
+				count: 1,
+				amount_by_currency: { usd: 1000 },
+				earliest_due_by: '2023-02-01 23:59:59',
+			},
 		} );
 
 		expect( actual ).toEqual(
@@ -412,13 +405,17 @@ describe( 'getTasks()', () => {
 
 	it( 'should include the dispute resolution task with multiple disputes from multiple currencies and 1 urgent dispute', () => {
 		const actual = getTasks( {
-			activeDisputes: mockActiveDisputes,
+			activeDisputesSummary: {
+				count: 3,
+				amount_by_currency: { usd: 2000, eur: 1000 },
+				earliest_due_by: '2023-02-01 23:59:59',
+			},
 		} );
 
 		expect( actual ).toEqual(
 			expect.arrayContaining( [
 				expect.objectContaining( {
-					key: 'dispute-resolution-task-dp_1-dp_2-dp_3',
+					key: 'dispute-resolution-task-summary',
 					completed: false,
 					level: 1,
 					title: 'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD',
@@ -437,13 +434,17 @@ describe( 'getTasks()', () => {
 				pastDue: false,
 				accountLink: 'http://example.com',
 			},
-			activeDisputes: mockActiveDisputes.slice( 0, 2 ),
+			activeDisputesSummary: {
+				count: 2,
+				amount_by_currency: { usd: 2000 },
+				earliest_due_by: '2023-02-01 23:59:59',
+			},
 		} );
 
 		expect( actual ).toEqual(
 			expect.arrayContaining( [
 				expect.objectContaining( {
-					key: 'dispute-resolution-task-dp_1-dp_2',
+					key: 'dispute-resolution-task-summary',
 					completed: false,
 					level: 1,
 					title: 'Respond to 2 active disputes for a total of $20.00',
@@ -458,13 +459,17 @@ describe( 'getTasks()', () => {
 		// Set Date.now to - 5 days to reduce urgency of disputes.
 		Date.now = jest.fn( () => new Date( '2023-01-27T08:00:00.000Z' ) );
 		const actual = getTasks( {
-			activeDisputes: mockActiveDisputes,
+			activeDisputesSummary: {
+				count: 3,
+				amount_by_currency: { usd: 2000, eur: 1000 },
+				earliest_due_by: '2023-02-01 23:59:59',
+			},
 		} );
 
 		expect( actual ).toEqual(
 			expect.arrayContaining( [
 				expect.objectContaining( {
-					key: 'dispute-resolution-task-dp_1-dp_2-dp_3',
+					key: 'dispute-resolution-task-summary',
 					completed: false,
 					level: 1,
 					title: 'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD',
@@ -478,13 +483,6 @@ describe( 'getTasks()', () => {
 
 describe( 'getDisputeResolutionTask()', () => {
 	const nextWeekDeadline = '2023-02-03 23:59:59';
-	const createDisputes = ( count, overrides = {} ) =>
-		Array.from( { length: count }, ( unused, index ) => ( {
-			...mockActiveDisputes[ 0 ],
-			dispute_id: `dp_${ index + 1 }`,
-			charge_id: `ch_${ index + 1 }`,
-			...overrides,
-		} ) );
 
 	beforeEach( () => {
 		moment.tz.setDefault( 'Etc/GMT+5' );
@@ -509,8 +507,8 @@ describe( 'getDisputeResolutionTask()', () => {
 		};
 	} );
 
-	it( 'uses the complete summary count and amount when only 50 rows are loaded', () => {
-		const task = getDisputeResolutionTask( createDisputes( 50 ), {
+	it( 'uses the complete summary count and amount', () => {
+		const task = getDisputeResolutionTask( {
 			count: 51,
 			amount_by_currency: { usd: 51000 },
 			earliest_due_by: nextWeekDeadline,
@@ -525,7 +523,7 @@ describe( 'getDisputeResolutionTask()', () => {
 	} );
 
 	it( 'shows two summary totals with stable ISO currency codes', () => {
-		const task = getDisputeResolutionTask( createDisputes( 3 ), {
+		const task = getDisputeResolutionTask( {
 			count: 3,
 			amount_by_currency: { usd: 2000, eur: 1000 },
 			earliest_due_by: nextWeekDeadline,
@@ -537,7 +535,7 @@ describe( 'getDisputeResolutionTask()', () => {
 	} );
 
 	it( 'shows a currency count instead of totals for three currencies', () => {
-		const task = getDisputeResolutionTask( createDisputes( 3 ), {
+		const task = getDisputeResolutionTask( {
 			count: 3,
 			amount_by_currency: { usd: 1000, eur: 1000, gbp: 1000 },
 			earliest_due_by: nextWeekDeadline,
@@ -552,14 +550,11 @@ describe( 'getDisputeResolutionTask()', () => {
 	} );
 
 	it( 'uses the summary deadline for the urgent state and subtitle', () => {
-		const task = getDisputeResolutionTask(
-			createDisputes( 2, { due_by: '2023-02-07 23:59:59' } ),
-			{
-				count: 2,
-				amount_by_currency: { usd: 2000 },
-				earliest_due_by: '2023-02-01 20:00:00',
-			}
-		);
+		const task = getDisputeResolutionTask( {
+			count: 2,
+			amount_by_currency: { usd: 2000 },
+			earliest_due_by: '2023-02-01 20:00:00',
+		} );
 
 		expect( task ).toEqual(
 			expect.objectContaining( {
@@ -571,7 +566,7 @@ describe( 'getDisputeResolutionTask()', () => {
 
 	it( 'uses the dated subtitle for a deadline tomorrow with less than 24 hours remaining', () => {
 		Date.now = jest.fn( () => new Date( '2023-02-01T23:00:00.000Z' ) );
-		const task = getDisputeResolutionTask( createDisputes( 1 ), {
+		const task = getDisputeResolutionTask( {
 			count: 1,
 			amount_by_currency: { usd: 1000 },
 			earliest_due_by: '2023-02-02 13:00:00',
@@ -598,41 +593,21 @@ describe( 'getDisputeResolutionTask()', () => {
 			{ count: 1, earliest_due_by: '2023-02-09 23:59:59' },
 		],
 	] )( 'does not return a task for %s', ( unused, summary ) => {
-		expect(
-			getDisputeResolutionTask( [ mockActiveDisputes[ 0 ] ], summary )
-		).toBeNull();
+		expect( getDisputeResolutionTask( summary ) ).toBeNull();
 	} );
 
-	it( 'uses complete rows when an old response omits the new fields', () => {
-		const task = getDisputeResolutionTask(
-			mockActiveDisputes.slice( 0, 3 ),
-			{
-				count: 3,
-			}
-		);
-
-		expect( task ).toEqual(
-			expect.objectContaining( {
-				title: 'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD',
-				content: 'Respond today by 6:59 PM',
-			} )
-		);
-	} );
-
-	it( 'treats an empty amount array as empty and uses a complete row total', () => {
-		const task = getDisputeResolutionTask( createDisputes( 2 ), {
+	it( 'treats an empty amount array as no amount', () => {
+		const task = getDisputeResolutionTask( {
 			count: 2,
 			amount_by_currency: [],
 			earliest_due_by: nextWeekDeadline,
 		} );
 
-		expect( task?.title ).toBe(
-			'Respond to 2 active disputes for a total of $20.00'
-		);
+		expect( task?.title ).toBe( 'Respond to 2 active disputes' );
 	} );
 
-	it( 'does not label a partial row amount as the total', () => {
-		const task = getDisputeResolutionTask( createDisputes( 2 ), {
+	it( 'does not show an amount when the summary amount map is empty', () => {
+		const task = getDisputeResolutionTask( {
 			count: 3,
 			amount_by_currency: {},
 			earliest_due_by: nextWeekDeadline,
@@ -642,28 +617,8 @@ describe( 'getDisputeResolutionTask()', () => {
 		expect( task?.title ).not.toContain( '$20.00' );
 	} );
 
-	it( 'opens one loaded dispute directly even when its row has no deadline', () => {
-		const dispute = { ...mockActiveDisputes[ 0 ], due_by: '' };
-		const task = getDisputeResolutionTask( [ dispute ], {
-			count: 1,
-			amount_by_currency: { usd: 1000 },
-			earliest_due_by: nextWeekDeadline,
-		} );
-
-		task?.action();
-
-		expect( mockHistoryPush ).toHaveBeenCalledWith(
-			getAdminUrl( {
-				page: 'wc-admin',
-				path: '/payments/transactions/details',
-				id: 'ch_mock',
-			} )
-		);
-	} );
-
-	it( 'opens the filtered list when the only loaded row has no charge ID', () => {
-		const dispute = { ...mockActiveDisputes[ 0 ], charge_id: '' };
-		const task = getDisputeResolutionTask( [ dispute ], {
+	it( 'opens the filtered dispute list for one dispute', () => {
+		const task = getDisputeResolutionTask( {
 			count: 1,
 			amount_by_currency: { usd: 1000 },
 			earliest_due_by: nextWeekDeadline,
@@ -680,29 +635,26 @@ describe( 'getDisputeResolutionTask()', () => {
 		);
 	} );
 
-	it.each( [
-		[ 'no loaded row', [] ],
-		[ 'more than one loaded row', mockActiveDisputes.slice( 0, 2 ) ],
-	] )(
-		'opens the filtered list when the summary has one dispute but %s',
-		( unused, disputes ) => {
-			const task = getDisputeResolutionTask( disputes, {
+	it( 'opens the single dispute transaction when its row is loaded', () => {
+		const task = getDisputeResolutionTask(
+			{
 				count: 1,
 				amount_by_currency: { usd: 1000 },
 				earliest_due_by: nextWeekDeadline,
-			} );
+			},
+			mockActiveDisputes[ 0 ]
+		);
 
-			task?.action();
+		task?.action();
 
-			expect( mockHistoryPush ).toHaveBeenCalledWith(
-				getAdminUrl( {
-					page: 'wc-admin',
-					path: '/payments/disputes',
-					filter: 'awaiting_response',
-				} )
-			);
-		}
-	);
+		expect( mockHistoryPush ).toHaveBeenCalledWith(
+			getAdminUrl( {
+				page: 'wc-admin',
+				path: '/payments/transactions/details',
+				id: 'ch_mock',
+			} )
+		);
+	} );
 } );
 
 describe( 'taskSort()', () => {
@@ -740,7 +692,13 @@ describe( 'taskSort()', () => {
 	} );
 	it( 'should sort the tasks', () => {
 		const unsortedTasks = getTasks( {
-			activeDisputes: mockActiveDisputes,
+			activeDisputesSummary: {
+				count: mockActiveDisputes.filter(
+					( dispute ) => dispute.due_by
+				).length,
+				amount_by_currency: { usd: 2000, eur: 1000 },
+				earliest_due_by: '2023-02-01 23:59:59',
+			},
 		} );
 		unsortedTasks.unshift( {
 			key: 'test-element',
@@ -757,7 +715,7 @@ describe( 'taskSort()', () => {
 		const sortedTasks = unsortedTasks.sort( taskSort );
 		expect( sortedTasks[ 0 ] ).toEqual(
 			expect.objectContaining( {
-				key: 'dispute-resolution-task-dp_1-dp_2-dp_3',
+				key: 'dispute-resolution-task-summary',
 				completed: false,
 				level: 1,
 			} )

--- a/client/overview/task-list/__tests__/tasks.test.js
+++ b/client/overview/task-list/__tests__/tasks.test.js
@@ -131,6 +131,7 @@ describe( 'getTasks()', () => {
 				detailsSubmitted: true,
 			},
 			zeroDecimalCurrencies: [],
+			shouldUseExplicitPrice: true,
 			connect: {
 				country: 'US',
 			},
@@ -489,21 +490,39 @@ describe( 'getDisputeResolutionTask()', () => {
 		Date.now = jest.fn( () => new Date( '2023-02-01T08:00:00.000Z' ) );
 		mockHistoryPush.mockClear();
 
-		global.wcpaySettings.currencyData.FR = {
-			code: 'EUR',
-			symbol: '€',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 2,
-		};
-		global.wcpaySettings.currencyData.GB = {
-			code: 'GBP',
-			symbol: '£',
-			symbolPosition: 'left',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			precision: 2,
+		global.wcpaySettings = {
+			zeroDecimalCurrencies: [],
+			shouldUseExplicitPrice: true,
+			connect: {
+				country: 'US',
+			},
+			currencyData: {
+				US: {
+					code: 'USD',
+					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+				FR: {
+					code: 'EUR',
+					symbol: '€',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+				GB: {
+					code: 'GBP',
+					symbol: '£',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+			},
+			dateFormat: 'M j, Y',
 		};
 	} );
 
@@ -531,6 +550,20 @@ describe( 'getDisputeResolutionTask()', () => {
 
 		expect( task?.title ).toBe(
 			'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD'
+		);
+	} );
+
+	it( 'honors the explicit price setting for two summary totals', () => {
+		global.wcpaySettings.shouldUseExplicitPrice = false;
+
+		const task = getDisputeResolutionTask( {
+			count: 3,
+			amount_by_currency: { usd: 2000, eur: 1000 },
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		expect( task?.title ).toBe(
+			'Respond to 3 active disputes for totals of €10.00 and $20.00'
 		);
 	} );
 
@@ -585,15 +618,26 @@ describe( 'getDisputeResolutionTask()', () => {
 		[ 'a zero count', { count: 0, earliest_due_by: nextWeekDeadline } ],
 		[ 'a null deadline', { count: 1, earliest_due_by: null } ],
 		[
-			'a past deadline',
-			{ count: 1, earliest_due_by: '2023-01-31 23:59:59' },
-		],
-		[
 			'a deadline after seven days',
 			{ count: 1, earliest_due_by: '2023-02-09 23:59:59' },
 		],
 	] )( 'does not return a task for %s', ( unused, summary ) => {
 		expect( getDisputeResolutionTask( summary ) ).toBeNull();
+	} );
+
+	it( 'keeps an actionable task visible when its earliest deadline is past', () => {
+		const task = getDisputeResolutionTask( {
+			count: 2,
+			amount_by_currency: { usd: 2000 },
+			earliest_due_by: '2023-01-31 23:59:59',
+		} );
+
+		expect( task ).toEqual(
+			expect.objectContaining( {
+				content: 'Response overdue',
+				dataAttrs: { 'data-urgent': true },
+			} )
+		);
 	} );
 
 	it( 'treats an empty amount array as no amount', () => {
@@ -652,6 +696,24 @@ describe( 'getDisputeResolutionTask()', () => {
 				page: 'wc-admin',
 				path: '/payments/transactions/details',
 				id: 'ch_mock',
+			} )
+		);
+	} );
+
+	it( 'opens the filtered dispute list for multiple disputes', () => {
+		const task = getDisputeResolutionTask( {
+			count: 2,
+			amount_by_currency: { usd: 2000 },
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		task?.action();
+
+		expect( mockHistoryPush ).toHaveBeenCalledWith(
+			getAdminUrl( {
+				page: 'wc-admin',
+				path: '/payments/disputes',
+				filter: 'awaiting_response',
 			} )
 		);
 	} );

--- a/client/overview/task-list/__tests__/tasks.test.js
+++ b/client/overview/task-list/__tests__/tasks.test.js
@@ -327,14 +327,14 @@ describe( 'getTasks()', () => {
 		expect( actual ).toEqual( [] );
 	} );
 
-	it( 'does not include the dispute task while its summary is loading', () => {
+	it( 'does not include the dispute task while its data is loading', () => {
 		const actual = getTasks( {
 			activeDisputesSummary: {
 				count: 1,
 				amount_by_currency: { usd: 1000 },
 				earliest_due_by: '2023-02-01 23:59:59',
 			},
-			activeDisputesSummaryIsLoading: true,
+			activeDisputeTaskIsLoading: true,
 		} );
 
 		expect( actual ).toEqual( [] );
@@ -755,9 +755,7 @@ describe( 'taskSort()', () => {
 	it( 'should sort the tasks', () => {
 		const unsortedTasks = getTasks( {
 			activeDisputesSummary: {
-				count: mockActiveDisputes.filter(
-					( dispute ) => dispute.due_by
-				).length,
+				count: 3,
 				amount_by_currency: { usd: 2000, eur: 1000 },
 				earliest_due_by: '2023-02-01 23:59:59',
 			},

--- a/client/overview/task-list/__tests__/tasks.test.js
+++ b/client/overview/task-list/__tests__/tasks.test.js
@@ -10,6 +10,15 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { getTasks, taskSort } from '../tasks';
+import { getDisputeResolutionTask } from '../tasks/dispute-task';
+import { getAdminUrl } from 'wcpay/utils';
+
+const mockHistoryPush = jest.fn();
+jest.mock( '@woocommerce/navigation', () => ( {
+	getHistory: () => ( {
+		push: mockHistoryPush,
+	} ),
+} ) );
 
 const mockActiveDisputes = [
 	{
@@ -130,6 +139,22 @@ describe( 'getTasks()', () => {
 				US: {
 					code: 'USD',
 					symbol: '$',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+				FR: {
+					code: 'EUR',
+					symbol: '€',
+					symbolPosition: 'left',
+					thousandSeparator: ',',
+					decimalSeparator: '.',
+					precision: 2,
+				},
+				GB: {
+					code: 'GBP',
+					symbol: '£',
 					symbolPosition: 'left',
 					thousandSeparator: ',',
 					decimalSeparator: '.',
@@ -304,6 +329,37 @@ describe( 'getTasks()', () => {
 		expect( actual ).toEqual( [] );
 	} );
 
+	it( 'does not include the dispute task while its summary is loading', () => {
+		const actual = getTasks( {
+			activeDisputes: [ mockActiveDisputes[ 0 ] ],
+			activeDisputesSummary: {
+				count: 1,
+				amount_by_currency: { usd: 1000 },
+				earliest_due_by: '2023-02-01 23:59:59',
+			},
+			activeDisputesSummaryIsLoading: true,
+		} );
+
+		expect( actual ).toEqual( [] );
+	} );
+
+	it( 'uses the row fallback after an old-server summary finishes loading', () => {
+		const actual = getTasks( {
+			activeDisputes: [ mockActiveDisputes[ 0 ] ],
+			activeDisputesSummary: { count: 1 },
+			activeDisputesSummaryIsLoading: false,
+		} );
+
+		expect( actual ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					key: 'dispute-resolution-task-dp_1',
+					title: 'Respond to a dispute for $10.00 – Last day',
+				} ),
+			] )
+		);
+	} );
+
 	it( 'should not include the dispute resolution task if dispute due_by > 7 days', () => {
 		// Set Date.now to - 7 days to reduce urgency of disputes.
 		Date.now = jest.fn( () => new Date( '2023-01-24T08:00:00.000Z' ) );
@@ -365,8 +421,8 @@ describe( 'getTasks()', () => {
 					key: 'dispute-resolution-task-dp_1-dp_2-dp_3',
 					completed: false,
 					level: 1,
-					title: 'Respond to 3 active disputes',
-					content: 'Final day to respond to 1 of the disputes',
+					title: 'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD',
+					content: 'Respond today by 6:59 PM',
 					actionLabel: 'See disputes',
 				} ),
 			] )
@@ -391,7 +447,7 @@ describe( 'getTasks()', () => {
 					completed: false,
 					level: 1,
 					title: 'Respond to 2 active disputes for a total of $20.00',
-					content: 'Final day to respond to 1 of the disputes',
+					content: 'Respond today by 6:59 PM',
 					actionLabel: 'See disputes',
 				} ),
 			] )
@@ -411,13 +467,242 @@ describe( 'getTasks()', () => {
 					key: 'dispute-resolution-task-dp_1-dp_2-dp_3',
 					completed: false,
 					level: 1,
-					title: 'Respond to 3 active disputes',
-					content: 'Last week to respond to 1 of the disputes',
+					title: 'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD',
+					content: 'By Feb 1, 2023 – 6 days left to respond',
 					actionLabel: 'See disputes',
 				} ),
 			] )
 		);
 	} );
+} );
+
+describe( 'getDisputeResolutionTask()', () => {
+	const nextWeekDeadline = '2023-02-03 23:59:59';
+	const createDisputes = ( count, overrides = {} ) =>
+		Array.from( { length: count }, ( unused, index ) => ( {
+			...mockActiveDisputes[ 0 ],
+			dispute_id: `dp_${ index + 1 }`,
+			charge_id: `ch_${ index + 1 }`,
+			...overrides,
+		} ) );
+
+	beforeEach( () => {
+		moment.tz.setDefault( 'Etc/GMT+5' );
+		Date.now = jest.fn( () => new Date( '2023-02-01T08:00:00.000Z' ) );
+		mockHistoryPush.mockClear();
+
+		global.wcpaySettings.currencyData.FR = {
+			code: 'EUR',
+			symbol: '€',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		};
+		global.wcpaySettings.currencyData.GB = {
+			code: 'GBP',
+			symbol: '£',
+			symbolPosition: 'left',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			precision: 2,
+		};
+	} );
+
+	it( 'uses the complete summary count and amount when only 50 rows are loaded', () => {
+		const task = getDisputeResolutionTask( createDisputes( 50 ), {
+			count: 51,
+			amount_by_currency: { usd: 51000 },
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		expect( task ).toEqual(
+			expect.objectContaining( {
+				title: 'Respond to 51 active disputes for a total of $510.00',
+				content: 'By Feb 3, 2023 – 3 days left to respond',
+			} )
+		);
+	} );
+
+	it( 'shows two summary totals with stable ISO currency codes', () => {
+		const task = getDisputeResolutionTask( createDisputes( 3 ), {
+			count: 3,
+			amount_by_currency: { usd: 2000, eur: 1000 },
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		expect( task?.title ).toBe(
+			'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD'
+		);
+	} );
+
+	it( 'shows a currency count instead of totals for three currencies', () => {
+		const task = getDisputeResolutionTask( createDisputes( 3 ), {
+			count: 3,
+			amount_by_currency: { usd: 1000, eur: 1000, gbp: 1000 },
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		expect( task?.title ).toBe(
+			'Respond to 3 active disputes in 3 currencies'
+		);
+		expect( task?.title ).not.toContain( '$' );
+		expect( task?.title ).not.toContain( '€' );
+		expect( task?.title ).not.toContain( '£' );
+	} );
+
+	it( 'uses the summary deadline for the urgent state and subtitle', () => {
+		const task = getDisputeResolutionTask(
+			createDisputes( 2, { due_by: '2023-02-07 23:59:59' } ),
+			{
+				count: 2,
+				amount_by_currency: { usd: 2000 },
+				earliest_due_by: '2023-02-01 20:00:00',
+			}
+		);
+
+		expect( task ).toEqual(
+			expect.objectContaining( {
+				content: 'Respond today by 3:00 PM',
+				dataAttrs: { 'data-urgent': true },
+			} )
+		);
+	} );
+
+	it( 'uses the dated subtitle for a deadline tomorrow with less than 24 hours remaining', () => {
+		Date.now = jest.fn( () => new Date( '2023-02-01T23:00:00.000Z' ) );
+		const task = getDisputeResolutionTask( createDisputes( 1 ), {
+			count: 1,
+			amount_by_currency: { usd: 1000 },
+			earliest_due_by: '2023-02-02 13:00:00',
+		} );
+
+		expect( task ).toEqual(
+			expect.objectContaining( {
+				title: 'Respond to a dispute for $10.00',
+				content: 'By Feb 2, 2023 – 14 hours left to respond',
+				dataAttrs: { 'data-urgent': true },
+			} )
+		);
+	} );
+
+	it.each( [
+		[ 'a zero count', { count: 0, earliest_due_by: nextWeekDeadline } ],
+		[ 'a null deadline', { count: 1, earliest_due_by: null } ],
+		[
+			'a past deadline',
+			{ count: 1, earliest_due_by: '2023-01-31 23:59:59' },
+		],
+		[
+			'a deadline after seven days',
+			{ count: 1, earliest_due_by: '2023-02-09 23:59:59' },
+		],
+	] )( 'does not return a task for %s', ( unused, summary ) => {
+		expect(
+			getDisputeResolutionTask( [ mockActiveDisputes[ 0 ] ], summary )
+		).toBeNull();
+	} );
+
+	it( 'uses complete rows when an old response omits the new fields', () => {
+		const task = getDisputeResolutionTask(
+			mockActiveDisputes.slice( 0, 3 ),
+			{
+				count: 3,
+			}
+		);
+
+		expect( task ).toEqual(
+			expect.objectContaining( {
+				title: 'Respond to 3 active disputes for totals of €10.00 EUR and $20.00 USD',
+				content: 'Respond today by 6:59 PM',
+			} )
+		);
+	} );
+
+	it( 'treats an empty amount array as empty and uses a complete row total', () => {
+		const task = getDisputeResolutionTask( createDisputes( 2 ), {
+			count: 2,
+			amount_by_currency: [],
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		expect( task?.title ).toBe(
+			'Respond to 2 active disputes for a total of $20.00'
+		);
+	} );
+
+	it( 'does not label a partial row amount as the total', () => {
+		const task = getDisputeResolutionTask( createDisputes( 2 ), {
+			count: 3,
+			amount_by_currency: {},
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		expect( task?.title ).toBe( 'Respond to 3 active disputes' );
+		expect( task?.title ).not.toContain( '$20.00' );
+	} );
+
+	it( 'opens one loaded dispute directly even when its row has no deadline', () => {
+		const dispute = { ...mockActiveDisputes[ 0 ], due_by: '' };
+		const task = getDisputeResolutionTask( [ dispute ], {
+			count: 1,
+			amount_by_currency: { usd: 1000 },
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		task?.action();
+
+		expect( mockHistoryPush ).toHaveBeenCalledWith(
+			getAdminUrl( {
+				page: 'wc-admin',
+				path: '/payments/transactions/details',
+				id: 'ch_mock',
+			} )
+		);
+	} );
+
+	it( 'opens the filtered list when the only loaded row has no charge ID', () => {
+		const dispute = { ...mockActiveDisputes[ 0 ], charge_id: '' };
+		const task = getDisputeResolutionTask( [ dispute ], {
+			count: 1,
+			amount_by_currency: { usd: 1000 },
+			earliest_due_by: nextWeekDeadline,
+		} );
+
+		task?.action();
+
+		expect( mockHistoryPush ).toHaveBeenCalledWith(
+			getAdminUrl( {
+				page: 'wc-admin',
+				path: '/payments/disputes',
+				filter: 'awaiting_response',
+			} )
+		);
+	} );
+
+	it.each( [
+		[ 'no loaded row', [] ],
+		[ 'more than one loaded row', mockActiveDisputes.slice( 0, 2 ) ],
+	] )(
+		'opens the filtered list when the summary has one dispute but %s',
+		( unused, disputes ) => {
+			const task = getDisputeResolutionTask( disputes, {
+				count: 1,
+				amount_by_currency: { usd: 1000 },
+				earliest_due_by: nextWeekDeadline,
+			} );
+
+			task?.action();
+
+			expect( mockHistoryPush ).toHaveBeenCalledWith(
+				getAdminUrl( {
+					page: 'wc-admin',
+					path: '/payments/disputes',
+					filter: 'awaiting_response',
+				} )
+			);
+		}
+	);
 } );
 
 describe( 'taskSort()', () => {

--- a/client/overview/task-list/__tests__/tasks.test.js
+++ b/client/overview/task-list/__tests__/tasks.test.js
@@ -484,6 +484,8 @@ describe( 'getTasks()', () => {
 
 describe( 'getDisputeResolutionTask()', () => {
 	const nextWeekDeadline = '2023-02-03 23:59:59';
+	// Get current timezone
+	const currentTimezone = moment.tz.guess();
 
 	beforeEach( () => {
 		moment.tz.setDefault( 'Etc/GMT+5' );
@@ -524,6 +526,11 @@ describe( 'getDisputeResolutionTask()', () => {
 			},
 			dateFormat: 'M j, Y',
 		};
+	} );
+	afterEach( () => {
+		// roll it back
+		Date.now = () => new Date();
+		moment.tz.setDefault( currentTimezone );
 	} );
 
 	it( 'uses the complete summary count and amount', () => {

--- a/client/overview/task-list/tasks.tsx
+++ b/client/overview/task-list/tasks.tsx
@@ -24,7 +24,7 @@ interface TaskListProps {
 	wpcomReconnectUrl: string;
 	activeDispute?: CachedDispute;
 	activeDisputesSummary?: DisputesSummaryData;
-	activeDisputesSummaryIsLoading?: boolean;
+	activeDisputeTaskIsLoading?: boolean;
 	showGoLiveTask: boolean;
 }
 
@@ -33,7 +33,7 @@ export const getTasks = ( {
 	wpcomReconnectUrl,
 	activeDispute,
 	activeDisputesSummary,
-	activeDisputesSummaryIsLoading = false,
+	activeDisputeTaskIsLoading = false,
 	showGoLiveTask = false,
 }: TaskListProps ): TaskItemProps[] => {
 	const {
@@ -69,7 +69,7 @@ export const getTasks = ( {
 
 	const isUpdateDetailsTaskVisible = showUpdateDetailsTask;
 
-	const disputeResolutionTask = activeDisputesSummaryIsLoading
+	const disputeResolutionTask = activeDisputeTaskIsLoading
 		? null
 		: getDisputeResolutionTask( activeDisputesSummary, activeDispute );
 

--- a/client/overview/task-list/tasks.tsx
+++ b/client/overview/task-list/tasks.tsx
@@ -22,7 +22,7 @@ const requirementBlacklist = [ 'invalid_value_other' ];
 interface TaskListProps {
 	showUpdateDetailsTask: boolean;
 	wpcomReconnectUrl: string;
-	activeDisputes?: CachedDispute[];
+	activeDispute?: CachedDispute;
 	activeDisputesSummary?: DisputesSummaryData;
 	activeDisputesSummaryIsLoading?: boolean;
 	showGoLiveTask: boolean;
@@ -31,7 +31,7 @@ interface TaskListProps {
 export const getTasks = ( {
 	showUpdateDetailsTask,
 	wpcomReconnectUrl,
-	activeDisputes = [],
+	activeDispute,
 	activeDisputesSummary,
 	activeDisputesSummaryIsLoading = false,
 	showGoLiveTask = false,
@@ -71,7 +71,7 @@ export const getTasks = ( {
 
 	const disputeResolutionTask = activeDisputesSummaryIsLoading
 		? null
-		: getDisputeResolutionTask( activeDisputes, activeDisputesSummary );
+		: getDisputeResolutionTask( activeDisputesSummary, activeDispute );
 
 	const isGoLiveTaskVisible =
 		wcpaySettings.isAccountConnected &&

--- a/client/overview/task-list/tasks.tsx
+++ b/client/overview/task-list/tasks.tsx
@@ -8,13 +8,10 @@
  * Internal dependencies.
  */
 import strings from './strings';
-import {
-	getDisputeResolutionTask,
-	getDisputesDueWithinDays,
-} from './tasks/dispute-task';
+import { getDisputeResolutionTask } from './tasks/dispute-task';
 import { getReconnectWpcomTask } from './tasks/reconnect-task';
 import { getUpdateBusinessDetailsTask } from './tasks/update-business-details-task';
-import { CachedDispute } from 'wcpay/types/disputes';
+import { CachedDispute, DisputesSummaryData } from 'wcpay/types/disputes';
 import { TaskItemProps } from './types';
 import { getGoLiveTask } from './tasks/go-live-task';
 import { isInTestModeOnboarding } from 'wcpay/utils';
@@ -26,6 +23,8 @@ interface TaskListProps {
 	showUpdateDetailsTask: boolean;
 	wpcomReconnectUrl: string;
 	activeDisputes?: CachedDispute[];
+	activeDisputesSummary?: DisputesSummaryData;
+	activeDisputesSummaryIsLoading?: boolean;
 	showGoLiveTask: boolean;
 }
 
@@ -33,6 +32,8 @@ export const getTasks = ( {
 	showUpdateDetailsTask,
 	wpcomReconnectUrl,
 	activeDisputes = [],
+	activeDisputesSummary,
+	activeDisputesSummaryIsLoading = false,
 	showGoLiveTask = false,
 }: TaskListProps ): TaskItemProps[] => {
 	const {
@@ -68,10 +69,9 @@ export const getTasks = ( {
 
 	const isUpdateDetailsTaskVisible = showUpdateDetailsTask;
 
-	const isDisputeTaskVisible =
-		!! activeDisputes &&
-		// Only show the dispute task if there are disputes due within 7 days.
-		getDisputesDueWithinDays( activeDisputes, 7 ).length > 0;
+	const disputeResolutionTask = activeDisputesSummaryIsLoading
+		? null
+		: getDisputeResolutionTask( activeDisputes, activeDisputesSummary );
 
 	const isGoLiveTaskVisible =
 		wcpaySettings.isAccountConnected &&
@@ -89,7 +89,7 @@ export const getTasks = ( {
 				detailsSubmitted ?? true
 			),
 		wpcomReconnectUrl && getReconnectWpcomTask( wpcomReconnectUrl ),
-		isDisputeTaskVisible && getDisputeResolutionTask( activeDisputes ),
+		disputeResolutionTask,
 		isGoLiveTaskVisible && getGoLiveTask(),
 	]
 		.filter( Boolean )

--- a/client/overview/task-list/tasks/dispute-task.tsx
+++ b/client/overview/task-list/tasks/dispute-task.tsx
@@ -10,7 +10,10 @@ import { getHistory } from '@woocommerce/navigation';
  */
 import type { TaskItemProps } from '../types';
 import type { CachedDispute, DisputesSummaryData } from 'wcpay/types/disputes';
-import { formatCurrency } from 'multi-currency/interface/functions';
+import {
+	formatCurrency,
+	formatExplicitCurrency,
+} from 'multi-currency/interface/functions';
 import { getAdminUrl } from 'wcpay/utils';
 import { recordEvent } from 'tracks';
 import { isDueWithin } from 'wcpay/disputes/utils';
@@ -25,11 +28,14 @@ export const getDisputeResolutionTask = (
 ): TaskItemProps | null => {
 	const activeDisputeCount = activeDisputesSummary?.count ?? 0;
 	const earliestDueBy = activeDisputesSummary?.earliest_due_by;
+	const isPastDue =
+		!! earliestDueBy &&
+		moment.utc( earliestDueBy ).isBefore( moment.utc() );
 
 	if (
 		activeDisputeCount === 0 ||
 		! earliestDueBy ||
-		! isDueWithin( { dueBy: earliestDueBy, days: 7 } )
+		( ! isPastDue && ! isDueWithin( { dueBy: earliestDueBy, days: 7 } ) )
 	) {
 		return null;
 	}
@@ -78,14 +84,16 @@ export const getDisputeResolutionTask = (
 	};
 
 	const isDueToday =
+		! isPastDue &&
 		formatDateTimeFromString( earliestDueBy, {
 			customFormat: 'Y-m-d',
 		} ) ===
-		formatDateTimeFromString(
-			moment.utc().format( 'YYYY-MM-DD HH:mm:ss' ),
-			{ customFormat: 'Y-m-d' }
-		);
-	const isDueWithin72h = isDueWithin( { dueBy: earliestDueBy, days: 3 } );
+			formatDateTimeFromString(
+				moment.utc().format( 'YYYY-MM-DD HH:mm:ss' ),
+				{ customFormat: 'Y-m-d' }
+			);
+	const isDueWithin72h =
+		isPastDue || isDueWithin( { dueBy: earliestDueBy, days: 3 } );
 
 	const disputeTask: TaskItemProps = {
 		key: `dispute-resolution-task-${
@@ -145,25 +153,20 @@ export const getDisputeResolutionTask = (
 			formatCurrency( amount, currency )
 		);
 	} else if ( amountEntries.length === 2 ) {
-		const formatAmountWithCurrencyCode = ( [ currency, amount ]: [
-			string,
-			number
-		] ): string => {
-			const formattedAmount = formatCurrency( amount, currency );
-			const currencyCode = currency.toUpperCase();
-
-			return formattedAmount.toUpperCase().includes( currencyCode )
-				? formattedAmount
-				: `${ formattedAmount } ${ currencyCode }`;
-		};
 		disputeTask.title = sprintf(
 			__(
 				'Respond to %1$d active disputes for totals of %2$s and %3$s',
 				'woocommerce-payments'
 			),
 			activeDisputeCount,
-			formatAmountWithCurrencyCode( amountEntries[ 0 ] ),
-			formatAmountWithCurrencyCode( amountEntries[ 1 ] )
+			formatExplicitCurrency(
+				amountEntries[ 0 ][ 1 ],
+				amountEntries[ 0 ][ 0 ]
+			),
+			formatExplicitCurrency(
+				amountEntries[ 1 ][ 1 ],
+				amountEntries[ 1 ][ 0 ]
+			)
 		);
 	} else if ( amountEntries.length >= 3 ) {
 		disputeTask.title = sprintf(
@@ -181,20 +184,24 @@ export const getDisputeResolutionTask = (
 		);
 	}
 
-	disputeTask.content = isDueToday
-		? sprintf(
-				__( 'Respond today by %s', 'woocommerce-payments' ),
-				// Show the deadline time in the local timezone: e.g. "11:59 PM".
-				formatDateTimeFromString( earliestDueBy, {
-					customFormat: 'g:i A',
-				} )
-		  )
-		: sprintf(
-				__( 'By %s – %s left to respond', 'woocommerce-payments' ),
-				// Show the deadline date in the local timezone: e.g. "Jan 1, 2021".
-				formatDateTimeFromString( earliestDueBy ),
-				moment.utc( earliestDueBy ).fromNow( true ) // E.g. "2 days".
-		  );
+	if ( isPastDue ) {
+		disputeTask.content = __( 'Response overdue', 'woocommerce-payments' );
+	} else if ( isDueToday ) {
+		disputeTask.content = sprintf(
+			__( 'Respond today by %s', 'woocommerce-payments' ),
+			// Show the deadline time in the local timezone: e.g. "11:59 PM".
+			formatDateTimeFromString( earliestDueBy, {
+				customFormat: 'g:i A',
+			} )
+		);
+	} else {
+		disputeTask.content = sprintf(
+			__( 'By %s – %s left to respond', 'woocommerce-payments' ),
+			// Show the deadline date in the local timezone: e.g. "Jan 1, 2021".
+			formatDateTimeFromString( earliestDueBy ),
+			moment.utc( earliestDueBy ).fromNow( true ) // E.g. "2 days".
+		);
+	}
 
 	return disputeTask;
 };

--- a/client/overview/task-list/tasks/dispute-task.tsx
+++ b/client/overview/task-list/tasks/dispute-task.tsx
@@ -18,35 +18,13 @@ import { formatDateTimeFromString } from 'wcpay/utils/date-time';
 
 export const getDisputeResolutionTask = (
 	/**
-	 * Active disputes (awaiting a response) to generate the notice string for.
+	 * Summary of active disputes (awaiting a response) for the notice.
 	 */
-	activeDisputes: CachedDispute[],
-	activeDisputesSummary?: DisputesSummaryData
+	activeDisputesSummary?: DisputesSummaryData,
+	activeDispute?: CachedDispute
 ): TaskItemProps | null => {
-	let disputesWithDeadlines: CachedDispute[] | undefined;
-	const getDisputesWithDeadlines = (): CachedDispute[] => {
-		disputesWithDeadlines ??= [ ...activeDisputes ]
-			.filter( ( dispute ) => dispute.due_by !== '' )
-			.sort( ( a, b ) => moment( a.due_by ).diff( moment( b.due_by ) ) );
-
-		return disputesWithDeadlines;
-	};
-
-	const fallbackDisputes =
-		activeDisputesSummary?.count === undefined
-			? getDisputesWithDeadlines()
-			: activeDisputes;
-	const activeDisputeCount =
-		activeDisputesSummary?.count ?? fallbackDisputes.length;
-	const hasSummaryDeadline =
-		activeDisputesSummary !== undefined &&
-		Object.prototype.hasOwnProperty.call(
-			activeDisputesSummary,
-			'earliest_due_by'
-		);
-	const earliestDueBy = hasSummaryDeadline
-		? activeDisputesSummary.earliest_due_by
-		: getDisputesWithDeadlines()[ 0 ]?.due_by;
+	const activeDisputeCount = activeDisputesSummary?.count ?? 0;
+	const earliestDueBy = activeDisputesSummary?.earliest_due_by;
 
 	if (
 		activeDisputeCount === 0 ||
@@ -57,7 +35,7 @@ export const getDisputeResolutionTask = (
 	}
 
 	const summaryAmounts = activeDisputesSummary?.amount_by_currency;
-	let amountEntries =
+	const amountEntries =
 		summaryAmounts && ! Array.isArray( summaryAmounts )
 			? Object.entries( summaryAmounts ).filter(
 					( [ currency, amount ] ) =>
@@ -67,26 +45,11 @@ export const getDisputeResolutionTask = (
 			  )
 			: [];
 
-	if (
-		amountEntries.length === 0 &&
-		fallbackDisputes.length === activeDisputeCount
-	) {
-		const rowAmounts = fallbackDisputes.reduce( ( amounts, dispute ) => {
-			amounts[ dispute.currency ] =
-				( amounts[ dispute.currency ] ?? 0 ) + dispute.amount;
-
-			return amounts;
-		}, {} as Record< string, number > );
-		amountEntries = Object.entries( rowAmounts );
-	}
-
 	amountEntries.sort( ( [ currencyA ], [ currencyB ] ) =>
 		currencyA.localeCompare( currencyB )
 	);
 	const canOpenSingleDispute =
-		activeDisputeCount === 1 &&
-		activeDisputes.length === 1 &&
-		!! activeDisputes[ 0 ].charge_id;
+		activeDisputeCount === 1 && !! activeDispute?.charge_id;
 
 	const handleClick = () => {
 		recordEvent( 'wcpay_overview_task_click', {
@@ -95,24 +58,23 @@ export const getDisputeResolutionTask = (
 		} );
 		const history = getHistory();
 		if ( canOpenSingleDispute ) {
-			// Redirect to the transaction details page if there is only one dispute.
-			const chargeId = activeDisputes[ 0 ].charge_id;
 			history.push(
 				getAdminUrl( {
 					page: 'wc-admin',
 					path: '/payments/transactions/details',
-					id: chargeId,
+					id: activeDispute.charge_id,
 				} )
 			);
-		} else {
-			history.push(
-				getAdminUrl( {
-					page: 'wc-admin',
-					path: '/payments/disputes',
-					filter: 'awaiting_response',
-				} )
-			);
+			return;
 		}
+
+		history.push(
+			getAdminUrl( {
+				page: 'wc-admin',
+				path: '/payments/disputes',
+				filter: 'awaiting_response',
+			} )
+		);
 	};
 
 	const isDueToday =
@@ -125,18 +87,10 @@ export const getDisputeResolutionTask = (
 		);
 	const isDueWithin72h = isDueWithin( { dueBy: earliestDueBy, days: 3 } );
 
-	// Create a unique key for each combination of dispute IDs
-	// to ensure the task is rendered if a previous task was dismissed.
-	const keyDisputes = hasSummaryDeadline
-		? activeDisputes
-		: getDisputesWithDeadlines();
-	const disputeTaskKey = `dispute-resolution-task-${
-		keyDisputes.map( ( dispute ) => dispute.dispute_id ).join( '-' ) ||
-		'summary'
-	}`;
-
 	const disputeTask: TaskItemProps = {
-		key: disputeTaskKey,
+		key: `dispute-resolution-task-${
+			activeDispute?.dispute_id ?? 'summary'
+		}`,
 		title: '', // Title text defined below.
 		content: '', // Subtitle text defined below.
 		level: 1,

--- a/client/overview/task-list/tasks/dispute-task.tsx
+++ b/client/overview/task-list/tasks/dispute-task.tsx
@@ -10,10 +10,7 @@ import { getHistory } from '@woocommerce/navigation';
  */
 import type { TaskItemProps } from '../types';
 import type { CachedDispute, DisputesSummaryData } from 'wcpay/types/disputes';
-import {
-	formatCurrency,
-	formatExplicitCurrency,
-} from 'multi-currency/interface/functions';
+import { formatCurrency } from 'multi-currency/interface/functions';
 import { getAdminUrl } from 'wcpay/utils';
 import { recordEvent } from 'tracks';
 import { isDueWithin } from 'wcpay/disputes/utils';
@@ -151,31 +148,6 @@ export const getDisputeResolutionTask = (
 			),
 			activeDisputeCount,
 			formatCurrency( amount, currency )
-		);
-	} else if ( amountEntries.length === 2 ) {
-		disputeTask.title = sprintf(
-			__(
-				'Respond to %1$d active disputes for totals of %2$s and %3$s',
-				'woocommerce-payments'
-			),
-			activeDisputeCount,
-			formatExplicitCurrency(
-				amountEntries[ 0 ][ 1 ],
-				amountEntries[ 0 ][ 0 ]
-			),
-			formatExplicitCurrency(
-				amountEntries[ 1 ][ 1 ],
-				amountEntries[ 1 ][ 0 ]
-			)
-		);
-	} else if ( amountEntries.length >= 3 ) {
-		disputeTask.title = sprintf(
-			__(
-				'Respond to %1$d active disputes in %2$d currencies',
-				'woocommerce-payments'
-			),
-			activeDisputeCount,
-			amountEntries.length
 		);
 	} else {
 		disputeTask.title = sprintf(

--- a/client/overview/task-list/tasks/dispute-task.tsx
+++ b/client/overview/task-list/tasks/dispute-task.tsx
@@ -92,7 +92,7 @@ export const getDisputeResolutionTask = (
 				moment.utc().format( 'YYYY-MM-DD HH:mm:ss' ),
 				{ customFormat: 'Y-m-d' }
 			);
-	const isDueWithin72h =
+	const isUrgent =
 		isPastDue || isDueWithin( { dueBy: earliestDueBy, days: 3 } );
 
 	const disputeTask: TaskItemProps = {
@@ -115,7 +115,7 @@ export const getDisputeResolutionTask = (
 			// Only handle clicks on the action button.
 		},
 		dataAttrs: {
-			'data-urgent': isDueWithin72h,
+			'data-urgent': isUrgent,
 		},
 	};
 

--- a/client/overview/task-list/tasks/dispute-task.tsx
+++ b/client/overview/task-list/tasks/dispute-task.tsx
@@ -9,45 +9,84 @@ import { getHistory } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import type { TaskItemProps } from '../types';
-import type { CachedDispute } from 'wcpay/types/disputes';
+import type { CachedDispute, DisputesSummaryData } from 'wcpay/types/disputes';
 import { formatCurrency } from 'multi-currency/interface/functions';
 import { getAdminUrl } from 'wcpay/utils';
 import { recordEvent } from 'tracks';
 import { isDueWithin } from 'wcpay/disputes/utils';
 import { formatDateTimeFromString } from 'wcpay/utils/date-time';
 
-/**
- * Returns an array of disputes that are due within the specified number of days.
- *
- * @param {CachedDispute[]} activeDisputes - The active disputes to filter.
- * @param {number}          days           - The number of days to check.
- *
- * @return {CachedDispute[]} The disputes that are due within the specified number of days.
- */
-export const getDisputesDueWithinDays = (
-	activeDisputes: CachedDispute[],
-	days: number
-): CachedDispute[] =>
-	activeDisputes.filter( ( dispute ) =>
-		isDueWithin( { dueBy: dispute.due_by, days } )
-	);
-
 export const getDisputeResolutionTask = (
 	/**
 	 * Active disputes (awaiting a response) to generate the notice string for.
 	 */
-	activeDisputes: CachedDispute[]
+	activeDisputes: CachedDispute[],
+	activeDisputesSummary?: DisputesSummaryData
 ): TaskItemProps | null => {
-	// Create a new array and sort by `due_by` ascending.
-	activeDisputes = [ ...activeDisputes ]
-		.filter( ( dispute ) => dispute.due_by !== '' )
-		.sort( ( a, b ) => moment( a.due_by ).diff( moment( b.due_by ) ) );
+	let disputesWithDeadlines: CachedDispute[] | undefined;
+	const getDisputesWithDeadlines = (): CachedDispute[] => {
+		disputesWithDeadlines ??= [ ...activeDisputes ]
+			.filter( ( dispute ) => dispute.due_by !== '' )
+			.sort( ( a, b ) => moment( a.due_by ).diff( moment( b.due_by ) ) );
 
-	const activeDisputeCount = activeDisputes.length;
+		return disputesWithDeadlines;
+	};
 
-	if ( activeDisputeCount === 0 ) {
+	const fallbackDisputes =
+		activeDisputesSummary?.count === undefined
+			? getDisputesWithDeadlines()
+			: activeDisputes;
+	const activeDisputeCount =
+		activeDisputesSummary?.count ?? fallbackDisputes.length;
+	const hasSummaryDeadline =
+		activeDisputesSummary !== undefined &&
+		Object.prototype.hasOwnProperty.call(
+			activeDisputesSummary,
+			'earliest_due_by'
+		);
+	const earliestDueBy = hasSummaryDeadline
+		? activeDisputesSummary.earliest_due_by
+		: getDisputesWithDeadlines()[ 0 ]?.due_by;
+
+	if (
+		activeDisputeCount === 0 ||
+		! earliestDueBy ||
+		! isDueWithin( { dueBy: earliestDueBy, days: 7 } )
+	) {
 		return null;
 	}
+
+	const summaryAmounts = activeDisputesSummary?.amount_by_currency;
+	let amountEntries =
+		summaryAmounts && ! Array.isArray( summaryAmounts )
+			? Object.entries( summaryAmounts ).filter(
+					( [ currency, amount ] ) =>
+						currency !== '' &&
+						typeof amount === 'number' &&
+						Number.isFinite( amount )
+			  )
+			: [];
+
+	if (
+		amountEntries.length === 0 &&
+		fallbackDisputes.length === activeDisputeCount
+	) {
+		const rowAmounts = fallbackDisputes.reduce( ( amounts, dispute ) => {
+			amounts[ dispute.currency ] =
+				( amounts[ dispute.currency ] ?? 0 ) + dispute.amount;
+
+			return amounts;
+		}, {} as Record< string, number > );
+		amountEntries = Object.entries( rowAmounts );
+	}
+
+	amountEntries.sort( ( [ currencyA ], [ currencyB ] ) =>
+		currencyA.localeCompare( currencyB )
+	);
+	const canOpenSingleDispute =
+		activeDisputeCount === 1 &&
+		activeDisputes.length === 1 &&
+		!! activeDisputes[ 0 ].charge_id;
 
 	const handleClick = () => {
 		recordEvent( 'wcpay_overview_task_click', {
@@ -55,7 +94,7 @@ export const getDisputeResolutionTask = (
 			active_dispute_count: activeDisputeCount,
 		} );
 		const history = getHistory();
-		if ( activeDisputeCount === 1 ) {
+		if ( canOpenSingleDispute ) {
 			// Redirect to the transaction details page if there is only one dispute.
 			const chargeId = activeDisputes[ 0 ].charge_id;
 			history.push(
@@ -76,21 +115,25 @@ export const getDisputeResolutionTask = (
 		}
 	};
 
-	const numDisputesDueWithin24h = getDisputesDueWithinDays(
-		activeDisputes,
-		1
-	).length;
-
-	const numDisputesDueWithin72h = getDisputesDueWithinDays(
-		activeDisputes,
-		3
-	).length;
+	const isDueToday =
+		formatDateTimeFromString( earliestDueBy, {
+			customFormat: 'Y-m-d',
+		} ) ===
+		formatDateTimeFromString(
+			moment.utc().format( 'YYYY-MM-DD HH:mm:ss' ),
+			{ customFormat: 'Y-m-d' }
+		);
+	const isDueWithin72h = isDueWithin( { dueBy: earliestDueBy, days: 3 } );
 
 	// Create a unique key for each combination of dispute IDs
 	// to ensure the task is rendered if a previous task was dismissed.
-	const disputeTaskKey = `dispute-resolution-task-${ activeDisputes
-		.map( ( dispute ) => dispute.dispute_id )
-		.join( '-' ) }`;
+	const keyDisputes = hasSummaryDeadline
+		? activeDisputes
+		: getDisputesWithDeadlines();
+	const disputeTaskKey = `dispute-resolution-task-${
+		keyDisputes.map( ( dispute ) => dispute.dispute_id ).join( '-' ) ||
+		'summary'
+	}`;
 
 	const disputeTask: TaskItemProps = {
 		key: disputeTaskKey,
@@ -102,120 +145,102 @@ export const getDisputeResolutionTask = (
 		expandable: true,
 		isDismissable: false,
 		showActionButton: true,
-		actionLabel: __( 'Respond now', 'woocommerce-payments' ),
+		actionLabel: canOpenSingleDispute
+			? __( 'Respond now', 'woocommerce-payments' )
+			: __( 'See disputes', 'woocommerce-payments' ),
 		action: handleClick,
 		onClick: () => {
 			// Only handle clicks on the action button.
 		},
 		dataAttrs: {
-			'data-urgent': !! ( numDisputesDueWithin72h >= 1 ),
+			'data-urgent': isDueWithin72h,
 		},
 	};
 
-	// Single dispute.
-	if ( activeDisputeCount === 1 ) {
-		const dispute = activeDisputes[ 0 ];
-		const amountFormatted = formatCurrency(
-			dispute.amount,
-			dispute.currency
-		);
+	if ( activeDisputeCount === 1 && amountEntries.length === 1 ) {
+		const [ currency, amount ] = amountEntries[ 0 ];
+		const amountFormatted = formatCurrency( amount, currency );
 
-		disputeTask.title =
-			numDisputesDueWithin24h >= 1
-				? sprintf(
-						__(
-							'Respond to a dispute for %s – Last day',
-							'woocommerce-payments'
-						),
-						amountFormatted
-				  )
-				: sprintf(
-						__(
-							'Respond to a dispute for %s',
-							'woocommerce-payments'
-						),
-						amountFormatted
-				  );
-
-		disputeTask.content =
-			numDisputesDueWithin24h >= 1
-				? sprintf(
-						__( 'Respond today by %s', 'woocommerce-payments' ),
-						// Show due_by time in local timezone: e.g. "11:59 PM".
-						formatDateTimeFromString( dispute.due_by, {
-							customFormat: 'g:i A',
-						} )
-				  )
-				: sprintf(
-						__(
-							'By %s – %s left to respond',
-							'woocommerce-payments'
-						),
-						// Show due_by date in local timezone: e.g. "Jan 1, 2021".
-						formatDateTimeFromString( dispute.due_by ),
-						moment.utc( dispute.due_by ).fromNow( true ) // E.g. "2 days".
-				  );
-
-		return disputeTask;
-	}
-
-	// Multiple disputes.
-	const disputeCurrencies = activeDisputes.reduce(
-		( currencies, dispute ) => {
-			const { currency } = dispute;
-			return currencies.includes( currency )
-				? currencies
-				: [ ...currencies, currency ];
-		},
-		[] as string[]
-	);
-
-	if ( disputeCurrencies.length > 1 ) {
-		// If multiple currencies, use simple title without total amounts.
-		disputeTask.title = sprintf(
-			__( 'Respond to %d active disputes', 'woocommerce-payments' ),
-			activeDisputeCount
-		);
-	} else {
-		// If single currency, show total amount.
-		const disputeTotal = activeDisputes.reduce(
-			( total, dispute ) => total + dispute.amount,
-			0
-		);
+		disputeTask.title = isDueToday
+			? sprintf(
+					__(
+						'Respond to a dispute for %s – Last day',
+						'woocommerce-payments'
+					),
+					amountFormatted
+			  )
+			: sprintf(
+					__( 'Respond to a dispute for %s', 'woocommerce-payments' ),
+					amountFormatted
+			  );
+	} else if ( activeDisputeCount === 1 ) {
+		disputeTask.title = isDueToday
+			? __(
+					'Respond to an active dispute – Last day',
+					'woocommerce-payments'
+			  )
+			: __( 'Respond to an active dispute', 'woocommerce-payments' );
+	} else if ( amountEntries.length === 1 ) {
+		const [ currency, amount ] = amountEntries[ 0 ];
 		disputeTask.title = sprintf(
 			__(
 				'Respond to %d active disputes for a total of %s',
 				'woocommerce-payments'
 			),
 			activeDisputeCount,
-			formatCurrency( disputeTotal, disputeCurrencies[ 0 ] )
+			formatCurrency( amount, currency )
+		);
+	} else if ( amountEntries.length === 2 ) {
+		const formatAmountWithCurrencyCode = ( [ currency, amount ]: [
+			string,
+			number
+		] ): string => {
+			const formattedAmount = formatCurrency( amount, currency );
+			const currencyCode = currency.toUpperCase();
+
+			return formattedAmount.toUpperCase().includes( currencyCode )
+				? formattedAmount
+				: `${ formattedAmount } ${ currencyCode }`;
+		};
+		disputeTask.title = sprintf(
+			__(
+				'Respond to %1$d active disputes for totals of %2$s and %3$s',
+				'woocommerce-payments'
+			),
+			activeDisputeCount,
+			formatAmountWithCurrencyCode( amountEntries[ 0 ] ),
+			formatAmountWithCurrencyCode( amountEntries[ 1 ] )
+		);
+	} else if ( amountEntries.length >= 3 ) {
+		disputeTask.title = sprintf(
+			__(
+				'Respond to %1$d active disputes in %2$d currencies',
+				'woocommerce-payments'
+			),
+			activeDisputeCount,
+			amountEntries.length
+		);
+	} else {
+		disputeTask.title = sprintf(
+			__( 'Respond to %d active disputes', 'woocommerce-payments' ),
+			activeDisputeCount
 		);
 	}
 
-	const numDisputesDueWithin7Days = getDisputesDueWithinDays(
-		activeDisputes,
-		7
-	).length;
-
-	disputeTask.content =
-		// Final day / Last week to respond to N of the disputes
-		numDisputesDueWithin24h >= 1
-			? sprintf(
-					__(
-						'Final day to respond to %d of the disputes',
-						'woocommerce-payments'
-					),
-					numDisputesDueWithin24h
-			  )
-			: sprintf(
-					__(
-						'Last week to respond to %d of the disputes',
-						'woocommerce-payments'
-					),
-					numDisputesDueWithin7Days
-			  );
-
-	disputeTask.actionLabel = __( 'See disputes', 'woocommerce-payments' );
+	disputeTask.content = isDueToday
+		? sprintf(
+				__( 'Respond today by %s', 'woocommerce-payments' ),
+				// Show the deadline time in the local timezone: e.g. "11:59 PM".
+				formatDateTimeFromString( earliestDueBy, {
+					customFormat: 'g:i A',
+				} )
+		  )
+		: sprintf(
+				__( 'By %s – %s left to respond', 'woocommerce-payments' ),
+				// Show the deadline date in the local timezone: e.g. "Jan 1, 2021".
+				formatDateTimeFromString( earliestDueBy ),
+				moment.utc( earliestDueBy ).fromNow( true ) // E.g. "2 days".
+		  );
 
 	return disputeTask;
 };

--- a/client/overview/task-list/tasks/dispute-task.tsx
+++ b/client/overview/task-list/tasks/dispute-task.tsx
@@ -48,9 +48,6 @@ export const getDisputeResolutionTask = (
 			  )
 			: [];
 
-	amountEntries.sort( ( [ currencyA ], [ currencyB ] ) =>
-		currencyA.localeCompare( currencyB )
-	);
 	const canOpenSingleDispute =
 		activeDisputeCount === 1 && !! activeDispute?.charge_id;
 

--- a/client/types/disputes.d.ts
+++ b/client/types/disputes.d.ts
@@ -179,11 +179,15 @@ export interface CachedDispute {
 	due_by: string;
 }
 
+export interface DisputesSummaryData {
+	count?: number;
+	currencies?: string[];
+	amount_by_currency?: Record< string, number > | [];
+	earliest_due_by?: string | null;
+}
+
 export interface DisputesSummary {
-	disputesSummary: {
-		count?: number;
-		currencies?: string[];
-	};
+	disputesSummary: DisputesSummaryData;
 	isLoading: boolean;
 }
 


### PR DESCRIPTION
Fixes WOOPMNT-6439

#### Changes proposed in this Pull Request

The Active Disputes task now uses the complete dispute summary. Merchants see the correct count, the complete total for single-currency disputes, and the earliest response deadline without loading the first 50 dispute rows.

| Case | Before | After |
| --- | --- | --- |
| Fewer than 50 disputes, one currency | Shows the correct count and combined amount. | Keeps the same count and combined amount. The subtitle uses the earliest response deadline. |
| Fewer than 50 disputes, multiple currencies | Shows only the dispute count. | Keeps the same count-only wording. The subtitle uses the earliest response deadline. |
| More than 50 disputes, one currency | Shows a maximum count of 50 and a partial total from the first 50 rows. | Shows the complete count and complete total from the summary API. |
| More than 50 disputes, multiple currencies | Uses only the first 50 rows. It shows a maximum count of 50. It can also show a misleading one-currency partial total when another currency exists after row 50. | Uses all matching disputes and shows the complete count. It keeps the same count-only wording for multiple currencies. |

The currency problem is not only a missing total. The old task infers the currency set from the first page. It can therefore hide a currency that exists after row 50 and present the first-page amount as a single-currency total.

This PR preserves the behavior from #6642. For every multi-currency case, the task keeps the existing `Respond to N active disputes` title without amounts. The complete summary prevents a currency after row 50 from being missed when the client selects that wording.

The Overview now requests the summary first. For zero or multiple disputes, it does not request dispute rows. If the summary count is exactly one, it requests one row so the existing **Respond now** action can continue to open that dispute's transaction. The task waits for this small request before it appears.

The hosted API added and deployed `amount_by_currency` and `earliest_due_by` before this client change. It did not remove or change the existing fields. Older WooPayments versions continue to use the existing response. This newer version does not need an older-server row fallback. It can use the summary as its source of truth and reduce the Overview request from 50 rows to zero or one row.

If the earliest actionable deadline is already past, the task stays visible as urgent and shows **Response overdue**. A stale actionable dispute must not hide other disputes that still need a response.

This change does not modify a public PHP signature, REST route, hook, or option key. The change does not add a multisite or install-layout dependency.

Session-settled decisions carried from planning: preserve the existing count-only wording for multiple currencies and show the earliest response deadline.

#### Screenshots

**Before: `develop` uses only the first 50 rows**

![Before: develop shows only the first 50 disputes](https://github.com/user-attachments/assets/db6958e4-5dde-4cae-806f-565f22e2bbc9)

**After: this PR uses the complete summary and keeps the count-only wording for multiple currencies**

![After: this PR shows all 57 active disputes without multi-currency totals](https://github.com/user-attachments/assets/f9445e43-4d21-4ed9-ba39-f1f552242cbc)

#### Testing instructions

1. Use a server that supplies `count`, `amount_by_currency`, and `earliest_due_by` in the disputes summary response.
2. Create disputes that await a response and have a deadline within seven days.
3. Open **Payments > Overview**.
4. Confirm the four display cases in the table above.
5. With exactly one dispute, confirm that the client requests one dispute row and **Respond now** opens its transaction.
6. With zero or multiple disputes, confirm that the Overview does not request dispute rows and **See disputes** opens the filtered Disputes list.
7. Use an actionable dispute with a past deadline. Confirm that the task stays visible, is urgent, and shows **Response overdue**.

Local browser evidence used 57 active disputes in USD and EUR and confirmed that the old task stopped at 50 disputes. The final multi-currency title keeps the existing count-only wording; the complete count and deadline behavior are covered by the focused task tests.

Automated checks:

- 51 focused data-hook, Overview, and task-list tests pass.
- The existing `useDisputes( query )` call shape is covered without the optional loading argument.
- The dispute task tests pass when selected in isolation.
- TypeScript and ESLint checks pass through the pre-commit hook.
- Prettier and `git diff --check` pass.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (does not apply: this change does not modify layout or styles)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
