### PR TITLE
fix(test): wait for the selected QIT and E2E order status

### DIFF
--- a/changelog/fix-qit-order-status
+++ b/changelog/fix-qit-order-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Make QIT order status assertions wait for the selected option.

--- a/changelog/fix-qit-order-status
+++ b/changelog/fix-qit-order-status
@@ -1,4 +1,4 @@
 Significance: patch
 Type: dev
 
-Make QIT order status assertions wait for the selected option.
+Make QIT and E2E order status assertions wait for the selected option.

--- a/tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.ts
@@ -17,7 +17,6 @@ const refundCancelSelector =
 	'.refund-confirmation-modal .wcpay-confirmation-modal__footer .is-secondary';
 const refundConfirmSelector =
 	'.refund-confirmation-modal .wcpay-confirmation-modal__footer .is-primary';
-const selectedOrderStatusSelector = '.wc-order-status > span';
 const orderPriceSelector =
 	'#woocommerce-order-items .total .woocommerce-Price-amount';
 
@@ -28,10 +27,9 @@ const saveOrder = async ( page: Page ) => {
 };
 
 const verifyOrderStatus = async ( page: Page, status: string ) => {
-	const selectedOrderStatus = await page.$( selectedOrderStatusSelector );
 	await expect(
-		selectedOrderStatus.evaluate( ( el ) => el.textContent )
-	).resolves.toBe( status );
+		page.locator( `${ orderStatusDropdownSelector } option:checked` )
+	).toHaveText( status );
 };
 
 test.describe( 'Order > Status Change', { tag: '@critical' }, () => {

--- a/tests/qit/test-package/tests/woopayments/merchant/merchant-orders-status-change.spec.ts
+++ b/tests/qit/test-package/tests/woopayments/merchant/merchant-orders-status-change.spec.ts
@@ -13,7 +13,6 @@ const refundCancelSelector =
 	'.refund-confirmation-modal .wcpay-confirmation-modal__footer .is-secondary';
 const refundConfirmSelector =
 	'.refund-confirmation-modal .wcpay-confirmation-modal__footer .is-primary';
-const selectedOrderStatusSelector = '.wc-order-status > span';
 const orderPriceSelector =
 	'#woocommerce-order-items .total .woocommerce-Price-amount';
 
@@ -23,10 +22,9 @@ const saveOrder = async ( page ) => {
 };
 
 const verifyOrderStatus = async ( page, status: string ) => {
-	const selectedOrderStatus = await page.$( selectedOrderStatusSelector );
 	await expect(
-		selectedOrderStatus.evaluate( ( el ) => el.textContent )
-	).resolves.toBe( status );
+		page.locator( `${ orderStatusDropdownSelector } option:checked` )
+	).toHaveText( status );
 };
 
 test.describe(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In both QIT and E2E, assert the selected option in the order-status field using Playwright's retrying `toHaveText` assertion. The previous helper read a Select2 display span immediately and called `evaluate` on the result, which could be null after an order update.

This fixes the assertion failure seen in [the QIT merchant job on WC 11.1.0](https://github.com/Automattic/woocommerce-payments/actions/runs/33931749362/job/101211965433). The refund cancellation test failed on both attempts; the failure snapshot showed the expected Processing status. A cancellation test also hit the same error before passing on retry.

The Processing, Cancelled and Refunded expectations remain unchanged. Both suites now check the selected native option rather than the visible SelectWoo label. This means they would no longer catch a stale label if a dismissal handler stopped dispatching the change event after resetting the native value. This changes test code only, with no plugin runtime or public API changes.

#### Testing instructions

1. Run `pnpm exec playwright test --project=merchant tests/woopayments/merchant/merchant-orders-status-change.spec.ts` from the QIT test package in a configured environment, on WC 11.1.0 and the older WC matrix version.
2. Run `pnpm run test:e2e tests/e2e/specs/wcpay/merchant/merchant-orders-status-change.spec.ts` from the repository root in a configured E2E environment.
3. Confirm all four tests in each suite pass, covering cancellation/refund confirmation, dismissing the dialogs and saving the order.
4. Review the description and testing instructions before marking the draft ready.

**Verification:** QIT merchant CI passed on [WC 10.9.4](https://github.com/Automattic/woocommerce-payments/actions/runs/33951041470/job/101265927203) and [WC 11.1.0](https://github.com/Automattic/woocommerce-payments/actions/runs/33951041470/job/101265927242) for the original QIT fix at `acf5746f9`. CI verification of the E2E mirror update is pending.

A local Chromium probe of the updated E2E helper passed with a hidden native select and no SelectWoo span, a delayed status change and delayed field insertion; an incorrect status was rejected. Prettier passed for both specs. These probes do not replace the full merchant scenarios, which were not rerun locally because this checkout has no configured E2E environment.

Correction to the earlier verification note: the QIT directory is excluded by `.eslintignore`, so a normal explicit ESLint invocation does not lint that file. After installing the locked dependencies, an explicit ESLint check with `--no-ignore` passed for both specs.

-------------------

- [x] Added a changelog entry.
- [x] Covered with tests: existing merchant scenarios exercise the helper; focused browser probes passed.
- [x] Tested on mobile: not applicable.

**Post merge**

- [x] Release testing: QA Testing Not Applicable.
- [x] Critical flow documentation: no flow changes.
- [x] Release announcement: not applicable.
