### PR TITLE
Check Test Drive readiness before fetching full account details

### DIFF
--- a/changelog/perf-test-drive-readiness-check
+++ b/changelog/perf-test-drive-readiness-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Avoid fetching full account details while Test Drive is still being prepared.

--- a/includes/class-wc-payments-account.php
+++ b/includes/class-wc-payments-account.php
@@ -2536,6 +2536,28 @@ class WC_Payments_Account implements MultiCurrencyAccountInterface {
 	}
 
 	/**
+	 * Refresh the full Test Drive account only when it is ready to accept payments.
+	 *
+	 * @return array|bool Refreshed account data, or false while pending or unavailable.
+	 */
+	public function refresh_test_account_data() {
+		try {
+			$request = Get_Account::create();
+			$request->set_test_drive_readiness();
+			$account = $request->send()->to_array();
+		} catch ( API_Exception $e ) {
+			return false;
+		}
+
+		if ( ! empty( $account['test_drive_readiness'] ) && empty( $account['payments_enabled'] ) ) {
+			return false;
+		}
+
+		// Keep partial responses out of the shared cache and its refresh hooks.
+		return $this->refresh_account_data();
+	}
+
+	/**
 	 * Change the account cache to hold the connected-but-no-account value (empty array).
 	 *
 	 * @return void

--- a/includes/core/server/request/class-get-account.php
+++ b/includes/core/server/request/class-get-account.php
@@ -47,4 +47,11 @@ class Get_Account extends Request {
 	public function set_woocommerce_store_id( string $woocommerce_store_id ): void {
 		$this->set_param( 'woocommerce_store_id', $woocommerce_store_id );
 	}
+
+	/**
+	 * Request only payment readiness for a Test Drive account.
+	 */
+	public function set_test_drive_readiness(): void {
+		$this->set_param( 'test_drive_readiness', true );
+	}
 }

--- a/tests/unit/core/server/request/test-class-core-get-account-request.php
+++ b/tests/unit/core/server/request/test-class-core-get-account-request.php
@@ -46,6 +46,13 @@ class Get_Account_Test extends WCPAY_UnitTestCase {
 		$this->assertSame( 'GET', $request->get_method() );
 	}
 
+	public function test_readiness_request_is_opt_in() {
+		$request = new Get_Account( $this->mock_api_client, $this->mock_wc_payments_http_client );
+		$this->assertArrayNotHasKey( 'test_drive_readiness', $request->get_params() );
+		$request->set_test_drive_readiness();
+		$this->assertSame( 'true', $request->get_params()['test_drive_readiness'] );
+	}
+
 	public function test_set_woocommerce_store_id() {
 		$request  = new Get_Account( $this->mock_api_client, $this->mock_wc_payments_http_client );
 		$store_id = 'test-store-uuid-1234';

--- a/tests/unit/test-class-wc-payments-account.php
+++ b/tests/unit/test-class-wc-payments-account.php
@@ -3252,6 +3252,67 @@ class WC_Payments_Account_Test extends WCPAY_UnitTestCase {
 		];
 	}
 
+	public function test_refresh_test_account_data_keeps_pending_response_out_of_cache() {
+		$request = $this->mock_wcpay_request( Get_Account::class );
+		$request->expects( $this->once() )->method( 'set_test_drive_readiness' );
+		$request->method( 'format_response' )->willReturn(
+			new Response(
+				[
+					'test_drive_readiness' => true,
+					'payments_enabled'     => false,
+				]
+			)
+		);
+		$this->mock_database_cache->expects( $this->never() )->method( 'get_or_add' );
+		$this->mock_database_cache->expects( $this->never() )->method( 'add' );
+		$refreshes = did_action( 'woocommerce_payments_account_refreshed' );
+
+		$this->assertFalse( $this->wcpay_account->refresh_test_account_data() );
+		$this->assertSame( $refreshes, did_action( 'woocommerce_payments_account_refreshed' ) );
+	}
+
+	/**
+	 * @dataProvider account_readiness_responses_provider
+	 */
+	public function test_refresh_test_account_data_fetches_full_account_when_ready_or_unsupported( array $response ) {
+		$this->mock_jetpack_connection();
+		$request = $this->mock_wcpay_request( Get_Account::class );
+		$request->method( 'format_response' )->willReturn( new Response( $response ) );
+		$this->mock_database_cache->expects( $this->once() )->method( 'get_or_add' )->with(
+			Database_Cache::ACCOUNT_KEY,
+			$this->isType( 'callable' ),
+			$this->isType( 'callable' ),
+			true
+		)->willReturn( [ 'account_id' => 'acct_full' ] );
+
+		$this->assertSame( [ 'account_id' => 'acct_full' ], $this->wcpay_account->refresh_test_account_data() );
+	}
+
+	public function account_readiness_responses_provider(): array {
+		return [
+			'ready'      => [
+				[
+					'test_drive_readiness' => true,
+					'payments_enabled'     => true,
+				],
+			],
+			'old server' => [
+				[
+					'account_id'       => 'acct_old',
+					'payments_enabled' => false,
+				],
+			],
+			'no account' => [ [] ],
+		];
+	}
+
+	public function test_refresh_test_account_data_preserves_cache_on_error() {
+		$request = $this->mock_wcpay_request( Get_Account::class );
+		$request->method( 'format_response' )->willThrowException( new API_Exception( 'Unavailable', 'test_error', 503 ) );
+		$this->mock_database_cache->expects( $this->never() )->method( 'get_or_add' );
+		$this->assertFalse( $this->wcpay_account->refresh_test_account_data() );
+	}
+
 	public function test_is_account_partially_onboarded_returns_false_if_account_not_connected() {
 		// The Jetpack connection is in working order.
 		$this->mock_jetpack_connection();


### PR DESCRIPTION

#### Changes proposed in this Pull Request

WooCommerce polling caller: https://github.com/woocommerce/woocommerce/pull/68400.

<!--
Title: A descriptive, yet concise, title.
-->

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Pending Test Drive polling does not need a complete account refresh. Add `refresh_test_account_data()` and an opt-in `Get_Account` request setter to check readiness first, then use the existing full refresh when ready. Partial responses stay out of the account cache and its refresh hooks; request failures leave the cache intact.

Existing methods and their signatures are unchanged. Older servers that ignore the parameter fall back to the full refresh. The WooCommerce polling caller uses a method-existence check, so the two client releases can ship independently. The server optimisation must be deployed to reduce request cost. Multisite was not tested.

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the WooCommerce Test Drive polling branch with a server supporting `test_drive_readiness`.
2. Start Test Drive onboarding. While pending, confirm refresh attempts request readiness and do not replace the full account cache or fire `woocommerce_payments_account_refreshed`.
3. Once ready, confirm a full account fetch occurs, onboarding completes and the refresh hook receives the complete account.
4. Simulate a server error and confirm cached data remains intact. Check a server without readiness support still takes the full-refresh path.
5. Run `WC_Payments_Account_Test` and `Get_Account_Test`.

Validation: 191 tests passed; PHPCS and PHPStan passed for the changed PHP. The pending-to-ready cache behaviour was also verified against the local server.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
If this PR need not be QA tested, edit to 'QA Testing Not Applicable'
-->

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
