### PR TITLE
Fix failed refund totals in transaction details

### DIFF
--- a/changelog/fix-woopmnt-6427-refund-totals
+++ b/changelog/fix-woopmnt-6427-refund-totals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Exclude failed and canceled refunds from transaction totals and refund status calculations.

--- a/client/payment-details/summary/__tests__/index.test.js
+++ b/client/payment-details/summary/__tests__/index.test.js
@@ -265,6 +265,24 @@ describe( 'PaymentDetailsSummary', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
+	test( 'renders refund failure without deducting the failed refund', () => {
+		const charge = getBaseCharge();
+		charge.refunded = false;
+		charge.amount_refunded = 2000;
+		charge.refunds?.data.push( {
+			status: 'failed',
+			balance_transaction: {
+				amount: -charge.amount_refunded,
+				currency: 'usd',
+			},
+		} );
+
+		renderCharge( charge );
+
+		screen.getByText( 'Refund failure' );
+		expect( screen.queryByText( /Refunded:/i ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'renders the Tap to Pay channel from metadata with ios COTS_DEVICE', () => {
 		const charge = getBaseCharge();
 		const metadata = createTapToPayMetadata( 'COTS_DEVICE', 'ios' );

--- a/client/types/charges.d.ts
+++ b/client/types/charges.d.ts
@@ -33,6 +33,7 @@ interface Level3Data {
 
 interface ChargeRefund {
 	balance_transaction: BalanceTransaction;
+	status?: string | null;
 }
 
 interface ChargeRefunds {

--- a/client/utils/charge/__tests__/index.test.js
+++ b/client/utils/charge/__tests__/index.test.js
@@ -121,6 +121,63 @@ describe( 'Charge utilities', () => {
 				false
 			);
 		} );
+
+		test.each( [ 'failed', 'canceled' ] )(
+			'should identify a charge with only %s refunds as refund failed',
+			( status ) => {
+				const charge = {
+					...paidCharge,
+					refunded: false,
+					amount_refunded: 300,
+					refunds: {
+						data: [
+							{
+								status,
+								balance_transaction: { amount: -300 },
+							},
+						],
+					},
+				};
+
+				expect( utils.getChargeStatus( charge ) ).toEqual(
+					'refund_failed'
+				);
+			}
+		);
+
+		test.each( [ 'succeeded', 'future_status', undefined, null ] )(
+			'should not identify a %s refund as refund failed',
+			( status ) => {
+				const charge = {
+					...paidCharge,
+					refunded: false,
+					amount_refunded: 0,
+					refunds: {
+						data: [
+							{
+								status,
+								balance_transaction: { amount: -300 },
+							},
+						],
+					},
+				};
+
+				expect( utils.isChargeRefundFailed( charge ) ).toEqual( false );
+				expect( utils.getChargeStatus( charge ) ).toEqual( 'paid' );
+			}
+		);
+
+		test( 'should not identify an empty refund list as refund failed', () => {
+			const charge = {
+				...paidCharge,
+				refunded: false,
+				amount_refunded: 0,
+				refunds: { data: [] },
+			};
+
+			expect( utils.isChargeRefundFailed( charge ) ).toEqual( false );
+			expect( utils.getChargeStatus( charge ) ).toEqual( 'paid' );
+		} );
 	} );
 
 	describe( 'getChargeStatus', () => {
@@ -302,6 +359,80 @@ describe( 'Charge utilities / getChargeAmounts', () => {
 				charge.amount_refunded,
 			fee: charge.application_fee_amount,
 			refunded: charge.amount_refunded,
+		} );
+	} );
+
+	test.each( [ 'failed', 'canceled' ] )(
+		'does not deduct a %s refund from legacy amounts',
+		( status ) => {
+			const charge = {
+				amount: 1800,
+				currency: 'usd',
+				application_fee_amount: 82,
+				amount_refunded: 300,
+				balance_transaction: {
+					amount: 1800,
+					currency: 'usd',
+					fee: 82,
+				},
+				refunds: {
+					data: [
+						{
+							status,
+							balance_transaction: { amount: -300 },
+						},
+					],
+				},
+			};
+
+			expect( utils.getChargeAmounts( charge ) ).toEqual( {
+				amount: 1800,
+				currency: 'usd',
+				net: 1718,
+				fee: 82,
+				refunded: 0,
+			} );
+		}
+	);
+
+	test( 'deducts compatible refunds from mixed legacy amounts', () => {
+		const charge = {
+			amount: 1800,
+			currency: 'usd',
+			application_fee_amount: 82,
+			amount_refunded: 900,
+			balance_transaction: {
+				amount: 1800,
+				currency: 'usd',
+				fee: 82,
+			},
+			refunds: {
+				data: [
+					{
+						status: 'failed',
+						balance_transaction: { amount: -100 },
+					},
+					{
+						status: 'succeeded',
+						balance_transaction: { amount: -200 },
+					},
+					{
+						status: 'future_status',
+						balance_transaction: { amount: -300 },
+					},
+					{
+						balance_transaction: { amount: -400 },
+					},
+				],
+			},
+		};
+
+		expect( utils.getChargeAmounts( charge ) ).toEqual( {
+			amount: 1800,
+			currency: 'usd',
+			net: 818,
+			fee: 82,
+			refunded: 900,
 		} );
 	} );
 

--- a/client/utils/charge/index.ts
+++ b/client/utils/charge/index.ts
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { sumBy, get } from 'lodash';
+import { sumBy } from 'lodash';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -51,6 +51,10 @@ export const getDisputeOrdinals = ( charge: Charge ): DisputeOrder => {
 
 const failedOutcomeTypes = [ 'issuer_declined', 'invalid' ];
 const blockedOutcomeTypes = [ 'blocked' ];
+const unsuccessfulRefundStatuses = [ 'failed', 'canceled' ];
+
+const isUnsuccessfulRefund = ( refund: { status?: string | null } ): boolean =>
+	unsuccessfulRefundStatuses.includes( refund.status ?? '' );
 
 export const getDisputeStatus = (
 	dispute: null | Pick< Dispute, 'status' > = <Dispute>{}
@@ -79,8 +83,16 @@ export const isChargeDisputed = ( charge: Charge = <Charge>{} ): boolean =>
 export const isChargeRefunded = ( charge: Charge = <Charge>{} ): boolean =>
 	charge.amount_refunded > 0;
 
-export const isChargeRefundFailed = ( charge: Charge = <Charge>{} ): boolean =>
-	charge.refunded === false && get( charge, 'refunds.data', [] ).length > 0;
+export const isChargeRefundFailed = (
+	charge: Charge = <Charge>{}
+): boolean => {
+	const refunds = charge.refunds?.data ?? [];
+	return (
+		charge.refunded === false &&
+		refunds.length > 0 &&
+		refunds.every( isUnsuccessfulRefund )
+	);
+};
 
 export const isChargeFullyRefunded = ( charge: Charge = <Charge>{} ): boolean =>
 	charge.refunded === true;
@@ -152,14 +164,14 @@ export const getChargeStatus = (
 	if ( isChargeDisputed( charge ) ) {
 		return 'disputed_' + getDisputeStatus( charge.dispute );
 	}
+	if ( isChargeRefundFailed( charge ) ) {
+		return 'refund_failed';
+	}
 	if ( isChargePartiallyRefunded( charge ) ) {
 		return 'refunded_partial';
 	}
 	if ( isChargeFullyRefunded( charge ) ) {
 		return 'refunded_full';
-	}
-	if ( isChargeRefundFailed( charge ) ) {
-		return 'refund_failed';
 	}
 	const paymentIntentStatus = getPaymentIntentDerivedStatus( paymentIntent );
 	if ( paymentIntentStatus ) {
@@ -260,7 +272,9 @@ export const getChargeAmounts = ( charge: Charge ): ChargeAmounts => {
 
 	if ( isChargeRefunded( charge ) ) {
 		balance.refunded -= sumBy(
-			charge.refunds?.data,
+			( charge.refunds?.data ?? [] ).filter(
+				( refund ) => ! isUnsuccessfulRefund( refund )
+			),
 			'balance_transaction.amount'
 		);
 	}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -128,6 +128,15 @@ function _manually_load_plugin() {
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
+/**
+ * Add WooCommerce roles and capabilities after WordPress installs the test database.
+ */
+function wcpay_install_woocommerce_roles() {
+	WC_Install::create_roles();
+}
+
+tests_add_filter( 'setup_theme', 'wcpay_install_woocommerce_roles' );
+
 // Need those polyfills to run tests in CI.
 require_once __DIR__ . '/../../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -133,6 +133,10 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
  */
 function wcpay_install_woocommerce_roles() {
 	WC_Install::create_roles();
+
+	// Reload the role objects after adding capabilities. See WordPress Trac #28374.
+	$GLOBALS['wp_roles'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	wp_roles();
 }
 
 tests_add_filter( 'setup_theme', 'wcpay_install_woocommerce_roles' );


### PR DESCRIPTION
Fixes WOOPMNT-6427

#### Changes proposed in this Pull Request

Howdy,

While I was on the maintenance rotation, we received 11581337-zd-a8c from a merchant whose €3,900 disputed payment also had a failed refund. The WooPayments transaction page counted both, so it showed €7,800 deducted. It also showed a net loss of €3,985.50 instead of the correct €85.50. I confirmed that our transaction-total calculation did not exclude failed refunds, documented the problem in [WOOPMNT-6396](https://linear.app/a8c/issue/WOOPMNT-6396/transaction-details-totals-count-a-failed-refund-showing-double-the), and opened 235096-Server to fix it.

When reviewing that same PR, we found a backward-compatibility problem. The server change also introduced a new timeline shape for canceled refunds, but older WooPayments versions do not safely handle that shape. The client also has a legacy fallback that can count failed or canceled refunds and show a failed-only refund as a partial refund. The null-safe failure-reason change is already merged in [WooPayments PR #12085](https://github.com/Automattic/woocommerce-payments/pull/12085), but it is not part of the latest stable release, WooPayments 11.1.0. I investigated our existing API patterns and found that we already return version-specific response shapes in the deposits endpoint, using the WooPayments client version from the request.

I have now updated the server PR for the client-side fix, tracked in [WOOPMNT-6427](https://linear.app/a8c/issue/WOOPMNT-6427/exclude-unsuccessful-refunds-from-legacy-transaction-totals-and-status). Older clients will continue to receive timeline format 1, while WooPayments 11.2.0 and later will receive timeline format 2 and show failed and canceled refunds correctly. Both response formats now exclude explicit failed and canceled refunds from the money totals. The client PR also fixes the legacy totals and prevents a failed-only refund from appearing as a partial refund.

The safe rollout order is to merge client PR #12105 first, confirm that PRs #12085 and #12105 are both included in WooPayments 11.2.0, and then merge the WPCOM PR. If either client fix misses 11.2.0, we will move the server version boundary to the first release that contains both fixes. The local tests and CI checks are green for both open PRs.

#### Testing instructions

* Run `pnpm run test:js -- client/utils/charge/__tests__/index.test.js client/payment-details/summary/__tests__/index.test.js --runInBand`.
* Run `pnpm run lint:js`.
* Run `pnpm run build:client`.
* With the paired server branch and local mocked data, open a transaction that contains a canceled refund:
  * Format 1 stays renderable with its legacy timeline event.
  * Format 2 shows `Refund failure` and the unknown-reason fallback.
  * In both cases, the failed refund does not reduce the displayed net amount.

-------------------

- [x] Added a patch changelog file.
- [x] Covered with tests.
- [x] Mobile testing does not apply.

**Post merge**

- [ ] Add the compatibility scenario to the WooPayments 11.2.0 release testing instructions.