### PR TITLE
fix: keep dependency failures from leaving WooPayments partially initialized

### DIFF
--- a/changelog/fix-dependency-initialization
+++ b/changelog/fix-dependency-initialization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent account cache clearing during updates from disabling WooPayments on older WooCommerce versions, and handle missing dependencies safely.

--- a/docs/version-support-policy.md
+++ b/docs/version-support-policy.md
@@ -6,7 +6,7 @@ However, in the practice, we're really enforcing only WordPress core with the `R
 
 For WooCommerce, we are yet to fully support this L-2 policy. The real minimum WooCommerce version can be found on [`woocommerce-payments.php`](https://github.com/Automattic/woocommerce-payments/blob/develop/woocommerce-payments.php) with the `WC requires at least` tag. There are two main reasons for this:
 
-- There is no reliable built-in functionality that prevents a merchant from installing the latest version of WooCommerce Payments (WCPay) with an unsupported WooCommerce version. To deal with this issue, we continue loading WCPay if sites have an active WCPay account, but nudge their owners to upgrade WooCommerce. More details in [this PR](https://github.com/Automattic/woocommerce-payments/pull/3010), which is later refactored to `WC_Payments_Dependency_Service`.
+- There is no reliable built-in functionality that prevents a merchant from installing WooPayments with an unsupported WooCommerce version. `WC_Payments_Dependency_Service` warns about unsupported versions without stopping initialization, even when the account cache is empty or cleared during an update. Missing WooCommerce or disabled WooCommerce Admin still prevents service initialization. This avoids a shutdown caused by the version check; it does not guarantee compatibility with every older version.
 - Some of our internal consumers are also not yet using the latest version of WooCommerce. See paJDYF-3fF-p2#comment-9591
 
 ## What does this policy mean for contributors?

--- a/includes/class-wc-payments-dependency-service.php
+++ b/includes/class-wc-payments-dependency-service.php
@@ -25,6 +25,11 @@ class WC_Payments_Dependency_Service {
 	const DEV_ASSETS_NOT_BUILT  = 'dev_assets_not_built';
 
 	/**
+	 * Missing dependencies that prevent initialization, unlike unsupported versions.
+	 */
+	const BLOCKING_DEPENDENCIES = [ self::WOOCORE_NOT_FOUND, self::WOOADMIN_NOT_FOUND ];
+
+	/**
 	 * Initializes this class's WP hooks.
 	 *
 	 * @return void
@@ -34,9 +39,9 @@ class WC_Payments_Dependency_Service {
 	}
 
 	/**
-	 * Checks if all the dependencies needed to run WooPayments are present
+	 * Checks whether the dependencies needed to initialize WooPayments are present.
 	 *
-	 * @return bool True if all required dependencies are met.
+	 * @return bool True if no blocking dependencies are missing.
 	 */
 	public function has_valid_dependencies() {
 
@@ -44,7 +49,16 @@ class WC_Payments_Dependency_Service {
 			return true;
 		}
 
-		return empty( $this->get_invalid_dependencies( true ) );
+		return empty( $this->get_blocking_dependencies() );
+	}
+
+	/**
+	 * Returns missing dependencies that prevent initialization, independent of account cache state.
+	 *
+	 * @return string[] Blocking dependency codes.
+	 */
+	public function get_blocking_dependencies() {
+		return array_values( array_intersect( $this->get_invalid_dependencies(), self::BLOCKING_DEPENDENCIES ) );
 	}
 
 	/**
@@ -66,9 +80,17 @@ class WC_Payments_Dependency_Service {
 
 		$invalid_dependencies = $this->get_invalid_dependencies();
 
-		if ( ! empty( $invalid_dependencies ) ) {
-			WC_Payments::display_admin_error( $this->get_notice_for_invalid_dependency( $invalid_dependencies[0] ) );
+		if ( empty( $invalid_dependencies ) ) {
+			return;
 		}
+
+		$blocking_dependencies = array_values( array_intersect( $invalid_dependencies, self::BLOCKING_DEPENDENCIES ) );
+		if ( ! empty( $blocking_dependencies ) ) {
+			WC_Payments::display_admin_error( $this->get_notice_for_invalid_dependency( $blocking_dependencies[0] ) );
+			return;
+		}
+
+		WC_Payments::display_admin_notice( $this->get_notice_for_invalid_dependency( $invalid_dependencies[0] ), 'notice-warning' );
 	}
 
 	/**
@@ -226,7 +248,7 @@ class WC_Payments_Dependency_Service {
 				$error_message = WC_Payments_Utils::esc_interpolated_html(
 					sprintf(
 						/* translators: %1: WooPayments, %2: current WooCommerce Payment version, %3: WooCommerce, %4: required WC version number, %5: currently installed WC version number */
-						__( '%1$s %2$s requires <strong>%3$s %4$s</strong> or greater to be installed (you are using %5$s). ', 'woocommerce-payments' ),
+						__( '%1$s %2$s supports <strong>%3$s %4$s</strong> or greater (you are using %5$s). ', 'woocommerce-payments' ),
 						'WooPayments',
 						WCPAY_VERSION_NUMBER,
 						'WooCommerce',
@@ -272,7 +294,7 @@ class WC_Payments_Dependency_Service {
 				$error_message = WC_Payments_Utils::esc_interpolated_html(
 					sprintf(
 						/* translators: %1: WooPayments, %2: WooCommerce Admin, %3: required WC-Admin version number, %4: currently installed WC-Admin version number */
-						__( '%1$s requires <strong>%2$s %3$s</strong> or greater to be installed (you are using %4$s).', 'woocommerce-payments' ),
+						__( '%1$s supports <strong>%2$s %3$s</strong> or greater (you are using %4$s).', 'woocommerce-payments' ),
 						'WooPayments',
 						'WooCommerce Admin',
 						WCPAY_MIN_WC_ADMIN_VERSION,
@@ -294,7 +316,7 @@ class WC_Payments_Dependency_Service {
 				$error_message = WC_Payments_Utils::esc_interpolated_html(
 					sprintf(
 						/* translators: %1: WooPayments, %2: required WP version number, %3: currently installed WP version number */
-						__( '%1$s requires <strong>WordPress %2$s</strong> or greater (you are using %3$s).', 'woocommerce-payments' ),
+						__( '%1$s supports <strong>WordPress %2$s</strong> or greater (you are using %3$s).', 'woocommerce-payments' ),
 						'WooPayments',
 						$wp_version,
 						get_bloginfo( 'version' )

--- a/includes/class-wc-payments.php
+++ b/includes/class-wc-payments.php
@@ -138,6 +138,13 @@ class WC_Payments {
 	private static $dependency_service;
 
 	/**
+	 * Whether service initialization has completed.
+	 *
+	 * @var bool
+	 */
+	private static $initialized = false;
+
+	/**
 	 * Instance of WC_Payments_Fraud_Service, created in init function
 	 *
 	 * @var WC_Payments_Fraud_Service
@@ -870,6 +877,17 @@ class WC_Payments {
 		self::$duplicate_payment_prevention_service->init( self::$card_gateway, self::$order_service );
 
 		wcpay_get_container()->get( \WCPay\Internal\PluginManagement\TranslationsLoader::class )->init_hooks();
+
+		self::$initialized = true;
+	}
+
+	/**
+	 * Returns whether service initialization has completed.
+	 *
+	 * @return bool
+	 */
+	public static function is_initialized(): bool {
+		return self::$initialized;
 	}
 
 	/**
@@ -1655,6 +1673,10 @@ class WC_Payments {
 	 * Removes WCPay notes from the WC-Admin inbox.
 	 */
 	public static function remove_woo_admin_notes() {
+		if ( null === self::$remote_note_service ) {
+			return;
+		}
+
 		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
 			self::$remote_note_service->delete_notes();
 			require_once WCPAY_ABSPATH . 'includes/notes/class-wc-payments-notes-qualitative-feedback.php';

--- a/tests/unit/test-class-wc-payments-dependency-service.php
+++ b/tests/unit/test-class-wc-payments-dependency-service.php
@@ -85,6 +85,70 @@ class WC_Payments_Dependency_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertStringContainsStringIgnoringCase( 'WooPayments requires WooCommerce Admin to be enabled', $result );
 	}
 
+	/**
+	 * @dataProvider blocking_dependencies_provider
+	 */
+	public function test_get_blocking_dependencies( $invalid_dependencies, $expected ) {
+		$service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setMethods( [ 'get_invalid_dependencies' ] )
+			->getMock();
+		$service->method( 'get_invalid_dependencies' )->willReturn( $invalid_dependencies );
+
+		$this->assertSame( $expected, $service->get_blocking_dependencies() );
+	}
+
+	public function blocking_dependencies_provider() {
+		return [
+			'compatible'        => [ [], [] ],
+			'old versions'      => [ [ 'woocore_outdated', 'wc_admin_outdated', 'wp_outdated' ], [] ],
+			'missing Woo'       => [ [ 'woocore_disabled', 'woocore_outdated', 'wc_admin_not_found' ], [ 'woocore_disabled', 'wc_admin_not_found' ] ],
+			'disabled WC Admin' => [ [ 'woocore_outdated', 'wc_admin_not_found' ], [ 'wc_admin_not_found' ] ],
+		];
+	}
+
+	public function test_account_cache_clear_does_not_change_blocking_dependencies() {
+		$service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setMethods( [ 'is_woo_core_version_compatible' ] )
+			->getMock();
+		$service->method( 'is_woo_core_version_compatible' )->willReturn( false );
+		update_option( WCPay\Database_Cache::ACCOUNT_KEY, [ 'data' => [ 'account_id' => 'acct_test' ] ] );
+
+		$this->assertSame( [], $service->get_blocking_dependencies() );
+		WC_Payments::get_account_service()->clear_cache();
+
+		$this->assertFalse( get_option( 'wcpay_account_data' ) );
+		$this->assertSame( [], $service->get_blocking_dependencies() );
+		$this->assertSame( [ 'woocore_outdated' ], $service->get_invalid_dependencies() );
+	}
+
+	/**
+	 * @dataProvider dependency_notice_provider
+	 */
+	public function test_dependency_notice_severity( $dependencies, $notice_class, $message ) {
+		$service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )
+			->setMethods( [ 'get_invalid_dependencies', 'are_assets_built' ] )
+			->getMock();
+		$service->method( 'get_invalid_dependencies' )->willReturn( $dependencies );
+		$service->method( 'are_assets_built' )->willReturn( true );
+
+		ob_start();
+		$service->display_admin_notices();
+		$notice = ob_get_clean();
+
+		$this->assertStringContainsString( $notice_class, $notice );
+		$this->assertStringContainsString( $message, $notice );
+	}
+
+	public function dependency_notice_provider() {
+		return [
+			'old Woo'           => [ [ 'woocore_outdated' ], 'notice-warning', 'WooCommerce' ],
+			'old WP'            => [ [ 'wp_outdated' ], 'notice-warning', 'WordPress' ],
+			'old WC Admin'      => [ [ 'wc_admin_outdated' ], 'notice-warning', 'WooCommerce Admin' ],
+			'missing Woo'       => [ [ 'woocore_disabled', 'woocore_outdated' ], 'notice-error', 'to be installed and active' ],
+			'disabled WC Admin' => [ [ 'woocore_outdated', 'wc_admin_not_found' ], 'notice-error', 'WooCommerce Admin to be enabled' ],
+		];
+	}
+
 	public function test_display_admin_notices_assets_not_built() {
 		// Create a partial mock, leaving out the method under test.
 		$dependency_service = $this->getMockBuilder( WC_Payments_Dependency_Service::class )

--- a/tests/unit/test-class-wc-payments.php
+++ b/tests/unit/test-class-wc-payments.php
@@ -42,6 +42,41 @@ class WC_Payments_Test extends WCPAY_UnitTestCase {
 		$this->assertEquals( 10, $install_actions_priority );
 	}
 
+	public function test_deactivation_without_initialized_note_service() {
+		$property = new ReflectionProperty( WC_Payments::class, 'remote_note_service' );
+		$property->setAccessible( true );
+		$service = $property->getValue();
+		$property->setValue( null, null );
+		set_transient( 'woocommerce_admin_pes_incentive_woopayments_cache', [ 'cached' ] );
+
+		try {
+			wcpay_deactivated();
+			$this->assertFalse( get_transient( 'woocommerce_admin_pes_incentive_woopayments_cache' ) );
+		} finally {
+			$property->setValue( null, $service );
+		}
+	}
+
+	public function test_blocked_initialization_does_not_register_woopay_session_hooks() {
+		$property = new ReflectionProperty( WC_Payments::class, 'initialized' );
+		$property->setAccessible( true );
+		$initialized = $property->getValue();
+		$property->setValue( null, false );
+		$callback = [ WooPay_Session::class, 'determine_current_user_for_woopay' ];
+		$priority = has_filter( 'determine_current_user', $callback );
+		remove_filter( 'determine_current_user', $callback, 20 );
+
+		try {
+			wcpay_init();
+			$this->assertFalse( has_filter( 'determine_current_user', $callback ) );
+		} finally {
+			$property->setValue( null, $initialized );
+			if ( false !== $priority ) {
+				add_filter( 'determine_current_user', $callback, $priority );
+			}
+		}
+	}
+
 	public function test_it_does_not_clean_up_deprecated_notes_on_admin_init() {
 		$this->assertFalse( has_action( 'admin_init', [ WC_Payments::class, 'remove_deprecated_notes' ] ) );
 	}

--- a/woocommerce-payments.php
+++ b/woocommerce-payments.php
@@ -163,6 +163,11 @@ function wcpay_init() {
 	require_once WCPAY_ABSPATH . '/includes/class-wc-payments.php';
 	require_once WCPAY_ABSPATH . '/includes/class-wc-payments-payment-request-session.php';
 	WC_Payments::init();
+
+	if ( ! WC_Payments::is_initialized() ) {
+		return;
+	}
+
 	/**
 	 * Needs to be loaded as soon as possible
 	 * Check https://github.com/Automattic/woocommerce-payments/issues/4759


### PR DESCRIPTION
Fixes #7147.

#### Changes proposed in this Pull Request

An update clears the account cache. On a store below the declared minimum versions, the next request then stops WooPayments service initialization while still registering WooPay session hooks. Deactivating the plugin can also call `delete_notes()` on a service that was never created.

- Make version mismatches produce warnings without blocking initialization, independent of account-cache contents.
- Stop dependent bootstrap code when WooCommerce is missing or WooCommerce Admin is disabled.
- Skip note cleanup when the note service was not initialized.

The version floors and update offers stay as they are. This fixes the shutdown caused by the dependency check; it does not guarantee compatibility with every older WooCommerce API.

**Backward compatibility:** Existing public signatures, including `get_invalid_dependencies(bool $check_account_connection = false)`, remain unchanged. That method retains its existing diagnostic and cached-account behaviour. `has_valid_dependencies()` now reports whether initialization is possible and returns true for version-only mismatches; external callers needing version diagnostics should use `get_invalid_dependencies()`. `get_blocking_dependencies()` and `WC_Payments::is_initialized()` are additive. WooPay session hooks are no longer registered when required dependencies prevent startup. Account-cache invalidation and the upgrade action remain in place. Multisite was not tested; the change adds no stored settings or migrations.

#### Testing instructions

Use a disposable test store when installing older WooCommerce versions.

1. On WooCommerce 7.5.1, with a connected WooPayments test account, install this branch and set `woocommerce_woocommerce_payments_version` to the previous WooPayments version to trigger the upgrade routine.
2. Load the site to run the update, then reload it. Confirm WooPayments still registers its gateway and shows a warning about the supported WooCommerce version. Clear the account cache explicitly and repeat the check.
3. Deactivate WooPayments. Confirm there is no fatal error.
4. Reactivate it with WooCommerce Admin disabled through `woocommerce_admin_disabled`. Confirm an error notice explains the missing dependency, WooPay session hooks are absent, and deactivation succeeds. Repeat with WooCommerce inactive, using the test harness or CLI if WordPress dependency controls prevent this combination in the UI.
5. Restore a supported WooCommerce version and enable WooCommerce Admin. Confirm normal startup and no dependency notice. Place a test payment to verify checkout.

**Verification completed:** 54 focused PHP tests / 184 assertions, PHPCS on all changed PHP files, and PHPStan on the changed production PHP files passed. Separate startup checks ran with `WCPAY_TEST_ENV=false`, WordPress 7.1 and PHP 8.1, using real WooCommerce 7.5.1 and 11.1.0 installations. They covered cached and empty account data, the upgrade/cache-clear action, missing WooCommerce, disabled WC Admin, warning/error notices, WooPay hook registration and deactivation. The unfixed code reproduced the cache-dependent shutdown and null-service deactivation failure; the fixed code passed all five scenarios. No payment transaction or browser checkout was performed in this verification.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file.
- [x] Covered with tests.
- [x] Tested on mobile (does not apply to the initialization change).

**Post merge**

- [ ] Link to testing instructions from the release testing doc.
- [ ] Update critical flows and testing instructions, if applicable.
- [ ] Include the change in the release announcement.
