### PR TITLE
fix: exit non-zero when the POT combine script fails

### DIFF
--- a/bin/combine-pot-files.php
+++ b/bin/combine-pot-files.php
@@ -10,15 +10,15 @@
 /**
  * Get the two file names from the command line.
  */
-if ( $argc < 2 ) {
-	echo "Usage: php -f {$argv[0]} source-file.pot destination-file.pot\n";
-	exit;
+if ( $argc < 3 ) {
+	fwrite( STDERR, "Usage: php -f {$argv[0]} source-file.pot destination-file.pot\n" );
+	exit( 2 );
 }
 
 for ( $index = 1; $index <= 2; $index++ ) {
 	if ( ! is_file( $argv[ $index ] ) ) {
-		echo "File not found: {$argv[ $index ]}\n";
-		exit;
+		fwrite( STDERR, "File not found: {$argv[ $index ]}\n" );
+		exit( 1 );
 	}
 }
 
@@ -92,12 +92,12 @@ function load_js_transpiling_source_maps(): array {
 	foreach ( glob( "dist/*.js.map", GLOB_NOSORT ) as $filename ) {
 		$file_content = file_get_contents( $filename );
 		if ( $file_content === false ) {
-			echo "[WARN] Unable to read file '". $filename . "'. Some translation strings might not have the correct references as a result.\n";
+			fwrite( STDERR, "[WARN] Unable to read file '". $filename . "'. Some translation strings might not have the correct references as a result.\n" );
 			continue;
 		}
 		$file_json = json_decode( $file_content, true );
 		if ( $file_json === null ) {
-			echo "[WARN] Unable to parse JSON file: '". $filename . "'. Some translation strings might not have the correct references as a result.\n";
+			fwrite( STDERR, "[WARN] Unable to parse JSON file: '". $filename . "'. Some translation strings might not have the correct references as a result.\n" );
 			continue;
 		}
 
@@ -110,8 +110,8 @@ function load_js_transpiling_source_maps(): array {
 	}
 
 	if ( empty( $mappings ) ) {
-		echo "[ERROR] Unable to load JS transpiling mappings from 'dist/*.js.map' files. Make sure the JS assets compilation was successful.\n";
-		die();
+		fwrite( STDERR, "[ERROR] Unable to load JS transpiling mappings from 'dist/*.js.map' files. Make sure the JS assets compilation was successful.\n" );
+		exit( 1 );
 	}
 
 	return $mappings;

--- a/changelog/fix-combine-pot-exit-codes
+++ b/changelog/fix-combine-pot-exit-codes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Make the POT combine build script exit non-zero on failure so broken translation builds stop instead of shipping.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed this while reviewing #12109.

`bin/combine-pot-files.php` builds the strings that get converted into language packs. When the script failed, it printed an error and then exited with status 0, which means "success". The build believed it and carried on.

So a build could package a plugin whose translation template was missing every string from the admin screens.
I got a zip with 1,343 strings gone and no reference to a single client file.

Each failure now exits non-zero and prints to stderr. With #12108 merged, the release script stops instead of packaging.

Still not caught, and worth its own issue: edit one file with strings in it on a warm cache and the template comes out with only that file's strings, exit code 0.

#### Testing instructions

- `pnpm run build:client` on a clean tree. It should finish, and `languages/woocommerce-payments.pot` should be the same as before this branch.
- Run it again straight away. It should now stop at `File not found: languages/woocommerce-payments-client.pot` instead of finishing quietly. Then `rm -rf node_modules/.cache/webpack` to get back to a working build.
- `php bin/combine-pot-files.php; echo $?` → usage line, `2`
- `php bin/combine-pot-files.php languages/nope.pot languages/woocommerce-payments.pot; echo $?` → `File not found`, `1`
- Add `2>/dev/null` to either one. Nothing should print - the errors go to stderr now.

-------------------

- [x] Run `pnpm run changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] Covered with tests (or have a good reason not to test in description ☝️) - build tooling; verified by triggering each failure path and by diffing the merged template before and after.
- [x] Tested on mobile (or does not apply)

**Post merge**

- [x] Link to testing instructions from [release testing doc](https://github.com/Automattic/woocommerce-payments/wiki/Release-testing-instructions) following [these instructions](https://github.com/Automattic/woocommerce-payments/wiki/How-to-write-good-manual-testing-scenarios) : _QA Testing Not Applicable_
- [x] Add or update [critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Critical-flows) and [testing instructions for critical flows](https://github.com/Automattic/woocommerce-payments/wiki/Testing-instructions-for-critical-flows), if applicable.
- [x] Add what's changed (description, screenshot, demo videos etc.) to the release announcement post, if applicable.
