### PR TITLE
fix(ci): compare bundle sizes against a real base build

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -44,9 +44,6 @@ jobs:
                   # bash -c: @actions/exec splits the command itself, so &&
                   # needs an explicit shell.
                   install-script: bash -c "rm -rf node_modules && pnpm install --no-frozen-lockfile --ignore-scripts --config.engine-strict=false --config.strict-dep-builds=false"
+                  # No exclude: composer-managed assets under vendor/ ship
+                  # to merchants too, so a dependency bump should show up here.
                   pattern: '{release/**/*.js,release/**/*.css}'
-                  # No braces: the action feeds this to Node's fs.globSync,
-                  # which reads a single-item {…} as a literal and matches
-                  # nothing. The wildcard covers the plugin-slug folder.
-                  exclude: 'release/*/vendor/**'
-                  package-manager: pnpm

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -37,13 +37,7 @@ jobs:
                   # reinstall re-checks builds approved by this branch's
                   # allowBuilds against the base's older or absent allowlist
                   # and hard-fails (seen on release→trunk PRs).
-                  # rm -rf node_modules: both installs share one node_modules
-                  # and pnpm only reconciles forward, so the base reinstall
-                  # drops a package this branch declares directly and the base
-                  # build fails on an import a clean install resolves.
-                  # bash -c: @actions/exec splits the command itself, so &&
-                  # needs an explicit shell.
+                  #
+                  # deleting `node_modules to ensure the directory isn't shared between the two installs.
                   install-script: bash -c "rm -rf node_modules && pnpm install --no-frozen-lockfile --ignore-scripts --config.engine-strict=false --config.strict-dep-builds=false"
-                  # No exclude: composer-managed assets under vendor/ ship
-                  # to merchants too, so a dependency bump should show up here.
                   pattern: '{release/**/*.js,release/**/*.css}'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -38,18 +38,15 @@ jobs:
                   # allowBuilds against the base's older or absent allowlist
                   # and hard-fails (seen on release→trunk PRs).
                   # rm -rf node_modules: both installs share one node_modules
-                  # and pnpm only reconciles forward. A package this branch
-                  # declares directly is linked at node_modules/<pkg> and left
-                  # out of the hoisted node_modules/.pnpm/node_modules, so the
-                  # base reinstall drops it outright and the base build fails
-                  # on an import the base branch resolves from a clean install.
-                  # bash -c: @actions/exec splits the command itself rather
-                  # than handing it to a shell, so && needs an explicit one.
+                  # and pnpm only reconciles forward, so the base reinstall
+                  # drops a package this branch declares directly and the base
+                  # build fails on an import a clean install resolves.
+                  # bash -c: @actions/exec splits the command itself, so &&
+                  # needs an explicit shell.
                   install-script: bash -c "rm -rf node_modules && pnpm install --no-frozen-lockfile --ignore-scripts --config.engine-strict=false --config.strict-dep-builds=false"
                   pattern: '{release/**/*.js,release/**/*.css}'
                   # No braces: the action feeds this to Node's fs.globSync,
-                  # which leaves a single-item {…} literal, so it matched
-                  # nothing. The wildcard covers the plugin-slug folder the
-                  # release task nests everything under.
+                  # which reads a single-item {…} as a literal and matches
+                  # nothing. The wildcard covers the plugin-slug folder.
                   exclude: 'release/*/vendor/**'
                   package-manager: pnpm

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -37,7 +37,19 @@ jobs:
                   # reinstall re-checks builds approved by this branch's
                   # allowBuilds against the base's older or absent allowlist
                   # and hard-fails (seen on release→trunk PRs).
-                  install-script: pnpm install --no-frozen-lockfile --ignore-scripts --config.engine-strict=false --config.strict-dep-builds=false
+                  # rm -rf node_modules: both installs share one node_modules
+                  # and pnpm only reconciles forward. A package this branch
+                  # declares directly is linked at node_modules/<pkg> and left
+                  # out of the hoisted node_modules/.pnpm/node_modules, so the
+                  # base reinstall drops it outright and the base build fails
+                  # on an import the base branch resolves from a clean install.
+                  # bash -c: @actions/exec splits the command itself rather
+                  # than handing it to a shell, so && needs an explicit one.
+                  install-script: bash -c "rm -rf node_modules && pnpm install --no-frozen-lockfile --ignore-scripts --config.engine-strict=false --config.strict-dep-builds=false"
                   pattern: '{release/**/*.js,release/**/*.css}'
-                  exclude: '{release/vendor/**}'
+                  # No braces: the action feeds this to Node's fs.globSync,
+                  # which leaves a single-item {…} literal, so it matched
+                  # nothing. The wildcard covers the plugin-slug folder the
+                  # release task nests everything under.
+                  exclude: 'release/*/vendor/**'
                   package-manager: pnpm

--- a/changelog/dev-bundle-size-base-build
+++ b/changelog/dev-bundle-size-base-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fail the release build when the client bundle fails, and fix the bundle-size CI comparison.

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -29,7 +29,15 @@ const filesToCopy = [
 
 // run npm dist
 rm( '-rf', 'dist' );
-exec( 'SOURCEMAP=hidden pnpm run build:client' );
+// shelljs never throws, so an unchecked exec() lets a failed webpack build
+// package a release with an empty dist and still exit 0.
+const clientBuild = exec( 'SOURCEMAP=hidden pnpm run build:client' );
+if ( clientBuild.code !== 0 ) {
+	console.error(
+		chalk.red( 'The client build failed; nothing was packaged.' )
+	);
+	process.exit( clientBuild.code );
+}
 
 // start with a clean release folder
 rm( '-rf', releaseFolder );

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -36,8 +36,9 @@ const clientBuild = exec( 'SOURCEMAP=hidden pnpm run build:client', {
 	// using fatal: false so that it doesn't throw
 	fatal: false,
 } );
-// checking both the code and the output, just to be safe
-if ( clientBuild.code !== 0 || ! fs.existsSync( 'dist' ) ) {
+// shelljs reports 0 when a command dies from a signal, and webpack creates
+// dist before it finishes emitting - so look for an entry file, not the folder.
+if ( clientBuild.code !== 0 || ! fs.existsSync( 'dist/index.js' ) ) {
 	console.error(
 		chalk.red( 'The client build failed; nothing was packaged.' )
 	);

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -2,6 +2,9 @@
 /* eslint no-process-exit: 0, no-undef: 0, strict: 0 */
 'use strict';
 require( 'shelljs/global' );
+// shelljs only warns on a failed command, so without this a missing source
+// directory would still produce a zip and exit 0.
+config.fatal = true;
 const chalk = require( 'chalk' );
 const archiver = require( 'archiver' );
 const fs = require( 'fs' );
@@ -29,14 +32,16 @@ const filesToCopy = [
 
 // run npm dist
 rm( '-rf', 'dist' );
-// shelljs never throws, so an unchecked exec() would package an empty dist
-// and exit 0 when webpack fails.
-const clientBuild = exec( 'SOURCEMAP=hidden pnpm run build:client' );
-if ( clientBuild.code !== 0 ) {
+// fatal: false to name the step that broke instead of throwing. A command
+// killed by a signal still reports code 0, so check the output too.
+const clientBuild = exec( 'SOURCEMAP=hidden pnpm run build:client', {
+	fatal: false,
+} );
+if ( clientBuild.code !== 0 || ! fs.existsSync( 'dist' ) ) {
 	console.error(
 		chalk.red( 'The client build failed; nothing was packaged.' )
 	);
-	process.exit( clientBuild.code );
+	process.exit( clientBuild.code || 1 );
 }
 
 // start with a clean release folder
@@ -45,7 +50,7 @@ mkdir( releaseFolder );
 mkdir( targetFolder );
 
 // remove the 'hidden' source maps; they are used to generate the POT file and are not referenced in the source files.
-rm( 'dist/*.map' );
+rm( '-f', 'dist/*.map' );
 
 // copy the directories to the release folder
 cp( '-Rf', filesToCopy, targetFolder );

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -29,8 +29,8 @@ const filesToCopy = [
 
 // run npm dist
 rm( '-rf', 'dist' );
-// shelljs never throws, so an unchecked exec() lets a failed webpack build
-// package a release with an empty dist and still exit 0.
+// shelljs never throws, so an unchecked exec() would package an empty dist
+// and exit 0 when webpack fails.
 const clientBuild = exec( 'SOURCEMAP=hidden pnpm run build:client' );
 if ( clientBuild.code !== 0 ) {
 	console.error(

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -32,11 +32,11 @@ const filesToCopy = [
 
 // run npm dist
 rm( '-rf', 'dist' );
-// fatal: false to name the step that broke instead of throwing. A command
-// killed by a signal still reports code 0, so check the output too.
 const clientBuild = exec( 'SOURCEMAP=hidden pnpm run build:client', {
+	// using fatal: false so that it doesn't throw
 	fatal: false,
 } );
+// checking both the code and the output, just to be safe
 if ( clientBuild.code !== 0 || ! fs.existsSync( 'dist' ) ) {
 	console.error(
 		chalk.red( 'The client build failed; nothing was packaged.' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We noticed in #12107 that the bundle size bot reported every single file as new, creating a fake 1.1 MB increase.

The issue is that the base branch build was failing.
Our release script starts the client build and doesn't check whether it worked. It continues, and it zipps a release with no JavaScript in it, exiting with `0`.

So the bot compared a full build against nothing.

Three fixes:

- The release script now stops when the client build fails, instead of packaging an empty release. It looks for an entry file rather than trusting the exit code: shelljs reports success when a command is killed by a signal, and webpack creates `dist` before it has finished filling it. The copies that follow now stop on a missing folder too, so a checkout with no `vendor/` fails instead of producing a junk zip.
- The bundle size job wipes `node_modules` before each install. The action builds both branches in the same folder, and pnpm only ever adds what the branch in front of it asks for - it doesn't put back what the previous branch removed. The base branch was building against a broken dependency tree.
- The "don't measure these files" pattern never matched anything. `{a}` with no comma is not a list, it's a literal, and the path was wrong on top of that. So vendor files have always been counted, and I removed the pattern instead of repairing it - that code ships to merchants, so a composer bump should show up here. Nothing changes about what gets measured.

#### Testing instructions

- Wait for CI. The bundle size comment should show no change.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
