### PR TITLE
perf(test): disable Xdebug in non-coverage PHP jobs

### DIFF
--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -71,7 +71,14 @@ jobs:
           tools:       composer
           coverage:    xdebug2
       # run CI checks
-      - run: bash bin/run-ci-tests.bash
+      - name: Profile PHP tests with and without Xdebug
+        run: |
+          echo 'PROFILE: baseline with Xdebug'
+          bash bin/run-ci-tests.bash
+          sudo phpdismod xdebug
+          if php -m | grep -qi xdebug; then exit 1; fi
+          echo 'PROFILE: same suite without Xdebug'
+          bash bin/phpunit.sh -c phpunit.xml.dist
         env:
           WC_VERSION: ${{ env.WC_MIN_SUPPORTED_VERSION }}
           GUTENBERG_VERSION: ${{ matrix.gutenberg }}

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -69,16 +69,9 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools:       composer
-          coverage:    xdebug2
+          coverage:    none
       # run CI checks
-      - name: Profile PHP tests with and without Xdebug
-        run: |
-          echo 'PROFILE: baseline with Xdebug'
-          bash bin/run-ci-tests.bash
-          sudo phpdismod xdebug
-          if php -m | grep -qi xdebug; then exit 1; fi
-          echo 'PROFILE: same suite without Xdebug'
-          bash bin/phpunit.sh -c phpunit.xml.dist
+      - run: bash bin/run-ci-tests.bash
         env:
           WC_VERSION: ${{ env.WC_MIN_SUPPORTED_VERSION }}
           GUTENBERG_VERSION: ${{ matrix.gutenberg }}

--- a/changelog/perf-php-no-xdebug
+++ b/changelog/perf-php-no-xdebug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Disable Xdebug in PHP unit test jobs that do not collect coverage.


### PR DESCRIPTION
Tracking: [WOOPMNT-6443](https://linear.app/a8c/issue/WOOPMNT-6443/reduce-unit-test-and-e2e-ci-runtime)

#### Changes proposed in this Pull Request

Set `coverage: none` in the ordinary PHP unit jobs. Those jobs do not collect coverage, but currently load Xdebug 2.9.8. The separate code-coverage workflow keeps Xdebug enabled.

**Profile:** each matrix entry ran the same full suite on the same runner, first with Xdebug and then with the extension disabled. PHPUnit reported:

| PHP 7.4 / Gutenberg | With Xdebug | Without Xdebug | Saved |
| --- | ---: | ---: | ---: |
| [latest](https://github.com/Automattic/woocommerce-payments/actions/runs/33930346392/job/101207512744) | 234.994s | 144.972s | 90.022s (38.3%) |
| [22.3.0](https://github.com/Automattic/woocommerce-payments/actions/runs/33930346392/job/101207512686) | 247.750s | 159.592s | 88.158s (35.6%) |

All four executions passed with **4,064 tests, 12,341 assertions and 25 skips**. Timings exclude environment installation. The second execution reused the runner/database, so this is a sequential comparison, not an isolated measurement of extension overhead. The temporary profiling steps are removed; [Final CI](https://github.com/Automattic/woocommerce-payments/actions/runs/33930927445) passed both fresh environments with `coverage: none`: **162.473s** (latest Gutenberg) and **150.785s** (22.3.0), with the same test and assertion totals.

This changes test infrastructure only, with no plugin runtime or public API changes.

#### Testing instructions

1. Check both ordinary PHP test jobs pass and the PHP setup step reports coverage disabled.
2. Compare PHPUnit's time, test and assertion totals against the linked profiles. Counts may change as develop advances.
3. Confirm the separate code-coverage jobs still collect coverage and pass their thresholds.
4. Please review the description and testing instructions before marking the draft ready.

-------------------

- [x] Added a changelog entry.
- [x] Covered with tests: both full PHP matrix entries passed with and without Xdebug.
- [x] Tested on mobile: not applicable.

**Post merge**

- [x] Release testing: QA Testing Not Applicable.
- [x] Critical flow documentation: no flow changes.
- [x] Release announcement: not applicable.
