### PR TITLE
perf(e2e): build client assets once per PR matrix

### DIFF
--- a/.github/actions/e2e/env-setup/action.yml
+++ b/.github/actions/e2e/env-setup/action.yml
@@ -53,7 +53,7 @@ runs:
 
     # Build WCPay client
     - name: Build WCPay Client
-      if: ${{ ! env.WCPAY_USE_BUILD_ARTIFACT }}
+      if: ${{ ! env.WCPAY_USE_BUILD_ARTIFACT && env.WCPAY_USE_CLIENT_BUILD_ARTIFACT != 'true' }}
       shell: bash
       run: |
         echo "::group::Build WCPay client"

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -122,7 +122,7 @@ jobs:
           name: wcpay-e2e-client-build
           path: /tmp/wcpay-client-build.tar.gz
           compression-level: 0
-          retention-days: 1
+          retention-days: 14
 
   wcpay-e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -94,9 +94,34 @@ jobs:
 
           echo "matrix={\"include\":$MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
 
+  build-client:
+    if: ${{ ! inputs.wcpay-use-build-artifact }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout WCPay repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.repo-branch || github.ref }}
+      - uses: ./.github/actions/setup-php
+      - run: corepack enable
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build:client
+      - name: Archive client build
+        run: tar -czf /tmp/wcpay-client-build.tar.gz dist languages/*.pot assets/css/admin-rtl.css assets/css/success-rtl.css
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wcpay-e2e-client-build
+          path: /tmp/wcpay-client-build.tar.gz
+          retention-days: 1
+
   wcpay-e2e-tests:
     runs-on: ubuntu-latest
-    needs: generate-matrix
+    needs: [ generate-matrix, build-client ]
+    if: ${{ ! cancelled() && needs.generate-matrix.result == 'success' && (needs.build-client.result == 'success' || (inputs.wcpay-use-build-artifact && needs.build-client.result == 'skipped')) }}
     strategy:
       fail-fast:     false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -104,6 +129,7 @@ jobs:
     name: WC - ${{ matrix.woocommerce }} | PHP - ${{ matrix.php }} | ${{ matrix.test_groups }} - ${{ matrix.test_branches }}
 
     env:
+      WCPAY_USE_CLIENT_BUILD_ARTIFACT: ${{ ! inputs.wcpay-use-build-artifact }}
       E2E_WP_VERSION: 'latest'
       E2E_WC_VERSION: ${{ matrix.woocommerce }}
       E2E_PHP_VERSION: ${{ matrix.php }}
@@ -124,6 +150,16 @@ jobs:
         with:
           name: woocommerce-payments
           path: ${{ env.WCPAY_ARTIFACT_DIRECTORY }}
+
+      - name: Download client build
+        if: ${{ ! inputs.wcpay-use-build-artifact }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wcpay-e2e-client-build
+          path: /tmp/wcpay-client-build
+      - name: Extract client build
+        if: ${{ ! inputs.wcpay-use-build-artifact }}
+        run: tar -xzf /tmp/wcpay-client-build/wcpay-client-build.tar.gz
 
       - name: Setup E2E environment
         uses: ./.github/actions/e2e/env-setup

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -97,11 +97,16 @@ jobs:
   build-client:
     if: ${{ ! inputs.wcpay-use-build-artifact }}
     runs-on: ubuntu-latest
+    outputs:
+      revision: ${{ steps.revision.outputs.sha }}
     steps:
       - name: Checkout WCPay repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.repo-branch || github.ref }}
+      - name: Record build revision
+        id: revision
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup-php
       - run: corepack enable
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -111,11 +116,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build:client
       - name: Archive client build
-        run: tar -czf /tmp/wcpay-client-build.tar.gz dist languages/*.pot assets/css/admin-rtl.css assets/css/success-rtl.css
+        run: tar -czf /tmp/wcpay-client-build.tar.gz dist languages/*.pot assets/css/admin.rtl.css assets/css/success.rtl.css
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wcpay-e2e-client-build
           path: /tmp/wcpay-client-build.tar.gz
+          compression-level: 0
           retention-days: 1
 
   wcpay-e2e-tests:
@@ -142,7 +148,7 @@ jobs:
       - name: Checkout WCPay repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.repo-branch || github.ref }}
+          ref: ${{ needs.build-client.outputs.revision || inputs.repo-branch || github.ref }}
 
       - name: "Download WooCommerce Payments build file"
         if: ${{ inputs.wcpay-use-build-artifact }}

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -170,11 +170,16 @@ jobs:
           path: ${{ env.WCPAY_ARTIFACT_DIRECTORY }}
 
       - name: Download client build
+        id: download-client-build
         if: ${{ ! inputs.wcpay-use-build-artifact }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: wcpay-e2e-client-build
           path: /tmp/wcpay-client-build
+      - name: Explain client build download failure
+        if: ${{ failure() && steps.download-client-build.outcome == 'failure' }}
+        run: |
+          echo '::error::Could not download the client build. The artifact expires after 14 days. If it has expired, choose "Re-run all jobs" to rebuild it; rerunning only failed jobs will not regenerate it. Otherwise, check the download error above.'
       - name: Extract client build
         if: ${{ ! inputs.wcpay-use-build-artifact }}
         run: tar -xzf /tmp/wcpay-client-build/wcpay-client-build.tar.gz

--- a/.github/workflows/e2e-pull-request.yml
+++ b/.github/workflows/e2e-pull-request.yml
@@ -105,6 +105,7 @@ jobs:
   build-client:
     if: ${{ ! inputs.wcpay-use-build-artifact }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       revision: ${{ steps.revision.outputs.sha }}
     steps:

--- a/changelog/perf-e2e-shared-build
+++ b/changelog/perf-e2e-shared-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Share the client build across pull request E2E jobs.


### PR DESCRIPTION
Tracking: [WOOPMNT-6443](https://linear.app/a8c/issue/WOOPMNT-6443/reduce-unit-test-and-e2e-ci-runtime)

#### Changes proposed in this Pull Request

Build the client once for the PR E2E matrix, archive the generated assets, and extract them in each environment. Consumers check out the exact revision used by the build job. The existing prebuilt-release input still skips the client producer and uses its release artifact.

**Profile:** the ten [baseline client-build steps](https://github.com/Automattic/woocommerce-payments/actions/runs/33930346400) totalled **419.477s**. In the [shared-build run](https://github.com/Automattic/woocommerce-payments/actions/runs/33930454784), the entire producer job took **98s**, including setup, compilation and upload; all ten consumers spent **17s combined** downloading/extracting the archive. That is approximately **304s (5.1 runner-minutes) saved** for build/distribution work, including the extra producer setup.

The runs share develop baseline `9d990a718` and the same application source. Baseline build steps ranged from 35.4s to 47.2s; the baseline workflow was later cancelled when its PHP profiling branch advanced, after all ten build steps had finished. Transfer timings use GitHub's whole-second step timestamps. This is a compute saving: the new dependency delays matrix startup and can increase elapsed CI time, so it is not a claim of a faster PR critical path.

The archive includes `dist`, generated POT files and both generated RTL stylesheets. A local build/archive/extraction check compared all **239 files byte-for-byte**. CI uploaded a roughly **4.7 MB** artifact, and completed consumers explicitly skipped their local build. All ten E2E jobs passed with the shared archive. The subsequent retention-only follow-up [built and uploaded successfully](https://github.com/Automattic/woocommerce-payments/actions/runs/33932063700/job/101212526893), and the artifact API confirmed expiry on 19 September for its 5 September upload. The archive is retained for 14 days, matching test-report retention; rerunning a consumer after expiration also requires rerunning the producer.

This changes test infrastructure only, with no plugin runtime or public API changes. The release-input path was reviewed against `build-zip-and-run-smoke-tests.yml`; that release wrapper has not been run as part of this verification.

#### Testing instructions

1. Check the producer builds once and uploads `wcpay-e2e-client-build` with the generated assets.
2. Check every matrix job downloads/extracts it, checks out the build revision and skips `Build WCPay Client`.
3. Confirm all ten E2E jobs pass and their test groups/versions are unchanged.
4. For the existing prebuilt-release caller, verify the producer is skipped while the matrix still runs using the supplied release artifact.
5. Please review the description and testing instructions before marking the draft ready.

-------------------

- [x] Added a changelog entry.
- [x] Covered with tests: byte-for-byte archive verification and all ten E2E matrix jobs passed.
- [x] Tested on mobile: not applicable.

**Post merge**

- [x] Release testing: QA Testing Not Applicable.
- [x] Critical flow documentation: no flow changes.
- [x] Release announcement: not applicable.
