### PR TITLE
fix: guard admin fraud tracking until screen initialization

### DIFF
--- a/changelog/fix-woopmnt-6454-admin-fraud-tracker
+++ b/changelog/fix-woopmnt-6454-admin-fraud-tracker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevented an admin fraud tracker warning when other plugins fire admin hooks on frontend pages.

--- a/includes/class-wc-payments-fraud-service.php
+++ b/includes/class-wc-payments-fraud-service.php
@@ -205,6 +205,10 @@ class WC_Payments_Fraud_Service {
 	 *                    This means that the method is called before the `init` hook.
 	 */
 	public function add_sift_js_tracker_in_admin() {
+		if ( ! is_admin() || ! did_action( 'current_screen' ) ) {
+			return;
+		}
+
 		// If the current page is a WooPayments dashboard page bail as there's separate logic
 		// that will include the Sift JS tracker on its own.
 		if ( isset( $_GET['path'] ) && strpos( $_GET['path'], '/payments/' ) === 0 ) { // phpcs:ignore WordPress.Security

--- a/tests/unit/test-class-wc-payments-fraud-service.php
+++ b/tests/unit/test-class-wc-payments-fraud-service.php
@@ -84,6 +84,13 @@ class WC_Payments_Fraud_Service_Test extends WCPAY_UnitTestCase {
 		$this->fraud_service->add_sift_js_tracker_in_admin();
 	}
 
+	public function test_admin_tracker_skips_admin_requests_before_screen_setup() {
+		$this->mock_in_admin();
+
+		$this->expectOutputString( '' );
+		$this->fraud_service->add_sift_js_tracker_in_admin();
+	}
+
 	public function test_admin_tracker_renders_on_a_woocommerce_admin_screen() {
 		set_current_screen( 'woocommerce_page_wc-admin' );
 		$original_get = $_GET;

--- a/tests/unit/test-class-wc-payments-fraud-service.php
+++ b/tests/unit/test-class-wc-payments-fraud-service.php
@@ -76,67 +76,42 @@ class WC_Payments_Fraud_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertNotFalse( has_action( 'admin_print_footer_scripts', [ $this->fraud_service, 'add_sift_js_tracker_in_admin' ] ) );
 	}
 
-	/**
-	 * @dataProvider admin_tracker_context_provider
-	 */
-	public function test_admin_tracker_requires_an_initialized_admin_screen( $in_admin, $screen_initialized, $should_render ) {
-		global $current_screen, $wp_actions;
+	public function test_admin_tracker_skips_frontend_requests_before_screen_setup() {
+		set_current_screen( 'front' );
+		unset( $GLOBALS['wp_actions']['current_screen'] );
 
-		$original_screen  = $current_screen;
-		$original_actions = $wp_actions;
-		$original_get     = $_GET;
-		$service          = $this->getMockBuilder( WC_Payments_Fraud_Service::class )
+		$this->expectOutputString( '' );
+		$this->fraud_service->add_sift_js_tracker_in_admin();
+	}
+
+	public function test_admin_tracker_renders_on_a_woocommerce_admin_screen() {
+		set_current_screen( 'woocommerce_page_wc-admin' );
+		$original_get = $_GET;
+		$_GET['page'] = 'wc-admin';
+
+		$service = $this->getMockBuilder( WC_Payments_Fraud_Service::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'get_fraud_services_config' ] )
 			->getMock();
-		$service->expects( $should_render ? $this->once() : $this->never() )
-			->method( 'get_fraud_services_config' )
-			->willReturn(
-				[
-					'sift' => [
-						'beacon_key' => 'test-beacon',
-						'user_id'    => 'test-user',
-						'session_id' => 'test-session',
-					],
-				]
-			);
+		$service->method( 'get_fraud_services_config' )->willReturn(
+			[
+				'sift' => [
+					'beacon_key' => 'test-beacon',
+					'user_id'    => 'test-user',
+					'session_id' => 'test-session',
+				],
+			]
+		);
 
+		ob_start();
 		try {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$current_screen = $this->getMockBuilder( stdClass::class )->addMethods( [ 'in_admin' ] )->getMock();
-			$current_screen->method( 'in_admin' )->willReturn( $in_admin );
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$wp_actions['current_screen'] = $screen_initialized ? 1 : 0;
-			$_GET                         = $in_admin ? [ 'page' => 'wc-admin' ] : [];
-
-			ob_start();
-			try {
-				$service->add_sift_js_tracker_in_admin();
-			} finally {
-				$output = ob_get_clean();
-			}
-
-			if ( $should_render ) {
-				$this->assertStringContainsString( 'https://cdn.sift.com/s.js', $output );
-			} else {
-				$this->assertSame( '', $output );
-			}
+			$service->add_sift_js_tracker_in_admin();
 		} finally {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$current_screen = $original_screen;
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			$wp_actions = $original_actions;
-			$_GET       = $original_get;
+			$output = ob_get_clean();
+			$_GET   = $original_get;
 		}
-	}
 
-	public function admin_tracker_context_provider() {
-		return [
-			'frontend before current_screen' => [ false, false, false ],
-			'frontend after current_screen'  => [ false, true, false ],
-			'admin before current_screen'    => [ true, false, false ],
-			'initialized WooCommerce admin'  => [ true, true, true ],
-		];
+		$this->assertStringContainsString( 'https://cdn.sift.com/s.js', $output );
 	}
 
 	public function test_get_fraud_services_config_returns_from_account() {

--- a/tests/unit/test-class-wc-payments-fraud-service.php
+++ b/tests/unit/test-class-wc-payments-fraud-service.php
@@ -76,6 +76,69 @@ class WC_Payments_Fraud_Service_Test extends WCPAY_UnitTestCase {
 		$this->assertNotFalse( has_action( 'admin_print_footer_scripts', [ $this->fraud_service, 'add_sift_js_tracker_in_admin' ] ) );
 	}
 
+	/**
+	 * @dataProvider admin_tracker_context_provider
+	 */
+	public function test_admin_tracker_requires_an_initialized_admin_screen( $in_admin, $screen_initialized, $should_render ) {
+		global $current_screen, $wp_actions;
+
+		$original_screen  = $current_screen;
+		$original_actions = $wp_actions;
+		$original_get     = $_GET;
+		$service          = $this->getMockBuilder( WC_Payments_Fraud_Service::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_fraud_services_config' ] )
+			->getMock();
+		$service->expects( $should_render ? $this->once() : $this->never() )
+			->method( 'get_fraud_services_config' )
+			->willReturn(
+				[
+					'sift' => [
+						'beacon_key' => 'test-beacon',
+						'user_id'    => 'test-user',
+						'session_id' => 'test-session',
+					],
+				]
+			);
+
+		try {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$current_screen = $this->getMockBuilder( stdClass::class )->addMethods( [ 'in_admin' ] )->getMock();
+			$current_screen->method( 'in_admin' )->willReturn( $in_admin );
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$wp_actions['current_screen'] = $screen_initialized ? 1 : 0;
+			$_GET                         = $in_admin ? [ 'page' => 'wc-admin' ] : [];
+
+			ob_start();
+			try {
+				$service->add_sift_js_tracker_in_admin();
+			} finally {
+				$output = ob_get_clean();
+			}
+
+			if ( $should_render ) {
+				$this->assertStringContainsString( 'https://cdn.sift.com/s.js', $output );
+			} else {
+				$this->assertSame( '', $output );
+			}
+		} finally {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$current_screen = $original_screen;
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$wp_actions = $original_actions;
+			$_GET       = $original_get;
+		}
+	}
+
+	public function admin_tracker_context_provider() {
+		return [
+			'frontend before current_screen' => [ false, false, false ],
+			'frontend after current_screen'  => [ false, true, false ],
+			'admin before current_screen'    => [ true, false, false ],
+			'initialized WooCommerce admin'  => [ true, true, true ],
+		];
+	}
+
 	public function test_get_fraud_services_config_returns_from_account() {
 		wp_set_current_user( 1 );
 		$this->mock_in_admin();


### PR DESCRIPTION
Closes #12116.
Closes WOOPMNT-6454.

#### Changes proposed in this Pull Request

Plugins such as Tutor LMS can fire `admin_print_footer_scripts` on a frontend request. WooPayments then asks WooCommerce for the current admin page before a screen exists, triggering a `get_current_page` incorrect-usage notice.

Return early unless the request is in the admin and `current_screen` has fired. Add regression coverage for frontend requests and tracker rendering on an initialized WooCommerce admin screen.

#### Testing instructions

1. Enable `WP_DEBUG` and `WP_DEBUG_LOG` on a development store with WooCommerce and WooPayments active.
2. Temporarily add this snippet to an MU-plugin, then visit the storefront with `?test_admin_footer=1`:

   ```php
   add_action( 'init', function () {
       if ( isset( $_GET['test_admin_footer'] ) ) {
           do_action( 'admin_print_footer_scripts' );
       }
   }, 999 );
   ```

3. Confirm the request adds no `get_current_page` incorrect-usage notice to the debug log. The same request produces the notice without this fix.
4. Remove the temporary snippet.
5. On an account with Sift enabled, open a WooCommerce admin screen outside Payments and confirm the Sift tracker is still included.

Verified: all 12 fraud-service tests pass (20 assertions), including valid admin tracker rendering. The frontend regression test fails with the original warning without the guard. The frontend HTTP reproduction no longer produces the warning. PHPCS passes for both changed PHP files. Tutor LMS itself was not exercised.

-------------------

- [x] Add a patch changelog entry.
- [x] Covered with tests.
- [x] Tested on mobile (does not apply).

**Post merge**

- [ ] Link to testing instructions from the release testing doc.
- [ ] Add or update critical flows and testing instructions, if applicable.
- [ ] Add what's changed to the release announcement post, if applicable.

