### PR TITLE
Fix WOOPMNT-6261: stop the test mode notice asserting a record's mode

### DIFF
--- a/changelog/fix-woopmnt-6261-test-mode-notice-copy
+++ b/changelog/fix-woopmnt-6261-test-mode-notice-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stopped the test mode notice on details pages from stating that live orders, payouts and disputes were created in test mode.

--- a/client/components/test-mode-notice/__tests__/index.test.tsx
+++ b/client/components/test-mode-notice/__tests__/index.test.tsx
@@ -120,4 +120,63 @@ describe( 'Test mode notification', () => {
 			'development or staging environment'
 		);
 	} );
+
+	describe( 'Details view', () => {
+		// Every CurrentPage the switch handles, with the plural noun it resolves
+		// to. documents/loans/transactions have no isDetailsView call site today,
+		// but the type permits them and the switch handles them, so pin them too.
+		const detailsPages: [ CurrentPage, string ][] = [
+			[ 'payments', 'orders' ],
+			[ 'deposits', 'payouts' ],
+			[ 'disputes', 'disputes' ],
+			[ 'documents', 'documents' ],
+			[ 'loans', 'loans' ],
+			[ 'transactions', 'orders' ],
+		];
+
+		const renderDetails = ( page: CurrentPage ) => {
+			mockIsInTestMode.mockReturnValue( true );
+			mockIsInDevMode.mockReturnValue( false );
+
+			return render(
+				<TestModeNotice currentPage={ page } isDetailsView={ true } />
+			).container;
+		};
+
+		test.each( detailsPages )(
+			'makes no claim about when the %s record was created',
+			( page ) => {
+				// The notice receives no order-, charge- or intent-scoped input,
+				// so it cannot know the mode a record was created in. This pins
+				// the shape of that claim rather than one past wording, so a
+				// reworded regression is still caught.
+				expect( renderDetails( page ).textContent ).not.toMatch(
+					/\b(was|were)\b[^.]*\b(placed|created)\b/
+				);
+			}
+		);
+
+		test.each( detailsPages )(
+			'states the store mode and what the %s view is scoped to',
+			( page, plural ) => {
+				expect( renderDetails( page ).textContent ).toBe(
+					`WooPayments is in test mode, so only test ${ plural } are shown. ` +
+						`To view live ${ plural }, disable test mode in WooPayments settings.`
+				);
+			}
+		);
+
+		test( 'dev mode still takes precedence over the details-view copy', () => {
+			mockIsInTestMode.mockReturnValue( true );
+			mockIsInDevMode.mockReturnValue( true );
+
+			const { container } = render(
+				<TestModeNotice currentPage="payments" isDetailsView={ true } />
+			);
+
+			expect( container.textContent ).toContain(
+				'development or staging environment'
+			);
+		} );
+	} );
 } );

--- a/client/components/test-mode-notice/index.tsx
+++ b/client/components/test-mode-notice/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -29,22 +29,15 @@ interface Props {
 	isTestModeOnboarding?: boolean;
 }
 
-const nounToUse = {
-	documents: __( 'document', 'woocommerce-payments' ),
-	deposits: __( 'payout', 'woocommerce-payments' ),
-	disputes: __( 'dispute', 'woocommerce-payments' ),
-	loans: __( 'loan', 'woocommerce-payments' ),
-	payments: __( 'order', 'woocommerce-payments' ),
-	transactions: __( 'order', 'woocommerce-payments' ),
-};
-
-const verbToUse = {
-	documents: __( 'created', 'woocommerce-payments' ),
-	deposits: __( 'created', 'woocommerce-payments' ),
-	disputes: __( 'created', 'woocommerce-payments' ),
-	loans: __( 'created', 'woocommerce-payments' ),
-	payments: __( 'placed', 'woocommerce-payments' ),
-	transactions: __( 'placed', 'woocommerce-payments' ),
+// Plural forms, supplied per locale rather than derived by appending "s" to a
+// translated singular — that only works in English.
+const pluralNounToUse = {
+	documents: __( 'documents', 'woocommerce-payments' ),
+	deposits: __( 'payouts', 'woocommerce-payments' ),
+	disputes: __( 'disputes', 'woocommerce-payments' ),
+	loans: __( 'loans', 'woocommerce-payments' ),
+	payments: __( 'orders', 'woocommerce-payments' ),
+	transactions: __( 'orders', 'woocommerce-payments' ),
 };
 
 const getNoticeContent = (
@@ -187,16 +180,13 @@ const getNoticeContent = (
 					<>
 						{ interpolateComponents( {
 							mixedString: sprintf(
-								/* translators: %1$s: WooPayments */
-								_n(
-									'%1$s was in test mode when this %2$s was %3$s. To view live %2$ss, disable test mode in {{settingsLink}}%1$s settings{{/settingsLink}}.',
-									'%1$s was in test mode when these %2$ss were %3$s. To view live %2$ss, disable test mode in {{settingsLink}}%1$s settings{{/settingsLink}}.',
-									currentPage === 'deposits' ? 2 : 1,
+								/* translators: %1$s: WooPayments, %2$s: plural record type, e.g. "orders" */
+								__(
+									'%1$s is in test mode, so only test %2$s are shown. To view live %2$s, disable test mode in {{settingsLink}}%1$s settings{{/settingsLink}}.',
 									'woocommerce-payments'
 								),
 								'WooPayments',
-								nounToUse[ currentPage ],
-								verbToUse[ currentPage ]
+								pluralNounToUse[ currentPage ]
 							),
 							components: {
 								settingsLink: (


### PR DESCRIPTION
Related to [WOOPMNT-6261](https://linear.app/a8c/issue/WOOPMNT-6261)

#### Changes proposed in this Pull Request

With the store in test mode, the details-view notice claims the record you're looking at was created in test mode:

> WooPayments **was in test mode when this order was placed**. To view live orders, disable test mode in WooPayments settings.

For a live order opened while the store is in test mode, that first clause is false. In ticket [#11389093](https://a8c.zendesk.com/tickets/11389093) it cost a long live chat and an escalation, because the merchant read it as a real charge taken in test mode.

**Root cause.** `client/components/test-mode-notice/index.tsx` builds that sentence from `isInTestMode()`, the store's *current global* mode. Its props (`currentPage`, `actions`, `isDetailsView`, `isTestModeOnboarding`) carry nothing order, charge or intent scoped, so the sentence is emitted identically either way. The repo already does this correctly elsewhere: `class-wc-payments-admin.php:868` derives the order-edit screen's `testMode` from the order's `_wcpay_mode` meta, and `client/order/test-mode-notice/` consumes it. Only the shared details-view notice lacks that signal.

**What changed.** The notice now says only what the code can know:

> WooPayments **is in test mode, so only test transactions are shown**. To view live transactions, disable test mode in WooPayments settings.

Design asked for "transactions" rather than "orders" on the payment details and card reader charge details pages, since the WooCommerce Orders list shows every order regardless of payment mode. Payouts and disputes keep their own nouns.

I reworded rather than gating on the record's mode because the client holds no record mode at that point (`charges.d.ts` has no `livemode`, and PHP sends none for charges). Making it available is feasible for this path but is a bigger change than the copy defect warrants, so it's a follow-up below.

Also fixed: the old string appended an English `s` to a *translated* singular (`%2$ss`) to pluralise, which doesn't work in de/ja/zh. Real plural forms are now supplied per locale, and English output is byte identical. `verbToUse` and the `_n` import go with it, since leaving them would fail `no-unused-vars`.

**Translation impact.** Changing the msgid orphans existing GlotPress translations of the old string until retranslated. An accepted cost of correcting a false statement, but worth knowing at review time.

**Adjacent behaviour.** Six call sites render the changed copy, all passing `isDetailsView`, and all six are covered by the added tests. Unchanged: the five list views (none passes `isDetailsView`), the `overview` case, the `isDevMode` branch, and `client/order/test-mode-notice/`.

**What I could not verify**

1. **Not reproduced on a live store**, which needs an account holding a real live-mode order, and I don't have one. What's verified instead is that the faulty sentence is emitted unconditionally, which is the defect itself. **If you have a live account, confirming the original scenario end to end would be genuinely useful**: open a live order while the store is in test mode, before and after this branch.
2. **The blank panel and `401 rest_forbidden` on `/payments/timeline/{intent}` are out of scope.** The reporter marks that part inferred and attributes it to `woocommerce-payments-server`. This PR fixes the false statement only.
3. **`readers/index.js:137` still resolves the noun to "transactions"** on a page listing card readers. Wrong before this change and wrong after, differently. Fixing it means changing which `currentPage` the readers screens pass, a behaviour change in another component.
4. **No locale was exercised.** Jest runs without translations, so the plural fix is verified structurally, not observed in de or ja.

**Follow-up, not done here.** For the order to payment-intent path, the order's mode could be passed as a query arg: the link is built server side with the `WC_Order` in hand (`compose_transaction_url()` already accepts arbitrary query args) and `class-wc-payments-admin.php:855-869` already computes the live/test/`null` triage. That would allow the richer "this is a live order, switch to live mode" wording. It doesn't help the transactions-list entry point, where there's no order context.

**What I'd like from a reviewer**

1. **A product call on the wording.** The issue suggested the richer mode-mismatch notice; this ships the neutral, always-true version. If you'd rather have the richer copy, that changes the shape of the fix and pulls in the follow-up above. Merchant-facing text either way, so Design input may be worth it.
2. **Confirmation the translation trade-off is acceptable.**
3. **A view on `readers/index.js:137`.** Happy to take it in a follow-up.
4. **An owner for the server-side half**, to say whether the blank panel and 401 warrant their own issue.

#### Testing instructions

The details-view branch had zero coverage before this: every existing test rendered with the default `isDetailsView = false`. That's how the bug survived.

```
pnpm run test:js -- client/components/test-mode-notice
```

24/24 passed, 14 snapshots. Red before green verified by reverting the component and re-running (6 red). `npx eslint` and `npx tsc --noEmit` both exit 0. Node 24.16.0, per `engines.node`.

Manually:

1. On a connected store with dev mode off, enable test mode in Payments → Settings.
2. Open any payment details view, e.g. WooCommerce → Orders → open an order → click the payment intent link.
3. The notice should read "WooPayments is in test mode, so only test transactions are shown." and make no claim about when the record was created.
4. Repeat on a payout and a dispute details view. The noun should change to "payouts" and "disputes".
5. Check the list views still show their unchanged "Viewing test..." copy, and that an order placed in test mode still shows "was in test mode when this order was placed" on the order edit screen (different component, correctly gated).

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply): does not apply, copy-only change to an admin notice

**Post merge**

- [ ] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _Add link here / 'QA Testing Not Applicable'_
- [ ] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [ ] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.






