### PR TITLE
fix(deps-dev): declare uuid for clean builds

### DIFF
--- a/changelog/dev-declare-uuid
+++ b/changelog/dev-declare-uuid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Declare uuid as a direct build dependency.

--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
 		"ts-loader": "9.5.7",
 		"typescript": "5.9.3",
 		"util": "0.12.5",
+		"uuid": "8.3.2",
 		"webpack": "5.106.2",
 		"webpack-cli": "7.0.2",
 		"webpack-dev-server": "5.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,6 +427,9 @@ importers:
       util:
         specifier: 0.12.5
         version: 0.12.5
+      uuid:
+        specifier: 8.3.2
+        version: 8.3.2
       webpack:
         specifier: 5.106.2
         version: 5.106.2(esbuild@0.25.12)(postcss@8.3.5)(webpack-cli@7.0.2)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`@wordpress/dataviews@14.3.0` imports `uuid` without declaring it. After a clean pnpm install, webpack cannot resolve the module and both client and release builds fail.

This also leaves the Compressed Size workflow without a base `dist` directory, causing it to report every generated bundle as a new file. That is the source of the false `+1.11 MB` result on #12106.

This PR declares `uuid@8.3.2` as a direct dev dependency. That CommonJS-compatible version is already present in the lockfile, so the dependency graph gains no new package. The lockfile change only adds three root-importer lines.

No production code or public API changes.

#### Testing instructions

- Confirmed `pnpm run build:client` fails on a clean `develop` install with `Cannot resolve uuid` from `@wordpress/dataviews`.
- `pnpm install --frozen-lockfile --ignore-scripts` succeeds.
- `pnpm run build:client` succeeds.
- `pnpm run build` succeeds and produces the release build.
- A focused JS test run passes: 1 suite and 17 tests.
- Manual testing is not applicable; this only makes an existing build dependency explicit.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.