### PR TITLE
perf(test): persist Jest transforms between CI runs

### DIFF
--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -49,4 +49,14 @@ jobs:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       # install dependencies and run linter
-      - run: pnpm install --frozen-lockfile && pnpm run test:js
+      - run: pnpm install --frozen-lockfile
+      - name: Cache Jest transforms
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: node_modules/.cache/jest
+          key: ${{ runner.os }}-jest-${{ hashFiles('.nvmrc', 'pnpm-lock.yaml', 'babel.config.js', 'tsconfig.json', 'tests/js/**') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-jest-${{ hashFiles('.nvmrc', 'pnpm-lock.yaml', 'babel.config.js', 'tsconfig.json', 'tests/js/**') }}-
+      - run: pnpm run test:js
+      - name: Profile warm Jest cache
+        run: pnpm run test:js

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -58,5 +58,3 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-jest-${{ hashFiles('.nvmrc', 'pnpm-lock.yaml', 'babel.config.js', 'tsconfig.json', 'tests/js/**') }}-
       - run: pnpm run test:js
-      - name: Profile warm Jest cache
-        run: pnpm run test:js

--- a/changelog/perf-jest-cache
+++ b/changelog/perf-jest-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Reuse Jest transform caches across CI test runs.

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
 	rootDir: '../../',
+	cacheDirectory: '<rootDir>/node_modules/.cache/jest',
 	moduleDirectories: [
 		'node_modules',
 		'<rootDir>/client',


### PR DESCRIPTION
Tracking: [WOOPMNT-6443](https://linear.app/a8c/issue/WOOPMNT-6443/reduce-unit-test-and-e2e-ci-runtime)

#### Changes proposed in this Pull Request

Persist Jest transforms between CI runs using `node_modules/.cache/jest`. Cache keys include the runner OS, Node version file, lockfile, Babel/TypeScript configuration and shared Jest setup. Each revision saves an updated cache and can restore a compatible earlier cache. The full suite still runs.

**Profile:** the [same-run CI comparison](https://github.com/Automattic/woocommerce-payments/actions/runs/33930349921/job/101207494443) took **171.276s cold → 146.543s warm**, saving **24.733s (14.4%)** of test execution. Both runs passed 372 suites, 3,665 tests and 340 snapshots; the same one suite/six tests remained skipped. These are test timings, excluding installation and cache transfer. The [final workflow on a fresh runner](https://github.com/Automattic/woocommerce-payments/actions/runs/33930844579/job/101208938638) restored the 12 MB cache and passed the same totals in **123.985s**. That cross-run result includes runner variability; the same-run comparison above is the primary benchmark.

A focused three-suite comparison also passed the same 138 tests and 20 snapshots in 26.071s cold and 20.278s warm. A changed-file probe confirmed a warm cache does not hide a newly introduced test failure; the file was restored and its tests passed again.

The temporary second test run used for profiling has been removed. The final workflow runs the suite once. This changes test infrastructure only, with no plugin runtime or public API changes.

#### Testing instructions

1. Check the JS testing job passes and saves its Jest cache on a cache miss.
2. Re-run the job. Confirm the Jest cache restores and all 372 suites, 3,665 tests and 340 snapshots still pass (counts may change as develop advances).
3. Change a tested source file and confirm the relevant tests reflect the change. Changes to dependencies or shared Jest configuration should produce a different cache prefix.
4. Please review the description and testing instructions before marking the draft ready.

-------------------

- [x] Added a changelog entry.
- [x] Covered with tests: full cold/warm CI runs and focused invalidation check.
- [x] Tested on mobile: not applicable.

**Post merge**

- [x] Release testing: QA Testing Not Applicable.
- [x] Critical flow documentation: no flow changes.
- [x] Release announcement: not applicable.
