### PR TITLE
fix(e2e): use toolbar inserter for currency switcher

### DIFF
--- a/changelog/fix-e2e-currency-switcher-inserter
+++ b/changelog/fix-e2e-currency-switcher-inserter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Use the editor toolbar inserter in the currency switcher E2E test.

--- a/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
+++ b/tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { test, expect, Page, errors } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 /**
  * Internal dependencies
  */
@@ -67,40 +67,23 @@ test.describe( 'Multi-currency', { tag: '@critical' }, () => {
 		// Dismiss the Welcome Guide; its overlay blocks the block inserter.
 		await disableEditorWelcomeGuide( page );
 
-		// Wait for the iframed canvas before branching — `isVisible()` doesn't
-		// auto-wait, so an early check raced the mount and took the WC 7.7.0
-		// inline path on WP nightly.
-		const editorCanvas = page.locator( '[name="editor-canvas"]' );
-		const usesIframedCanvas = await editorCanvas
-			.waitFor( { state: 'visible', timeout: 15000 } )
-			.then( () => true )
-			.catch( ( error ) => {
-				// Only a timeout means the inline (non-iframed) WC 7.7.0 editor;
-				// surface anything else (page closed, navigation, bad selector).
-				if ( error instanceof errors.TimeoutError ) {
-					return false;
-				}
-				throw error;
-			} );
-
-		if ( usesIframedCanvas ) {
-			const editor = editorCanvas.contentFrame();
-			await editor.getByRole( 'button', { name: 'Add block' } ).click();
-		} else {
-			// Fallback for the inline (non-iframed) editor on WC 7.7.0.
-			await page.getByRole( 'button', { name: 'Add block' } ).click();
-		}
-
+		// The toolbar inserter works with both iframed and inline editors.
 		await page
-			.locator( 'input[placeholder="Search"]' )
-			.pressSequentially( 'switcher', { delay: 20 } );
-		await expect(
-			page.getByRole( 'option', { name: 'Currency Switcher Block' } )
-		).toBeVisible();
+			.getByLabel( 'Editor top bar' )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 
-		// Insert the block.
-		await page
-			.getByRole( 'option', { name: 'Currency Switcher Block' } )
+		const blockLibrary = page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
+		await blockLibrary
+			.getByLabel( 'Search', { exact: true } )
+			.fill( 'switcher' );
+		await blockLibrary
+			.getByRole( 'option', {
+				name: 'Currency Switcher Block',
+				exact: true,
+			} )
 			.click();
 
 		// Publish the post — click the top bar button to open the publish panel.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The currency switcher works on WordPress nightly, but its E2E test waits for an "Add block" button that no longer exists in the editor canvas. This causes the [120-second timeout](https://github.com/Automattic/woocommerce-payments/actions/runs/34603420187/job/103275994920).

Use the toolbar's Block Inserter instead. This changes only the test. I also confirmed this is just a broken test (and not a broken code path)

#### Testing instructions

Browser verification passed on the exact failing nightly build, WordPress `7.2-alpha-63596`, with WooCommerce 11.1.0:

- Inserted the currency switcher and published the post.
- Selected EUR on the frontend and confirmed a product price changed from $18.00 to €36.00 with a test exchange rate of 2.
- Reloaded the product page and confirmed the currency and price persisted.

The old "Add block" button was confirmed absent. The same insertion and publishing flow also passed on WordPress 7.1. ESLint, TypeScript and formatting checks passed.

To verify the automated test, run `pnpm run test:e2e tests/e2e/specs/wcpay/merchant/multi-currency.spec.ts` in a configured E2E environment. CI is still running; the full nightly and WC 7.7.0 configurations remain unverified.

-------------------

- [x] Added a changelog entry.
- [x] Verified the functionality in a browser; CI verification is pending.
- [x] Tested on mobile: not applicable.

**Post merge**

- [x] Release testing: QA Testing Not Applicable.
- [x] Critical flow documentation: no flow changes.
- [x] Release announcement: not applicable.
